### PR TITLE
Honor StartNewModule movie arguments and suppress world audio during movie playback

### DIFF
--- a/include/reone/audio/mixer.h
+++ b/include/reone/audio/mixer.h
@@ -32,6 +32,7 @@ public:
     virtual ~IAudioMixer() = default;
 
     virtual void render() = 0;
+    virtual void stop(AudioType type) = 0;
 
     virtual std::shared_ptr<AudioSource> play(
         std::shared_ptr<AudioClip> clip,
@@ -48,6 +49,7 @@ public:
     }
 
     void render() override;
+    void stop(AudioType type) override;
 
     std::shared_ptr<AudioSource> play(
         std::shared_ptr<AudioClip> clip,
@@ -57,9 +59,14 @@ public:
         std::optional<glm::vec3> = std::nullopt) override;
 
 private:
+    struct ActiveSource {
+        std::shared_ptr<AudioSource> source;
+        AudioType type {AudioType::Sound};
+    };
+
     AudioOptions &_options;
 
-    std::vector<std::shared_ptr<AudioSource>> _sources;
+    std::vector<ActiveSource> _sources;
 
     float gainByType(AudioType type, float gain) const;
 };

--- a/include/reone/audio/mixer.h
+++ b/include/reone/audio/mixer.h
@@ -33,6 +33,7 @@ public:
 
     virtual void render() = 0;
     virtual void stop(AudioType type) = 0;
