### PR TITLE
Run scripts for party members and the player character

### DIFF
--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -239,6 +239,19 @@ public:
     void runDialogueScript(uint32_t speakerId, int32_t listenNumber);
     void runAttackedScript(uint32_t attackerId);
 
+    void setOnHeartbeat(std::string onHeartbeat) { _onHeartbeat = onHeartbeat; }
+    void setOnSpawn(std::string onSpawn) { _onSpawn = onSpawn; }
+    void setOnDeath(std::string onDeath) { _onDeath = onDeath; }
+    void setOnNotice(std::string onNotice) { _onNotice = onNotice; }
+    void setOnEndRound(std::string onEndRound) { _onEndRound = onEndRound; }
+    void setOnSpellAt(std::string onSpellAt) { _onSpellAt = onSpellAt; }
+    void setOnAttacked(std::string onAttacked) { _onAttacked = onAttacked; }
+    void setOnDamaged(std::string onDamaged) { _onDamaged = onDamaged; }
+    void setOnDisturbed(std::string onDisturbed) { _onDisturbed = onDisturbed; }
+    void setOnEndDialogue(std::string onEndDialogue) { _onEndDialogue = onEndDialogue; }
+    void setOnBlocked(std::string onBlocked) { _onBlocked = onBlocked; }
+    void setOnDialogue(std::string onDialogue) { _onDialogue = onDialogue; }
+
     // END Scripts
 
     // IAnimationEventListener

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -340,6 +340,15 @@ void CharacterGeneration::finish() {
         player->setImmortal(true);
         player->attributes() = _character.attributes;
 
+        player->setOnHeartbeat("k_hen_heartbt01");
+        player->setOnSpawn("k_hen_spawn01");
+        player->setOnNotice("k_hen_percept01");
+        player->setOnEndRound("k_hen_combend01");
+        player->setOnAttacked("k_hen_attacked01");
+        player->setOnDamaged("k_hen_damage01");
+        player->setOnBlocked("k_hen_blocked01");
+        player->setOnDialogue("k_hen_dialogue01");
+
         Party &party = _game.party();
         party.clear();
         party.addMember(kNpcPlayer, player);

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -610,6 +610,7 @@ void Area::loadParty(const glm::vec3 &position, float facing, bool fromSave) {
         }
         landObject(*member);
         add(member);
+        member->runSpawnScript();
     }
 }
 


### PR DESCRIPTION
Scripts are essential for combat: `onSpawn` scripts register listener for creature-to-creature communication (aka "shouts"), `onAttacked` is needed to actually trigger these shouts, `onCombatEnd` works for target selection, etc.

The player character used to have no scripts assigned, so henchmen never engaged combat when the player character is attacked, and the PC never reacted to attacks when it is not under direct control. Furthermore, `onSpawn` scripts did not run for party members at all, which disabled shouts for henchmen that had these scripts assigned to them.

This patch set addressed both problems to improve #7.
Please see individual commit messages for more details.