### PR TITLE
[game] Reduce default duration for dialog entries

### DIFF
--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -42,7 +42,7 @@ namespace reone {
 
 namespace game {
 
-static constexpr float kDefaultEntryDuration = 10.0f;
+static constexpr float kDefaultEntryDuration = 3.0f;
 
 static bool g_allEntriesSkippable = false;
 


### PR DESCRIPTION
Default 10s delay seems too conservative. It is noticeable on all cinematic cutscenes on Endar Spire, where soldiers stay idle for seconds after making an attack. Delay of 3 seconds seems about right, but we can adjust it later if it cases problems elsewhere.