### PR TITLE
[system] Fix ISmallVector

### DIFF
--- a/include/reone/system/smallvector.h
+++ b/include/reone/system/smallvector.h
@@ -115,7 +115,7 @@ public:
     }
 
     const_reference back() const {
-        return const_cast<ISmallVector<T> &>(*this)->back();
+        return const_cast<ISmallVector<T> &>(*this).back();
     }
 
     reference front() {
@@ -124,7 +124,7 @@ public:
     }
 
     const_reference front() const {
-        return const_cast<ISmallVector<T> &>(*this)->front();
+        return const_cast<ISmallVector<T> &>(*this).front();
     }
 
     /**


### PR DESCRIPTION
The const_reference versions of front() and back() in the ISmallVector class were trying to dereference a reference. This commit fixes that.