### PR TITLE
[ci] Use a short ref to name releases

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 env:
   VCPKG_ROOT: C:/vcpkg
+  RELEASE: reone-${{ github.ref_name }}
+  TAG: ${{ github.ref_name }}
 
 jobs:
   build:
@@ -14,19 +16,20 @@ jobs:
       - uses: ./.github/actions/build-windows
 
       - name: Zip
+        shell: bash
         working-directory: ${{github.workspace}}/build
         run: |-
-          mkdir reone-${{ github.ref }}
-          mv bin reone-${{ github.ref }}/
-          7z a -r reone-${{ github.ref }}.zip reone-${{ github.ref }}
+          mkdir $RELEASE
+          mv bin $RELEASE/
+          7z a -r $RELEASE.zip $RELEASE
 
       - name: Tag a release
         shell: bash
         working-directory: ${{github.workspace}}/build
         run: |-
-          gh release create ${{ github.ref }} reone-${{ github.ref }}.zip \
-            --title "Reone ${{ github.ref }}" \
-            --notes ${{github.sha}} \
+          gh release create $TAG $RELEASE.zip \
+            --title "Reone $TAG" \
+            --notes "Commit: ${{github.sha}}" \
             --draft --prerelease
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
GITHUB_REF is `refs/heads/<branch_name>` or `refs/tags/tag`. GITHUB_REF_NAME is a short name (the last component).

[ci skip]