### PR TITLE
Fix text rendering

### DIFF
--- a/include/reone/graphics/texture.h
+++ b/include/reone/graphics/texture.h
@@ -68,7 +68,7 @@ public:
         Filtering minFilter {Filtering::LinearMipmapLinear};
         Filtering magFilter {Filtering::Linear};
         Wrapping wrap {Wrapping::Repeat};
-        glm::vec3 borderColor {0.0f};
+        glm::vec4 borderColor {0.0f};
         float anisotropy {1.0f};
     };
 

--- a/src/libs/graphics/textureutil.cpp
+++ b/src/libs/graphics/textureutil.cpp
@@ -141,7 +141,7 @@ Texture::Properties getTextureProperties(TextureUsage usage) {
     } else if (usage == TextureUsage::Font) {
         properties.minFilter = Texture::Filtering::Linear;
         properties.wrap = Texture::Wrapping::ClampToBorder;
-				properties.borderColor = glm::vec4(0.0f);
+        properties.borderColor = glm::vec4(0.0f);
     }
 
     return properties;

--- a/src/libs/graphics/textureutil.cpp
+++ b/src/libs/graphics/textureutil.cpp
@@ -140,7 +140,8 @@ Texture::Properties getTextureProperties(TextureUsage usage) {
 
     } else if (usage == TextureUsage::Font) {
         properties.minFilter = Texture::Filtering::Linear;
-        properties.wrap = Texture::Wrapping::Repeat;
+        properties.wrap = Texture::Wrapping::ClampToBorder;
+				properties.borderColor = glm::vec4(0.0f);
     }
 
     return properties;

--- a/src/libs/graphics/textureutil.cpp
+++ b/src/libs/graphics/textureutil.cpp
@@ -140,7 +140,7 @@ Texture::Properties getTextureProperties(TextureUsage usage) {
 
     } else if (usage == TextureUsage::Font) {
         properties.minFilter = Texture::Filtering::Linear;
-        properties.wrap = Texture::Wrapping::ClampToBorder;
+        properties.wrap = Texture::Wrapping::Repeat;
     }
 
     return properties;


### PR DESCRIPTION
This PR fixes #25 .
When trying to debug this issue, I noticed the lines only appeared for glyphs that were on the edge of the font's texture. That's when it occured to me that the GPU was simply reading past the edge of the texture, and since the texture wrapping was set to ClampToBorder, this would end up as full pixels the color of the text.

By setting the texture wrapping to repeat, the GPU instead wraps to the end of the texture, which happens to be transparent pixels, fixing the issue.