### PR TITLE
[game] Initialize skill icons for context actions

### DIFF
--- a/src/libs/game/di/module.cpp
+++ b/src/libs/game/di/module.cpp
@@ -56,6 +56,7 @@ void GameModule::init() {
     _portraits->init();
     _reputes->init();
     _feats->init();
+    _skills->init();
     _spells->init();
     _surfaces->init();
     _projectiles->init();


### PR DESCRIPTION
## Summary

Initializes the skills service during game module setup so skill-backed context actions can resolve their icons.

This fixes missing/invisible icons for context actions such as Security while preserving the existing action eligibility rules.

## Testing

- Built `engine` and `launcher` in `RelWithDebInfo` on Windows
- Ran `git diff --check upstream/master...HEAD`
- Verified branch diff only includes:
  - `src/libs/game/di/module.cpp`

## Manual verification

- K1 Endar Spire: Trask's Security context action appears with a visible icon
- K1 Dantooine: Security icon appears only for party members with Security
- Unlocked doors still show normal interaction, not Security
