### PR TITLE
[game] Remove restriction on the number of party members

### DIFF
--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -297,15 +297,19 @@ void HUD::renderHealth(int memberIndex) {
         return;
 
     Party &party = _game.party();
-    std::shared_ptr<Creature> member(party.getMember(memberIndex));
     std::vector<Label *> backLabels {
         _controls.LBL_BACK1.get(),
         _controls.LBL_BACK2.get(),
         _controls.LBL_BACK3.get()};
 
+    if (memberIndex >= backLabels.size()) {
+        return;
+    }
+
     Label &LBL_CHAR = *backLabels[memberIndex];
     const Control::Extent &extent = LBL_CHAR.extent();
 
+    std::shared_ptr<Creature> member(party.getMember(memberIndex));
     float w = 5.0f;
     float h = glm::clamp(member->currentHitPoints() / static_cast<float>(member->hitPoints()), 0.0f, 1.0f) * extent.height;
 

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -26,9 +26,7 @@ namespace reone {
 
 namespace game {
 
-static constexpr int kMaxMemberCount = 3;
-
-static constexpr char kBlueprintResRefCarth[] = "p_juhani";
+static constexpr char kBlueprintResRefCarth[] = "p_carth";
 static constexpr char kBlueprintResRefBastila[] = "p_bastilla";
 static constexpr char kBlueprintResRefAtton[] = "p_atton";
 static constexpr char kBlueprintResRefKreia[] = "p_kreia";
@@ -75,10 +73,6 @@ bool Party::removeAvailableMember(int npc) {
 }
 
 bool Party::addMember(int npc, std::shared_ptr<Creature> creature) {
-    if (_members.size() == kMaxMemberCount) {
-        warn("Party: cannot add another member");
-        return false;
-    }
     Member member;
     member.npc = npc;
     member.creature = creature;
@@ -92,25 +86,13 @@ void Party::clear() {
 }
 
 void Party::switchLeader() {
-    int count = static_cast<int>(_members.size());
-    if (count < 2)
+    if (_members.size() <= 1) {
         return;
+    }
 
-    switch (count) {
-    case 2: {
-        Member tmp(_members[0]);
-        _members[0] = _members[1];
-        _members[1] = tmp;
-        break;
-    }
-    case 3: {
-        Member tmp(_members[0]);
-        _members[0] = _members[1];
-        _members[1] = _members[2];
-        _members[2] = tmp;
-        break;
-    }
-    }
+    Member tmp(_members[0]);
+    _members.erase(_members.begin());
+    _members.push_back(tmp);
 
     onLeaderChanged();
 }


### PR DESCRIPTION
The patch removes this restriction for game logic, but GUI still supports only 3. The only way to switch to extra party members is to use TAB key.

This feature is primarily needed for testing with `spawncompanion` console command, but it can be enabled to control "friendly follower" NPCs in the future.

The patch also restores Carth as the default companion for K1.