### PR TITLE
[game] Complete PlayAnimation actions immediately for loop anims

### DIFF
--- a/src/libs/game/action/playanimation.cpp
+++ b/src/libs/game/action/playanimation.cpp
@@ -17,6 +17,7 @@
 
 #include "reone/game/action/playanimation.h"
 
+#include "reone/game/animationutil.h"
 #include "reone/game/object.h"
 #include "reone/scene/animproperties.h"
 
@@ -39,7 +40,13 @@ void PlayAnimationAction::execute(std::shared_ptr<Action> self, Object &actor, f
     properties.speed = _speed;
     properties.duration = _durationSeconds;
 
+    bool looping = isAnimationLooping(_animation) && properties.duration == -1.0f;
     actor.playAnimation(_animation, std::move(properties));
+    if (looping) {
+        // Looping animations never finish. Complete the action
+        // immediately to avoid stalling the action queue.
+        complete();
+    }
 
     _playing = true;
 }


### PR DESCRIPTION
Loop animations never finish, so if we keep the corresponding PlayAnimation around, it is going to completely stall action queue of the target object.

This happens on Endar Spire after the jedi fight. Reinforcement units have the following actions:
```
Move -> PlayAnimation(LoopingReady) -> DoCommand.
```
The last DoCommand is supposed to change faction to Hostile, but we used to never reach it because PlayAnimation was looping.

The patch fixes #3 "Enemies after jedi fight spawn as neutral" and unblocks the door to the bridge on Endar Spire.