### PR TITLE
[game] Add muzzle flash effect for projectiles

### DIFF
--- a/include/reone/game/attack.h
+++ b/include/reone/game/attack.h
@@ -173,6 +173,7 @@ private:
     Source _source;
     bool _miss;
     std::shared_ptr<scene::ModelSceneNode> _model;
+    std::shared_ptr<scene::ModelSceneNode> _flash;
     glm::vec3 _target {0.0f};
 };
 

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -35,6 +35,7 @@ class Item : public Object {
 public:
     struct AmmunitionType {
         std::shared_ptr<graphics::Model> model;
+        std::shared_ptr<graphics::Model> muzzleFlash;
         std::shared_ptr<audio::AudioClip> shotSound1;
         std::shared_ptr<audio::AudioClip> shotSound2;
         std::shared_ptr<audio::AudioClip> impactSound1;

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -164,6 +164,7 @@ void Item::loadAmmunitionType() {
         std::shared_ptr<TwoDA> twoDa(_services.resource.twoDas.get("ammunitiontypes"));
         _ammunitionType = std::make_shared<Item::AmmunitionType>();
         _ammunitionType->model = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "model")));
+        _ammunitionType->muzzleFlash = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "muzzleflash")));
         _ammunitionType->shotSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound0")));
         _ammunitionType->shotSound2 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound1")));
         _ammunitionType->impactSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "impactsound0")));


### PR DESCRIPTION
Muzzle flash effect is a model specified in `ammunitiontypes.2da` (`muzzleflash` column) for each ammunition type. The model is normally invisible, but there is an emitter sub-model that we trigger with `signalEvent(kModelEventDetonate)`.

A flash originates at `muzzlehook` sub-model of the corresponding weapon model, or at the projectile origin as a fallback.

The patch also fixes a missed `return` in determineProjectileOrigin.