### PR TITLE
Add MessageBus for SpeakString and SetListenPattern

### DIFF
--- a/include/reone/game/messagebus.h
+++ b/include/reone/game/messagebus.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/game/types.h"
+
+namespace reone {
+
+namespace game {
+
+/**
+ * MessageBus implements a queue of messages for SpeakString and
+ * SetListenPattern.
+ */
+class MessageBus {
+public:
+    /**
+     * Adds a listener object for a pattern. The same object may listen for
+     * multiple patterns, as long as it uses a different number for each.
+     */
+    void addListener(uint32_t listenerId, std::string pattern, int32_t number);
+
+    void addMessage(uint32_t speakerId, std::string msg, TalkVolume volume);
+
+    using OnMessage = std::function<void(uint32_t speakerId, uint32_t listenerId,
+                                         int32_t number, TalkVolume volume)>;
+
+    /**
+     * Process accumulated messages and call onMessage for each "matched"
+     * listener.
+     */
+    void update(OnMessage onMessage);
+
+private:
+    struct Message {
+        uint32_t speakerId;
+        std::string str;
+        TalkVolume volume;
+    };
+
+    struct Listener {
+        uint32_t id;
+        int32_t number;
+    };
+
+    using ListenerVec = std::vector<Listener>;
+
+private:
+    std::queue<Message> _pendingMessages;
+    std::unordered_map<std::string, ListenerVec> _listeners;
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "reone/game/messagebus.h"
 #include "reone/graphics/texture.h"
 #include "reone/graphics/types.h"
 #include "reone/input/event.h"
@@ -207,6 +208,13 @@ public:
 
     // END Scripts
 
+    // Listeners
+
+    MessageBus &messageBus() { return _messageBus; }
+    void updateMessageBus();
+
+    // END Listeners
+
 private:
     std::string _sceneName;
 
@@ -252,6 +260,10 @@ private:
     std::set<uint32_t> _objectsToDestroy;
 
     // END Objects
+
+    // Listeners
+    MessageBus _messageBus;
+    // END Listeners
 
     // Stealth
 

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -236,6 +236,7 @@ public:
 
     void runSpawnScript();
     void runEndRoundScript();
+    void runDialogueScript(uint32_t speakerId, int32_t listenNumber);
 
     // END Scripts
 
@@ -244,6 +245,13 @@ public:
     void onEventSignalled(const std::string &name) override;
 
     // END IAnimationEventListener
+
+    // Listeners
+
+    bool isListening() { return _isListening; }
+    void setIsListening(bool value) { _isListening = value; }
+
+    // END Listeners
 
 private:
     Gender _gender {Gender::Male};
@@ -290,6 +298,7 @@ private:
     int _walkmeshMaterial {-1};
     int _gold {0}; /**< aka credits */
     std::string _envmap;
+    bool _isListening {false};
 
     std::shared_ptr<audio::AudioSource> _audioSourceVoice;
     std::shared_ptr<audio::AudioSource> _audioSourceFootstep;

--- a/include/reone/game/types.h
+++ b/include/reone/game/types.h
@@ -925,7 +925,8 @@ enum class TalkVolume {
     Whisper = 1,
     Shout = 2,
     SilentTalk = 3,
-    SilentShout = 4
+    SilentShout = 4,
+    Last = 4
 };
 
 enum class ProjectilePathType {

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -98,6 +98,8 @@ enum class ArgKind {
     LastPerceptionSeen,
     LastPerceptionVanished,
     LastUsedBy,
+    LastSpeaker,
+    ListenPatternNumber,
 };
 
 struct Argument {

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -278,6 +278,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/selectoverlay.h
     ${GAME_INCLUDE_DIR}/gui/sounds.h
     ${GAME_INCLUDE_DIR}/location.h
+    ${GAME_INCLUDE_DIR}/messagebus.h
     ${GAME_INCLUDE_DIR}/object.h
     ${GAME_INCLUDE_DIR}/object/area.h
     ${GAME_INCLUDE_DIR}/object/camera.h
@@ -469,6 +470,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/saveload.cpp
     ${GAME_SOURCE_DIR}/gui/selectoverlay.cpp
     ${GAME_SOURCE_DIR}/gui/sounds.cpp
+    ${GAME_SOURCE_DIR}/messagebus.cpp
     ${GAME_SOURCE_DIR}/object.cpp
     ${GAME_SOURCE_DIR}/object/area.cpp
     ${GAME_SOURCE_DIR}/object/camera/animated.cpp

--- a/src/libs/game/messagebus.cpp
+++ b/src/libs/game/messagebus.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/messagebus.h"
+
+#include "reone/game/object/creature.h"
+
+namespace reone {
+namespace game {
+
+void MessageBus::addListener(uint32_t listenerId, std::string pattern, int32_t number) {
+    ListenerVec &vec = _listeners[pattern];
+    for (Listener &listener : vec) {
+        if (listenerId == listener.id) {
+            listener.number = number;
+            return;
+        }
+    }
+    vec.push_back({listenerId, number});
+}
+
+void MessageBus::addMessage(uint32_t speakerId, std::string pattern, TalkVolume volume) {
+    _pendingMessages.push({speakerId, std::move(pattern), volume});
+}
+
+void MessageBus::update(OnMessage onMessage) {
+    while (!_pendingMessages.empty()) {
+        Message &msg = _pendingMessages.front();
+
+        // Pattern may be a regexp (** for a sequence of any characters, *n for numbers, etc.)
+        // KOTOR does not seem to have these yet, so we only match the whole string.
+
+        ListenerVec &vec = _listeners[msg.str];
+
+        for (Listener &listener : vec) {
+            onMessage(msg.speakerId, listener.id, listener.number, msg.volume);
+        }
+        _pendingMessages.pop();
+    }
+}
+
+} // namespace game
+} // namespace reone

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -463,6 +463,14 @@ void Creature::runEndRoundScript() {
     }
 }
 
+void Creature::runDialogueScript(uint32_t speakerId, int32_t listenNumber) {
+    _game.scriptRunner().run(
+        _onDialogue,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastSpeaker, Variable::ofObject(speakerId)},
+         {script::ArgKind::ListenPatternNumber, Variable::ofInt(listenNumber)}});
+}
+
 void Creature::giveXP(int amount) {
     _xp += amount;
 }

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -168,6 +168,10 @@ const char *argKindToString(ArgKind kind) {
         return "LastPerceptionVanished";
     case ArgKind::LastUsedBy:
         return "LastUsedBy";
+    case ArgKind::LastSpeaker:
+        return "LastSpeaker";
+    case ArgKind::ListenPatternNumber:
+        return "ListenPatternNumber";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -230,6 +234,12 @@ Argument Argument::fromString(std::string str) {
     if (kind == "LastUsedBy") {
         return {ArgKind::LastUsedBy, Variable::ofObject(std::stoul(value))};
     }
+    if (kind == "LastSpeaker") {
+        return {ArgKind::LastSpeaker, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "ListenPatternNumber") {
+        return {ArgKind::ListenPatternNumber, Variable::ofInt(std::stoi(value))};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
@@ -243,7 +253,8 @@ void Argument::verify() {
     case ArgKind::LastClosedBy:
     case ArgKind::LastOpenedBy:
     case ArgKind::LastPerceived:
-    case ArgKind::LastUsedBy: {
+    case ArgKind::LastUsedBy:
+    case ArgKind::LastSpeaker: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");
         }
@@ -254,7 +265,8 @@ void Argument::verify() {
     case ArgKind::LastPerceptionHeard:
     case ArgKind::LastPerceptionInaudible:
     case ArgKind::LastPerceptionSeen:
-    case ArgKind::LastPerceptionVanished: {
+    case ArgKind::LastPerceptionVanished:
+    case ArgKind::ListenPatternNumber: {
         if (var.type != VariableType::Int) {
             throw std::invalid_argument(toString() + ": expected an integer");
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TESTS_HEADERS
 set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/audio/format/wavreader.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
+    ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/bwmreader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/mdlmdxreader.cpp

--- a/test/game/messagebus.cpp
+++ b/test/game/messagebus.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/messagebus.h"
+
+using namespace reone;
+using namespace reone::game;
+
+struct Msg {
+    uint32_t speakerId;
+    uint32_t listenerId;
+    int32_t number;
+    TalkVolume volume;
+
+    bool operator==(const struct Msg &m) const {
+        return speakerId == m.speakerId && listenerId == m.listenerId && number == m.number && volume == m.volume;
+    }
+};
+
+TEST(MessageBus, test_basic) {
+    MessageBus bus;
+    bus.addListener(10, "foo", 1);
+    bus.addListener(11, "foo", 1);
+    bus.addListener(11, "bar", 2);
+
+    bus.addMessage(20, "foo", TalkVolume::Shout);
+    bus.addMessage(20, "bar", TalkVolume::Shout);
+
+    std::vector<Msg> expected = {
+        {20, 10, 1, TalkVolume::Shout},
+        {20, 11, 1, TalkVolume::Shout},
+        {20, 11, 2, TalkVolume::Shout}};
+
+    std::vector<Msg> got;
+
+    bus.update([&](uint32_t speakerId, uint32_t listenerId, int32_t number, TalkVolume volume) {
+        got.push_back({speakerId, listenerId, number, volume});
+    });
+
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(expected[i], got[i]);
+    }
+}
+
+TEST(MessageBus, test_update_number) {
+    MessageBus bus;
+    bus.addListener(10, "foo", 1);
+    bus.addListener(10, "foo", 2);
+
+    bus.addMessage(20, "foo", TalkVolume::Shout);
+
+    std::vector<Msg> expected = {
+        {20, 10, 2, TalkVolume::Shout},
+    };
+
+    std::vector<Msg> got;
+
+    bus.update([&](uint32_t speakerId, uint32_t listenerId, int32_t number, TalkVolume volume) {
+        got.push_back({speakerId, listenerId, number, volume});
+    });
+
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(expected[i], got[i]);
+    }
+}


### PR DESCRIPTION
SpeakString and SetListenPattern routines are critical to `k_ai_master` script (#7). They allow objects to broadcast messages that reach other objects within hearing range.

For example, an attacked creature may call `SpeakString("GEN_I_WAS_ATTACKED")`, and that would trigger nearby enemies to engage combat.

SetListenPattern is supposed to be quite flexible, and support regular  expressions:
```
  ** will match zero or more characters
  *w one or more whitespace
  *n one or more numeric
  *p one or more punctuation
  *a one or more alphabetic
  | is or
  ( and ) can be used for blocks
```

However, this patch does not implement regular expressions for simplicity. It seems that such patterns are not used in K1 and K2.