### PR TITLE
Introduce arguments to ExecutionContext

### DIFF
--- a/include/reone/game/action/openlock.h
+++ b/include/reone/game/action/openlock.h
@@ -27,15 +27,15 @@ class OpenLockAction : public Action {
 public:
     OpenLockAction(Game &game,
                    ServicesView &services,
-                   std::shared_ptr<Object> object) :
+                   std::shared_ptr<Object> target) :
         Action(game, services, ActionType::OpenLock),
-        _object(std::move(object)) {
+        _target(std::move(target)) {
     }
 
     void execute(std::shared_ptr<Action> self, Object &actor, float dt) override;
 
 private:
-    std::shared_ptr<Object> _object;
+    std::shared_ptr<Object> _target;
 };
 
 } // namespace game

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -75,8 +75,6 @@ public:
         float hearingRange {0.0f};
         std::set<std::shared_ptr<Object>> seen;
         std::set<std::shared_ptr<Object>> heard;
-        PerceptionType lastPerception {PerceptionType::Seen};
-        std::shared_ptr<Object> lastPerceived;
     };
 
     struct CombatState {
@@ -194,6 +192,10 @@ public:
     void onObjectVanished(const std::shared_ptr<Object> &object);
     void onObjectHeard(const std::shared_ptr<Object> &object);
     void onObjectInaudible(const std::shared_ptr<Object> &object);
+
+    void setObjectSeen(const std::shared_ptr<Object> &object, bool seen);
+    void setObjectHeard(const std::shared_ptr<Object> &object, bool heard);
+    void runOnNotice(const Object &object, bool heard, bool seen);
 
     const Perception &perception() const { return _perception; }
 
@@ -323,7 +325,6 @@ private:
     void updateCombat(float dt);
 
     inline void runDeathScript();
-    inline void runOnNoticeScript();
 
     ModelType parseModelType(const std::string &s) const;
 

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -48,12 +48,15 @@ public:
 
     bool isSelectable() const override;
 
-    void open(const std::shared_ptr<Object> &triggerrer);
-    void close(const std::shared_ptr<Object> &triggerrer);
+    void open();
+    void close();
 
     bool isLocked() const { return _locked; }
     bool isStatic() const { return _static; }
     bool isKeyRequired() const { return _keyRequired; }
+
+    void onOpen(const Object &triggerer);
+    void onFailToOpen(const Object &triggerer);
 
     const std::string &getOnOpen() const { return _onOpen; }
     const std::string &getOnFailToOpen() const { return _onFailToOpen; }

--- a/include/reone/game/script/routine/argutil.h
+++ b/include/reone/game/script/routine/argutil.h
@@ -45,7 +45,6 @@ class Sound;
 class Talent;
 
 std::shared_ptr<Object> getCaller(const RoutineContext &ctx);
-std::shared_ptr<Object> getTriggerrer(const RoutineContext &ctx);
 
 int getInt(const std::vector<script::Variable> &args, int index);
 float getFloat(const std::vector<script::Variable> &args, int index);

--- a/include/reone/game/script/runner.h
+++ b/include/reone/game/script/runner.h
@@ -45,14 +45,11 @@ public:
 
     int run(
         const std::string &resRef,
-        uint32_t callerId = script::kObjectInvalid,
-        uint32_t triggerrerId = script::kObjectInvalid,
-        int userDefinedEventNumber = -1,
-        int scriptVar = -1);
-
-    int run(
-        const std::string &resRef,
         const std::vector<script::Argument> &args);
+
+    // Run a script with a single ArgKind::Caller argument. When callerId is 0,
+    // run a script without arguments.
+    int run(const std::string &resRef, uint32_t callerId = 0);
 
 private:
     script::IRoutines &_routines;

--- a/include/reone/game/script/runner.h
+++ b/include/reone/game/script/runner.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "reone/script/types.h"
+#include "reone/script/variable.h"
 
 namespace reone {
 
@@ -48,6 +49,10 @@ public:
         uint32_t triggerrerId = script::kObjectInvalid,
         int userDefinedEventNumber = -1,
         int scriptVar = -1);
+
+    int run(
+        const std::string &resRef,
+        const std::vector<script::Argument> &args);
 
 private:
     script::IRoutines &_routines;

--- a/include/reone/script/executioncontext.h
+++ b/include/reone/script/executioncontext.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "types.h"
+#include "variable.h"
 
 namespace reone {
 
@@ -32,8 +33,18 @@ struct ExecutionContext {
     std::shared_ptr<ExecutionState> savedState;
     uint32_t callerId {kObjectInvalid};
     uint32_t triggererId {kObjectInvalid};
-    int userDefinedEventNumber {-1};
     int scriptVar {-1};
+
+    std::vector<Argument> args;
+
+    /// Find an argument variable or return nullptr.
+    ///
+    /// Arguments are specific to a script run. For example, LastOpenedBy
+    /// argument is passed to an onOpen script (typically set on a
+    /// door). Scripts can read arguments by calling corresponding routine
+    /// actions. For example, scripts use GetLastOpenedBy routine to read
+    /// LastOpenedBy argument.
+    const Variable *findArg(ArgKind kind);
 };
 
 } // namespace script

--- a/include/reone/script/executioncontext.h
+++ b/include/reone/script/executioncontext.h
@@ -31,9 +31,6 @@ class IRoutines;
 struct ExecutionContext {
     IRoutines *routines {nullptr};
     std::shared_ptr<ExecutionState> savedState;
-    uint32_t callerId {kObjectInvalid};
-    uint32_t triggererId {kObjectInvalid};
-    int scriptVar {-1};
 
     std::vector<Argument> args;
 

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -86,6 +86,8 @@ struct Variable {
 enum class ArgKind {
     Caller,
     UserDefinedEventNumber,
+    EnteringObject,
+    ExitingObject,
 };
 
 struct Argument {

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -83,6 +83,31 @@ struct Variable {
     static Variable ofAction(std::shared_ptr<ExecutionContext> context);
 };
 
+enum class ArgKind {
+    Caller,
+    UserDefinedEventNumber,
+};
+
+struct Argument {
+    Argument() = default;
+    Argument(ArgKind kind, Variable var) :
+        kind(kind), var(var) {
+
+        verify();
+    }
+
+    ArgKind kind;
+    Variable var;
+
+    std::string toString() const;
+
+    /// Parse "kind:value" and construct an Argument
+    static Argument fromString(std::string str);
+
+private:
+    void verify();
+};
+
 } // namespace script
 
 } // namespace reone

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -89,6 +89,11 @@ enum class ArgKind {
     UserDefinedEventNumber,
     EnteringObject,
     ExitingObject,
+    LastPerceived,
+    LastPerceptionHeard,
+    LastPerceptionInaudible,
+    LastPerceptionSeen,
+    LastPerceptionVanished,
 };
 
 struct Argument {

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -87,6 +87,7 @@ enum class ArgKind {
     Caller,
     ScriptVar,
     UserDefinedEventNumber,
+    ClickingObject,
     EnteringObject,
     ExitingObject,
     LastClosedBy,

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -97,6 +97,7 @@ enum class ArgKind {
     LastPerceptionInaudible,
     LastPerceptionSeen,
     LastPerceptionVanished,
+    LastUsedBy,
 };
 
 struct Argument {

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -85,6 +85,7 @@ struct Variable {
 
 enum class ArgKind {
     Caller,
+    ScriptVar,
     UserDefinedEventNumber,
     EnteringObject,
     ExitingObject,

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -89,6 +89,8 @@ enum class ArgKind {
     UserDefinedEventNumber,
     EnteringObject,
     ExitingObject,
+    LastClosedBy,
+    LastOpenedBy,
     LastPerceived,
     LastPerceptionHeard,
     LastPerceptionInaudible,

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -321,6 +321,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/action/castfakespellatlocation.cpp
     ${GAME_SOURCE_DIR}/action/castfakespellatobject.cpp
     ${GAME_SOURCE_DIR}/action/castspellatobject.cpp
+    ${GAME_SOURCE_DIR}/action/commonactions.cpp
     ${GAME_SOURCE_DIR}/action/closedoor.cpp
     ${GAME_SOURCE_DIR}/action/docommand.cpp
     ${GAME_SOURCE_DIR}/action/equipitem.cpp

--- a/src/libs/game/action/closedoor.cpp
+++ b/src/libs/game/action/closedoor.cpp
@@ -31,7 +31,7 @@ void CloseDoorAction::execute(std::shared_ptr<Action> self, Object &actor, float
 
     bool reached = !creatureActor || creatureActor->navigateTo(door->position(), true, kDefaultMaxObjectDistance, dt);
     if (reached) {
-        door->close(creatureActor);
+        door->close();
         complete();
     }
 }

--- a/src/libs/game/action/commonactions.h
+++ b/src/libs/game/action/commonactions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2025 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,28 +17,16 @@
 
 #pragma once
 
-#include "../action.h"
-
 namespace reone {
 
 namespace game {
 
 class Door;
+class Object;
 
-class OpenDoorAction : public Action {
-public:
-    OpenDoorAction(Game &game,
-                   ServicesView &services,
-                   std::shared_ptr<Door> door) :
-        Action(game, services, ActionType::OpenDoor),
-        _door(std::move(door)) {
-    }
-
-    void execute(std::shared_ptr<Action> self, Object &actor, float dt) override;
-
-private:
-    std::shared_ptr<Door> _door;
-};
+// Move an actor to a door, unlock and open it. Returns true when this action is
+// complete.
+bool unlockDoor(Door &door, Object &actor, float distance, float dt);
 
 } // namespace game
 

--- a/src/libs/game/action/docommand.cpp
+++ b/src/libs/game/action/docommand.cpp
@@ -44,10 +44,18 @@ void DoCommandAction::execute(std::shared_ptr<Action> self, Object &actor, float
     //
     // Besides the Caller, scripts do not seem to use other arguments with
     // AssignCommand.
+
+    bool foundCaller = false;
     for (Argument &arg : executionCtx->args) {
         if (arg.kind == script::ArgKind::Caller) {
             arg.var.objectId = actor.id();
+            foundCaller = true;
+            break;
         }
+    }
+    if (!foundCaller) {
+        executionCtx->args.emplace_back(script::ArgKind::Caller,
+                                        Variable::ofObject(actor.id()));
     }
 
     // FIXME: keep ExecutionContext::callerId until transition to using

--- a/src/libs/game/action/docommand.cpp
+++ b/src/libs/game/action/docommand.cpp
@@ -58,10 +58,6 @@ void DoCommandAction::execute(std::shared_ptr<Action> self, Object &actor, float
                                         Variable::ofObject(actor.id()));
     }
 
-    // FIXME: keep ExecutionContext::callerId until transition to using
-    // arguments in complete.
-    executionCtx->callerId = actor.id();
-
     std::shared_ptr<ScriptProgram> program(_actionToDo->savedState->program);
     VirtualMachine(program, std::move(executionCtx)).run();
     complete();

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1021,17 +1021,18 @@ void Game::consoleWarp(const IConsole::TokenList &tokens) {
 
 void Game::consoleRunScript(const IConsole::TokenList &tokens) {
     if (tokens.size() < 3) {
-        _console.printLine("Usage: runscript resref caller_id [triggerrer_id [event_number [script_var]]], e.g. runscript k_ai_master 1 2 3 4");
+        _console.printLine("Usage: runscript resref [kind:value ...], e.g. runscript k_ai_master Caller:4 ScriptVar:2");
         return;
     }
 
     std::string resRef = tokens[1];
-    auto callerId = static_cast<uint32_t>(stoi(tokens[2]));
-    auto triggerrerId = tokens.size() > 3 ? static_cast<uint32_t>(stoi(tokens[3])) : kObjectInvalid;
-    int eventNumber = tokens.size() > 4 ? stoi(tokens[4]) : -1;
-    int scriptVar = tokens.size() > 5 ? stoi(tokens[5]) : -1;
 
-    int result = scriptRunner().run(resRef, callerId, triggerrerId, eventNumber, scriptVar);
+    std::vector<script::Argument> vars;
+    for (size_t i = 1; i < tokens.size(); ++i) {
+        vars.push_back(script::Argument::fromString(tokens[i]));
+    }
+
+    int result = scriptRunner().run(resRef, vars);
     _console.printLine(str(boost::format("%s -> %d") % resRef % result));
 }
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1215,23 +1215,23 @@ void Area::doUpdatePerception() {
 
             // Hearing
             bool wasHeard = creature->perception().heard.count(other) > 0;
-            if (!wasHeard && heard) {
-                debug(str(boost::format("%s heard by %s") % other->tag() % creature->tag()), LogChannel::Perception);
-                creature->onObjectHeard(other);
-            } else if (wasHeard && !heard) {
-                debug(str(boost::format("%s inaudible to %s") % other->tag() % creature->tag()), LogChannel::Perception);
-                creature->onObjectInaudible(other);
+            bool wasSeen = creature->perception().seen.count(other) > 0;
+
+            if (wasHeard == heard && wasSeen == seen) {
+                continue; // no change in perception
             }
 
-            // Sight
-            bool wasSeen = creature->perception().seen.count(other) > 0;
-            if (!wasSeen && seen) {
-                debug(str(boost::format("%s seen by %s") % other->tag() % creature->tag()), LogChannel::Perception);
-                creature->onObjectSeen(other);
-            } else if (wasSeen && !seen) {
-                debug(str(boost::format("%s vanished from %s") % other->tag() % creature->tag()), LogChannel::Perception);
-                creature->onObjectVanished(other);
+            if (wasHeard != heard) {
+                debug(str(boost::format("%s %s %s") % other->tag() % (heard ? "heard by" : "inaudible by") % creature->tag()), LogChannel::Perception);
+                creature->setObjectHeard(other, heard);
             }
+
+            if (wasSeen != seen) {
+                debug(str(boost::format("%s %s %s") % other->tag() % (seen ? "seen by" : "vanished from") % creature->tag()), LogChannel::Perception);
+                creature->setObjectSeen(other, seen);
+            }
+
+            creature->runOnNotice(*other, heard, seen);
         }
     }
 }

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -755,7 +755,10 @@ void Area::runOnEnterScript() {
     if (!player)
         return;
 
-    _game.scriptRunner().run(_onEnter, _id, player->id());
+    _game.scriptRunner().run(
+        _onEnter,
+        {{script::ArgKind::Caller, script::Variable::ofObject(_id)},
+         {script::ArgKind::EnteringObject, script::Variable::ofObject(player->id())}});
 }
 
 void Area::runOnExitScript() {
@@ -766,7 +769,10 @@ void Area::runOnExitScript() {
     if (!player)
         return;
 
-    _game.scriptRunner().run(_onExit, _id, player->id());
+    _game.scriptRunner().run(
+        _onExit,
+        {{script::ArgKind::Caller, script::Variable::ofObject(_id)},
+         {script::ArgKind::ExitingObject, script::Variable::ofObject(player->id())}});
 }
 
 void Area::destroyObject(const Object &object) {
@@ -880,7 +886,11 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer) 
             return;
         }
         if (!trigger->getOnEnter().empty()) {
-            _game.scriptRunner().run(trigger->getOnEnter(), trigger->id(), triggerrer->id());
+            _game.scriptRunner().run(
+                trigger->getOnEnter(),
+                {{script::ArgKind::Caller, script::Variable::ofObject(trigger->id())},
+                 {script::ArgKind::EnteringObject,
+                  script::Variable::ofObject(triggerrer->id())}});
         }
     }
 }

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -885,13 +885,6 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer) 
             _game.scheduleModuleTransition(trigger->linkedToModule(), trigger->linkedTo());
             return;
         }
-        if (!trigger->getOnEnter().empty()) {
-            _game.scriptRunner().run(
-                trigger->getOnEnter(),
-                {{script::ArgKind::Caller, script::Variable::ofObject(trigger->id())},
-                 {script::ArgKind::EnteringObject,
-                  script::Variable::ofObject(triggerrer->id())}});
-        }
     }
 }
 

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -453,13 +453,13 @@ int Creature::getNeededXP() const {
 
 void Creature::runSpawnScript() {
     if (!_onSpawn.empty()) {
-        _game.scriptRunner().run(_onSpawn, _id, kObjectInvalid);
+        _game.scriptRunner().run(_onSpawn, _id);
     }
 }
 
 void Creature::runEndRoundScript() {
     if (!_onEndRound.empty()) {
-        _game.scriptRunner().run(_onEndRound, _id, kObjectInvalid);
+        _game.scriptRunner().run(_onEndRound, _id);
     }
 }
 
@@ -501,7 +501,7 @@ void Creature::die() {
 
 void Creature::runDeathScript() {
     if (!_onDeath.empty()) {
-        _game.scriptRunner().run(_onDeath, _id, kObjectInvalid);
+        _game.scriptRunner().run(_onDeath, _id);
     }
 }
 

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -152,14 +152,22 @@ void Door::onOpen(const Object &triggerer) {
     if (_onOpen.empty()) {
         return;
     }
-    _game.scriptRunner().run(_onOpen, _id, triggerer.id());
+    // FIXME: add ClickingObject and EnteringObject.
+    _game.scriptRunner().run(
+        _onOpen,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggerer.id())}});
 }
 
 void Door::onFailToOpen(const Object &triggerer) {
     if (_onFailToOpen.empty()) {
         return;
     }
-    _game.scriptRunner().run(_onFailToOpen, _id, triggerer.id());
+
+    // FIXME: add ClickingObject.
+    _game.scriptRunner().run(
+        _onFailToOpen,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)}});
 }
 
 void Door::setLocked(bool locked) {

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -112,7 +112,7 @@ bool Door::isSelectable() const {
     return !_static && !_open;
 }
 
-void Door::open(const std::shared_ptr<Object> &triggerrer) {
+void Door::open() {
     auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
     if (model) {
         // model->setDefaultAnimation("opened1", AnimationProperties::fromFlags(AnimationFlags::loop));
@@ -130,7 +130,7 @@ void Door::open(const std::shared_ptr<Object> &triggerrer) {
     _open = true;
 }
 
-void Door::close(const std::shared_ptr<Object> &triggerrer) {
+void Door::close() {
     auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
     if (model) {
         // model->setDefaultAnimation("closed", AnimationProperties::fromFlags(AnimationFlags::loop));
@@ -146,6 +146,20 @@ void Door::close(const std::shared_ptr<Object> &triggerrer) {
         _walkmeshClosed->setEnabled(true);
     }
     _open = false;
+}
+
+void Door::onOpen(const Object &triggerer) {
+    if (_onOpen.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(_onOpen, _id, triggerer.id());
+}
+
+void Door::onFailToOpen(const Object &triggerer) {
+    if (_onFailToOpen.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(_onFailToOpen, _id, triggerer.id());
 }
 
 void Door::setLocked(bool locked) {

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -152,11 +152,12 @@ void Door::onOpen(const Object &triggerer) {
     if (_onOpen.empty()) {
         return;
     }
-    // FIXME: add ClickingObject and EnteringObject.
     _game.scriptRunner().run(
         _onOpen,
         {{script::ArgKind::Caller, Variable::ofObject(_id)},
-         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggerer.id())}});
+         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggerer.id())},
+         {script::ArgKind::ClickingObject, Variable::ofObject(triggerer.id())},
+         {script::ArgKind::EnteringObject, Variable::ofObject(triggerer.id())}});
 }
 
 void Door::onFailToOpen(const Object &triggerer) {
@@ -164,10 +165,10 @@ void Door::onFailToOpen(const Object &triggerer) {
         return;
     }
 
-    // FIXME: add ClickingObject.
     _game.scriptRunner().run(
         _onFailToOpen,
-        {{script::ArgKind::Caller, Variable::ofObject(_id)}});
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::ClickingObject, Variable::ofObject(triggerer.id())}});
 }
 
 void Door::setLocked(bool locked) {

--- a/src/libs/game/object/placeable.cpp
+++ b/src/libs/game/object/placeable.cpp
@@ -87,15 +87,31 @@ void Placeable::loadTransformFromGIT(const resource::generated::GIT_Placeable_Li
 }
 
 void Placeable::runOnUsed(std::shared_ptr<Object> usedBy) {
-    if (!_onUsed.empty()) {
-        _game.scriptRunner().run(_onUsed, _id, usedBy ? usedBy->id() : kObjectInvalid);
+    if (_onUsed.empty()) {
+        return;
     }
+
+    std::vector<script::Argument> args;
+    args.emplace_back(script::ArgKind::Caller, Variable::ofObject(_id));
+
+    // FIXME: implement GetLastUsedBy
+    // usedBy ? usedBy->id() : kObjectInvalid;
+
+    _game.scriptRunner().run(_onUsed, args);
 }
 
 void Placeable::runOnInvDisturbed(std::shared_ptr<Object> triggerrer) {
-    if (!_onInvDisturbed.empty()) {
-        _game.scriptRunner().run(_onInvDisturbed, _id, triggerrer ? triggerrer->id() : kObjectInvalid);
+    if (_onInvDisturbed.empty()) {
+        return;
     }
+
+    std::vector<script::Argument> args;
+    args.emplace_back(script::ArgKind::Caller, Variable::ofObject(_id));
+
+    // FIXME: implement LastDisturbed
+    // triggerrer ? triggerrer->id() : kObjectInvalid
+
+    _game.scriptRunner().run(_onInvDisturbed, args);
 }
 
 void Placeable::loadUTP(const resource::generated::UTP &utp) {

--- a/src/libs/game/object/placeable.cpp
+++ b/src/libs/game/object/placeable.cpp
@@ -94,8 +94,10 @@ void Placeable::runOnUsed(std::shared_ptr<Object> usedBy) {
     std::vector<script::Argument> args;
     args.emplace_back(script::ArgKind::Caller, Variable::ofObject(_id));
 
-    // FIXME: implement GetLastUsedBy
-    // usedBy ? usedBy->id() : kObjectInvalid;
+    if (usedBy) {
+        args.emplace_back(script::ArgKind::LastUsedBy,
+                          Variable::ofObject(usedBy->id()));
+    }
 
     _game.scriptRunner().run(_onUsed, args);
 }

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -94,9 +94,16 @@ void Trigger::update(float dt) {
     }
     for (auto &tenant : tenantsToRemove) {
         _tenants.erase(tenant);
-        if (!_onExit.empty()) {
-            _game.scriptRunner().run(_onExit, _id, tenant->id());
+
+        // FIXME: run onEnter too?
+        if (_onExit.empty()) {
+            continue;
         }
+
+        _game.scriptRunner().run(
+            _onExit,
+            {{script::ArgKind::Caller, script::Variable::ofObject(_id)},
+             {script::ArgKind::ExitingObject, script::Variable::ofObject(tenant->id())}});
     }
 }
 

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -95,7 +95,6 @@ void Trigger::update(float dt) {
     for (auto &tenant : tenantsToRemove) {
         _tenants.erase(tenant);
 
-        // FIXME: run onEnter too?
         if (_onExit.empty()) {
             continue;
         }
@@ -109,6 +108,15 @@ void Trigger::update(float dt) {
 
 void Trigger::addTenant(const std::shared_ptr<Object> &object) {
     _tenants.insert(object);
+    if (_onEnter.empty()) {
+        return;
+    }
+
+    _game.scriptRunner().run(
+        _onEnter,
+        {{script::ArgKind::Caller, script::Variable::ofObject(_id)},
+         {script::ArgKind::EnteringObject,
+          script::Variable::ofObject(object->id())}});
 }
 
 bool Trigger::isIn(const glm::vec2 &point) const {

--- a/src/libs/game/script/routine/argutil.cpp
+++ b/src/libs/game/script/routine/argutil.cpp
@@ -115,21 +115,13 @@ static inline void throwIfInvalidTalent(const std::shared_ptr<Talent> &talent) {
 }
 
 std::shared_ptr<Object> getCaller(const RoutineContext &ctx) {
-    // FIXME: keep ExecutionContext::callerId until transition to using
-    // arguments in complete.
-    uint32_t id = ctx.execution.callerId;
+    uint32_t id = kObjectInvalid;
     if (const Variable *caller = ctx.execution.findArg(ArgKind::Caller)) {
         id = caller->objectId;
     }
 
     auto object = ctx.game.getObjectById(id);
     throwIfInvalidObject(id, object);
-    return object;
-}
-
-std::shared_ptr<Object> getTriggerrer(const RoutineContext &ctx) {
-    auto object = ctx.game.getObjectById(ctx.execution.triggererId);
-    throwIfInvalidObject(ctx.execution.triggererId, object);
     return object;
 }
 
@@ -165,10 +157,6 @@ std::shared_ptr<Object> getObject(const std::vector<Variable> &args, int index, 
     if (objectId == kObjectSelf) {
         if (const Variable *caller = ctx.execution.findArg(ArgKind::Caller)) {
             objectId = caller->objectId;
-        } else {
-            // FIXME: keep ExecutionContext::callerId until transition to using
-            // arguments in complete.
-            objectId = ctx.execution.callerId;
         }
     }
     auto object = ctx.game.getObjectById(objectId);

--- a/src/libs/game/script/routine/impl/action.cpp
+++ b/src/libs/game/script/routine/impl/action.cpp
@@ -244,9 +244,10 @@ static Variable ActionOpenDoor(const std::vector<Variable> &args, const RoutineC
     auto oDoor = getObject(args, 0, ctx);
 
     // Transform
+    auto door = checkDoor(oDoor);
 
     // Execute
-    auto action = ctx.game.newAction<OpenDoorAction>(std::move(oDoor));
+    auto action = ctx.game.newAction<OpenDoorAction>(std::move(door));
     getCaller(ctx)->addAction(std::move(action));
     return Variable::ofNull();
 }

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2878,7 +2878,10 @@ static Variable GetLastWeaponUsed(const std::vector<Variable> &args, const Routi
 
 static Variable GetLastUsedBy(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetLastUsedBy");
+    if (const Variable *usedBy = ctx.execution.findArg(ArgKind::LastUsedBy)) {
+        return *usedBy;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetAbilityModifier(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2850,7 +2850,10 @@ static Variable GetLocked(const std::vector<Variable> &args, const RoutineContex
 
 static Variable GetClickingObject(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetClickingObject");
+    if (const Variable *object = ctx.execution.findArg(ArgKind::ClickingObject)) {
+        return *object;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable SetAssociateListenPatterns(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -269,14 +269,20 @@ static Variable GetArea(const std::vector<Variable> &args, const RoutineContext 
 
 static Variable GetEnteringObject(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto triggerrer = getTriggerrer(ctx);
-    return Variable::ofObject(getObjectIdOrInvalid(triggerrer));
+    if (const Variable *entering = ctx.execution.findArg(ArgKind::EnteringObject)) {
+        return *entering;
+    }
+
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetExitingObject(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto triggerrer = getTriggerrer(ctx);
-    return Variable::ofObject(getObjectIdOrInvalid(triggerrer));
+    if (const Variable *exiting = ctx.execution.findArg(ArgKind::ExitingObject)) {
+        return *exiting;
+    }
+
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetPosition(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -1210,7 +1210,12 @@ static Variable SignalEvent(const std::vector<Variable> &args, const RoutineCont
 
     // Execute
     debug(str(boost::format("Event signalled: %s %s") % oObject->tag() % evToRun->number()), LogChannel::Script);
-    ctx.game.scriptRunner().run(oObject->getOnUserDefined(), oObject->id(), kObjectInvalid, evToRun->number());
+
+    ctx.game.scriptRunner().run(
+        oObject->getOnUserDefined(),
+        {{script::ArgKind::Caller, Variable::ofObject(oObject->id())},
+         {script::ArgKind::UserDefinedEventNumber, Variable::ofInt(evToRun->number())}});
+
     return Variable::ofNull();
 }
 
@@ -2161,7 +2166,11 @@ static Variable GetLastSpell(const std::vector<Variable> &args, const RoutineCon
 
 static Variable GetUserDefinedEventNumber(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    return Variable::ofInt(ctx.execution.userDefinedEventNumber);
+    if (const Variable *eventNum = ctx.execution.findArg(ArgKind::UserDefinedEventNumber)) {
+        return *eventNum;
+    }
+
+    return Variable::ofInt(-1);
 }
 
 static Variable GetSpellId(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2267,8 +2267,10 @@ static Variable GetLastPerceptionSeen(const std::vector<Variable> &args, const R
 
 static Variable GetLastClosedBy(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto triggerrer = getTriggerrer(ctx);
-    return Variable::ofObject(getObjectIdOrInvalid(triggerrer));
+    if (const Variable *lastClosed = ctx.execution.findArg(ArgKind::LastClosedBy)) {
+        return *lastClosed;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetLastPerceptionVanished(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -3266,8 +3268,10 @@ static Variable GetAttemptedSpellTarget(const std::vector<Variable> &args, const
 
 static Variable GetLastOpenedBy(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto triggerrer = getTriggerrer(ctx);
-    return Variable::ofObject(getObjectIdOrInvalid(triggerrer));
+    if (const Variable *opened = ctx.execution.findArg(ArgKind::LastOpenedBy)) {
+        return *opened;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetHasSpell(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2235,30 +2235,34 @@ static Variable BeginConversation(const std::vector<Variable> &args, const Routi
 
 static Variable GetLastPerceived(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto caller = checkCreature(getCaller(ctx));
-    auto perceived = caller->perception().lastPerceived;
-    return Variable::ofObject(getObjectIdOrInvalid(perceived));
+    if (const Variable *percieved = ctx.execution.findArg(ArgKind::LastPerceived)) {
+        return *percieved;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetLastPerceptionHeard(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto caller = checkCreature(getCaller(ctx));
-    bool heard = caller->perception().lastPerception == PerceptionType::Heard;
-    return Variable::ofInt(static_cast<int>(heard));
+    if (const Variable *heard = ctx.execution.findArg(ArgKind::LastPerceptionHeard)) {
+        return *heard;
+    }
+    return Variable::ofInt(0);
 }
 
 static Variable GetLastPerceptionInaudible(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto caller = checkCreature(getCaller(ctx));
-    bool inaudible = caller->perception().lastPerception == PerceptionType::NotHeard;
-    return Variable::ofInt(static_cast<int>(inaudible));
+    if (const Variable *inaudible = ctx.execution.findArg(ArgKind::LastPerceptionInaudible)) {
+        return *inaudible;
+    }
+    return Variable::ofInt(0);
 }
 
 static Variable GetLastPerceptionSeen(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto caller = checkCreature(getCaller(ctx));
-    bool seen = caller->perception().lastPerception == PerceptionType::Seen;
-    return Variable::ofInt(static_cast<int>(seen));
+    if (const Variable *seen = ctx.execution.findArg(ArgKind::LastPerceptionSeen)) {
+        return *seen;
+    }
+    return Variable::ofInt(0);
 }
 
 static Variable GetLastClosedBy(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -2269,9 +2273,10 @@ static Variable GetLastClosedBy(const std::vector<Variable> &args, const Routine
 
 static Variable GetLastPerceptionVanished(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    auto caller = checkCreature(getCaller(ctx));
-    bool vanished = caller->perception().lastPerception == PerceptionType::NotSeen;
-    return Variable::ofInt(static_cast<int>(vanished));
+    if (const Variable *vanished = ctx.execution.findArg(ArgKind::LastPerceptionVanished)) {
+        return *vanished;
+    }
+    return Variable::ofInt(0);
 }
 
 static Variable GetFirstInPersistentObject(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/runner.cpp
+++ b/src/libs/game/script/runner.cpp
@@ -30,27 +30,6 @@ namespace reone {
 
 namespace game {
 
-int ScriptRunner::run(const std::string &resRef, uint32_t callerId, uint32_t triggerrerId, int userDefinedEventNumber, int scriptVar) {
-    if (callerId == kObjectSelf) {
-        throw std::invalid_argument("Invalid callerId: " + std::to_string(callerId));
-    }
-    if (triggerrerId == kObjectSelf) {
-        throw std::invalid_argument("Invalid triggerrerId: " + std::to_string(triggerrerId));
-    }
-
-    auto program = _scripts.get(resRef);
-    if (!program)
-        return -1;
-
-    auto ctx = std::make_unique<ExecutionContext>();
-    ctx->routines = &_routines;
-    ctx->callerId = callerId;
-    ctx->triggererId = triggerrerId;
-    ctx->scriptVar = scriptVar;
-
-    return VirtualMachine(program, std::move(ctx)).run();
-}
-
 int ScriptRunner::run(const std::string &resRef, const std::vector<Argument> &args) {
     auto program = _scripts.get(resRef);
     if (!program)
@@ -61,6 +40,14 @@ int ScriptRunner::run(const std::string &resRef, const std::vector<Argument> &ar
     ctx->args = args;
 
     return VirtualMachine(program, std::move(ctx)).run();
+}
+
+int ScriptRunner::run(const std::string &resRef, uint32_t callerId) {
+    std::vector<Argument> args;
+    if (callerId) {
+        args.emplace_back(script::ArgKind::Caller, Variable::ofObject(callerId));
+    }
+    return run(resRef, args);
 }
 
 } // namespace game

--- a/src/libs/game/script/runner.cpp
+++ b/src/libs/game/script/runner.cpp
@@ -46,8 +46,19 @@ int ScriptRunner::run(const std::string &resRef, uint32_t callerId, uint32_t tri
     ctx->routines = &_routines;
     ctx->callerId = callerId;
     ctx->triggererId = triggerrerId;
-    ctx->userDefinedEventNumber = userDefinedEventNumber;
     ctx->scriptVar = scriptVar;
+
+    return VirtualMachine(program, std::move(ctx)).run();
+}
+
+int ScriptRunner::run(const std::string &resRef, const std::vector<Argument> &args) {
+    auto program = _scripts.get(resRef);
+    if (!program)
+        return -1;
+
+    auto ctx = std::make_unique<ExecutionContext>();
+    ctx->routines = &_routines;
+    ctx->args = args;
 
     return VirtualMachine(program, std::move(ctx)).run();
 }

--- a/src/libs/script/CMakeLists.txt
+++ b/src/libs/script/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SCRIPT_HEADERS
 
 set(SCRIPT_SOURCES
     ${SCRIPT_SOURCE_DIR}/di/module.cpp
+    ${SCRIPT_SOURCE_DIR}/executioncontext.cpp
     ${SCRIPT_SOURCE_DIR}/format/ncsreader.cpp
     ${SCRIPT_SOURCE_DIR}/format/ncswriter.cpp
     ${SCRIPT_SOURCE_DIR}/instrutil.cpp

--- a/src/libs/script/executioncontext.cpp
+++ b/src/libs/script/executioncontext.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/script/executioncontext.h"
+
+using namespace reone::script;
+
+const Variable *ExecutionContext::findArg(ArgKind kind) {
+    for (const Argument &var : args) {
+        if (var.kind == kind) {
+            return &var.var;
+        }
+    }
+    return nullptr;
+}

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -150,6 +150,16 @@ const char *argKindToString(ArgKind kind) {
         return "EnteringObject";
     case ArgKind::ExitingObject:
         return "ExitingObject";
+    case ArgKind::LastPerceived:
+        return "LastPerceived";
+    case ArgKind::LastPerceptionHeard:
+        return "LastPerceptionHeard";
+    case ArgKind::LastPerceptionInaudible:
+        return "LastPerceptionInaudible";
+    case ArgKind::LastPerceptionSeen:
+        return "LastPerceptionSeen";
+    case ArgKind::LastPerceptionVanished:
+        return "LastPerceptionVanished";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -185,6 +195,21 @@ Argument Argument::fromString(std::string str) {
     if (kind == "ExitingObject") {
         return {ArgKind::ExitingObject, Variable::ofObject(std::stoul(value))};
     }
+    if (kind == "LastPerceived") {
+        return {ArgKind::LastPerceived, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "LastPerceptionHeard") {
+        return {ArgKind::LastPerceptionHeard, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "LastPerceptionInaudible") {
+        return {ArgKind::LastPerceptionInaudible, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "LastPerceptionSeen") {
+        return {ArgKind::LastPerceptionSeen, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "LastPerceptionVanished") {
+        return {ArgKind::LastPerceptionVanished, Variable::ofInt(std::stoi(value))};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
@@ -193,14 +218,19 @@ void Argument::verify() {
     switch (kind) {
     case ArgKind::Caller:
     case ArgKind::EnteringObject:
-    case ArgKind::ExitingObject: {
+    case ArgKind::ExitingObject:
+    case ArgKind::LastPerceived: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");
         }
         return;
     }
     case ArgKind::ScriptVar:
-    case ArgKind::UserDefinedEventNumber: {
+    case ArgKind::UserDefinedEventNumber:
+    case ArgKind::LastPerceptionHeard:
+    case ArgKind::LastPerceptionInaudible:
+    case ArgKind::LastPerceptionSeen:
+    case ArgKind::LastPerceptionVanished: {
         if (var.type != VariableType::Int) {
             throw std::invalid_argument(toString() + ": expected an integer");
         }

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -150,6 +150,10 @@ const char *argKindToString(ArgKind kind) {
         return "EnteringObject";
     case ArgKind::ExitingObject:
         return "ExitingObject";
+    case ArgKind::LastClosedBy:
+        return "LastClosedBy";
+    case ArgKind::LastOpenedBy:
+        return "LastOpenedBy";
     case ArgKind::LastPerceived:
         return "LastPerceived";
     case ArgKind::LastPerceptionHeard:
@@ -195,6 +199,12 @@ Argument Argument::fromString(std::string str) {
     if (kind == "ExitingObject") {
         return {ArgKind::ExitingObject, Variable::ofObject(std::stoul(value))};
     }
+    if (kind == "LastClosedBy") {
+        return {ArgKind::LastClosedBy, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "LastOpenedBy") {
+        return {ArgKind::LastOpenedBy, Variable::ofObject(std::stoul(value))};
+    }
     if (kind == "LastPerceived") {
         return {ArgKind::LastPerceived, Variable::ofObject(std::stoul(value))};
     }
@@ -219,6 +229,8 @@ void Argument::verify() {
     case ArgKind::Caller:
     case ArgKind::EnteringObject:
     case ArgKind::ExitingObject:
+    case ArgKind::LastClosedBy:
+    case ArgKind::LastOpenedBy:
     case ArgKind::LastPerceived: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -146,6 +146,8 @@ const char *argKindToString(ArgKind kind) {
         return "ScriptVar";
     case ArgKind::UserDefinedEventNumber:
         return "UserDefinedEventNumber";
+    case ArgKind::ClickingObject:
+        return "ClickingObject";
     case ArgKind::EnteringObject:
         return "EnteringObject";
     case ArgKind::ExitingObject:
@@ -193,6 +195,9 @@ Argument Argument::fromString(std::string str) {
     if (kind == "UserDefinedEventNumber") {
         return {ArgKind::UserDefinedEventNumber, Variable::ofInt(std::stoi(value))};
     }
+    if (kind == "ClickingObject") {
+        return {ArgKind::ClickingObject, Variable::ofObject(std::stoul(value))};
+    }
     if (kind == "EnteringObject") {
         return {ArgKind::EnteringObject, Variable::ofObject(std::stoul(value))};
     }
@@ -227,6 +232,7 @@ Argument Argument::fromString(std::string str) {
 void Argument::verify() {
     switch (kind) {
     case ArgKind::Caller:
+    case ArgKind::ClickingObject:
     case ArgKind::EnteringObject:
     case ArgKind::ExitingObject:
     case ArgKind::LastClosedBy:

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -166,6 +166,8 @@ const char *argKindToString(ArgKind kind) {
         return "LastPerceptionSeen";
     case ArgKind::LastPerceptionVanished:
         return "LastPerceptionVanished";
+    case ArgKind::LastUsedBy:
+        return "LastUsedBy";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -225,6 +227,9 @@ Argument Argument::fromString(std::string str) {
     if (kind == "LastPerceptionVanished") {
         return {ArgKind::LastPerceptionVanished, Variable::ofInt(std::stoi(value))};
     }
+    if (kind == "LastUsedBy") {
+        return {ArgKind::LastUsedBy, Variable::ofObject(std::stoul(value))};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
@@ -237,7 +242,8 @@ void Argument::verify() {
     case ArgKind::ExitingObject:
     case ArgKind::LastClosedBy:
     case ArgKind::LastOpenedBy:
-    case ArgKind::LastPerceived: {
+    case ArgKind::LastPerceived:
+    case ArgKind::LastUsedBy: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");
         }

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -144,6 +144,10 @@ const char *argKindToString(ArgKind kind) {
         return "Caller";
     case ArgKind::UserDefinedEventNumber:
         return "UserDefinedEventNumber";
+    case ArgKind::EnteringObject:
+        return "EnteringObject";
+    case ArgKind::ExitingObject:
+        return "ExitingObject";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -170,13 +174,21 @@ Argument Argument::fromString(std::string str) {
     if (kind == "UserDefinedEventNumber") {
         return {ArgKind::UserDefinedEventNumber, Variable::ofInt(std::stoi(value))};
     }
+    if (kind == "EnteringObject") {
+        return {ArgKind::EnteringObject, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "ExitingObject") {
+        return {ArgKind::ExitingObject, Variable::ofObject(std::stoul(value))};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
 
 void Argument::verify() {
     switch (kind) {
-    case ArgKind::Caller: {
+    case ArgKind::Caller:
+    case ArgKind::EnteringObject:
+    case ArgKind::ExitingObject: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");
         }

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -142,6 +142,8 @@ const char *argKindToString(ArgKind kind) {
     switch (kind) {
     case ArgKind::Caller:
         return "Caller";
+    case ArgKind::ScriptVar:
+        return "ScriptVar";
     case ArgKind::UserDefinedEventNumber:
         return "UserDefinedEventNumber";
     case ArgKind::EnteringObject:
@@ -171,6 +173,9 @@ Argument Argument::fromString(std::string str) {
     if (kind == "Caller") {
         return {ArgKind::Caller, Variable::ofObject(std::stoul(value))};
     }
+    if (kind == "ScriptVar") {
+        return {ArgKind::ScriptVar, Variable::ofInt(std::stoi(value))};
+    }
     if (kind == "UserDefinedEventNumber") {
         return {ArgKind::UserDefinedEventNumber, Variable::ofInt(std::stoi(value))};
     }
@@ -194,6 +199,7 @@ void Argument::verify() {
         }
         return;
     }
+    case ArgKind::ScriptVar:
     case ArgKind::UserDefinedEventNumber: {
         if (var.type != VariableType::Int) {
             throw std::invalid_argument(toString() + ": expected an integer");

--- a/src/libs/script/virtualmachine.cpp
+++ b/src/libs/script/virtualmachine.cpp
@@ -210,15 +210,11 @@ int VirtualMachine::run() {
         insOff = _context->savedState->insOffset;
     }
 
-    // FIXME: keep ExecutionContext::callerId until transition to using
-    // arguments in complete.
     if (Logger::instance.isChannelEnabled(LogChannel::Script)) {
         std::stringstream ss;
-        ss << boost::format("Run '%s': offset=%04x, caller=%u, triggerrer=%u") %
+        ss << boost::format("Run '%s': Offset=%04x") %
                   _program->name() %
-                  insOff %
-                  _context->callerId %
-                  _context->triggererId;
+                  insOff;
 
         if (!_context->args.empty()) {
             for (const Argument &var : _context->args) {
@@ -368,9 +364,7 @@ void VirtualMachine::executeCONSTO(const Instruction &ins) {
         return;
     }
 
-    // FIXME: keep ExecutionContext::callerId until transition to using
-    // arguments in complete.
-    _stack.push_back(Variable::ofObject(_context->callerId));
+    _stack.push_back(Variable::ofObject(kObjectInvalid));
     logResults(1);
 }
 


### PR DESCRIPTION
This patchset replaces fields of ExectuionContext with a list of "tagged" variables (arguments). These are used to store data for `GetLast*` routines: `GetLastOpenedBy`, `GetEnteringObject`, etc. They are local to a script run, but can be copied over to other script runs that originate from `STORE_STATE` or `ExecuteScript`.

This approach makes it easier to add new arguments, and run scripts with a list of arguments. This should also fix some unrelated routines that used to share the same field of ExcecutionContext. For example, `GetLastOpenedBy` and `GetEnteringObject` used to be functionally identical, because they both used `triggererId`.