### PR TITLE
[game] Fix animations for ranged attacks

### DIFF
--- a/src/libs/game/attack.cpp
+++ b/src/libs/game/attack.cpp
@@ -472,7 +472,15 @@ bool navigateToAttackTarget(Creature &attacker, Object &target, float dt, bool &
 }
 
 static bool hasAnim(const graphics::Model &model, const std::string &anim) {
-    return model.animations().count(anim);
+    if (model.animations().count(anim)) {
+        return true;
+    }
+
+    if (std::shared_ptr<graphics::Model> super = model.superModel()) {
+        return hasAnim(*super, anim);
+    }
+
+    return false;
 }
 
 std::string getRangedAttackAnim(Creature &attacker, int kind) {


### PR DESCRIPTION
`hasAnim` should look into super models recursively to traverse a complete list of animations.

The patch fixes a regression introduced in #58.