### PR TITLE
[system] Fix issues with ThreadPool

### DIFF
--- a/include/reone/system/threadpool.h
+++ b/include/reone/system/threadpool.h
@@ -68,9 +68,11 @@ public:
     void deinit();
 
     std::shared_ptr<Task> enqueue(TaskFunc func) override {
-        std::lock_guard<std::mutex> lock(_mutex);
         auto task = std::make_shared<Task>(std::move(func));
-        _tasks.push(task);
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _tasks.push(task);
+        }
         _condVar.notify_one();
         return task;
     }

--- a/src/libs/system/threadpool.cpp
+++ b/src/libs/system/threadpool.cpp
@@ -23,18 +23,19 @@ void ThreadPool::init() {
     if (_numThreads == -1) {
         _numThreads = static_cast<int>(std::thread::hardware_concurrency());
     }
+    _running = true;
     for (auto i = 0; i < _numThreads; ++i) {
         _threads.emplace_back(std::bind(&ThreadPool::workerThreadFunc, this));
     }
-    _running = true;
 }
 
 void ThreadPool::deinit() {
-    _running = false;
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _condVar.notify_all();
+        _running = false;
     }
+    _condVar.notify_all();
+
     for (auto &thread : _threads) {
         if (thread.joinable()) {
             thread.join();


### PR DESCRIPTION
This patch has 3 changes to improve ThreadPool and fix #26 "ThreadPool unit tests are flaky":

1. In ThreadPool::enqueue we now have only `_tasks.push(task)` under the lock. Doing otherwise is functionally correct, but suboptimal. It wakes up a Worker thread while the Enqueue thread holds the lock. Worker then immediately attempts to take the lock and have to suspend until Enqueue thread releases it. After the patch Enqueue releases the lock first, and then wakes up a Worker.

2. In `ThreadPool::init` we have to set `_running = true` before starting threads. Their thread function is a `while (_running) {}` loop, so if they reach the check before `_running` is set, they exit immediately. It seems that this issue caused #26.

3. In `ThreadPool::deinit` we have to set `_running = false` under the lock. I haven't seen this to cause any issue so far, but theoretically, this is what can happen:

```
  Worker thread:          |    Main thread:
                          |
    lock();               |
    if (_running) {       |
                          |
                          |    _running = false;
                          |    notify_all();
                          |
      unlock_and_wait();  |
    }                     |

```
Notify does not work for threads that wait *after* notify is done. The patch makes these two sequences mutually exclusive. `notify_all()` is also moved out of the lock for the same reason as in (1).