### PR TITLE
[game] Add bash support for eligible doors

### DIFF
--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -51,6 +51,7 @@ public:
     void loadFromBlueprint(const std::string &resRef);
 
     bool isSelectable() const override;
+    void damage(int amount, uint32_t damager) override;
 
     void open();
     void close();
@@ -58,6 +59,7 @@ public:
     bool isLocked() const { return _locked; }
     bool isStatic() const { return _static; }
     bool isKeyRequired() const { return _keyRequired; }
+    bool isNotBlastable() const { return _notBlastable; }
 
     void onOpen(const Object &triggerer);
     void onFailToOpen(const Object &triggerer);
@@ -95,6 +97,7 @@ private:
     int _hardness {0};
     int _fortitude {0};
     bool _lockable {false};
+    bool _notBlastable {false};
     std::string _keyName;
 
     // Walkmeshes
@@ -121,6 +124,8 @@ private:
 
     void loadUTD(const resource::generated::UTD &utd);
     void loadTransformFromGIT(const resource::generated::GIT_Door_List &git);
+    void runDamagedScript(uint32_t damagerId);
+    void runDeathScript(uint32_t damagerId);
 
     void updateTransform() override;
 };

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -61,7 +61,7 @@ public:
     bool isKeyRequired() const { return _keyRequired; }
     bool isNotBlastable() const { return _notBlastable; }
 
-    void onOpen(const Object &triggerer);
+    void onOpen(uint32_t triggererId);
     void onFailToOpen(const Object &triggerer);
 
     const std::string &getOnOpen() const { return _onOpen; }

--- a/include/reone/game/reputes.h
+++ b/include/reone/game/reputes.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "types.h"
+
 namespace reone {
 
 namespace resource {
@@ -34,6 +36,7 @@ public:
     virtual ~IReputes() = default;
 
     virtual bool getIsEnemy(const Creature &left, const Creature &right) const = 0;
+    virtual bool getIsEnemy(Faction left, Faction right) const = 0;
     virtual bool getIsFriend(const Creature &left, const Creature &right) const = 0;
     virtual bool getIsNeutral(const Creature &left, const Creature &right) const = 0;
 };
@@ -47,13 +50,14 @@ public:
     void init();
 
     bool getIsEnemy(const Creature &left, const Creature &right) const override;
+    bool getIsEnemy(Faction left, Faction right) const override;
     bool getIsFriend(const Creature &left, const Creature &right) const override;
     bool getIsNeutral(const Creature &left, const Creature &right) const override;
 
 private:
     resource::TwoDAs &_twoDas;
 
-    int getRepute(const Creature &left, const Creature &right) const;
+    int getRepute(Faction left, Faction right) const;
 };
 
 } // namespace game

--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -44,7 +44,7 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
 
     door.setLocked(false);
     door.open();
-    door.onOpen(actor);
+    door.onOpen(actor.id());
 
     return true;
 }

--- a/src/libs/game/action/opendoor.cpp
+++ b/src/libs/game/action/opendoor.cpp
@@ -45,7 +45,7 @@ void OpenDoorAction::execute(std::shared_ptr<Action> self, Object &actor, float 
         if (_door->isLocked()) {
             _door->onFailToOpen(actor);
         } else {
-            _door->onOpen(actor);
+            _door->onOpen(actor.id());
         }
     }
 

