### PR TITLE
[game] Fix damager id for runDeathScript

### DIFF
--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -243,7 +243,8 @@ void Creature::damage(int amount, uint32_t damager) {
         _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, _currentHitPoints - amount);
     }
 
-    runDamagedScript(damager ? damager : script::kObjectInvalid);
+    damager = damager ? damager : script::kObjectInvalid;
+    runDamagedScript(damager);
 
     if (_immortal || _currentHitPoints > 0) {
         return;


### PR DESCRIPTION
Scripts require either a valid id, or kObjectInvalid (1), but we used to pass 0 (aka kObjectSelf). This used to be handled correctly for runDamagedScript, but runDeathScript below used the parameter as is.

This patch fixes a regression introduced in 92dd2051: "[game][nfc] Keep damagerid instead of a shared_ptr in DamageEffect" (#51)