### PR TITLE
[system][nfc] Add an explicit check against malloc overflow

### DIFF
--- a/include/reone/system/smallvector.h
+++ b/include/reone/system/smallvector.h
@@ -207,23 +207,23 @@ public:
     }
 
     /**
-     * Resize the vector. When \p new_size is greater than size(), new elements
-     * are initialized by a default constructor. When \p new_size is less that
+     * Resize the vector. When \p newSize is greater than size(), new elements
+     * are initialized by a default constructor. When \p newSize is less that
      * size(), exceeding elements at the end of the vector are destroyed.
      *
      * This function may reallocate storage and invalidate pointers that are
      * saved elsewhere.
      */
-    void resize(size_t new_size) {
+    void resize(size_t newSize) {
         size_t orig_size = _size;
-        if (new_size > orig_size) {
-            reserve(new_size);
-            createRangeDefault(_begin + orig_size, _begin + new_size);
-            _size = new_size;
+        if (newSize > orig_size) {
+            reserve(newSize);
+            createRangeDefault(_begin + orig_size, _begin + newSize);
+            _size = newSize;
             return;
         }
-        _size = new_size;
-        destroyRange(_begin + new_size, _begin + orig_size);
+        _size = newSize;
+        destroyRange(_begin + newSize, _begin + orig_size);
     }
 
     /**
@@ -232,17 +232,17 @@ public:
      * This function may reallocate storage and invalidate pointers that are
      * saved elsewhere.
      */
-    void reserve(size_t new_cap) {
-        if (new_cap <= capacity()) {
+    void reserve(size_t newCap) {
+        if (newCap <= capacity()) {
             return;
         }
 
         if (isSmall()) {
-            allocHeap(new_cap);
+            allocHeap(newCap);
             return;
         }
 
-        reallocHeap(new_cap);
+        reallocHeap(newCap);
     }
 
 protected:
@@ -398,14 +398,14 @@ private:
     }
 
     /**
-     * Reserve up to \p new_cap or by a factor of 1.5, whatever is higher.
+     * Reserve up to \p newCap or by a factor of 1.5, whatever is higher.
      */
-    void grow(size_t new_cap) {
-        if (capacity() >= new_cap) {
+    void grow(size_t newCap) {
+        if (capacity() >= newCap) {
             return;
         }
-        size_t grow_cap = capacity() * 1.5f;
-        reserve(grow_cap > new_cap ? grow_cap : new_cap);
+        size_t growCap = capacity() * 1.5f;
+        reserve(growCap > newCap ? growCap : newCap);
     }
 
     /**
@@ -435,25 +435,25 @@ private:
     /**
      * Make a heap allocation and copy data from co-allocated storage.
      */
-    void allocHeap(size_t new_cap) {
+    void allocHeap(size_t newCap) {
         assert(isSmall());
-        T *heap = allocate(new_cap);
+        T *heap = allocate(newCap);
         moveRange(begin(), end(), heap);
         _begin = heap;
-        _capacity = new_cap;
+        _capacity = newCap;
     }
 
     /**
      * Reallocate a heap allocation to a larger size.
      */
-    void reallocHeap(size_t new_cap) {
-        assert(!isSmall() && new_cap != 0);
-        T *heap = allocate(new_cap);
+    void reallocHeap(size_t newCap) {
+        assert(!isSmall() && newCap != 0);
+        T *heap = allocate(newCap);
         moveRange(begin(), end(), heap);
         free(_begin);
 
         _begin = heap;
-        _capacity = new_cap;
+        _capacity = newCap;
     }
 };
 


### PR DESCRIPTION
Malloc typically does not support single allocations larger than half of the address space (`PTRDIFF_MAX`). GCC issues a warning to catch cases that may potentially overflow:
```
  warning: argument 1 value ‘18446744073709551600’ exceeds maximum
  object size 9223372036854775807 [-Walloc-size-larger-than=]
```
The patch wraps malloc into a helper function with "fatal" error handling.

The second patch updates spelling of variables to match the code style.