### PR TITLE
[game] Enable projectiles for CutsceneAttackAction

### DIFF
--- a/include/reone/game/action/cutsceneattack.h
+++ b/include/reone/game/action/cutsceneattack.h
@@ -37,15 +37,20 @@ public:
     }
 
     void execute(std::shared_ptr<Action> self, Object &actor, float dt) override;
+    void cancel(std::shared_ptr<Action> self, Object &actor) override;
     const std::shared_ptr<Object> &target() const { return _target; }
 
 private:
+    void addProjectiles(const Creature &creature, std::string attackAnim);
+    void finish(Creature &attacker);
+
     std::shared_ptr<Object> _target;
     int _animation;
     AttackResultType _result;
     int _damage;
 
     AttackSchedule _schedule;
+    ProjectileSequence _projectiles;
 };
 
 } // namespace game

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -497,6 +497,7 @@ private:
     void consoleAutoSkipEntries(const ConsoleArgs &tokens);
     void consoleAutoSkipReplies(const ConsoleArgs &tokens);
     void consoleStartConversation(const ConsoleArgs &tokens);
+    void consoleCutsceneAttack(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/src/libs/game/action/attackobject.cpp
+++ b/src/libs/game/action/attackobject.cpp
@@ -73,6 +73,8 @@ static void attack(const CombatRound &round, Creature &attacker, Object &target,
     int variant = randomInt(1, 5);
 
     CreatureWieldType attackerWield = attacker.getWieldType();
+
+    // TODO: support stun batons and unarmed.
     bool isMelee = isMeleeWieldType(attacker.getWieldType());
 
     std::string attackAnim = isMelee

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -20,6 +20,7 @@
 #include "reone/audio/context.h"
 #include "reone/audio/di/services.h"
 #include "reone/audio/mixer.h"
+#include "reone/game/action/cutsceneattack.h"
 #include "reone/game/action/startconversation.h"
 #include "reone/game/combat.h"
 #include "reone/game/debug.h"
@@ -127,6 +128,7 @@ void Game::initConsole() {
     registerConsoleCommand("autoskipentries", "add a sequence of entries to skip", &Game::consoleAutoSkipEntries);
     registerConsoleCommand("autoskipreplies", "add a sequence of replies to pick", &Game::consoleAutoSkipReplies);
     registerConsoleCommand("startconversation", "starts a conversation with the selected object", &Game::consoleStartConversation);
+    registerConsoleCommand("cutsceneattack", "attack an object by id with a pre-determined animation and result", &Game::consoleCutsceneAttack);
 }
 
 void Game::initLocalServices() {
@@ -1328,6 +1330,25 @@ void Game::consoleStartConversation(const ConsoleArgs &args) {
 
     auto action = newAction<StartConversationAction>(target, target->conversation());
     leader->addAction(std::move(action));
+}
+
+void Game::consoleCutsceneAttack(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 4, 4, "target_id animation_id result damage");
+
+    std::shared_ptr<Creature> actor = getConsoleTargetCreature();
+
+    std::shared_ptr<Object> target = getObjectById(args.get<uint32_t>(1).value());
+    if (!target) {
+        throw std::runtime_error("Target not found");
+    }
+
+    int anim = args.get<int>(2).value();
+    AttackResultType result = args.getEnum<AttackResultType>(3).value();
+    int damage = args.get<int>(4).value();
+
+    auto action = newAction<CutsceneAttackAction>(
+        std::move(target), anim, result, damage);
+    actor->addAction(std::move(action));
 }
 
 } // namespace game


### PR DESCRIPTION
`CutsceneAttack` is a special action that is supposed to be used only by scripts for 'cinematic' fights in dialogs. It allows to use any animation ID as an attack regardless of the attacker's wield type. This makes determining the corresponding projectiles a bit tricky.
Given an animation ID, we first lookup the corresponding name. Let's take `b5a1` as an example:

  - 'b' is a blaster animation.
  - '5' is a wield type - a single blaster.
  - 'a' is a key for 'attack'.
  - '1' is a 'basic' attack.

With this data we can find the corresponding sequence of projectiles required for this attack.