--- a/src/libs/game/di/module.cpp
+++ b/src/libs/game/di/module.cpp
@@ -56,6 +56,7 @@ void GameModule::init() {
     _portraits->init();
     _reputes->init();
     _feats->init();
+    _skills->init();
     _spells->init();
     _surfaces->init();
     _projectiles->init();

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1981,7 +1981,7 @@ void Game::consoleOpenCloseDoor(const ConsoleArgs &args) {
     if (args[0].value() == "opendoor") {
         target->open();
         if (triggerer) {
-            target->onOpen(*triggerer);
+            target->onOpen(triggerer->id());
         }
     } else {
         target->close();

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -140,6 +140,7 @@ void Door::damage(int amount, uint32_t damager) {
     _dead = true;
     _locked = false;
     open();
+    onOpen(damager);
     runDeathScript(damager);
 }
 
@@ -179,16 +180,16 @@ void Door::close() {
     _open = false;
 }
 
-void Door::onOpen(const Object &triggerer) {
+void Door::onOpen(uint32_t triggererId) {
     if (_onOpen.empty()) {
         return;
     }
     _game.scriptRunner().run(
         _onOpen,
         {{script::ArgKind::Caller, Variable::ofObject(_id)},
-         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggerer.id())},
-         {script::ArgKind::ClickingObject, Variable::ofObject(triggerer.id())},
-         {script::ArgKind::EnteringObject, Variable::ofObject(triggerer.id())}});
+         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggererId)},
+         {script::ArgKind::ClickingObject, Variable::ofObject(triggererId)},
+         {script::ArgKind::EnteringObject, Variable::ofObject(triggererId)}});
 }
 
 void Door::onFailToOpen(const Object &triggerer) {

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -17,6 +17,9 @@
 
 #include "reone/game/object/door.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "reone/graphics/di/services.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/di/services.h"
@@ -112,6 +115,34 @@ bool Door::isSelectable() const {
     return !_static && !_open;
 }
 
+void Door::damage(int amount, uint32_t damager) {
+    if (_dead || _plot || _notBlastable) {
+        return;
+    }
+    if (amount <= 0) {
+        return;
+    }
+
+    int currentHitPoints = _currentHitPoints > 0 ? _currentHitPoints : _hitPoints;
+    if (amount == std::numeric_limits<int>::max()) {
+        _currentHitPoints = isMinOneHP() ? 1 : 0;
+    } else {
+        _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, currentHitPoints - amount);
+    }
+
+    damager = damager ? damager : script::kObjectInvalid;
+    runDamagedScript(damager);
+
+    if (_currentHitPoints > 0) {
+        return;
+    }
+
+    _dead = true;
+    _locked = false;
+    open();
+    runDeathScript(damager);
+}
+
 void Door::open() {
     auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
     if (model) {
@@ -171,6 +202,28 @@ void Door::onFailToOpen(const Object &triggerer) {
          {script::ArgKind::ClickingObject, Variable::ofObject(triggerer.id())}});
 }
 
+void Door::runDamagedScript(uint32_t damagerId) {
+    if (_onDamaged.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(
+        _onDamaged,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastAttacker, Variable::ofObject(damagerId)},
+         {script::ArgKind::LastDamager, Variable::ofObject(damagerId)}});
+}
+
+void Door::runDeathScript(uint32_t damagerId) {
+    if (_onDeath.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(
+        _onDeath,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastAttacker, Variable::ofObject(damagerId)},
+         {script::ArgKind::LastDamager, Variable::ofObject(damagerId)}});
+}
+
 void Door::setLocked(bool locked) {
     _locked = locked;
 }
