### PR TITLE
[game] Fix runscript console command

### DIFF
--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1023,7 +1023,7 @@ void Game::consoleRunScript(const ConsoleArgs &args) {
 
     std::string resRef(args[1].value());
     std::vector<script::Argument> vars;
-    for (size_t i = 1; i < args.size(); ++i) {
+    for (size_t i = 2; i < args.size(); ++i) {
         vars.push_back(script::Argument::fromString(std::string(args[i].value())));
     }
 


### PR DESCRIPTION
Optional arguments start at index 2:

  - index 0 is the command name.
  - index 1 is the script name.
  - index 2 and the rest are arguments.