### PR TITLE
[game][nfc] Keep damager id instead of a shared_ptr in DamageEffect

### DIFF
--- a/include/reone/game/effect/damage.h
+++ b/include/reone/game/effect/damage.h
@@ -30,25 +30,25 @@ public:
     DamageEffect(int amount,
                  DamageType type,
                  DamagePower power,
-                 std::shared_ptr<Creature> damager) :
+                 uint32_t damager) :
         Effect(EffectType::Damage),
         _amount(amount),
         _type(type),
         _power(power),
-        _damager(std::move(damager)) {
+        _damager(damager) {
     }
 
     void applyTo(Object &object) override;
 
     int amount() const { return _amount; }
     DamageType type() const { return _type; }
-    std::shared_ptr<Creature> damager() const { return _damager; }
+    uint32_t damager() const { return _damager; }
 
 private:
     int _amount;
     DamageType _type;
     DamagePower _power;
-    std::shared_ptr<Creature> _damager;
+    uint32_t _damager;
 };
 
 } // namespace game

--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -49,7 +49,7 @@ public:
     }
 
     virtual void update(float dt);
-    virtual void damage(int amount, const Object *damager);
+    virtual void damage(int amount, uint32_t damager);
 
     void face(const Object &other);
     void face(const glm::vec3 &point);

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -109,7 +109,7 @@ public:
     void update(float dt) override;
 
     void clearAllActions() override;
-    void damage(int amount, const Object *damager) override;
+    void damage(int amount, uint32_t damager) override;
 
     void giveXP(int amount);
 

--- a/src/libs/game/combat.cpp
+++ b/src/libs/game/combat.cpp
@@ -422,7 +422,7 @@ void Combat::applyAttackResult(const Attack &attack, bool offHand) {
             multiplier * attack.damage,
             DamageType::Universal,
             DamagePower::Normal,
-            attack.attacker);
+            attack.attacker->id());
         attack.target->applyEffect(std::move(effect), DurationType::Instant);
         return;
     }
@@ -444,7 +444,7 @@ std::vector<std::shared_ptr<DamageEffect>> Combat::getDamageEffects(std::shared_
         type = static_cast<DamageType>(weapon->damageFlags());
     }
     amount = glm::max(1, amount);
-    std::shared_ptr<DamageEffect> effect(_game.newEffect<DamageEffect>(multiplier * amount, type, DamagePower::Normal, std::move(damager)));
+    std::shared_ptr<DamageEffect> effect(_game.newEffect<DamageEffect>(multiplier * amount, type, DamagePower::Normal, damager->id()));
 
     return std::vector<std::shared_ptr<DamageEffect>> {std::move(effect)};
 }

--- a/src/libs/game/effect/damage.cpp
+++ b/src/libs/game/effect/damage.cpp
@@ -28,7 +28,7 @@ namespace game {
 
 void DamageEffect::applyTo(Object &object) {
     debug(str(boost::format("Damage taken: %s %d") % object.tag() % _amount));
-    object.damage(_amount, _damager.get());
+    object.damage(_amount, _damager);
 }
 
 } // namespace game

--- a/src/libs/game/effect/death.cpp
+++ b/src/libs/game/effect/death.cpp
@@ -24,7 +24,7 @@ namespace reone {
 namespace game {
 
 void DeathEffect::applyTo(Object &object) {
-    object.damage(std::numeric_limits<int>::max(), nullptr);
+    object.damage(std::numeric_limits<int>::max(), 0);
 }
 
 } // namespace game

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -971,7 +971,7 @@ void Game::consoleKill(const IConsole::TokenList &tokens) {
         100000,
         DamageType::Universal,
         DamagePower::Normal,
-        std::shared_ptr<Creature>());
+        /*damager=*/ 0);
     object->applyEffect(std::move(effect), DurationType::Instant);
 }
 

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -364,7 +364,7 @@ void Object::clearAllEffects() {
     _effects.clear();
 }
 
-void Object::damage(int amount, const Object *damager) {
+void Object::damage(int amount, uint32_t damager) {
 }
 
 void Object::startStuntMode() {

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -232,7 +232,7 @@ void Creature::updateModelAnimation() {
     _animDirty = false;
 }
 
-void Creature::damage(int amount, const Object *damager) {
+void Creature::damage(int amount, uint32_t damager) {
     if (_dead) {
         return;
     }
@@ -243,7 +243,7 @@ void Creature::damage(int amount, const Object *damager) {
         _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, _currentHitPoints - amount);
     }
 
-    runDamagedScript(damager ? damager->id() : script::kObjectInvalid);
+    runDamagedScript(damager ? damager : script::kObjectInvalid);
 
     if (_immortal || _currentHitPoints > 0) {
         return;
@@ -256,7 +256,7 @@ void Creature::damage(int amount, const Object *damager) {
 
     playSound(SoundSetEntry::Dead);
     playAnimation(getDieAnimation());
-    runDeathScript(damager ? damager->id() : script::kObjectInvalid);
+    runDeathScript(damager);
 }
 
 void Creature::updateCombat(float dt) {

--- a/src/libs/game/script/routine/impl/effect.cpp
+++ b/src/libs/game/script/routine/impl/effect.cpp
@@ -157,7 +157,7 @@ static Variable EffectDamage(const std::vector<Variable> &args, const RoutineCon
     auto damagePower = static_cast<DamagePower>(nDamagePower);
 
     // Execute
-    auto effect = ctx.game.newEffect<DamageEffect>(nDamageAmount, damageType, damagePower, nullptr);
+    auto effect = ctx.game.newEffect<DamageEffect>(nDamageAmount, damageType, damagePower, 0);
     return Variable::ofEffect(std::move(effect));
 }
 


### PR DESCRIPTION
Damager is only used as an argument for onDamaged scripts. There is no real need for a shared_ptr here, so it is removed. Now we don't need to lookup for a shared_ptr when there is only a reference to Creature, for example.