### PR TITLE
Fix font out of bounds exception for non ascii chars

### DIFF
--- a/src/libs/graphics/font.cpp
+++ b/src/libs/graphics/font.cpp
@@ -117,8 +117,8 @@ glm::vec2 Font::getTextOffset(const std::string &text, TextGravity gravity) cons
 
 float Font::measure(const std::string &text) const {
     float w = 0.0f;
-    for (auto &glyph : text) {
-        w += _glyphs[static_cast<int>(glyph)].size.x;
+    for (const char &glyph : text) {
+        w += _glyphs[reinterpret_cast<const unsigned char &>(glyph)].size.x;
     }
     return w;
 }


### PR DESCRIPTION
Glyphs library has 256 glyphs in total. Lower 128 glyphs are ASCII, higher values are for non-ASCII characters. Char type is 8-bit signed, so we need to bitcast it to unsigned to avoid negative indices.

The problem was reported and fixed in https://github.com/seedhartha/reone/pull/61.