### PR TITLE
[game][gui] Fix crash when opening K2 containers

### DIFF
--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -19,18 +19,22 @@
 
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
-#include "reone/game/object/placeable.h"
+#include "reone/game/object/creature.h"
 
 namespace reone {
 
 namespace game {
 
 void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    auto creatureActor = _game.getObjectById<Creature>(actor.id());
-    auto placeable = std::static_pointer_cast<Placeable>(_object);
-    bool reached = creatureActor->navigateTo(placeable->position(), true, kDefaultMaxObjectDistance, dt);
+    if (!_object || actor.type() != ObjectType::Creature) {
+        complete();
+        return;
+    }
+
+    auto &creatureActor = static_cast<Creature &>(actor);
+    bool reached = creatureActor.navigateTo(_object->position(), true, kDefaultMaxObjectDistance, dt);
     if (reached) {
-        _game.openContainer(placeable);
+        _game.openContainer(_object);
         complete();
     }
 }

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -26,7 +26,7 @@ namespace reone {
 namespace game {
 
 void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    if (!_object || actor.type() != ObjectType::Creature) {
+    if (!_object || !isa<Creature>(actor)) {
         complete();
         return;
     }

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -31,7 +31,7 @@ void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, f
         return;
     }
 
-    auto &creatureActor = static_cast<Creature &>(actor);
+    auto &creatureActor = cast<Creature>(actor);
     bool reached = creatureActor.navigateTo(_object->position(), true, kDefaultMaxObjectDistance, dt);
     if (reached) {
         _game.openContainer(_object);

--- a/src/libs/gui/control/imagebutton.cpp
+++ b/src/libs/gui/control/imagebutton.cpp
@@ -43,6 +43,9 @@ static const char kIconFontResRef[] = "dialogfont10x10a";
 void ImageButton::load(const resource::generated::GUI_BASECONTROL &gui, bool protoItem) {
     Control::load(gui, protoItem);
     _iconFont = _resourceSvc.fonts.get(kIconFontResRef);
+    if (!_iconFont) {
+        _iconFont = _text.font;
+    }
 }
 
 void ImageButton::render(
@@ -106,7 +109,7 @@ void ImageButton::renderIcon(
             {_extent.height, _extent.height});
     }
 
-    if (!iconText.empty()) {
+    if (!iconText.empty() && _iconFont) {
         glm::vec3 position(0.0f);
         position.x = static_cast<float>(offset.x + _extent.left + _extent.height);
         position.y = static_cast<float>(offset.y + _extent.top + _extent.height - 0.5f * _iconFont->height());


### PR DESCRIPTION
## Summary

Fixes crashes when opening certain KOTOR 2 containers.

The container action path now keeps the original object target instead of assuming every container target is a placeable. This avoids unsafe placeable-only handling for object-shaped container targets such as corpse loot.

Also guards image-button icon rendering when the icon font is unavailable, falling back to the control text font where possible.

## Testing

- Built `engine` and `launcher` in `RelWithDebInfo` on Windows
- Ran `git diff --check upstream/master...HEAD`
- Verified branch diff only includes:
  - `src/libs/game/action/opencontainer.cpp`
  - `src/libs/gui/control/imagebutton.cpp`

## Manual verification

- K2: open loot container / corpse container without crashing
- K2: container UI appears
- K1: open normal container as regression smoke