+    virtual void stopAll() = 0;
 
     virtual std::shared_ptr<AudioSource> play(
         std::shared_ptr<AudioClip> clip,
@@ -50,6 +51,7 @@ public:
 
     void render() override;
     void stop(AudioType type) override;
+    void stopAll() override;
 
     std::shared_ptr<AudioSource> play(
         std::shared_ptr<AudioClip> clip,

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <queue>
+
 #include "reone/audio/source.h"
 #include "reone/graphics/cursor.h"
 #include "reone/input/event.h"
@@ -322,7 +324,7 @@ private:
     Screen _screen {Screen::None};
 
     std::shared_ptr<movie::IMovie> _movie;
-    std::vector<std::string> _moduleTransitionMovies;
+    std::queue<std::string> _moduleTransitionMovies;
     resource::CursorType _cursorType {resource::CursorType::None};
     std::shared_ptr<graphics::Cursor> _cursor;
     float _gameSpeed {1.0f};

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -183,6 +183,7 @@ public:
     void loadModule(const std::string &name, std::string entry = "");
 
     void scheduleModuleTransition(const std::string &moduleName, const std::string &entry);
+    void scheduleModuleTransitionWithMovies(const std::string &moduleName, const std::string &entry, std::vector<std::string> movies);
 
     // END Module loading
 
@@ -321,6 +322,7 @@ private:
     Screen _screen {Screen::None};
 
     std::shared_ptr<movie::IMovie> _movie;
+    std::vector<std::string> _moduleTransitionMovies;
     resource::CursorType _cursorType {resource::CursorType::None};
     std::shared_ptr<graphics::Cursor> _cursor;
     float _gameSpeed {1.0f};
@@ -408,6 +410,8 @@ private:
 
     // Updates
 
+    bool startVideo(const std::string &name);
+    bool playNextModuleTransitionMovie();
     void updateMovie(float dt);
     void updateMusic();
     void updateCamera(float dt);

--- a/src/libs/audio/mixer.cpp
+++ b/src/libs/audio/mixer.cpp
@@ -45,6 +45,13 @@ void AudioMixer::stop(AudioType type) {
     }
 }
 
+void AudioMixer::stopAll() {
+    for (auto &source : _sources) {
+        source.source->stop();
+    }
+    _sources.clear();
+}
+
 std::shared_ptr<AudioSource> AudioMixer::play(std::shared_ptr<AudioClip> clip,
                                               AudioType type,
                                               float gain,

--- a/src/libs/audio/mixer.cpp
+++ b/src/libs/audio/mixer.cpp
@@ -23,13 +23,25 @@ namespace audio {
 
 void AudioMixer::render() {
     for (auto it = _sources.begin(); it != _sources.end();) {
-        auto &source = *it;
+        auto &source = it->source;
         source->render();
         if (!source->isPlaying()) {
             it = _sources.erase(it);
         } else {
             ++it;
         }
+    }
+}
+
+void AudioMixer::stop(AudioType type) {
+    for (auto it = _sources.begin(); it != _sources.end();) {
+        if (it->type != type) {
+            ++it;
+            continue;
+        }
+
+        it->source->stop();
+        it = _sources.erase(it);
     }
 }
 
@@ -45,7 +57,7 @@ std::shared_ptr<AudioSource> AudioMixer::play(std::shared_ptr<AudioClip> clip,
         std::move(position));
     source->init();
     source->play();
-    _sources.push_back(source);
+    _sources.push_back(ActiveSource {source, type});
     return source;
 }
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -567,6 +567,8 @@ bool Game::startVideo(const std::string &name) {
         return false;
     }
 
+    _services.audio.mixer.stop(AudioType::Sound);
+
     if (_music) {
         _music->stop();
         _music.reset();

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -565,13 +565,14 @@ void Game::scheduleModuleTransitionWithMovies(const std::string &moduleName, con
 }
 
 bool Game::startVideo(const std::string &name) {
+    _services.audio.mixer.stopAll();
+    _music.reset();
+
     _movie = _services.resource.movies.get(name);
     if (!_movie) {
         return false;
     }
 
-    _services.audio.mixer.stopAll();
-    _music.reset();
     return true;
 }
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -412,7 +412,7 @@ void Game::setCursorType(CursorType type) {
 }
 
 void Game::playVideo(const std::string &name) {
-    _moduleTransitionMovies.clear();
+    _moduleTransitionMovies = std::queue<std::string>();
     startVideo(name);
 }
 
@@ -548,13 +548,16 @@ void Game::stopMovement() {
 void Game::scheduleModuleTransition(const std::string &moduleName, const std::string &entry) {
     _nextModule = moduleName;
     _nextEntry = entry;
-    _moduleTransitionMovies.clear();
+    _moduleTransitionMovies = std::queue<std::string>();
 }
 
 void Game::scheduleModuleTransitionWithMovies(const std::string &moduleName, const std::string &entry, std::vector<std::string> movies) {
     _nextModule = moduleName;
     _nextEntry = entry;
-    _moduleTransitionMovies = std::move(movies);
+    _moduleTransitionMovies = std::queue<std::string>();
+    for (auto &movie : movies) {
+        _moduleTransitionMovies.push(std::move(movie));
+    }
 
     if (!_movie) {
         playNextModuleTransitionMovie();
@@ -567,19 +570,15 @@ bool Game::startVideo(const std::string &name) {
         return false;
     }
 
-    _services.audio.mixer.stop(AudioType::Sound);
-
-    if (_music) {
-        _music->stop();
-        _music.reset();
-    }
+    _services.audio.mixer.stopAll();
+    _music.reset();
     return true;
 }
 
 bool Game::playNextModuleTransitionMovie() {
     while (!_moduleTransitionMovies.empty()) {
         auto name = std::move(_moduleTransitionMovies.front());
-        _moduleTransitionMovies.erase(_moduleTransitionMovies.begin());
+        _moduleTransitionMovies.pop();
 
         if (startVideo(name)) {
             return true;

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -412,15 +412,8 @@ void Game::setCursorType(CursorType type) {
 }
 
 void Game::playVideo(const std::string &name) {
-    _movie = _services.resource.movies.get(name);
-    if (!_movie) {
-        return;
-    }
-
-    if (_music) {
-        _music->stop();
-        _music.reset();
-    }
+    _moduleTransitionMovies.clear();
+    startVideo(name);
 }
 
 void Game::playMusic(const std::string &resRef) {
@@ -526,14 +519,6 @@ void Game::renderGUI() {
     }
 }
 
-void Game::updateMovie(float dt) {
-    _movie->update(dt);
-
-    if (_movie->isFinished()) {
-        _movie.reset();
-    }
-}
-
 void Game::updateMusic() {
     if (_musicResRef.empty()) {
         return;
@@ -563,6 +548,51 @@ void Game::stopMovement() {
 void Game::scheduleModuleTransition(const std::string &moduleName, const std::string &entry) {
     _nextModule = moduleName;
     _nextEntry = entry;
+    _moduleTransitionMovies.clear();
+}
+
+void Game::scheduleModuleTransitionWithMovies(const std::string &moduleName, const std::string &entry, std::vector<std::string> movies) {
+    _nextModule = moduleName;
+    _nextEntry = entry;
+    _moduleTransitionMovies = std::move(movies);
+
+    if (!_movie) {
+        playNextModuleTransitionMovie();
+    }
+}
+
+bool Game::startVideo(const std::string &name) {
+    _movie = _services.resource.movies.get(name);
+    if (!_movie) {
+        return false;
+    }
+
+    if (_music) {
+        _music->stop();
+        _music.reset();
+    }
+    return true;
+}
+
+bool Game::playNextModuleTransitionMovie() {
+    while (!_moduleTransitionMovies.empty()) {
+        auto name = std::move(_moduleTransitionMovies.front());
+        _moduleTransitionMovies.erase(_moduleTransitionMovies.begin());
+
+        if (startVideo(name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void Game::updateMovie(float dt) {
+    _movie->update(dt);
+
+    if (_movie->isFinished()) {
+        _movie.reset();
+        playNextModuleTransitionMovie();
+    }
 }
 
 void Game::updateCamera(float dt) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -4389,9 +4389,25 @@ static Variable StartNewModule(const std::vector<Variable> &args, const RoutineC
     // Transform
     auto moduleName = boost::to_lower_copy(sModuleName);
     auto waypoint = boost::to_lower_copy(sWayPoint);
+    std::vector<std::string> movies;
+    auto addMovie = [&movies](const std::string &movie) {
+        if (!movie.empty()) {
+            movies.push_back(boost::to_lower_copy(movie));
+        }
+    };
+    addMovie(sMovie1);
+    addMovie(sMovie2);
+    addMovie(sMovie3);
+    addMovie(sMovie4);
+    addMovie(sMovie5);
+    addMovie(sMovie6);
 
     // Execute
-    ctx.game.scheduleModuleTransition(moduleName, waypoint);
+    if (movies.empty()) {
+        ctx.game.scheduleModuleTransition(moduleName, waypoint);
+    } else {
+        ctx.game.scheduleModuleTransitionWithMovies(moduleName, waypoint, std::move(movies));
+    }
     return Variable::ofNull();
 }
 

--- a/test/fixtures/audio.h
+++ b/test/fixtures/audio.h
@@ -46,6 +46,7 @@ public:
 class MockAudioMixer : public IAudioMixer, boost::noncopyable {
 public:
     MOCK_METHOD(void, render, (), (override));
+    MOCK_METHOD(void, stop, (AudioType), (override));
     MOCK_METHOD(std::shared_ptr<AudioSource>, play, (std::shared_ptr<AudioClip>, AudioType, float, bool, std::optional<glm::vec3>), (override));
 };
 

--- a/test/fixtures/audio.h
+++ b/test/fixtures/audio.h
@@ -47,6 +47,7 @@ class MockAudioMixer : public IAudioMixer, boost::noncopyable {
 public:
     MOCK_METHOD(void, render, (), (override));
     MOCK_METHOD(void, stop, (AudioType), (override));
+    MOCK_METHOD(void, stopAll, (), (override));
     MOCK_METHOD(std::shared_ptr<AudioSource>, play, (std::shared_ptr<AudioClip>, AudioType, float, bool, std::optional<glm::vec3>), (override));
 };
 


### PR DESCRIPTION
## Summary

This PR fixes two closely related movie-playback issues:

1. `StartNewModule` was parsing movie args (`sMovie1..sMovie6`) but ignoring them, so transition BIKs were skipped.
2. Once movie playback was restored, already-playing world/ambient audio continued underneath the movie because active `AudioType::Sound` sources were left alive.

## Changes

### 1. Honor `StartNewModule` movie arguments before transition

Scripts were already passing movie args correctly, e.g.:

- `StartNewModule("STUNT_00", "", "01c", "", "", "", "", "")`
- `StartNewModule("tar_m02af", "", "01f", "", "", "", "", "")`

but the runtime parsed `sMovie1..sMovie6` and then immediately scheduled the module transition without honoring them, so the BIKs were skipped.

The fix makes `StartNewModule` collect non-empty movie args, play them through the existing movie backend, and only let the pending module transition proceed after those movies finish.

### 2. Suppress world audio during movie playback

Currently movie start stops `_music`, but leaves active world `AudioType::Sound` sources alive, so ambient/module audio continues while the movie is playing.

The fix adds type-based stopping in the mixer and suppresses active `AudioType::Sound` sources when a movie begins, while leaving movie audio intact.

## Scope

- no movie-resref special casing
- no Taris wake-up placement fix
- no aspect/stretch fix
- no broad movie/audio subsystem rewrite