### PR TITLE
[game] Do not consider dead enemies as enemies for GetNearestCreature

### DIFF
--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1091,8 +1091,12 @@ static bool matchesReputation(const Creature &creature, const Object *target,
     switch (reputation) {
     case ReputationType::Friend:
         return reputes.getIsFriend(creature, targetCreature);
-    case ReputationType::Enemy:
-        return reputes.getIsEnemy(creature, targetCreature);
+    case ReputationType::Enemy: {
+        // Do not consider dead enemies as enemies. Scripts use
+        // GetNearestCreature to find a new target, and targeting dead bodies is
+        // a poor tactic.
+        return !creature.isDead() && reputes.getIsEnemy(creature, targetCreature);
+    }
     case ReputationType::Neutral:
         return reputes.getIsNeutral(creature, targetCreature);
     }


### PR DESCRIPTION
While there is a dedicated criteria to only match "alive" creatures, `k_ai_master` doesn't use it when looking for a target to attack.

Before the patch, `k_ai_master` used to select the same target regardless of `isDead` condition, so it got stuck the moment its target died: it couldn't attack anymore because the target is dead, and couldn't find another target.

This change makes k_ai_master to ignore a dead target, and select a new one.

The patch improves combat for #7.