### PR TITLE
[game] Complete FollowAction and FollowLeaderAction

### DIFF
--- a/src/libs/game/action/follow.cpp
+++ b/src/libs/game/action/follow.cpp
@@ -30,7 +30,9 @@ void FollowAction::execute(std::shared_ptr<Action> self, Object &actor, float dt
     float distance2 = creatureActor->getSquareDistanceTo(glm::vec2(dest));
     bool run = distance2 > kDistanceWalk * kDistanceWalk;
 
-    creatureActor->navigateTo(dest, run, _followDistance, dt);
+    if (creatureActor->navigateTo(dest, run, _followDistance, dt)) {
+        complete();
+    }
 }
 
 } // namespace game

--- a/src/libs/game/action/followleader.cpp
+++ b/src/libs/game/action/followleader.cpp
@@ -31,7 +31,9 @@ void FollowLeaderAction::execute(std::shared_ptr<Action> self, Object &actor, fl
     float distance2 = creatureActor->getSquareDistanceTo(glm::vec2(destination));
     bool run = distance2 > kDistanceWalk;
 
-    creatureActor->navigateTo(destination, run, kDefaultFollowDistance, dt);
+    if (creatureActor->navigateTo(destination, run, kDefaultFollowDistance, dt)) {
+        complete();
+    }
 }
 
 } // namespace game


### PR DESCRIPTION
`FollowAction` and `FollowLeaderAction` used to never complete. AI scripts routinely call `ClearAllActions` which forcefully removes these actions. However, when combat is not active, these actions stay in the front of the queue and do not let other actions to execute.

On Endar Spire this locked a `DoCommandAction` for Trask after clicking on the "level-up" door on the bridge.