### PR TITLE
[gui][system] Support clipboard for text input

### DIFF
--- a/include/reone/system/clipboard.h
+++ b/include/reone/system/clipboard.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/system/stream/memoryinput.h"
+#include <memory>
+#include <string>
+
+namespace reone {
+
+class ClipboardStream : public MemoryInputStream {
+public:
+    ClipboardStream(char *data, size_t length) :
+        MemoryInputStream(data, length) {}
+
+    std::string_view str() { return std::string_view(_data, _length); }
+
+    ~ClipboardStream();
+};
+
+std::unique_ptr<ClipboardStream> getClipboard();
+
+} // namespace reone

--- a/include/reone/system/stream/memoryinput.h
+++ b/include/reone/system/stream/memoryinput.h
@@ -33,6 +33,10 @@ public:
         _length(bytes.size()) {
     }
 
+    MemoryInputStream(char *data, size_t length) :
+        _data(data), _length(length) {
+    }
+
     void seek(int64_t off, SeekOrigin origin) override {
         if (origin == SeekOrigin::Begin) {
             _position = off;
@@ -57,7 +61,7 @@ public:
     size_t position() override { return _position; }
     size_t length() override { return _length; }
 
-private:
+protected:
     char *_data;
     size_t _length;
 

--- a/src/libs/gui/textinput.cpp
+++ b/src/libs/gui/textinput.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "reone/gui/textinput.h"
+#include "reone/system/clipboard.h"
 
 namespace reone {
 
@@ -55,6 +56,10 @@ static inline bool isShiftPressed(const input::KeyEvent &event) {
     return event.mod & input::KeyModifiers::shift;
 }
 
+static inline bool isControlPressed(const input::KeyEvent &event) {
+    return event.mod & input::KeyModifiers::control;
+}
+
 bool TextInput::handleKeyDown(const input::KeyEvent &event) {
     if (!isKeyAllowed(event)) {
         return false;
@@ -64,6 +69,11 @@ bool TextInput::handleKeyDown(const input::KeyEvent &event) {
     bool letter = isLetterKey(event);
     bool symbol = isSymbolKey(event);
     bool shift = isShiftPressed(event);
+
+    if (isControlPressed(event) && event.code == input::KeyCode::V && !event.repeat) {
+        _buffer.write(getClipboard()->str());
+        return true;
+    }
 
     if (event.code == input::KeyCode::Backspace) {
         backspace();

--- a/src/libs/system/CMakeLists.txt
+++ b/src/libs/system/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SYSTEM_HEADERS
     ${SYSTEM_INCLUDE_DIR}/cache.h
     ${SYSTEM_INCLUDE_DIR}/cast.h
     ${SYSTEM_INCLUDE_DIR}/checkutil.h
+    ${SYSTEM_INCLUDE_DIR}/clipboard.h
     ${SYSTEM_INCLUDE_DIR}/clock.h
     ${SYSTEM_INCLUDE_DIR}/di/module.h
     ${SYSTEM_INCLUDE_DIR}/di/services.h
@@ -59,6 +60,7 @@ set(SYSTEM_HEADERS
 set(SYSTEM_SOURCES
     ${SYSTEM_SOURCE_DIR}/binaryreader.cpp
     ${SYSTEM_SOURCE_DIR}/binarywriter.cpp
+    ${SYSTEM_SOURCE_DIR}/clipboard.cpp
     ${SYSTEM_SOURCE_DIR}/clock.cpp
     ${SYSTEM_SOURCE_DIR}/di/module.cpp
     ${SYSTEM_SOURCE_DIR}/fileutil.cpp

--- a/src/libs/system/clipboard.cpp
+++ b/src/libs/system/clipboard.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/system/clipboard.h"
+#include "SDL2/SDL.h"
+#include <string.h>
+
+namespace reone {
+
+ClipboardStream::~ClipboardStream() {
+    free(_data);
+}
+
+std::unique_ptr<ClipboardStream> getClipboard() {
+    char *text = SDL_GetClipboardText();
+    size_t len = strlen(text);
+    if (!len) {
+        free(text);
+        throw std::runtime_error("SDL_GetClipboardText failed: " + std::string(SDL_GetError()));
+    }
+    return std::make_unique<ClipboardStream>(text, len);
+}
+
+} // namespace reone


### PR DESCRIPTION
The patch adds `ClipboardStream` wrapper around `SDL_GetClipboardText`, and integrates it to `TextInput`.
`TextInput` now recognizes Ctrl-V shortcut and inserts clipboard content before the cursor.

For example, this allows to copy-paste commands to console, and execute them all at once.