### PR TITLE
[ci] Install SDL3 dependency, upgrade to ubuntu-25.10

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -7,20 +7,23 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: "ubuntu:25.10"
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |-
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
-          sudo apt-get update
-          sudo apt install \
-            libboost-all-dev libsdl2-dev libglew-dev libopenal-dev libmad0-dev libwxgtk3.0-gtk3-dev libgmock-dev \
+          apt-get update
+          apt install --no-install-recommends -y \
+            cmake build-essential g++ \
+            libboost-all-dev libsdl2-dev libsdl3-dev libglew-dev libopenal-dev libmad0-dev libwxgtk3.2-dev libgmock-dev \
             libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev
 
       - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}/build
+        working-directory: ${{github.workspace}}
+        run: cmake -E make_directory build
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -25,16 +25,16 @@ jobs:
         id: vcpkg-installed
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: ${{ runner.os }}-vcpkg-installed
+          key: ${{ runner.os }}-vcpkg-installed-v2
           restore-keys: |
-            ${{ runner.os }}-vcpkg-installed
+            ${{ runner.os }}-vcpkg-installed-v2
 
       - name: Install dependencies
         if: steps.vcpkg-installed.outputs.cache-hit != 'true'
         run: |-
           vcpkg install --triplet x64-windows `
             boost-algorithm boost-endian boost-format boost-functional boost-program-options `
-            glm sdl2 glew openal-soft libmad ffmpeg wxwidgets gtest
+            glm sdl2 sdl3 glew openal-soft libmad ffmpeg wxwidgets gtest
 
       - name: Generate solution
         run: |-


### PR DESCRIPTION
SDL3 is not supported in Ubuntu 24.04. We need to use 25.10 until the next LTS version is released.
For older versions where SDL3 is not available in repositories, it should be possible to build it from source.

Bumped `vcpkg-installed-v2` cache key to rebuild cache once this commit lands.
