### PR TITLE
[game][nfc] More refactoring for console commands

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -447,7 +447,7 @@ private:
 
     void initConsole();
 
-    using ConsoleCommandHandler = void (Game::*)(const IConsole::TokenList &);
+    using ConsoleCommandHandler = void (Game::*)(const ConsoleArgs &);
     void registerConsoleCommand(std::string name, std::string description, ConsoleCommandHandler handler);
 
     /**
@@ -465,19 +465,19 @@ private:
      */
     std::shared_ptr<Creature> getConsoleLeader();
 
-    void consoleInfo(const IConsole::TokenList &tokens);
-    void consoleListGlobals(const IConsole::TokenList &tokens);
-    void consoleListLocals(const IConsole::TokenList &tokens);
-    void consoleListAnim(const IConsole::TokenList &tokens);
-    void consolePlayAnim(const IConsole::TokenList &tokens);
-    void consoleKill(const IConsole::TokenList &tokens);
-    void consoleAddItem(const IConsole::TokenList &tokens);
-    void consoleGiveXP(const IConsole::TokenList &tokens);
-    void consoleWarp(const IConsole::TokenList &tokens);
-    void consoleRunScript(const IConsole::TokenList &tokens);
-    void consoleShowAABB(const IConsole::TokenList &tokens);
-    void consoleShowWalkmesh(const IConsole::TokenList &tokens);
-    void consoleShowTriggers(const IConsole::TokenList &tokens);
+    void consoleInfo(const ConsoleArgs &tokens);
+    void consoleListGlobals(const ConsoleArgs &tokens);
+    void consoleListLocals(const ConsoleArgs &tokens);
+    void consoleListAnim(const ConsoleArgs &tokens);
+    void consolePlayAnim(const ConsoleArgs &tokens);
+    void consoleKill(const ConsoleArgs &tokens);
+    void consoleAddItem(const ConsoleArgs &tokens);
+    void consoleGiveXP(const ConsoleArgs &tokens);
+    void consoleWarp(const ConsoleArgs &tokens);
+    void consoleRunScript(const ConsoleArgs &tokens);
+    void consoleShowAABB(const ConsoleArgs &tokens);
+    void consoleShowWalkmesh(const ConsoleArgs &tokens);
+    void consoleShowTriggers(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/src/apps/engine/console.cpp
+++ b/src/apps/engine/console.cpp
@@ -169,19 +169,21 @@ bool Console::handleKeyUp(const input::KeyEvent &event) {
 }
 
 void Console::executeInputText() {
-    TokenList tokens;
+    game::ConsoleArgs::TokenList tokens;
     boost::split(tokens, _input.text(), boost::is_space(), boost::token_compress_on);
     if (tokens.empty()) {
         return;
     }
-    auto commandByName = _nameToCommand.find(tokens[0]);
+
+    const std::string &name = tokens[0];
+    auto commandByName = _nameToCommand.find(name);
     if (commandByName == _nameToCommand.end()) {
-        printLine("Unrecognized command: " + tokens[0]);
+        printLine("Unrecognized command: " + name);
         return;
     }
     auto &handler = commandByName->second.get().handler;
     try {
-        handler(tokens);
+        handler(std::move(tokens));
     } catch (const std::exception &ex) {
         printLine("Command failed: " + std::string(ex.what()));
     }


### PR DESCRIPTION
This patchset adds more utility functions and classes to make console commands easier to implement:
- `registerConsoleCommand` wraps `std::bind` with placeholder arguments to make to make command registration less verbose.
- Error handling is not done primarily using exceptions to match the rest of the code for console commands.
- `ConsoleArgs` wraps common conversions for command arguments (string, integer, float, enum).
