### PR TITLE
[game] Use 2DA files for combat animation sequences

### DIFF
--- a/include/reone/game/animations.h
+++ b/include/reone/game/animations.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/game/types.h"
+
+namespace reone {
+
+namespace resource {
+
+class TwoDAs;
+class TwoDA;
+
+} // namespace resource
+
+namespace game {
+
+class IAnimations {
+public:
+    virtual ~IAnimations() = default;
+    virtual void clear() = 0;
+
+    virtual std::string getNameById(uint32_t id) const = 0;
+    virtual std::string getAttackResult(std::string attackAnim, CreatureWieldType targetWield, AttackResultType result) const = 0;
+};
+
+class Animations : public IAnimations {
+public:
+    Animations(resource::TwoDAs &twoDas) :
+        _twoDas(twoDas) {}
+
+    void init();
+    void clear() override;
+
+    std::string getNameById(uint32_t id) const override;
+    std::string getAttackResult(std::string attackAnim, CreatureWieldType targetWield, AttackResultType result) const override;
+
+private:
+    struct Anim {
+        std::string name;
+        bool attack {false};
+    };
+
+    static constexpr uint32_t kNoAnim = std::numeric_limits<uint32_t>::max();
+
+    struct AttackResult {
+        uint32_t parry {kNoAnim};
+        uint32_t dodge {kNoAnim};
+        uint32_t damage {kNoAnim};
+    };
+
+    void parseAnims(resource::TwoDA &animDa);
+    void parseCombatAnim(resource::TwoDA &combatAnimDa);
+
+    using AttackResultMap = std::map<std::pair<std::string, CreatureWieldType>, AttackResult>;
+
+    resource::TwoDAs &_twoDas;
+    std::vector<Anim> _anims;
+    AttackResultMap _attackResults;
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/di/module.h
+++ b/include/reone/game/di/module.h
@@ -23,6 +23,7 @@
 #include "reone/scene/di/module.h"
 #include "reone/script/di/module.h"
 
+#include "../animations.h"
 #include "../camerastyles.h"
 #include "../d20/classes.h"
 #include "../d20/feats.h"
@@ -90,6 +91,7 @@ private:
     std::unique_ptr<Spells> _spells;
     std::unique_ptr<Surfaces> _surfaces;
     std::unique_ptr<Projectiles> _projectiles;
+    std::unique_ptr<Animations> _animations;
 
     std::unique_ptr<GameServices> _services;
 };

--- a/include/reone/game/di/services.h
+++ b/include/reone/game/di/services.h
@@ -41,6 +41,7 @@ class ISkills;
 class ISpells;
 class ISurfaces;
 class IProjectiles;
+class IAnimations;
 
 struct GameServices {
     ICameraStyles &cameraStyles;
@@ -54,6 +55,7 @@ struct GameServices {
     ISpells &spells;
     ISurfaces &surfaces;
     IProjectiles &projectiles;
+    IAnimations &animations;
 
     GameServices(
         ICameraStyles &cameraStyles,
@@ -66,7 +68,8 @@ struct GameServices {
         ISkills &skills,
         ISpells &spells,
         ISurfaces &surfaces,
-        IProjectiles &projectiles) :
+        IProjectiles &projectiles,
+        IAnimations &animations) :
         cameraStyles(cameraStyles),
         classes(classes),
         feats(feats),
@@ -77,7 +80,8 @@ struct GameServices {
         skills(skills),
         spells(spells),
         surfaces(surfaces),
-        projectiles(projectiles) {
+        projectiles(projectiles),
+        animations(animations) {
     }
 };
 

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -66,6 +66,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/action/usetalentatlocation.h
     ${GAME_INCLUDE_DIR}/action/usetalentonobject.h
     ${GAME_INCLUDE_DIR}/action/wait.h
+    ${GAME_INCLUDE_DIR}/animations.h
     ${GAME_INCLUDE_DIR}/animationutil.h
     ${GAME_INCLUDE_DIR}/camerastyle.h
     ${GAME_INCLUDE_DIR}/camerastyles.h
@@ -362,6 +363,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/action/useskill.cpp
     ${GAME_SOURCE_DIR}/action/usetalentonobject.cpp
     ${GAME_SOURCE_DIR}/action/wait.cpp
+    ${GAME_SOURCE_DIR}/animations.cpp
     ${GAME_SOURCE_DIR}/animationutil.cpp
     ${GAME_SOURCE_DIR}/attack.cpp
     ${GAME_SOURCE_DIR}/camerastyles.cpp

--- a/src/libs/game/animations.cpp
+++ b/src/libs/game/animations.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/animations.h"
+#include "reone/game/attack.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/provider/2das.h"
+#include "reone/system/logutil.h"
+
+#include <cctype>
+#include <string>
+
+using namespace reone::resource;
+
+namespace reone {
+
+namespace game {
+
+void Animations::parseAnims(TwoDA &animDa) {
+    for (int row = 0; row < animDa.getRowCount(); ++row) {
+        Anim anim;
+        anim.name = animDa.getString(row, "name");
+        anim.attack = animDa.getBool(row, "attack");
+        _anims.push_back(anim);
+    }
+}
+
+struct CombatAnimColumn {
+    enum Kind {
+        Parry,
+        Dodge,
+        Damage,
+    } kind;
+
+    std::string name;
+    CreatureWieldType wield;
+};
+
+// Split a string followed by a number.
+static std::pair<std::string, int> splitStrInt(std::string s) {
+    size_t i;
+    for (i = s.size(); i > 0; --i) {
+        if (!std::isdigit(s[i - 1])) {
+            break;
+        }
+    }
+
+    if (i == 0 || i == s.size()) {
+        return {"", 0};
+    }
+
+    std::string num = s.substr(i);
+    return {s.substr(0, i), std::stoi(num)};
+}
+
+static std::vector<CombatAnimColumn> parseCombatAnimColumns(TwoDA &combatAnimDa) {
+    std::vector<CombatAnimColumn> result;
+
+    for (const std::string &columnName : combatAnimDa.columns()) {
+        std::pair<std::string, int> pair = splitStrInt(columnName);
+        if (pair.first.empty()) {
+            continue;
+        }
+
+        CombatAnimColumn::Kind kind;
+        if (pair.first == "parry") {
+            kind = CombatAnimColumn::Parry;
+        } else if (pair.first == "dodge") {
+            kind = CombatAnimColumn::Dodge;
+        } else if (pair.first == "damage") {
+            kind = CombatAnimColumn::Damage;
+        } else {
+            continue;
+        }
+
+        CombatAnimColumn column;
+        column.name = columnName;
+        column.kind = kind;
+        column.wield = static_cast<CreatureWieldType>(pair.second);
+        result.push_back(column);
+    }
+    return result;
+}
+
+void Animations::parseCombatAnim(TwoDA &combatAnimDa) {
+    std::vector<CombatAnimColumn> columns = parseCombatAnimColumns(combatAnimDa);
+
+    // Rows of combatanimations.2da match the order of attack animations from
+    // animations.2da.
+    int row = 0;
+    for (const Anim &attackAnim : _anims) {
+        if (row == combatAnimDa.getRowCount()) {
+            return;
+        }
+
+        if (!attackAnim.attack) {
+            continue;
+        }
+
+        // Parse animations that follow an attack: parry, dodge, damage.
+        for (const CombatAnimColumn &column : columns) {
+            uint32_t animId = combatAnimDa.getInt(row, column.name, kNoAnim);
+            if (animId == kNoAnim) {
+                continue;
+            }
+            if (animId >= _anims.size()) {
+                warn("combatanimations.2da: unknown anim " + std::to_string(animId));
+                continue;
+            }
+            AttackResult &result = _attackResults[{attackAnim.name, column.wield}];
+            switch (column.kind) {
+            case CombatAnimColumn::Parry:
+                result.parry = animId;
+                break;
+            case CombatAnimColumn::Dodge:
+                result.dodge = animId;
+                break;
+            case CombatAnimColumn::Damage:
+                result.damage = animId;
+                break;
+            }
+        }
+
+        ++row;
+    }
+}
+
+void Animations::init() {
+    std::shared_ptr<TwoDA> animDa(_twoDas.get("animations"));
+    if (!animDa) {
+        return;
+    }
+
+    parseAnims(*animDa);
+
+    std::shared_ptr<TwoDA> combatAnimDa(_twoDas.get("combatanimations.2da"));
+    if (!combatAnimDa) {
+        return;
+    }
+
+    parseCombatAnim(*combatAnimDa);
+}
+
+void Animations::clear() {
+    _anims.clear();
+    _attackResults.clear();
+}
+
+std::string Animations::getNameById(uint32_t id) const {
+    if (id >= _anims.size()) {
+        return std::string();
+    }
+    return _anims[id].name;
+}
+
+std::string Animations::getAttackResult(std::string attackAnim,
+                                        CreatureWieldType targetWield,
+                                        AttackResultType result) const {
+    auto it = _attackResults.find({attackAnim, targetWield});
+    if (it == _attackResults.end()) {
+        return std::string();
+    }
+
+    switch (result) {
+    case AttackResultType::Invalid:
+        return std::string();
+    case AttackResultType::HitSuccessful:
+    case AttackResultType::CriticalHit:
+    case AttackResultType::AutomaticHit:
+        return getNameById(it->second.damage);
+
+    case AttackResultType::Miss:
+    case AttackResultType::AttackResisted:
+    case AttackResultType::AttackFailed:
+    case AttackResultType::Parried:
+    case AttackResultType::Deflected:
+        if (isRangedWieldType(targetWield)) {
+            return getNameById(it->second.dodge);
+        }
+        return getNameById(it->second.damage);
+    }
+
+    return std::string();
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/di/module.cpp
+++ b/src/libs/game/di/module.cpp
@@ -33,6 +33,7 @@ void GameModule::init() {
     _spells = std::make_unique<Spells>(_resource.textures(), _resource.strings(), _resource.twoDas());
     _surfaces = std::make_unique<Surfaces>(_resource.twoDas());
     _projectiles = std::make_unique<Projectiles>(_resource.twoDas());
+    _animations = std::make_unique<Animations>(_resource.twoDas());
 
     _services = std::make_unique<GameServices>(
         *_cameraStyles,
@@ -45,7 +46,8 @@ void GameModule::init() {
         *_skills,
         *_spells,
         *_surfaces,
-        *_projectiles);
+        *_projectiles,
+        *_animations);
 
     _cameraStyles->init();
     _guiSounds->init();
@@ -53,6 +55,7 @@ void GameModule::init() {
     _reputes->init();
     _surfaces->init();
     _projectiles->init();
+    _animations->init();
 }
 
 void GameModule::deinit() {


### PR DESCRIPTION
The patch replaces hardcoded attack/dodge/damage animation sequences with the ones specified in `combatanimations.2da` file.

New Animations resource class parses `animations.2da` and `combatanimations.2da` at startup, and provides API to query:

1. Animation ID to name mapping. For now this is only going to be used for `CutsceneAttack`, because scripts specify animations by ID. There may be other places where this is useful.

2. "Result" animation selection. This animation should play in case of a duel (when the attacker and the target attack each other) as a response to an attack. `AttackResultType` determines what kind of animation to select: dodge, damage, or parry animation.