### PR TITLE
Implement routines to turn enemies hostile 

### DIFF
--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -59,6 +59,7 @@ public:
     bool isMinOneHP() const { return _minOneHP; }
     bool isDead() const { return _dead; }
     bool isCommandable() const { return _commandable; }
+    bool isInConversation() const { return _isInConversation; }
 
     float getDistanceTo(const glm::vec2 &point) const;
     float getSquareDistanceTo(const glm::vec2 &point) const;
@@ -87,6 +88,7 @@ public:
     void setTag(std::string tag) { _tag = std::move(tag); }
     void setPlotFlag(bool plot) { _plot = plot; }
     void setCommandable(bool commandable) { _commandable = commandable; }
+    void setIsInConversation(bool isInConversation) { _isInConversation = isInConversation; }
 
     void setRoom(Room *room);
     void setPosition(const glm::vec3 &position);
@@ -227,6 +229,7 @@ protected:
     bool _commandable {true};
     bool _autoRemoveKey {false};
     bool _interruptable {false};
+    bool _isInConversation {false};
 
     glm::vec3 _position {0.0f};
     glm::quat _orientation {1.0f, 0.0f, 0.0f, 0.0f};

--- a/include/reone/game/types.h
+++ b/include/reone/game/types.h
@@ -438,7 +438,8 @@ enum class Faction {
     Gizka2 = 17,
     SelfLoathing = 21,
     OneOnOne = 22,
-    PartyPuppet = 23
+    PartyPuppet = 23,
+    Last = 24
 };
 
 enum class Ability {

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -36,6 +36,7 @@ struct Variable {
     glm::vec3 vecValue {0.0f};
     std::shared_ptr<EngineType> engineType;
     std::shared_ptr<ExecutionContext> context;
+    uint64_t id {0};
 
     union {
         int32_t intValue {0};

--- a/include/reone/script/virtualmachine.h
+++ b/include/reone/script/virtualmachine.h
@@ -20,6 +20,8 @@
 #include "executionstate.h"
 #include "types.h"
 
+#include <sstream>
+
 namespace reone {
 
 namespace script {
@@ -56,6 +58,8 @@ private:
     uint32_t _nextInstruction {0};
     int _globalCount {0};
     ExecutionState _savedState;
+    std::stringstream _logStream;
+    bool _logEnabled {false};
 
     void registerHandler(InstructionType type, std::function<void(VirtualMachine *, const Instruction &)> handler) {
         _handlers.insert(std::make_pair(type, std::bind(handler, this, std::placeholders::_1)));
@@ -82,6 +86,20 @@ private:
     void withVectorsFromStack(const std::function<void(const glm::vec3 &, const glm::vec3 &)> &fn);
 
     void throwIfInvalidType(VariableType expected, VariableType actual);
+
+    using InstRevIterator = std::vector<Variable>::reverse_iterator;
+
+    void logOperandsIt(InstRevIterator begin, InstRevIterator end);
+    void logResultsIt(InstRevIterator begin, InstRevIterator end);
+
+    void logOperands(unsigned n);
+    void logResults(unsigned n);
+
+    enum class JumpType {
+        Jump,
+        Fallthrough,
+    };
+    void logJump(JumpType type);
 
     // Handlers
 

--- a/include/reone/script/virtualmachine.h
+++ b/include/reone/script/virtualmachine.h
@@ -45,6 +45,8 @@ public:
     int getStackSize() const;
     const Variable &getStackVariable(int index) const;
 
+    void dump() const;
+
 private:
     std::shared_ptr<ScriptProgram> _program;
     std::unique_ptr<ExecutionContext> _context;

--- a/src/libs/game/di/module.cpp
+++ b/src/libs/game/di/module.cpp
@@ -48,6 +48,7 @@ void GameModule::init() {
     _cameraStyles->init();
     _guiSounds->init();
     _portraits->init();
+    _reputes->init();
     _surfaces->init();
 }
 

--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -172,6 +172,7 @@ void DialogGUI::loadStuntParticipants() {
             creature->startStuntMode();
         }
 
+        participant.creature->setIsInConversation(true);
         _participantByTag.insert(std::make_pair(stunt.participant, std::move(participant)));
     }
 }
@@ -345,6 +346,7 @@ void DialogGUI::onFinish() {
 void DialogGUI::releaseStuntParticipants() {
     for (auto &participant : _participantByTag) {
         participant.second.creature->stopStuntMode();
+        participant.second.creature->setIsInConversation(false);
     }
 }
 

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -5093,7 +5093,8 @@ static Variable IsNPCPartyMember(const std::vector<Variable> &args, const Routin
 
 static Variable GetIsConversationActive(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetIsConversationActive");
+    bool active = ctx.game.currentScreen() == game::Game::Screen::Conversation;
+    return Variable::ofInt(active);
 }
 
 static Variable GetPartyAIStyle(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3484,9 +3484,14 @@ static Variable ChangeToStandardFaction(const std::vector<Variable> &args, const
     auto nStandardFaction = getInt(args, 1);
 
     // Transform
+    if (nStandardFaction <= (int)Faction::Invalid || nStandardFaction >= (int)Faction::Last) {
+        throw RoutineArgumentException(str(boost::format("Invalid faction: %d") % nStandardFaction));
+    }
 
     // Execute
-    throw RoutineNotImplementedException("ChangeToStandardFaction");
+    auto creature = checkCreature(oCreatureToChange);
+    creature->setFaction((Faction)nStandardFaction);
+    return Variable::ofNull();
 }
 
 static Variable SoundObjectPlay(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -1493,9 +1493,12 @@ static Variable ChangeFaction(const std::vector<Variable> &args, const RoutineCo
     auto oMemberOfFactionToJoin = getObject(args, 1, ctx);
 
     // Transform
+    auto target = checkCreature(oObjectToChangeFaction);
+    auto source = checkCreature(oMemberOfFactionToJoin);
 
     // Execute
-    throw RoutineNotImplementedException("ChangeFaction");
+    target->setFaction(source->faction());
+    return Variable::ofNull();
 }
 
 static Variable GetIsListening(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3795,11 +3795,8 @@ static Variable TakeGoldFromCreature(const std::vector<Variable> &args, const Ro
 static Variable GetIsInConversation(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto oObject = getObject(args, 0, ctx);
-
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("GetIsInConversation");
+    return Variable::ofInt(oObject->isInConversation());
 }
 
 static Variable GetPlotFlag(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -21,6 +21,8 @@ namespace reone {
 
 namespace script {
 
+std::atomic<uint64_t> g_id {0};
+
 Variable Variable::ofNull() {
     Variable result;
     result.type = VariableType::Void;
@@ -31,6 +33,7 @@ Variable Variable::ofInt(int value) {
     Variable result;
     result.type = VariableType::Int;
     result.intValue = value;
+    result.id = ++g_id;
     return result;
 }
 
@@ -38,6 +41,7 @@ Variable Variable::ofFloat(float value) {
     Variable result;
     result.type = VariableType::Float;
     result.floatValue = value;
+    result.id = ++g_id;
     return result;
 }
 
@@ -45,6 +49,7 @@ Variable Variable::ofString(std::string value) {
     Variable result;
     result.type = VariableType::String;
     result.strValue = std::move(value);
+    result.id = ++g_id;
     return result;
 }
 
@@ -52,6 +57,7 @@ Variable Variable::ofVector(glm::vec3 value) {
     Variable result;
     result.type = VariableType::Vector;
     result.vecValue = std::move(value);
+    result.id = ++g_id;
     return result;
 }
 
@@ -59,6 +65,7 @@ Variable Variable::ofObject(uint32_t objectId) {
     Variable result;
     result.type = VariableType::Object;
     result.objectId = objectId;
+    result.id = ++g_id;
     return result;
 }
 
@@ -66,6 +73,7 @@ Variable Variable::ofEffect(std::shared_ptr<EngineType> engineType) {
     Variable result;
     result.type = VariableType::Effect;
     result.engineType = std::move(engineType);
+    result.id = ++g_id;
     return result;
 }
 
@@ -73,6 +81,7 @@ Variable Variable::ofEvent(std::shared_ptr<EngineType> engineType) {
     Variable result;
     result.type = VariableType::Event;
     result.engineType = std::move(engineType);
+    result.id = ++g_id;
     return result;
 }
 
@@ -80,6 +89,7 @@ Variable Variable::ofLocation(std::shared_ptr<EngineType> engineType) {
     Variable result;
     result.type = VariableType::Location;
     result.engineType = std::move(engineType);
+    result.id = ++g_id;
     return result;
 }
 
@@ -87,6 +97,7 @@ Variable Variable::ofTalent(std::shared_ptr<EngineType> engineType) {
     Variable result;
     result.type = VariableType::Talent;
     result.engineType = std::move(engineType);
+    result.id = ++g_id;
     return result;
 }
 
@@ -94,6 +105,7 @@ Variable Variable::ofAction(std::shared_ptr<ExecutionContext> context) {
     Variable result;
     result.type = VariableType::Action;
     result.context = std::move(context);
+    result.id = ++g_id;
     return result;
 }
 
@@ -102,25 +114,25 @@ const std::string Variable::toString() const {
     case VariableType::Void:
         return "void";
     case VariableType::Int:
-        return std::to_string(intValue);
+        return str(boost::format("%%%u:%d") % id % intValue);
     case VariableType::Float:
-        return std::to_string(floatValue);
+        return str(boost::format("%%%u:%f") % id % floatValue);
     case VariableType::String:
-        return str(boost::format("\"%s\"") % strValue);
+        return str(boost::format("%%%u:\"%s\"") % id % strValue);
     case VariableType::Object:
-        return std::to_string(objectId);
+        return str(boost::format("%%%u:%u") % id % objectId);
     case VariableType::Vector:
-        return str(boost::format("[%f,%f,%f]") % vecValue.x % vecValue.y % vecValue.z);
+        return str(boost::format("%%%u:[%f,%f,%f]") % id % vecValue.x % vecValue.y % vecValue.z);
     case VariableType::Effect:
-        return "effect";
+        return str(boost::format("%%%u:effect") % id);
     case VariableType::Event:
-        return "event";
+        return str(boost::format("%%%u:event") % id);
     case VariableType::Location:
-        return "location";
+        return str(boost::format("%%%u:location") % id);
     case VariableType::Talent:
-        return "talent";
+        return str(boost::format("%%%u:talent") % id);
     case VariableType::Action:
-        return "action";
+        return str(boost::format("%%%u:action") % id);
     default:
         throw std::logic_error("Unsupported variable type: " + std::to_string(static_cast<int>(type)));
     }

--- a/src/libs/script/virtualmachine.cpp
+++ b/src/libs/script/virtualmachine.cpp
@@ -987,6 +987,13 @@ const Variable &VirtualMachine::getStackVariable(int index) const {
     return _stack[index];
 }
 
+void VirtualMachine::dump() const {
+    std::cerr << "PROGRAM " << _program->name() << "\n";
+    for (const Instruction &inst : _program->instructions()) {
+        std::cerr << describeInstruction(inst, *_context->routines) << "\n";
+    }
+}
+
 } // namespace script
 
 } // namespace reone


### PR DESCRIPTION
Scripts actively use `ChangeToStandardFaction` to change NPCs faction from Neutral (usually it is the default) to Hostile. Without it enemies stay neutral and cannot be attacked. This blocks Endar Spire, because the game counts dead enemies and locks corresponding doors.

There are also patches that proved to be useful for debugging: 
  - Added `VirtualMachine::dump()` function to print the current script.
  - Added unique values IDs for each stack value, so we can track them as a def/use chain.

 See commit messages for more details about each patch.