### PR TITLE
Add developer observability tools, fix trigger visualiser rendering, fix text overlap

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -17,10 +17,9 @@
 
 #pragma once
 
-#include <queue>
-
 #include "reone/audio/source.h"
 #include "reone/graphics/cursor.h"
+#include "reone/graphics/types.h"
 #include "reone/input/event.h"
 #include "reone/movie/movie.h"
 #include "reone/script/routines.h"
@@ -65,11 +64,20 @@
 #include "script/runner.h"
 #include "talent.h"
 
+#include <queue>
+#include <vector>
+
 namespace reone {
 
 namespace gui {
 
 class GUI;
+
+}
+
+namespace graphics {
+
+class Font;
 
 }
 
@@ -323,6 +331,17 @@ private:
 
     Screen _screen {Screen::None};
 
+    struct DeveloperOverlay {
+        bool visible {false};
+        bool triggers {true};
+        bool actorLabels {true};
+        bool longActorLabels {false};
+        bool watchedValues {true};
+    };
+
+    DeveloperOverlay _developerOverlay;
+    std::shared_ptr<graphics::Font> _developerFont;
+
     std::shared_ptr<movie::IMovie> _movie;
     std::queue<std::string> _moduleTransitionMovies;
     resource::CursorType _cursorType {resource::CursorType::None};
@@ -403,6 +422,7 @@ private:
     bool handleMouseMotion(const input::MouseMotionEvent &event);
     bool handleMouseButtonDown(const input::MouseButtonEvent &event);
     bool handleMouseButtonUp(const input::MouseButtonEvent &event);
+    bool handleDeveloperKeyDown(const input::KeyEvent &event);
 
     void onModuleSelected(const std::string &name);
     void renderHUD();
@@ -425,6 +445,14 @@ private:
 
     void renderScene();
     void renderGUI();
+    void renderDeveloperOverlay();
+    void renderDeveloperBanner();
+    void renderDeveloperTriggerOverlay(const glm::mat4 &projection, const glm::mat4 &view);
+    void renderDeveloperActorLabels(const glm::mat4 &projection, const glm::mat4 &view);
+    void renderDeveloperWatchedValues();
+    void renderDeveloperText(const std::string &text, const glm::vec3 &position, const glm::vec3 &color, graphics::TextGravity gravity = graphics::TextGravity::LeftTop);
+    void renderDeveloperPanel(const std::vector<std::string> &lines, glm::vec2 position, glm::vec3 color);
+    void renderDeveloperRect(glm::vec2 position, glm::vec2 size, glm::vec4 color);
 
     // END Rendering
 

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -66,6 +66,7 @@ public:
     const std::string &getOnFailToOpen() const { return _onFailToOpen; }
 
     int genericType() const { return _genericType; }
+    Faction faction() const { return _faction; }
     const std::string &linkedToModule() const { return _linkedToModule; }
     const std::string &linkedTo() const { return _linkedTo; }
     const std::string &transitionDestin() const { return _transitionDestin; }

--- a/include/reone/game/object/placeable.h
+++ b/include/reone/game/object/placeable.h
@@ -55,6 +55,7 @@ public:
     bool isUsable() const { return _usable; }
 
     int appearance() const { return _appearance; }
+    Faction faction() const { return _faction; }
     std::shared_ptr<scene::WalkmeshSceneNode> walkmesh() const { return _walkmesh; }
 
     // Scripts

--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -29,6 +29,13 @@ namespace game {
 
 class Trigger : public Object {
 public:
+    enum class DebugState {
+        Default,
+        Tested,
+        Inside,
+        Entered
+    };
+
     Trigger(
         uint32_t id,
         std::string sceneName,
@@ -56,6 +63,13 @@ public:
     bool isIn(const glm::vec2 &point) const;
     bool isTenant(const std::shared_ptr<Object> &object) const;
 
+    const std::vector<glm::vec3> &geometry() const { return _geometry; }
+    DebugState debugState() const;
+    glm::vec4 debugColor() const;
+
+    void markDebugTested(bool inside);
+    void markDebugEntered();
+
     const std::string &getOnEnter() const { return _onEnter; }
     const std::string &getOnExit() const { return _onExit; }
 
@@ -79,6 +93,9 @@ private:
     std::vector<glm::vec3> _geometry;
     std::set<std::shared_ptr<Object>> _tenants;
     std::string _keyName;
+    float _debugTestAge {0.0f};
+    float _debugInsideAge {0.0f};
+    float _debugEnterAge {0.0f};
 
     // Scripts
 
@@ -91,6 +108,7 @@ private:
 
     void loadTransformFromGIT(const resource::generated::GIT_TriggerList &git);
     void loadGeometryFromGIT(const resource::generated::GIT_TriggerList &git);
+    void syncDebugVisual();
 
     void loadUTT(const resource::generated::UTT &utt);
 };

--- a/include/reone/scene/node/trigger.h
+++ b/include/reone/scene/node/trigger.h
@@ -53,8 +53,13 @@ public:
 
     bool isIn(const glm::vec2 &pt) const;
 
+    void setDebugColor(glm::vec4 color) {
+        _debugColor = std::move(color);
+    }
+
 private:
     std::vector<glm::vec3> _geometry;
+    glm::vec4 _debugColor {0.48f, 0.74f, 1.0f, 1.0f};
 
     std::unique_ptr<graphics::Mesh> _mesh;
 };

--- a/include/reone/system/logger.h
+++ b/include/reone/system/logger.h
@@ -34,6 +34,8 @@ public:
                 LogChannel channel,
                 LogSeverity severity);
 
+    void flush();
+
     bool isChannelEnabled(LogChannel channel) const {
         return _enabledChannels.count(channel) > 0;
     }

--- a/src/apps/engine/main.cpp
+++ b/src/apps/engine/main.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "reone/system/logger.h"
+#include "reone/system/logutil.h"
 #include "reone/system/threadutil.h"
 
 #include "engine.h"
@@ -31,6 +32,7 @@ using namespace reone;
 using namespace reone::graphics;
 
 static constexpr char kLogFilename[] = "engine.log";
+static constexpr char kEngineStartupMessage[] = "reone smoke signal: engine startup";
 
 int main(int argc, char **argv) {
 #ifdef _WIN32
@@ -48,6 +50,8 @@ int main(int argc, char **argv) {
     }
     try {
         Logger::instance.init(options->logging.severity, options->logging.channels, kLogFilename);
+        info(kEngineStartupMessage);
+        Logger::instance.flush();
     } catch (const std::exception &ex) {
         std::cerr << "Error initializing logging: " << ex.what() << std::endl;
         return 2;

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -35,6 +35,7 @@
 #include "reone/game/surfaces.h"
 #include "reone/graphics/context.h"
 #include "reone/graphics/di/services.h"
+#include "reone/graphics/font.h"
 #include "reone/graphics/format/tgawriter.h"
 #include "reone/graphics/meshregistry.h"
 #include "reone/graphics/renderbuffer.h"
@@ -53,6 +54,7 @@
 #include "reone/resource/provider/audioclips.h"
 #include "reone/resource/provider/cursors.h"
 #include "reone/resource/provider/dialogs.h"
+#include "reone/resource/provider/fonts.h"
 #include "reone/resource/provider/gffs.h"
 #include "reone/resource/provider/lips.h"
 #include "reone/resource/provider/models.h"
@@ -86,6 +88,125 @@ using namespace reone::script;
 namespace reone {
 
 namespace game {
+
+static constexpr char kDeveloperOverlayToggleHelp[] = "Ctrl+Shift+D";
+static constexpr char kDeveloperTriggerToggleHelp[] = "Ctrl+Shift+T";
+static constexpr char kDeveloperActorToggleHelp[] = "Ctrl+Shift+A";
+static constexpr char kDeveloperActorLongToggleHelp[] = "Ctrl+Shift+L";
+static constexpr char kDeveloperWatchToggleHelp[] = "Ctrl+Shift+W";
+static constexpr float kDeveloperActorLabelDistance = 32.0f;
+
+static const char *screenName(Game::Screen screen) {
+    switch (screen) {
+    case Game::Screen::None:
+        return "None";
+    case Game::Screen::MainMenu:
+        return "MainMenu";
+    case Game::Screen::Loading:
+        return "Loading";
+    case Game::Screen::CharacterGeneration:
+        return "CharacterGeneration";
+    case Game::Screen::InGame:
+        return "InGame";
+    case Game::Screen::InGameMenu:
+        return "InGameMenu";
+    case Game::Screen::Conversation:
+        return "Conversation";
+    case Game::Screen::Container:
+        return "Container";
+    case Game::Screen::PartySelection:
+        return "PartySelection";
+    case Game::Screen::SaveLoad:
+        return "SaveLoad";
+    default:
+        return "Unknown";
+    }
+}
+
+static const char *cameraTypeName(CameraType type) {
+    switch (type) {
+    case CameraType::FirstPerson:
+        return "FirstPerson";
+    case CameraType::ThirdPerson:
+        return "ThirdPerson";
+    case CameraType::Static:
+        return "Static";
+    case CameraType::Animated:
+        return "Animated";
+    case CameraType::Dialog:
+        return "Dialog";
+    default:
+        return "Unknown";
+    }
+}
+
+static const char *objectTypeName(ObjectType type) {
+    switch (type) {
+    case ObjectType::Creature:
+        return "creature";
+    case ObjectType::Item:
+        return "item";
+    case ObjectType::Trigger:
+        return "trigger";
+    case ObjectType::Door:
+        return "door";
+    case ObjectType::Waypoint:
+        return "waypoint";
+    case ObjectType::Placeable:
+        return "placeable";
+    case ObjectType::Store:
+        return "store";
+    case ObjectType::Encounter:
+        return "encounter";
+    case ObjectType::Sound:
+        return "sound";
+    case ObjectType::Module:
+        return "module";
+    case ObjectType::Area:
+        return "area";
+    case ObjectType::Room:
+        return "room";
+    case ObjectType::Camera:
+        return "camera";
+    default:
+        return "object";
+    }
+}
+
+static bool isDeveloperOverlayChord(const input::KeyEvent &event) {
+    bool control = (event.mod & input::KeyModifiers::control) != 0;
+    bool shift = (event.mod & input::KeyModifiers::shift) != 0;
+    return control && shift;
+}
+
+static const char *triggerDebugStateName(Trigger::DebugState state) {
+    switch (state) {
+    case Trigger::DebugState::Entered:
+        return "enter";
+    case Trigger::DebugState::Inside:
+        return "inside";
+    case Trigger::DebugState::Tested:
+        return "tested";
+    default:
+        return "default";
+    }
+}
+
+static int getDebugFaction(const std::shared_ptr<Object> &object) {
+    if (!object) {
+        return -1;
+    }
+    if (auto creature = dyn_cast<Creature>(object)) {
+        return static_cast<int>(creature->faction());
+    }
+    if (auto door = dyn_cast<Door>(object)) {
+        return static_cast<int>(door->faction());
+    }
+    if (auto placeable = dyn_cast<Placeable>(object)) {
+        return static_cast<int>(placeable->faction());
+    }
+    return -1;
+}
 
 void Game::init() {
     initConsole();
@@ -254,6 +375,10 @@ bool Game::handleKeyDown(const input::KeyEvent &event) {
     if (event.repeat)
         return false;
 
+    if (handleDeveloperKeyDown(event)) {
+        return true;
+    }
+
     switch (event.code) {
     case input::KeyCode::Minus:
         if (_options.game.developer && _gameSpeed > 1.0f) {
@@ -281,6 +406,59 @@ bool Game::handleKeyDown(const input::KeyEvent &event) {
     }
 
     return false;
+}
+
+bool Game::handleDeveloperKeyDown(const input::KeyEvent &event) {
+    if (!_options.game.developer || _screen != Screen::InGame) {
+        return false;
+    }
+    if (!isDeveloperOverlayChord(event)) {
+        return false;
+    }
+
+    switch (event.code) {
+    case input::KeyCode::D:
+        _developerOverlay.visible = !_developerOverlay.visible;
+        return true;
+    case input::KeyCode::T:
+        if (!_developerOverlay.visible) {
+            _developerOverlay.visible = true;
+            _developerOverlay.triggers = true;
+        } else {
+            _developerOverlay.triggers = !_developerOverlay.triggers;
+        }
+        return true;
+    case input::KeyCode::A:
+        if (!_developerOverlay.visible) {
+            _developerOverlay.visible = true;
+            _developerOverlay.actorLabels = true;
+        } else {
+            _developerOverlay.actorLabels = !_developerOverlay.actorLabels;
+        }
+        return true;
+    case input::KeyCode::L:
+        if (!_developerOverlay.visible) {
+            _developerOverlay.visible = true;
+            _developerOverlay.actorLabels = true;
+            _developerOverlay.longActorLabels = true;
+        } else if (!_developerOverlay.actorLabels) {
+            _developerOverlay.actorLabels = true;
+            _developerOverlay.longActorLabels = true;
+        } else {
+            _developerOverlay.longActorLabels = !_developerOverlay.longActorLabels;
+        }
+        return true;
+    case input::KeyCode::W:
+        if (!_developerOverlay.visible) {
+            _developerOverlay.visible = true;
+            _developerOverlay.watchedValues = true;
+        } else {
+            _developerOverlay.watchedValues = !_developerOverlay.watchedValues;
+        }
+        return true;
+    default:
+        return false;
+    }
 }
 
 bool Game::handleMouseMotion(const input::MouseMotionEvent &event) {
@@ -517,6 +695,292 @@ void Game::renderGUI() {
     if (_cursor && !_relativeMouseMode) {
         _cursor->render();
     }
+    renderDeveloperOverlay();
+}
+
+void Game::renderDeveloperOverlay() {
+    if (!_options.game.developer || !_developerOverlay.visible || !_module || _screen != Screen::InGame) {
+        return;
+    }
+    if (!_developerFont) {
+        _developerFont = _services.resource.fonts.get("fnt_console");
+    }
+    if (!_developerFont) {
+        return;
+    }
+
+    auto camera = getActiveCamera();
+    bool hasCamera = camera != nullptr;
+    glm::mat4 projection(1.0f);
+    glm::mat4 view(1.0f);
+    if (camera) {
+        projection = camera->cameraSceneNode()->camera()->projection();
+        view = camera->cameraSceneNode()->camera()->view();
+    }
+
+    _services.graphics.uniforms.setGlobals([this](auto &globals) {
+        globals.reset();
+        globals.projection = glm::ortho(
+            0.0f,
+            static_cast<float>(_options.graphics.width),
+            static_cast<float>(_options.graphics.height),
+            0.0f, 0.0f, 100.0f);
+        globals.projectionInv = glm::inverse(globals.projection);
+    });
+    _services.graphics.context.withBlendMode(BlendMode::Normal, [this]() {
+        renderDeveloperBanner();
+    });
+    _services.graphics.context.withBlendMode(BlendMode::Normal, [this, hasCamera, &projection, &view]() {
+        if (_developerOverlay.triggers && hasCamera) {
+            renderDeveloperTriggerOverlay(projection, view);
+        }
+        if (_developerOverlay.actorLabels && hasCamera) {
+            renderDeveloperActorLabels(projection, view);
+        }
+        if (_developerOverlay.watchedValues) {
+            renderDeveloperWatchedValues();
+        }
+    });
+}
+
+void Game::renderDeveloperBanner() {
+    std::vector<std::string> lines;
+    lines.push_back("DEV OBSERVABILITY");
+    lines.push_back(str(boost::format("%s overlay | %s triggers") %
+                        kDeveloperOverlayToggleHelp %
+                        kDeveloperTriggerToggleHelp));
+    lines.push_back(str(boost::format("%s labels (%s) | %s verbose") %
+                        kDeveloperActorToggleHelp %
+                        (_developerOverlay.longActorLabels ? "long" : "short") %
+                        kDeveloperActorLongToggleHelp));
+    lines.push_back(str(boost::format("%s watch | ` console | F5 profiler") %
+                        kDeveloperWatchToggleHelp));
+    lines.push_back("V camera | +/- speed");
+
+    float maxWidth = 0.0f;
+    for (const auto &line : lines) {
+        maxWidth = glm::max(maxWidth, _developerFont->measure(line));
+    }
+    renderDeveloperPanel(
+        lines,
+        glm::vec2(0.5f * (static_cast<float>(_options.graphics.width) - maxWidth - 14.0f), 12.0f),
+        glm::vec3(0.58f, 1.0f, 0.58f));
+}
+
+void Game::renderDeveloperTriggerOverlay(const glm::mat4 &projection, const glm::mat4 &view) {
+    static glm::vec4 viewport(0.0f, 0.0f, 1.0f, 1.0f);
+    auto area = _module ? _module->area() : nullptr;
+    if (!area) {
+        return;
+    }
+
+    const auto &opts = _options.graphics;
+    for (const auto &object : area->getObjectsByType(ObjectType::Trigger)) {
+        auto trigger = dyn_cast<Trigger>(object);
+        if (!trigger) {
+            continue;
+        }
+        const auto &geometry = trigger->geometry();
+        if (geometry.empty()) {
+            continue;
+        }
+
+        glm::vec3 centroid(0.0f);
+        for (const auto &localPoint : geometry) {
+            centroid += trigger->position() + localPoint;
+        }
+
+        // Trigger geometry now renders through the main scene pipeline; the overlay only adds labels.
+        auto state = trigger->debugState();
+        glm::vec4 color = trigger->debugColor();
+        centroid /= static_cast<float>(geometry.size());
+        glm::vec3 labelScreen = glm::project(centroid, view, projection, viewport);
+        if (labelScreen.z >= 0.0f && labelScreen.z < 1.0f) {
+            std::string label = str(boost::format("#%u %s") %
+                                    trigger->id() %
+                                    trigger->tag());
+            if (!trigger->blueprintResRef().empty()) {
+                label += " " + trigger->blueprintResRef();
+            }
+            label += str(boost::format(" [%s]") % triggerDebugStateName(state));
+            glm::vec3 position(opts.width * labelScreen.x, opts.height * (1.0f - labelScreen.y), 0.0f);
+            renderDeveloperText(label, position, glm::vec3(color), TextGravity::CenterBottom);
+        }
+    }
+}
+
+void Game::renderDeveloperActorLabels(const glm::mat4 &projection, const glm::mat4 &view) {
+    auto area = _module ? _module->area() : nullptr;
+    auto leader = _party.getLeader();
+    if (!area || !leader) {
+        return;
+    }
+
+    const auto &opts = _options.graphics;
+    int rendered = 0;
+    for (const auto &object : area->objects()) {
+        bool supported = object->type() == ObjectType::Creature ||
+                         object->type() == ObjectType::Door ||
+                         object->type() == ObjectType::Placeable;
+        bool inspected = object == area->hilightedObject() || object == area->selectedObject();
+        if (!supported && !inspected) {
+            continue;
+        }
+
+        float distance = object->getDistanceTo(*leader);
+        if (!inspected && distance > kDeveloperActorLabelDistance) {
+            continue;
+        }
+
+        glm::vec3 screen = area->getSelectableScreenCoords(object, projection, view);
+        if (screen.z >= 1.0f) {
+            continue;
+        }
+
+        int faction = getDebugFaction(object);
+        bool hostile = false;
+        auto creature = dyn_cast<Creature>(object);
+        if (creature) {
+            hostile = !creature->isDead() && _services.game.reputes.getIsEnemy(*leader, *creature);
+        }
+
+        glm::vec3 color = inspected ? glm::vec3(1.0f, 1.0f, 1.0f) : (hostile ? glm::vec3(1.0f, 0.42f, 0.36f) : glm::vec3(0.68f, 0.92f, 1.0f));
+        std::string label;
+        if (_developerOverlay.longActorLabels) {
+            label = str(boost::format("#%u %s %s f=%d H=%d sel=%d cmd=%d vis=%d plot=%d") %
+                        object->id() %
+                        object->tag() %
+                        object->blueprintResRef() %
+                        faction %
+                        static_cast<int>(hostile) %
+                        static_cast<int>(object->isSelectable()) %
+                        static_cast<int>(object->isCommandable()) %
+                        static_cast<int>(object->visible()) %
+                        static_cast<int>(object->plotFlag()));
+        } else {
+            label = str(boost::format("#%u %s") %
+                        object->id() %
+                        object->tag());
+            if (!object->blueprintResRef().empty()) {
+                label += " " + object->blueprintResRef();
+            }
+            if (hostile) {
+                label += " [enemy]";
+            }
+            if (inspected) {
+                label += str(boost::format(" [%s") % objectTypeName(object->type()));
+                if (faction >= 0) {
+                    label += str(boost::format(" f=%d") % faction);
+                }
+                label += "]";
+            }
+        }
+
+        glm::vec3 position(opts.width * screen.x, opts.height * (1.0f - screen.y) - 18.0f - (rendered % 2) * 10.0f, 0.0f);
+        renderDeveloperText(label, position, color, TextGravity::CenterBottom);
+        if (++rendered >= 16) {
+            break;
+        }
+    }
+}
+
+void Game::renderDeveloperWatchedValues() {
+    auto area = _module ? _module->area() : nullptr;
+    auto leader = _party.getLeader();
+    auto selected = area ? area->selectedObject() : nullptr;
+    auto hover = area ? area->hilightedObject() : nullptr;
+    std::string room = leader && leader->room() ? leader->room()->name() : "-";
+    glm::vec3 position = leader ? leader->position() : glm::vec3(0.0f);
+
+    std::vector<std::string> lines;
+    lines.push_back(str(boost::format("Watch (%s)") % kDeveloperWatchToggleHelp));
+    lines.push_back(str(boost::format("screen=%s module=%s area=%s camera=%s") %
+                        screenName(_screen) %
+                        (_module ? _module->name() : "-") %
+                        (area ? area->localizedName() : "-") %
+                        cameraTypeName(_cameraType)));
+    lines.push_back(str(boost::format("speed=%.1fx paused=%d relativeMouse=%d room=%s") %
+                        _gameSpeed %
+                        static_cast<int>(_paused) %
+                        static_cast<int>(_relativeMouseMode) %
+                        room));
+    lines.push_back(str(boost::format("leader=#%u %s hp=%d/%d pos=%.2f,%.2f,%.2f") %
+                        (leader ? leader->id() : 0) %
+                        (leader ? leader->tag() : "-") %
+                        (leader ? leader->currentHitPoints() : -1) %
+                        (leader ? leader->maxHitPoints() : -1) %
+                        position.x %
+                        position.y %
+                        position.z));
+    lines.push_back(str(boost::format("selected=#%u %s/%s type=%s hp=%d/%d") %
+                        (selected ? selected->id() : 0) %
+                        (selected ? selected->tag() : "-") %
+                        (selected ? selected->blueprintResRef() : "-") %
+                        (selected ? objectTypeName(selected->type()) : "-") %
+                        (selected ? selected->currentHitPoints() : -1) %
+                        (selected ? selected->maxHitPoints() : -1)));
+    lines.push_back(str(boost::format("hover=#%u %s/%s type=%s hp=%d/%d") %
+                        (hover ? hover->id() : 0) %
+                        (hover ? hover->tag() : "-") %
+                        (hover ? hover->blueprintResRef() : "-") %
+                        (hover ? objectTypeName(hover->type()) : "-") %
+                        (hover ? hover->currentHitPoints() : -1) %
+                        (hover ? hover->maxHitPoints() : -1)));
+
+    float maxWidth = 0.0f;
+    for (const auto &line : lines) {
+        maxWidth = glm::max(maxWidth, _developerFont->measure(line));
+    }
+    float panelWidth = maxWidth + 14.0f;
+    float panelHeight = (_developerFont->height() + 2.0f) * static_cast<float>(lines.size()) + 10.0f;
+    renderDeveloperPanel(
+        lines,
+        glm::vec2(static_cast<float>(_options.graphics.width) - panelWidth - 4.0f, 16.0f + panelHeight),
+        glm::vec3(0.92f));
+}
+
+void Game::renderDeveloperText(const std::string &text, const glm::vec3 &position, const glm::vec3 &color, TextGravity gravity) {
+    if (!_developerFont) {
+        return;
+    }
+    _developerFont->render(text, position + glm::vec3(1.0f, 1.0f, 0.0f), glm::vec3(0.0f), gravity);
+    _developerFont->render(text, position, color, gravity);
+}
+
+void Game::renderDeveloperPanel(const std::vector<std::string> &lines, glm::vec2 position, glm::vec3 color) {
+    if (!_developerFont || lines.empty()) {
+        return;
+    }
+
+    float maxWidth = 0.0f;
+    for (const auto &line : lines) {
+        maxWidth = glm::max(maxWidth, _developerFont->measure(line));
+    }
+    float lineHeight = _developerFont->height() + 2.0f;
+    glm::vec2 size(maxWidth + 14.0f, lineHeight * lines.size() + 10.0f);
+    position.x = glm::clamp(position.x, 4.0f, static_cast<float>(_options.graphics.width) - size.x - 4.0f);
+    position.y = glm::clamp(position.y, 4.0f, static_cast<float>(_options.graphics.height) - size.y - 4.0f);
+
+    renderDeveloperRect(position, size, glm::vec4(0.0f, 0.0f, 0.0f, 0.58f));
+    glm::vec3 textPosition(position.x + 7.0f, position.y + 5.0f, 0.0f);
+    for (const auto &line : lines) {
+        renderDeveloperText(line, textPosition, color, TextGravity::RightBottom);
+        textPosition.y += lineHeight;
+    }
+}
+
+void Game::renderDeveloperRect(glm::vec2 position, glm::vec2 size, glm::vec4 color) {
+    glm::mat4 transform(1.0f);
+    transform = glm::translate(transform, glm::vec3(position.x, position.y, 0.0f));
+    transform = glm::scale(transform, glm::vec3(size.x, size.y, 1.0f));
+
+    _services.graphics.uniforms.setLocals([transform, color](auto &locals) {
+        locals.reset();
+        locals.model = transform;
+        locals.color = color;
+    });
+    _services.graphics.context.useProgram(_services.graphics.shaderRegistry.get(ShaderProgramId::mvpColor));
+    _services.graphics.meshRegistry.get(MeshName::quad).draw(_services.graphics.statistic);
 }
 
 void Game::updateMusic() {
@@ -643,7 +1107,11 @@ void Game::updateSceneGraph(float dt) {
     sceneGraph.setUpdateRoots(!_paused);
     sceneGraph.setRenderAABB(isShowAABBEnabled());
     sceneGraph.setRenderWalkmeshes(isShowWalkmeshEnabled());
-    sceneGraph.setRenderTriggers(isShowTriggersEnabled());
+    bool renderDeveloperTriggers = _options.game.developer &&
+                                   _screen == Screen::InGame &&
+                                   _developerOverlay.visible &&
+                                   _developerOverlay.triggers;
+    sceneGraph.setRenderTriggers(isShowTriggersEnabled() || renderDeveloperTriggers);
     sceneGraph.update(dt);
 }
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -877,11 +877,14 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer) 
 
     for (auto &object : _objectsByType[ObjectType::Trigger]) {
         auto trigger = std::static_pointer_cast<Trigger>(object);
-        if (trigger->isTenant(triggerrer) || !trigger->isIn(position2d)) {
+        bool inside = trigger->isIn(position2d);
+        trigger->markDebugTested(inside);
+        if (trigger->isTenant(triggerrer) || !inside) {
             continue;
         }
         debug(str(boost::format("Trigger '%s' triggerred by '%s'") % trigger->tag() % triggerrer->tag()));
         trigger->addTenant(triggerrer);
+        trigger->markDebugEntered();
 
         if (!trigger->linkedToModule().empty()) {
             _game.scheduleModuleTransition(trigger->linkedToModule(), trigger->linkedTo());

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -37,6 +37,23 @@ namespace reone {
 
 namespace game {
 
+static constexpr float kDebugTestDuration = 0.25f;
+static constexpr float kDebugInsideDuration = 0.25f;
+static constexpr float kDebugEnterDuration = 1.5f;
+
+static glm::vec4 debugColorForState(Trigger::DebugState state) {
+    switch (state) {
+    case Trigger::DebugState::Entered:
+        return glm::vec4(1.0f, 0.42f, 0.12f, 0.95f);
+    case Trigger::DebugState::Inside:
+        return glm::vec4(0.16f, 0.95f, 0.38f, 0.95f);
+    case Trigger::DebugState::Tested:
+        return glm::vec4(1.0f, 0.88f, 0.18f, 0.95f);
+    default:
+        return glm::vec4(0.48f, 0.74f, 1.0f, 0.85f);
+    }
+}
+
 void Trigger::loadFromGIT(const resource::generated::GIT_TriggerList &git) {
     std::string templateResRef(boost::to_lower_copy(git.TemplateResRef));
     loadFromBlueprint(templateResRef);
@@ -53,6 +70,7 @@ void Trigger::loadFromGIT(const resource::generated::GIT_TriggerList &git) {
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
     _sceneNode = sceneGraph.newTrigger(_geometry);
     _sceneNode->setLocalTransform(glm::translate(_position));
+    syncDebugVisual();
 }
 
 void Trigger::loadTransformFromGIT(const resource::generated::GIT_TriggerList &git) {
@@ -85,6 +103,10 @@ void Trigger::loadFromBlueprint(const std::string &resRef) {
 void Trigger::update(float dt) {
     Object::update(dt);
 
+    _debugTestAge = glm::max(0.0f, _debugTestAge - dt);
+    _debugInsideAge = glm::max(0.0f, _debugInsideAge - dt);
+    _debugEnterAge = glm::max(0.0f, _debugEnterAge - dt);
+
     std::set<std::shared_ptr<Object>> tenantsToRemove;
     for (auto &tenant : _tenants) {
         if (tenant) {
@@ -106,10 +128,13 @@ void Trigger::update(float dt) {
             {{script::ArgKind::Caller, script::Variable::ofObject(_id)},
              {script::ArgKind::ExitingObject, script::Variable::ofObject(tenant->id())}});
     }
+
+    syncDebugVisual();
 }
 
 void Trigger::addTenant(const std::shared_ptr<Object> &object) {
     _tenants.insert(object);
+    syncDebugVisual();
     if (_onEnter.empty()) {
         return;
     }
@@ -128,6 +153,43 @@ bool Trigger::isIn(const glm::vec2 &point) const {
 bool Trigger::isTenant(const std::shared_ptr<Object> &object) const {
     auto maybeTenant = find(_tenants.begin(), _tenants.end(), object);
     return maybeTenant != _tenants.end();
+}
+
+Trigger::DebugState Trigger::debugState() const {
+    if (_debugEnterAge > 0.0f) {
+        return DebugState::Entered;
+    }
+    if (!_tenants.empty() || _debugInsideAge > 0.0f) {
+        return DebugState::Inside;
+    }
+    if (_debugTestAge > 0.0f) {
+        return DebugState::Tested;
+    }
+    return DebugState::Default;
+}
+
+glm::vec4 Trigger::debugColor() const {
+    return debugColorForState(debugState());
+}
+
+void Trigger::markDebugTested(bool inside) {
+    _debugTestAge = kDebugTestDuration;
+    if (inside) {
+        _debugInsideAge = kDebugInsideDuration;
+    }
+    syncDebugVisual();
+}
+
+void Trigger::markDebugEntered() {
+    _debugEnterAge = kDebugEnterDuration;
+    syncDebugVisual();
+}
+
+void Trigger::syncDebugVisual() {
+    if (!_sceneNode) {
+        return;
+    }
+    static_cast<TriggerSceneNode *>(_sceneNode.get())->setDebugColor(debugColor());
 }
 
 void Trigger::loadUTT(const resource::generated::UTT &utt) {

--- a/src/libs/scene/node/trigger.cpp
+++ b/src/libs/scene/node/trigger.cpp
@@ -102,9 +102,14 @@ void TriggerSceneNode::init() {
 }
 
 void TriggerSceneNode::render(IRenderPass &pass) {
+    _graphicsSvc.uniforms.setWalkmesh([this](auto &walkmesh) {
+        walkmesh.materials[kMaxWalkmeshMaterials - 1] = _debugColor;
+    });
+
     Material material;
     material.type = MaterialType::Walkmesh;
-    material.faceCulling = FaceCullMode::Back;
+    material.faceCulling = FaceCullMode::None;
+    material.polygonMode = PolygonMode::Line;
     pass.draw(*_mesh, material, _absTransform, _absTransformInv);
 }
 

--- a/src/libs/system/logger.cpp
+++ b/src/libs/system/logger.cpp
@@ -98,6 +98,13 @@ void Logger::append(std::string message,
     }
 }
 
+void Logger::flush() {
+    if (!_inited || !buffer) {
+        return;
+    }
+    flush(buffer->get());
+}
+
 void Logger::flush(std::ostringstream &buffer) {
     if (!_stream) {
         return;
@@ -106,6 +113,7 @@ void Logger::flush(std::ostringstream &buffer) {
     {
         std::lock_guard<std::mutex> lock {_streamMutex};
         _stream->write(&str[0], str.length());
+        _stream->flush();
     }
     buffer.str("");
 }


### PR DESCRIPTION
## Summary

This PR contains the developer-observability work split out from the earlier mixed branch.

Included:
- developer observability overlay / watch panel / hotkey help
- trigger visualisation rendered through the main scene pipeline
- fix for the trigger visualiser projection/distortion issue
- short/long actor labels (`Ctrl+Shift+A` / `Ctrl+Shift+L`)
- `dyn_cast` downcasts in this code path
- small overlay/watch-panel layout cleanups

Not included:
- gameplay/runtime dialogue progression fixes
- trigger delayed-action / action-semantics fixes
- movie/audio fixes
- docs/scripts/evals/log junk

## Verification

- manual in-game validation of trigger outlines across camera angles
- manual validation of short/verbose labels
- manual validation of overlay/watch panel behaviour
- local Windows Release build passed
- local unit tests passed
- combined smoke-stack test passed

## Expected sibling PR overlap

This branch may need a small follow-up rebase if a sibling PR lands first.

Expected overlap is limited to:
- `src/libs/game/object/area.cpp`
- `src/libs/game/object/trigger.cpp`
- `include/reone/game/game.h`
- `src/libs/game/game.cpp`

The overlap is expected because the split is by concern rather than by touched file.
