### PR TITLE
Fix trigger action updates and dialogue continuation semantics

### DIFF
--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -256,6 +256,7 @@ protected:
 
     std::deque<std::shared_ptr<Action>> _actions;
     std::vector<DelayedAction> _delayed;
+    std::weak_ptr<Action> _executingAction;
 
     // END Actions
 

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -65,6 +65,26 @@ void Object::setLocalNumber(int index, int value) {
 }
 
 void Object::clearAllActions(bool force) {
+    // If the current front action clears the queue while it is executing, keep
+    // that action and its queued continuation alive instead of trimming from the
+    // back and deleting the follow-up it is about to hand off to.
+    if (!force) {
+        auto executingAction = _executingAction.lock();
+        if (executingAction) {
+            while (!_actions.empty() && _actions.front() != executingAction) {
+                const std::shared_ptr<Action> &action = _actions.front();
+                if (action->locked()) {
+                    break;
+                }
+                action->cancel(action, *this);
+                _actions.pop_front();
+            }
+            if (!_actions.empty() && _actions.front() == executingAction) {
+                return;
+            }
+        }
+    }
+
     while (!_actions.empty()) {
         const std::shared_ptr<Action> &action = _actions.back();
         if (!force && action->locked()) {
@@ -129,7 +149,14 @@ void Object::executeActions(float dt) {
         return;
     }
     std::shared_ptr<Action> action(_actions.front());
-    action->execute(action, *this, dt);
+    _executingAction = action;
+    try {
+        action->execute(action, *this, dt);
+    } catch (...) {
+        _executingAction.reset();
+        throw;
+    }
+    _executingAction.reset();
 }
 
 bool Object::hasUserActionsPending() const {

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -802,7 +802,7 @@ void Area::startDialog(const std::shared_ptr<Object> &object, const std::string 
     if (resRef.empty()) {
         finalResRef = object->conversation();
     }
-    if (resRef.empty()) {
+    if (finalResRef.empty()) {
         return;
     }
     _game.startDialog(object, finalResRef);

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -83,6 +83,8 @@ void Trigger::loadFromBlueprint(const std::string &resRef) {
 }
 
 void Trigger::update(float dt) {
+    Object::update(dt);
+
     std::set<std::shared_ptr<Object>> tenantsToRemove;
     for (auto &tenant : _tenants) {
         if (tenant) {


### PR DESCRIPTION
## Summary

This PR contains the gameplay/runtime fixes split out from the earlier mixed branch.

Included:
- trigger `Object::update(dt)` fix so delayed/queued trigger actions actually advance
- dialogue continuation fix around `ClearAllActions()`
- the gameplay/runtime semantics behind the Endar Spire / Trask / Carth progression fixes
- `Area::startDialog()` fix to use the resolved conversation resref

Not included:
- developer observability tools
- movie/audio suppression changes
- docs/scripts/evals/log junk

## ClearAllActions note

The failure mode here is that the currently executing front action can call `ClearAllActions()` on its owner while it is still running. The old implementation trims from the back, which can delete the queued continuation that the current action is about to hand off to.

This PR tracks the currently executing action via `_executingAction` and preserves that active front action and its continuation chain when `clearAllActions(false)` is called during execution.

I did not use a temporary `Action::lock()` approach here because the goal is not just to preserve the executing action object; it is to preserve the active front-of-queue handoff/continuation semantics without changing the broader action-locking model.

## Verification

- manual Endar Spire progression validation covering the affected sequence/dialogue flow
- local Windows Release build passed
- local unit tests passed
- combined smoke-stack test passed

## Expected sibling PR overlap

This branch may need a small follow-up rebase if the dev-tools PR lands first.

Expected overlap is limited to:
- `src/libs/game/object/area.cpp`
- `src/libs/game/object/trigger.cpp`
