### PR TITLE
Implement generic combat routines

### DIFF
--- a/include/reone/game/combat.h
+++ b/include/reone/game/combat.h
@@ -66,6 +66,8 @@ public:
 
     void update(float dt);
 
+    const Attack *getLastAttack(Creature &creature);
+
 private:
     enum class RoundState {
         Started,
@@ -98,11 +100,13 @@ private:
     };
 
     using RoundMap = std::map<uint32_t, std::unique_ptr<Round>>;
+    using LastAttackMap = std::map<uint32_t, std::unique_ptr<Attack>>;
 
     Game &_game;
     ServicesView &_services;
 
     RoundMap _roundByAttacker;
+    LastAttackMap _lastAttacks;
 
     void updateRound(Round &round, float dt);
     void startAttack(Attack &attack, bool duel);

--- a/include/reone/game/combat.h
+++ b/include/reone/game/combat.h
@@ -67,6 +67,7 @@ public:
     void update(float dt);
 
     const Attack *getLastAttack(Creature &creature);
+    uint32_t getLastHostile(Object &object);
 
 private:
     enum class RoundState {
@@ -101,12 +102,14 @@ private:
 
     using RoundMap = std::map<uint32_t, std::unique_ptr<Round>>;
     using LastAttackMap = std::map<uint32_t, std::unique_ptr<Attack>>;
+    using LastHostileMap = std::map<uint32_t, uint32_t>;
 
     Game &_game;
     ServicesView &_services;
 
     RoundMap _roundByAttacker;
     LastAttackMap _lastAttacks;
+    LastHostileMap _lastHostile;
 
     void updateRound(Round &round, float dt);
     void startAttack(Attack &attack, bool duel);

--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -44,7 +44,7 @@ public:
     virtual ~Object() = default;
 
     virtual void update(float dt);
-    virtual void die();
+    virtual void damage(int amount, const Object *damager);
 
     void face(const Object &other);
     void face(const glm::vec3 &point);

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -237,6 +237,7 @@ public:
     void runSpawnScript();
     void runEndRoundScript();
     void runDialogueScript(uint32_t speakerId, int32_t listenNumber);
+    void runAttackedScript(uint32_t attackerId);
 
     // END Scripts
 
@@ -333,6 +334,7 @@ private:
     void updateCombat(float dt);
 
     void runDeathScript(uint32_t damagerId);
+    void runDamagedScript(uint32_t damagerId);
 
     ModelType parseModelType(const std::string &s) const;
 

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -105,7 +105,7 @@ public:
     void update(float dt) override;
 
     void clearAllActions() override;
-    void die() override;
+    void damage(int amount, const Object *damager) override;
 
     void giveXP(int amount);
 
@@ -330,10 +330,9 @@ private:
     void loadTransformFromGIT(const resource::generated::GIT_Creature_List &git);
 
     void updateModel();
-    void updateHealth();
     void updateCombat(float dt);
 
-    inline void runDeathScript();
+    void runDeathScript(uint32_t damagerId);
 
     ModelType parseModelType(const std::string &s) const;
 

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -100,6 +100,8 @@ enum class ArgKind {
     LastUsedBy,
     LastSpeaker,
     ListenPatternNumber,
+    LastAttacker,
+    LastDamager,
 };
 
 struct Argument {

--- a/src/libs/game/combat.cpp
+++ b/src/libs/game/combat.cpp
@@ -365,6 +365,10 @@ void Combat::applyAttackResult(const Attack &attack, bool offHand) {
 
     debug(str(boost::format("Attack %s: %s -> %s") % attackResultDesc(attack.resultType) % attack.attacker->tag() % attack.target->tag()), LogChannel::Combat);
 
+    if (attack.target->type() == ObjectType::Creature) {
+        static_cast<Creature &>(*attack.target).runAttackedScript(attack.attacker->id());
+    }
+
     switch (attack.resultType) {
     case AttackResultType::Miss:
     case AttackResultType::AttackResisted:

--- a/src/libs/game/combat.cpp
+++ b/src/libs/game/combat.cpp
@@ -183,6 +183,9 @@ void Combat::startAttack(Attack &attack, bool duel) {
     attack.attacker->setAttackTarget(attack.target);
     attack.attacker->playAnimation(animation.attackerAnimation, animation.attackerWieldType, animation.animationVariant);
 
+    _lastHostile[attack.target->id()] = attack.attacker->id();
+    _lastHostile[attack.attacker->id()] = attack.target->id();
+
     if (duel) {
         auto target = std::static_pointer_cast<Creature>(attack.target);
         target->face(*attack.attacker);
@@ -497,6 +500,14 @@ void Combat::resetProjectile(Round &round) {
 
 const Combat::Attack *Combat::getLastAttack(Creature &creature) {
     return _lastAttacks[creature.id()].get();
+}
+
+uint32_t Combat::getLastHostile(Object &object) {
+    auto it = _lastHostile.find(object.id());
+    if (it != _lastHostile.end()) {
+        return it->second;
+    }
+    return 0;
 }
 
 } // namespace game

--- a/src/libs/game/combat.cpp
+++ b/src/libs/game/combat.cpp
@@ -211,6 +211,11 @@ void Combat::finishRound(Round &round) {
     }
     round.state = RoundState::Finished;
     debug(str(boost::format("Finish round: %s -> %s") % round.attack1->attacker->tag() % round.attack1->target->tag()), LogChannel::Combat);
+
+    _lastAttacks[round.attack1->attacker->id()] = std::move(round.attack1);
+    if (round.attack2) {
+        _lastAttacks[round.attack2->attacker->id()] = std::move(round.attack2);
+    }
 }
 
 static bool isAttackSuccessful(AttackResultType result) {
@@ -488,6 +493,10 @@ void Combat::resetProjectile(Round &round) {
     auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
     sceneGraph.removeRoot(*round.projectile);
     round.projectile.reset();
+}
+
+const Combat::Attack *Combat::getLastAttack(Creature &creature) {
+    return _lastAttacks[creature.id()].get();
 }
 
 } // namespace game

--- a/src/libs/game/effect/damage.cpp
+++ b/src/libs/game/effect/damage.cpp
@@ -20,6 +20,7 @@
 #include "reone/system/logutil.h"
 
 #include "reone/game/object.h"
+#include "reone/game/object/creature.h"
 
 namespace reone {
 
@@ -27,7 +28,7 @@ namespace game {
 
 void DamageEffect::applyTo(Object &object) {
     debug(str(boost::format("Damage taken: %s %d") % object.tag() % _amount));
-    object.setCurrentHitPoints(glm::max(object.isMinOneHP() ? 1 : 0, object.currentHitPoints() - _amount));
+    object.damage(_amount, _damager.get());
 }
 
 } // namespace game

--- a/src/libs/game/effect/death.cpp
+++ b/src/libs/game/effect/death.cpp
@@ -24,7 +24,7 @@ namespace reone {
 namespace game {
 
 void DeathEffect::applyTo(Object &object) {
-    object.die();
+    object.damage(std::numeric_limits<int>::max(), nullptr);
 }
 
 } // namespace game

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -364,7 +364,7 @@ void Object::clearAllEffects() {
     _effects.clear();
 }
 
-void Object::die() {
+void Object::damage(int amount, const Object *damager) {
 }
 
 void Object::startStuntMode() {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -4647,10 +4647,12 @@ static Variable GetLastHostileActor(const std::vector<Variable> &args, const Rou
     // Load
     auto oVictim = getObjectOrCaller(args, 0, ctx);
 
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("GetLastHostileActor");
+    if (uint32_t hostileId = ctx.game.combat().getLastHostile(*oVictim)) {
+        return Variable::ofObject(hostileId);
+    }
+
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable ExportAllCharacters(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -368,10 +368,16 @@ static Variable GetLastAttacker(const std::vector<Variable> &args, const Routine
     // Load
     auto oAttackee = getObjectOrCaller(args, 0, ctx);
 
-    // Transform
+    // Ignore oAttackee - this argument is not used in K1 and K2. Given that
+    // nwscript.nss mentions that GetLastAttacker is supposed to be used only in
+    // onAttacked scripts (and apparently in onDamaged and onDeath scripts as
+    // well), it does not make sense to query objects other than the caller.
 
     // Execute
-    throw RoutineNotImplementedException("GetLastAttacker");
+    if (const Variable *attacker = ctx.execution.findArg(ArgKind::LastAttacker)) {
+        return *attacker;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetNearestCreature(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -3064,7 +3070,10 @@ static Variable GetTotalDamageDealt(const std::vector<Variable> &args, const Rou
 
 static Variable GetLastDamager(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetLastDamager");
+    if (const Variable *damager = ctx.execution.findArg(ArgKind::LastDamager)) {
+        return *damager;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetLastDisarmed(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -5349,19 +5349,31 @@ static Variable GetLastHostileTarget(const std::vector<Variable> &args, const Ro
     auto oAttacker = getObjectOrCaller(args, 0, ctx);
 
     // Transform
+    auto attacker = checkCreature(oAttacker);
 
     // Execute
-    throw RoutineNotImplementedException("GetLastHostileTarget");
+    const Combat::Attack *attack = ctx.game.combat().getLastAttack(*attacker);
+    if (!attack) {
+        return Variable::ofObject(kObjectInvalid);
+    }
+
+    return Variable::ofObject(attack->target->id());
 }
 
-static Variable GetLastAttackObjectAction(const std::vector<Variable> &args, const RoutineContext &ctx) {
+static Variable GetLastAttackAction(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto oAttacker = getObjectOrCaller(args, 0, ctx);
 
     // Transform
+    auto attacker = checkCreature(oAttacker);
 
     // Execute
-    throw RoutineNotImplementedException("GetLastAttackObjectAction");
+    const Combat::Attack *attack = ctx.game.combat().getLastAttack(*attacker);
+    if (!attack || !attack->action) {
+        return Variable::ofInt(static_cast<int>(ActionType::QueueEmpty));
+    }
+
+    return Variable::ofInt(static_cast<int>(attack->action->type()));
 }
 
 static Variable GetLastForcePowerUsed(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5389,9 +5401,15 @@ static Variable GetLastAttackResult(const std::vector<Variable> &args, const Rou
     auto oAttacker = getObjectOrCaller(args, 0, ctx);
 
     // Transform
+    auto attacker = checkCreature(oAttacker);
 
     // Execute
-    throw RoutineNotImplementedException("GetLastAttackResult");
+    const Combat::Attack *attack = ctx.game.combat().getLastAttack(*attacker);
+    if (attack) {
+        return Variable::ofInt(static_cast<int>(attack->resultType));
+    }
+
+    return Variable::ofInt(static_cast<int>(AttackResultType::Invalid));
 }
 
 static Variable GetWasForcePowerSuccessful(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -7159,7 +7177,7 @@ void Routines::registerMainKotorRoutines() {
     insert(719, "SetGlobalFadeIn", R_VOID, {R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT}, &SetGlobalFadeIn);
     insert(720, "SetGlobalFadeOut", R_VOID, {R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT}, &SetGlobalFadeOut);
     insert(721, "GetLastHostileTarget", R_OBJECT, {R_OBJECT}, &GetLastHostileTarget);
-    insert(722, "GetLastAttackObjectAction", R_INT, {R_OBJECT}, &GetLastAttackObjectAction);
+    insert(722, "GetLastAttackAction", R_INT, {R_OBJECT}, &GetLastAttackAction);
     insert(723, "GetLastForcePowerUsed", R_INT, {R_OBJECT}, &GetLastForcePowerUsed);
     insert(724, "GetLastCombatFeatUsed", R_INT, {R_OBJECT}, &GetLastCombatFeatUsed);
     insert(725, "GetLastAttackResult", R_INT, {R_OBJECT}, &GetLastAttackResult);
@@ -7715,7 +7733,7 @@ void Routines::registerMainTslRoutines() {
     insert(719, "SetGlobalFadeIn", R_VOID, {R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT}, &SetGlobalFadeIn);
     insert(720, "SetGlobalFadeOut", R_VOID, {R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT, R_FLOAT}, &SetGlobalFadeOut);
     insert(721, "GetLastHostileTarget", R_OBJECT, {R_OBJECT}, &GetLastHostileTarget);
-    insert(722, "GetLastAttackObjectAction", R_INT, {R_OBJECT}, &GetLastAttackObjectAction);
+    insert(722, "GetLastAttackAction", R_INT, {R_OBJECT}, &GetLastAttackAction);
     insert(723, "GetLastForcePowerUsed", R_INT, {R_OBJECT}, &GetLastForcePowerUsed);
     insert(724, "GetLastCombatFeatUsed", R_INT, {R_OBJECT}, &GetLastCombatFeatUsed);
     insert(725, "GetLastAttackResult", R_INT, {R_OBJECT}, &GetLastAttackResult);

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -172,6 +172,10 @@ const char *argKindToString(ArgKind kind) {
         return "LastSpeaker";
     case ArgKind::ListenPatternNumber:
         return "ListenPatternNumber";
+    case ArgKind::LastAttacker:
+        return "LastAttacker";
+    case ArgKind::LastDamager:
+        return "LastDamager";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -240,6 +244,12 @@ Argument Argument::fromString(std::string str) {
     if (kind == "ListenPatternNumber") {
         return {ArgKind::ListenPatternNumber, Variable::ofInt(std::stoi(value))};
     }
+    if (kind == "LastAttacker") {
+        return {ArgKind::LastAttacker, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "LastDamager") {
+        return {ArgKind::LastDamager, Variable::ofObject(std::stoul(value))};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
@@ -254,7 +264,9 @@ void Argument::verify() {
     case ArgKind::LastOpenedBy:
     case ArgKind::LastPerceived:
     case ArgKind::LastUsedBy:
-    case ArgKind::LastSpeaker: {
+    case ArgKind::LastSpeaker:
+    case ArgKind::LastAttacker:
+    case ArgKind::LastDamager: {
         if (var.type != VariableType::Object || var.objectId == kObjectSelf) {
             throw std::invalid_argument(toString() + ": expected an object != self");
         }


### PR DESCRIPTION
The patchset adds the following routines necessary for `k_ai_master` script (see #7):
- GetLastAttacker
- GetLastDamager
- GetLastHostileActor
- GetLastHostileTarget
- GetLastAttackAction
- GetLastAttackResult

These routines unblock most of `k_ai_master` for basic attacks, but more patches are required to make enemies work as expected. Routines for feats and spells are not supported yet.

For `GetLastHostileActor`, `GetLastHostileTarget`, `GetLastAttackAction` and `GetLastAttackResult` we have to diverge from using script arguments (introduced in #33), and add a state to Combat instead. The primary limitation of arguments is that they are local to a script run, and therefore tied to a caller. These 3 routines, however, are called as part of `DetermineCombatRound` , which can query for other objects besides the caller.

`GetLastAttacker` and `GetLastDamager` are implemented via arguments.

Please see individual commit messages for more details.