### PR TITLE
[game] Add opendoor and closedoor console commands

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -503,6 +503,7 @@ private:
     void consoleAddOrRemoveFeat(const ConsoleArgs &tokens);
     void consoleAddOrRemoveSpell(const ConsoleArgs &tokens);
     void consoleCastSpellAtObject(const ConsoleArgs &tokens);
+    void consoleOpenCloseDoor(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -175,7 +175,7 @@ public:
     // Object Selection
 
     void hilightObject(std::shared_ptr<Object> object);
-    void selectObject(std::shared_ptr<Object> object);
+    void selectObject(std::shared_ptr<Object> object, bool force = false);
 
     std::shared_ptr<Object> hilightedObject() const { return _hilightedObject; }
     std::shared_ptr<Object> selectedObject() const { return _selectedObject; }
@@ -244,6 +244,7 @@ private:
     Timer _perceptionTimer;
     std::shared_ptr<Object> _hilightedObject;
     std::shared_ptr<Object> _selectedObject;
+    bool _forceSelection {false};
 
     // Scripts
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -138,6 +138,8 @@ void Game::initConsole() {
     registerConsoleCommand("addspell", "add spell by type", &Game::consoleAddOrRemoveSpell);
     registerConsoleCommand("removespell", "remove spell by type", &Game::consoleAddOrRemoveSpell);
     registerConsoleCommand("castspellatobject", "cast spell at object", &Game::consoleCastSpellAtObject);
+    registerConsoleCommand("opendoor", "open a selected door object", &Game::consoleOpenCloseDoor);
+    registerConsoleCommand("closedoor", "close a selected door object", &Game::consoleOpenCloseDoor);
 }
 
 void Game::initLocalServices() {
@@ -1145,7 +1147,7 @@ void Game::consoleSelectObjectById(const ConsoleArgs &args) {
         throw std::runtime_error("Object not found");
     }
 
-    getConsoleArea()->selectObject(object);
+    getConsoleArea()->selectObject(object, /*force=*/true);
 }
 
 void Game::consoleSelectObjectByTag(const ConsoleArgs &args) {
@@ -1154,7 +1156,7 @@ void Game::consoleSelectObjectByTag(const ConsoleArgs &args) {
 
     for (auto [id, object] : _objectById) {
         if (object->tag() == tag) {
-            getConsoleArea()->selectObject(object);
+            getConsoleArea()->selectObject(object, /*force=*/true);
             return;
         }
     }
@@ -1456,6 +1458,35 @@ void Game::consoleCastSpellAtObject(const ConsoleArgs &args) {
         spell, std::move(target), std::move(item), cheat);
 
     leader->addAction(std::move(action));
+}
+
+void Game::consoleOpenCloseDoor(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 0, 1, "[triggerer_id]");
+
+    auto target = dyn_cast<Door>(getConsoleTargetObject());
+    if (!target) {
+        throw std::runtime_error("Selected object must be a door");
+    }
+
+    auto triggerer_id = args.get<uint32_t>(1);
+    std::shared_ptr<Object> triggerer;
+    if (triggerer_id) {
+        if (uint32_t id = triggerer_id.value()) {
+            triggerer = getObjectById(id);
+        }
+    } else {
+        triggerer = getConsoleLeader();
+    }
+
+    if (args[0].value() == "opendoor") {
+        target->open();
+        if (triggerer) {
+            target->onOpen(*triggerer);
+        }
+    } else {
+        target->close();
+        // There is no Door::onClose yet
+    }
 }
 
 } // namespace game

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1024,7 +1024,7 @@ void Area::updateObjectSelection() {
             }
         }
     }
-    if (_selectedObject) {
+    if (_selectedObject && !_forceSelection) {
         if (!_selectedObject->isSelectable()) {
             _selectedObject.reset();
         } else {
@@ -1041,8 +1041,9 @@ void Area::hilightObject(std::shared_ptr<Object> object) {
     _hilightedObject = std::move(object);
 }
 
-void Area::selectObject(std::shared_ptr<Object> object) {
+void Area::selectObject(std::shared_ptr<Object> object, bool force) {
     _selectedObject = std::move(object);
+    _forceSelection = force;
 }
 
 std::shared_ptr<Object> Area::getNearestObject(const glm::vec3 &origin, int nth, const std::function<bool(const std::shared_ptr<Object> &)> &predicate) {


### PR DESCRIPTION
`opendoor` command bypasses any prerequisites and opens a selected door. Optional `triggerer_id` parameter allows to specify an argument for the corresponding onOpen script. If `triggerer_id` is invalid (for example, 0 or 1) `onOpen` script is not invoked.

`closedoor` command closes a selected door. There is no in-game way to select an opened door, so use `selectobjectbyid` or `selectobjectbytag` commands to select a door first. There is no support for `onClose` scripts yet, so `triggerer_id` does nothing and can be omitted.

Before the patch, Area used to reset selection on closed doors, which rendered `closedoor` command useless. Added `force` parameter to selectObject to bypass this restriction for console use.