### PR TITLE
[game][nfc] Refactor console commands

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -447,6 +447,18 @@ private:
 
     void registerConsoleCommands();
 
+    /**
+     * Returns the currently selected object, or the party leader. Otherwise
+     * returns nullptr.
+     */
+    std::shared_ptr<Object> getCommandTargetObject();
+
+    /**
+     * Returns the currently selected Creature object, or the party
+     * leader. Otherwise returns nullptr.
+     */
+    std::shared_ptr<Creature> getCommandTargetCreature();
+
     void consoleInfo(const IConsole::TokenList &tokens);
     void consoleListGlobals(const IConsole::TokenList &tokens);
     void consoleListLocals(const IConsole::TokenList &tokens);


### PR DESCRIPTION
Refactored "selected object or leader" pattern into two functions (one for any object, and another only for creatures).

Refactored other commands to use of `dyn_cast` instead of `std::static_pointer_cast`, dropped unnecessary `static_cast`, added explicit `std::` namespace to `stoi`.