@@ -196,6 +249,7 @@ void Door::loadUTD(const resource::generated::UTD &utd) {
     _fortitude = utd.Fort;
     _genericType = utd.GenericType;
     _static = utd.Static;
+    _notBlastable = utd.NotBlastable;
 
     _onClosed = utd.OnClosed;   // always empty, but could be useful
     _onDamaged = utd.OnDamaged; // always empty, but could be useful

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -40,6 +40,24 @@ namespace reone {
 
 namespace game {
 
+static bool isHostileDoorFaction(Faction faction) {
+    switch (faction) {
+    case Faction::Hostile1:
+    case Faction::Hostile2:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool canBashDoor(const Door &door) {
+    return door.isSelectable() &&
+           !door.isDead() &&
+           !door.plotFlag() &&
+           isHostileDoorFaction(door.faction()) &&
+           (door.hitPoints() > 0 || door.currentHitPoints() > 0);
+}
+
 void Module::load(std::string name, const Gff &ifo, bool fromSave) {
     _name = std::move(name);
 
@@ -342,6 +360,9 @@ std::vector<ContextAction> Module::getContextActions(const std::shared_ptr<Objec
     }
     case ObjectType::Door: {
         auto door = std::static_pointer_cast<Door>(object);
+        if (canBashDoor(*door)) {
+            actions.push_back(ContextAction(ActionType::AttackObject));
+        }
         if (door->isLocked() && !door->isKeyRequired() && _game.party().getLeader()->attributes().hasSkill(SkillType::Security)) {
             actions.push_back(ContextAction(SkillType::Security));
         }

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -40,21 +40,13 @@ namespace reone {
 
 namespace game {
 
-static bool isHostileDoorFaction(Faction faction) {
-    switch (faction) {
-    case Faction::Hostile1:
-    case Faction::Hostile2:
-        return true;
-    default:
-        return false;
-    }
-}
-
-static bool canBashDoor(const Door &door) {
-    return door.isSelectable() &&
+static bool canBashDoor(const Door &door, const Creature &actor, const IReputes &reputes) {
+    return door.isLocked() &&
+           door.isSelectable() &&
            !door.isDead() &&
            !door.plotFlag() &&
-           isHostileDoorFaction(door.faction()) &&
+           !door.isNotBlastable() &&
+           reputes.getIsEnemy(actor.faction(), door.faction()) &&
            (door.hitPoints() > 0 || door.currentHitPoints() > 0);
 }
 
@@ -360,10 +352,11 @@ std::vector<ContextAction> Module::getContextActions(const std::shared_ptr<Objec
     }
     case ObjectType::Door: {
         auto door = std::static_pointer_cast<Door>(object);
-        if (canBashDoor(*door)) {
+        auto leader = _game.party().getLeader();
+        if (canBashDoor(*door, *leader, _services.game.reputes)) {
             actions.push_back(ContextAction(ActionType::AttackObject));
         }
-        if (door->isLocked() && !door->isKeyRequired() && _game.party().getLeader()->attributes().hasSkill(SkillType::Security)) {
+        if (door->isLocked() && !door->isKeyRequired() && leader->attributes().hasSkill(SkillType::Security)) {
             actions.push_back(ContextAction(SkillType::Security));
         }
         break;

--- a/src/libs/game/reputes.cpp
+++ b/src/libs/game/reputes.cpp
@@ -69,20 +69,24 @@ bool Reputes::getIsEnemy(const Creature &left, const Creature &right) const {
         return left.isMinOneHP() && right.isMinOneHP();
     }
 
+    return getIsEnemy(left.faction(), right.faction());
+}
+
+bool Reputes::getIsEnemy(Faction left, Faction right) const {
     return getRepute(left, right) < 50;
 }
 
 bool Reputes::getIsFriend(const Creature &left, const Creature &right) const {
-    return getRepute(left, right) > 50;
+    return getRepute(left.faction(), right.faction()) > 50;
 }
 
 bool Reputes::getIsNeutral(const Creature &left, const Creature &right) const {
-    return getRepute(left, right) == 50;
+    return getRepute(left.faction(), right.faction()) == 50;
 }
 
-int Reputes::getRepute(const Creature &left, const Creature &right) const {
-    int leftFaction = static_cast<int>(left.faction());
-    int rightFaction = static_cast<int>(right.faction());
+int Reputes::getRepute(Faction left, Faction right) const {
+    int leftFaction = static_cast<int>(left);
+    int rightFaction = static_cast<int>(right);
 
     if (leftFaction < 0 || leftFaction >= g_factionValues.size() ||
         rightFaction < 0 || rightFaction >= g_factionValues[leftFaction].size())


### PR DESCRIPTION
## Summary

Adds door bash support for eligible locked doors.

Locked, selectable, non-plot, blastable hostile doors now expose the existing Attack context action. Door damage now reduces HP and opens/unlocks the door when HP reaches zero.

## Scope

- Uses existing `AttackObject` context action and icon
- Uses door faction via `IReputes::getIsEnemy(Faction, Faction)`
- Honors Plot and NotBlastable
- Does not implement placeable bash, Security DC rolls, key handling, or Slice/ComputerUse

## Testing

- Built `engine` and `launcher` in `RelWithDebInfo` on Windows
- Ran `git diff --check upstream/master...HEAD`
- Verified branch diff only includes door/reputes/module files

## Manual verification

- K1 Dantooine locked hostile non-plot door: Attack appears and damages the door
- K1 unlocked ordinary door: Attack does not appear
- K1 plot door: Attack does not appear
- K1 Endar Spire Security tutorial door: Security still works

## Known issues

-  K2 door bash not yet implemented
-  Container bash / security interactions not yet implemented