### PR TITLE
[game] Add new console commands

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -465,6 +465,11 @@ private:
      */
     std::shared_ptr<Creature> getConsoleLeader();
 
+    /**
+     * Returns the current Area.
+     */
+    std::shared_ptr<Area> getConsoleArea();
+
     void consoleInfo(const ConsoleArgs &tokens);
     void consoleListGlobals(const ConsoleArgs &tokens);
     void consoleListLocals(const ConsoleArgs &tokens);
@@ -478,6 +483,14 @@ private:
     void consoleShowAABB(const ConsoleArgs &tokens);
     void consoleShowWalkmesh(const ConsoleArgs &tokens);
     void consoleShowTriggers(const ConsoleArgs &tokens);
+    void consoleSpawnCreature(const ConsoleArgs &tokens);
+    void consoleSpawnCompanion(const ConsoleArgs &tokens);
+    void consoleSelectObjectById(const ConsoleArgs &tokens);
+    void consoleSelectLeader(const ConsoleArgs &tokens);
+    void consoleSetFaction(const ConsoleArgs &tokens);
+    void consoleSetPosition(const ConsoleArgs &tokens);
+    void consoleProfessionalTools(const ConsoleArgs &tokens);
+    void consoleKillRoom(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -88,9 +88,11 @@ public:
     void update3rdPersonCameraFacing();
     void update3rdPersonCameraTarget();
     void landObject(Object &object);
+    void add(const std::shared_ptr<Object> &object);
 
     bool moveCreature(const std::shared_ptr<Creature> &creature, const glm::vec2 &dir, bool run, float dt);
     bool moveCreatureTowards(const std::shared_ptr<Creature> &creature, const glm::vec2 &dest, bool run, float dt);
+    void determineObjectRoom(Object &object);
 
     bool isUnescapable() const { return _unescapable; }
 
@@ -293,7 +295,6 @@ private:
     void loadVIS();
     void loadPTH();
 
-    void add(const std::shared_ptr<Object> &object);
     void doDestroyObject(uint32_t objectId);
     void doDestroyObjects();
     void updateVisibility();
@@ -311,7 +312,6 @@ private:
      */
     resource::Visibility fixVisibility(const resource::Visibility &visiblity);
 
-    void determineObjectRoom(Object &object);
     void checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer);
 
     // Loading ARE

--- a/include/reone/game/room.h
+++ b/include/reone/game/room.h
@@ -62,6 +62,7 @@ public:
 
     void addTenant(Object *object);
     void removeTenant(Object *object);
+    const std::set<Object *> tenants() const { return _tenants; }
 
     // END Tenants
 


### PR DESCRIPTION
The patch adds the following commands:
- `spawncreature res [id]` spawns a creature from a template (`c_drdmktwo`, for example) and optionally assigns it the given `id`. Having a fixed id is useful if we need to select this creature later using `selectobjectbyid` command. All creatures are spawned as Neutral at the position of the party leader.
- `spawncompanion res npcindex [id]` spawns a party member from a template (`p_juhani`, or `c_drdmktwo`, for example) with a given npcindex (from 1 to 9) and an optional object id.
- `selectobjectbyid id` selects an object with the provided `id`. All objects are supposed to have unique ids. Use `info` command to find an object id of the selected object.
- `selectleader` selects the current party leader. This can be useful to effectively "cancel" selection of another object, so that follow-up commands can target the party leader instead.
- `setfaction number` changes faction of the selected creature (or the party leader). See enum class Faction in [types.h](https://github.com/modawan/reone/blob/e58f7dfdcee058b5d14fd724825afb621c510ca1/include/reone/game/types.h#L420) for a complete list, but the following are typical factions to set: 1 for Hostile, 2 for Friendly, and 5 for Neutral.
- `setposition x y z` changes position of the selected creature (or the party leader). X, Y, Z are world coordinates. The easiest way to find coordinates in game is to position a creature there and use `info` command.
- `professionaltools` adds different kinds of weapons and consumables to the inventory of the selected object (or the party leader). This is useful to test combat features (along with `spawncreature` and `setfaction`).
- `killroom` kills all hostile creatures in the same room as the selected object (or the party leader). If a creature other than the party leader is selected, all creatures of the same faction are killed. Otherwise all enemies of the party leader are killed.
