### PR TITLE
[engine] Add an option to execute console commands at startup

### DIFF
--- a/src/apps/engine/engine.cpp
+++ b/src/apps/engine/engine.cpp
@@ -133,6 +133,18 @@ void Engine::init() {
         *_services,
         *_console);
     _game->init();
+
+    if (!_options.commandsFile.empty()) {
+        std::ifstream file(_options.commandsFile);
+        if (!file.good()) {
+            throw std::runtime_error("Failed to open commands file: " + _options.commandsFile);
+        }
+        for (std::string line; std::getline(file, line);) {
+            if (!line.empty()) {
+                _console->execute(line);
+            }
+        }
+    }
 }
 
 void Engine::deinit() {

--- a/src/apps/engine/options.h
+++ b/src/apps/engine/options.h
@@ -36,6 +36,11 @@ struct Options {
 
     Logging logging;
 
+    /**
+     * Execute console commands from a file at startup.
+     */
+    std::string commandsFile;
+
     std::unique_ptr<game::OptionsView> toView() {
         return std::make_unique<game::OptionsView>(game, graphics, audio);
     }

--- a/src/apps/engine/optionsparser.cpp
+++ b/src/apps/engine/optionsparser.cpp
@@ -41,6 +41,7 @@ std::unique_ptr<Options> OptionsParser::parse() {
     options_description descCommon;
     descCommon.add_options()                                                                                                    //
         ("game", value<std::string>(), "path to game directory")                                                                //
+        ("commands-file", value<std::string>()->default_value(""), "execute console commands from a file at startup")           //
         ("dev", value<bool>()->default_value(options->game.developer), "enable developer mode")                                 //
         ("width", value<int>()->default_value(options->graphics.width), "render width")                                         //
         ("height", value<int>()->default_value(options->graphics.height), "render height")                                      //
@@ -140,6 +141,8 @@ std::unique_ptr<Options> OptionsParser::parse() {
         logChannels.insert(LogChannel::Script3);
     }
     options->logging.channels = std::move(logChannels);
+
+    options->commandsFile = vars["commands-file"].as<std::string>();
 
     return options;
 }


### PR DESCRIPTION
The patch adds `--command-file` command line option that takes a file name:
```
./engine --command-file path/to/commands.txt
```
When this option is specified, once the engine is initialized, it reads the file and executes each line as a console command.

This is useful for debugging to quickly reach the required game state. For example, you can warp to a particular module, set variables, turn on debug rendering, spawn objects, etc.