### PR TITLE
Fix crash when pressing a key outside reply range in conversation

### DIFF
--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -308,7 +308,11 @@ bool Conversation::handleKeyUp(const input::KeyEvent &event) {
     if (code >= static_cast<char>(input::KeyCode::Key1) && code <= static_cast<char>(input::KeyCode::Key9)) {
         int index = code - static_cast<char>(input::KeyCode::Key1);
         if (_entryEnded) {
-            pickReply(index);
+            if (index >= 0 && index < static_cast<int>(_replies.size())) {
+                pickReply(index);
+            } else {
+                debug("Invalid reply index: " + std::to_string(index), LogChannel::Conversation);
+            }
             return true;
         }
     }


### PR DESCRIPTION
This PR fixes a crash that occurs in the conversation system when a player presses a number key that does not correspond to any available reply.

**Details:**

- The crash happened in Conversation::handleKeyUp() because the code called pickReply(index) without checking whether index is within _replies.size().

- Added a boundary check to ensure index is valid before calling pickReply().

- If the pressed key is out of range, the input is ignored and a debug message is logged.

- Tested on Windows 10: pressing invalid keys no longer crashes the game, and valid replies still work correctly.

**Steps to reproduce the original bug:**

1. Start a conversation with fewer than 9 replies.
2. Press a number key that exceeds the number of available replies.
3. The game would previously crash; now it ignores the invalid input.

This fix improves stability without changing existing conversation behavior.