### PR TITLE
[game] Do use FOV to determine visibility

### DIFF
--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -54,7 +54,6 @@ public:
 
     virtual bool isSelectable() const;
     bool isOpen() const { return _open; }
-    bool isInLineOfSight(const Object &other, float fov) const;
 
     bool isMinOneHP() const { return _minOneHP; }
     bool isDead() const { return _dead; }

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -393,16 +393,6 @@ std::shared_ptr<Effect> Object::getNextEffect() {
     return (_effectIndex < _effects.size()) ? _effects[_effectIndex++].effect : nullptr;
 }
 
-bool Object::isInLineOfSight(const Object &other, float fov) const {
-    if (other._position == _position) {
-        return true;
-    }
-    auto normal = _orientation * glm::vec3(0.0f, 1.0f, 0.0f);
-    auto dir = glm::normalize(glm::vec3(glm::vec2(other._position - _position), 0.0f));
-    float dot = glm::dot(normal, dir);
-    return dot > 0.0f && glm::acos(dot) < fov;
-}
-
 } // namespace game
 
 } // namespace reone

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -71,7 +71,6 @@ namespace game {
 static constexpr float kDefaultFieldOfView = 75.0f;
 static constexpr float kUpdatePerceptionInterval = 1.0f; // seconds
 static constexpr float kLineOfSightHeight = 1.7f;        // TODO: make it appearance-based
-static constexpr float kLineOfSightFOV = glm::radians(60.0f);
 
 static constexpr float kMaxCollisionDistance = 8.0f;
 static constexpr float kMaxCollisionDistance2 = kMaxCollisionDistance * kMaxCollisionDistance;
@@ -723,10 +722,6 @@ bool Area::moveCreatureTowards(const std::shared_ptr<Creature> &creature, const 
 }
 
 bool Area::isObjectSeen(const Creature &subject, const Object &object) const {
-    if (!subject.isInLineOfSight(object, kLineOfSightFOV)) {
-        return false;
-    }
-
     if (!object.visible()) {
         return false;
     }


### PR DESCRIPTION
The idea is great, but `k_ai_master` does not play well with it: when a creature is not engaged in combat, it only reacts to "seen" objects and completely ignores objects which are only "heard".

Without the patch, a creature can stand right behind enemies and they never trigger (unless it gets into their 60 degree FOV).

The patch makes visibility perception work in all directions, but still requires line-of-sight. If an enemy is behind a door, it is counted as not "seen", but maybe "heard" if is within hearing range.

~~WARNING: this breaks enemy AI further. It seems that `sceneGraph.testLineOfSight` check is broken, or something else is at play here. Without FOV limitation, enemies now happily see and shoot through walls (second room on Endar Spire level 1), and attempt to run through closed doors in order to reach enemies that they hear.~~

Patch set #43 is a prerequisite for this patch: it fixes problems with visibility that were hidden by the strict FOV check.

This patch helps #7 by making enemies notice and not loose their targets easily.