### PR TITLE
[graphics] Initialize shadows FB with a depth buffer

### DIFF
--- a/src/libs/scene/render/pipeline/retro.cpp
+++ b/src/libs/scene/render/pipeline/retro.cpp
@@ -63,6 +63,11 @@ void RetroRenderPipeline::initRenderTargets() {
     _targets.pointLightShadowsDepth->init();
 
     _targets.shadows = std::make_shared<Framebuffer>();
+    // Always attach a depth buffer during initialization. Render
+    // calls glClear(GL_DEPTH_BUFFER_BIT) before a depth buffer is
+    // attached. If nothing is attached before glClear, some drivers
+    // trip and never recover.
+    _targets.shadows->attachDepth(_targets.pointLightShadowsDepth);
     _targets.shadows->init();
 
     // Opaque framebuffer


### PR DESCRIPTION
Always attach a depth buffer during initialization. Render calls `glClear(GL_DEPTH_BUFFER_BIT)` before a depth buffer is attached. If nothing is attached before `glClear`, some drivers trip and never recover.

Reproduced on Linux with Nvidia GTX 1070 and driver versions 535.261 and 550.163.

Fixes #82 "Retro renderer is broken".
