### PR TITLE
[game] Face destination after MoveToObjectAction

### DIFF
--- a/src/libs/game/action/movetoobject.cpp
+++ b/src/libs/game/action/movetoobject.cpp
@@ -31,6 +31,7 @@ void MoveToObjectAction::execute(std::shared_ptr<Action> self, Object &actor, fl
 
     bool reached = creatureActor->navigateTo(dest, _run, _range, dt);
     if (reached) {
+        creatureActor->face(dest);
         complete();
     }
 }


### PR DESCRIPTION
When an enemy is heard, but not seen by a creature, `k_ai_master` issues a `MoveToObjectAction` in an attempt to find it.

However, `MoveToObjectAction` completes early when the target is already in close range, so the creature does not move. Still, it must face the target in order to make it "seen" (i.e. turn to bring the target into FOV).

This is an improvement for #7.