### PR TITLE
[scene] Disable culling objects in an animated cutscene

### DIFF
--- a/include/reone/scene/node.h
+++ b/include/reone/scene/node.h
@@ -60,6 +60,7 @@ public:
 
     bool isEnabled() const { return _enabled; }
     bool isCulled() const { return _culled; }
+    bool isCullingEnabled() const { return _cullingEnabled; }
     bool isPoint() const { return _point; }
 
     glm::vec3 origin() const;
@@ -90,6 +91,7 @@ public:
 
     void setEnabled(bool enabled) { _enabled = enabled; }
     void setCulled(bool culled) { _culled = culled; }
+    void setCullingEnabled(bool enabled) { _cullingEnabled = enabled; }
 
     // END Flags
 
@@ -122,6 +124,15 @@ protected:
     bool _enabled {true};
     bool _culled {false}; /**< has this node been frustum- or distance-culled? */
     bool _point {true};   /**< is this node represented by a single point?  */
+
+    /**
+     * Can this node be culled?
+     *
+     * For some nodes we disable culling because their position is changed
+     * significantly by animations. For example, a node may be at zero position,
+     * which is out of frame, but an animation moves in frame.
+     */
+    bool _cullingEnabled {true};
 
     // END Flags
 

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -379,6 +379,7 @@ void Object::damage(int amount, uint32_t damager) {
 void Object::startStuntMode() {
     if (_sceneNode) {
         _sceneNode->setLocalTransform(glm::mat4(1.0f));
+        _sceneNode->setCullingEnabled(false);
     }
     _stunt = true;
 }
@@ -389,6 +390,7 @@ void Object::stopStuntMode() {
 
     if (_sceneNode) {
         _sceneNode->setLocalTransform(_transform);
+        _sceneNode->setCullingEnabled(true);
     }
     _stunt = false;
 }

--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -173,11 +173,20 @@ void SceneGraph::update(float dt) {
 
 void SceneGraph::cullRoots() {
     for (auto &root : _modelRoots) {
-        bool culled =
-            !root->isEnabled() ||
-            root->getSquareDistanceTo(*_activeCamera) > root->drawDistance() * root->drawDistance() ||
-            !_activeCamera->isInFrustum(*root);
+        if (!root->isEnabled()) {
+            root->setCulled(true);
+            continue;
+        }
 
+        if (!root->isCullingEnabled()) {
+            root->setCulled(false);
+            continue; // disable distance and frustum culling
+        }
+
+        float distanceToCamera = root->getSquareDistanceTo(*_activeCamera);
+        float drawDistance = root->drawDistance() * root->drawDistance();
+
+        bool culled = (distanceToCamera > drawDistance) || (!_activeCamera->isInFrustum(*root));
         root->setCulled(culled);
     }
 }


### PR DESCRIPTION
For objects participating in an animated cutscene, animation takes complete control over actual position of the model, and SceneNode's local transform is reset to 0. Unless the object is disabled, always assume it is visible in a cutscene.

Fixes #17 "Player character does not appear in the first cutscene", as well as other stunts like this.