### PR TITLE
Fix visibility for inactive rooms

### DIFF
--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -119,8 +119,8 @@ void Area::load(std::string name, const Gff &are, const Gff &git, bool fromSave)
     auto gitParsed = resource::generated::parseGIT(git);
 
     loadARE(areParsed);
-    loadGIT(gitParsed);
     loadLYT();
+    loadGIT(gitParsed);
     loadVIS();
     loadPTH();
 }

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -726,6 +726,11 @@ bool Area::isObjectSeen(const Creature &subject, const Object &object) const {
     if (!subject.isInLineOfSight(object, kLineOfSightFOV)) {
         return false;
     }
+
+    if (!object.visible()) {
+        return false;
+    }
+
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
 
     glm::vec3 origin(subject.position());

--- a/src/libs/game/room.cpp
+++ b/src/libs/game/room.cpp
@@ -30,6 +30,7 @@ namespace game {
 
 void Room::addTenant(Object *object) {
     _tenants.insert(object);
+    object->setVisible(_visible);
 }
 
 void Room::removeTenant(Object *object) {


### PR DESCRIPTION
The patch set addresses a problem with visibility that was exposed in patch #42.
Rooms are "invisible" (or inactive) when they are far enough from player's current room. Objects in such rooms used to ignore walkmeshes and essentially "see" other objects through walls and attempt to attack them if they were enemies.

Please see individual commit messages for more details.