### PR TITLE
[tool] Add gff2json tool

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -14,16 +14,16 @@ runs:
       id: vcpkg-installed
       with:
         path: ${{ env.VCPKG_ROOT }}/installed
-        key: ${{ runner.os }}-vcpkg-installed-v2
+        key: ${{ runner.os }}-vcpkg-installed-v3
         restore-keys: |
-          ${{ runner.os }}-vcpkg-installed-v2
+          ${{ runner.os }}-vcpkg-installed-v3
 
     - name: Install dependencies
       shell: bash
       if: steps.vcpkg-installed.outputs.cache-hit != 'true'
       run: |-
         vcpkg install --triplet x64-windows \
-          boost-algorithm boost-endian boost-format boost-functional boost-program-options \
+          boost-algorithm boost-endian boost-format boost-functional boost-program-options boost-json \
           glm sdl2 sdl3 glew openal-soft libmad ffmpeg wxwidgets gtest \
 
     - name: Generate solution

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BUILD_TESTS "build tests" ON)
 option(BUILD_LAUNCHER "build launcher application" ON)
 option(BUILD_TOOLKIT "build toolkit application" ON)
 option(BUILD_DATAMINER "build dataminer application" ON)
+option(BUILD_GFF2JSON "build gff2json application" ON)
 
 option(ENABLE_MOVIE "enable movie playback" ON)
 option(ENABLE_ASAN "enable address sanitizer" OFF)
@@ -34,7 +35,7 @@ option(ENABLE_ASAN "enable address sanitizer" OFF)
 # Dependencies
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-find_package(Boost REQUIRED COMPONENTS program_options exception)
+find_package(Boost REQUIRED COMPONENTS program_options exception json)
 find_package(OpenGL REQUIRED)
 find_package(MAD REQUIRED)
 
@@ -94,6 +95,7 @@ add_subdirectory(src/libs/resource) # resource static library
 add_subdirectory(src/libs/graphics) # graphics static library
 add_subdirectory(src/libs/audio) # audio static library
 add_subdirectory(src/libs/input) # input static library
+add_subdirectory(src/libs/json) # json static library
 add_subdirectory(src/libs/gui) # gui static library
 add_subdirectory(src/libs/scene) # scene static library
 add_subdirectory(src/libs/movie) # movie static library
@@ -118,6 +120,10 @@ endif()
 
 if(BUILD_DATAMINER)
     add_subdirectory(src/apps/dataminer) # dataminer application
+endif()
+
+if(BUILD_GFF2JSON)
+    add_subdirectory(src/apps/gff2json) # gff2json application
 endif()
 
 if(BUILD_TESTS)

--- a/include/reone/json/resource.h
+++ b/include/reone/json/resource.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/json.hpp>
+
+namespace reone {
+
+namespace resource {
+class Gff;
+}
+
+namespace json {
+
+boost::json::object fromGff(const resource::Gff &gff);
+
+} // namespace json
+} // namespace reone

--- a/include/reone/json/util.h
+++ b/include/reone/json/util.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/json.hpp>
+
+namespace reone {
+namespace json {
+
+void print(std::ostream &os, const boost::json::value &jv, bool pretty = true);
+
+} // namespace json
+} // namespace reone

--- a/include/reone/resource/gff.h
+++ b/include/reone/resource/gff.h
@@ -200,12 +200,17 @@ public:
     std::vector<std::shared_ptr<Gff>> getList(const std::string &name) const;
     ByteBuffer getData(const std::string &name) const;
 
+    const std::optional<std::string> &signature() const { return _signature; }
     uint32_t type() const { return _type; }
     std::vector<Field> &fields() { return _fields; }
     const std::vector<Field> &fields() const { return _fields; }
 
     void setType(uint32_t type) {
         _type = type;
+    }
+
+    void setSignature(std::string signature) {
+        _signature = signature;
     }
 
     std::shared_ptr<Gff> deepCopy() const {
@@ -231,6 +236,7 @@ public:
     }
 
 private:
+    std::optional<std::string> _signature;
     uint32_t _type {0};
     std::vector<Field> _fields;
 

--- a/src/apps/gff2json/CMakeLists.txt
+++ b/src/apps/gff2json/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The reone project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(GFF2JSON_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/apps/gff2json)
+
+set(GFF2JSON_HEADERS)
+
+set(GFF2JSON_SOURCES
+    ${GFF2JSON_SOURCE_DIR}/main.cpp)
+
+add_executable(gff2json ${GFF2JSON_SOURCES} ${GFF2JSON_HEADERS} ${CLANG_FORMAT_PATH})
+set_target_properties(gff2json PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}$<$<CONFIG:Debug>:/debug>/bin)
+target_precompile_headers(gff2json PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_link_libraries(gff2json PRIVATE resource system json ${Boost_PROGRAM_OPTIONS_LIBRARY})
+

--- a/src/apps/gff2json/main.cpp
+++ b/src/apps/gff2json/main.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/json/resource.h"
+#include "reone/json/util.h"
+#include "reone/resource/format/gffreader.h"
+#include "reone/system/stream/fileinput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+using CmdArgs = boost::program_options::variables_map;
+
+static int run(const CmdArgs &args) {
+    auto file = FileInputStream(args["input-file"].as<std::string>());
+    auto reader = GffReader(file);
+    reader.load();
+    std::shared_ptr<Gff> gff = reader.root();
+
+    boost::json::object json = json::fromGff(*gff);
+    json::print(std::cout, json);
+    return 0;
+}
+
+static void parseOptions(int argc, char **argv, CmdArgs &vars) {
+    using namespace boost::program_options;
+    options_description description;
+    description.add_options()("input-file", value<std::string>()->required());
+
+    positional_options_description positional;
+    positional.add("input-file", 1);
+
+    basic_command_line_parser parser(argc, argv);
+    store(parser.options(description).positional(positional).run(),
+          vars, /*utf8=*/true);
+}
+
+int main(int argc, char **argv) {
+    try {
+        CmdArgs args;
+        parseOptions(argc, argv, args);
+        return run(args);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return -1;
+    }
+}

--- a/src/libs/json/CMakeLists.txt
+++ b/src/libs/json/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 The reone project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(JSON_INCLUDE_DIR ${REONE_INCLUDE_DIR}/reone/json)
+set(JSON_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/libs/json)
+
+set(JSON_HEADERS
+    ${JSON_INCLUDE_DIR}/resource.h
+    ${JSON_INCLUDE_DIR}/util.h)
+
+set(JSON_SOURCES
+    ${JSON_SOURCE_DIR}/gff.cpp
+    ${JSON_SOURCE_DIR}/util.cpp)
+
+add_library(json STATIC ${JSON_HEADERS} ${JSON_SOURCES} ${CLANG_FORMAT_PATH})
+set_target_properties(json PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}$<$<CONFIG:Debug>:/debug>/lib)
+set_target_properties(json PROPERTIES DEBUG_POSTFIX "d")
+target_precompile_headers(json PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_link_libraries(json PRIVATE resource ${Boost_JSON_LIBRARY})

--- a/src/libs/json/gff.cpp
+++ b/src/libs/json/gff.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/gff.h"
+#include "reone/json/resource.h"
+#include <boost/algorithm/hex.hpp>
+
+using namespace reone::resource;
+
+namespace reone {
+namespace json {
+
+static boost::json::object serializeGff(const Gff &gff);
+
+static std::string serializeGffFieldType(Gff::FieldType type) {
+    switch (type) {
+    case Gff::FieldType::Byte:
+        return "Byte";
+    case Gff::FieldType::Char:
+        return "Char";
+    case Gff::FieldType::Word:
+        return "Word";
+    case Gff::FieldType::Short:
+        return "Short";
+    case Gff::FieldType::Dword:
+        return "Dword";
+    case Gff::FieldType::Int:
+        return "Int";
+    case Gff::FieldType::Dword64:
+        return "Dword64";
+    case Gff::FieldType::Int64:
+        return "Int64";
+    case Gff::FieldType::Float:
+        return "Float";
+    case Gff::FieldType::Double:
+        return "Double";
+    case Gff::FieldType::CExoString:
+        return "CExoString";
+    case Gff::FieldType::ResRef:
+        return "ResRef";
+    case Gff::FieldType::CExoLocString:
+        return "CExoLocString";
+    case Gff::FieldType::Void:
+        return "Void";
+    case Gff::FieldType::Struct:
+        return "Struct";
+    case Gff::FieldType::List:
+        return "List";
+    case Gff::FieldType::Orientation:
+        return "Orientation";
+    case Gff::FieldType::Vector:
+        return "Vector";
+    case Gff::FieldType::StrRef:
+        return "StrRef";
+    }
+    assert(0 && "unhandled type");
+    return "invalid";
+}
+
+static boost::json::value serializeGffFieldValue(const Gff::Field &field) {
+    switch (field.type) {
+    case Gff::FieldType::Char:
+    case Gff::FieldType::Short:
+    case Gff::FieldType::Int:
+    case Gff::FieldType::StrRef:
+        return field.intValue;
+
+    case Gff::FieldType::Byte:
+    case Gff::FieldType::Word:
+    case Gff::FieldType::Dword:
+        return field.uintValue;
+
+    case Gff::FieldType::Int64:
+        return field.int64Value;
+
+    case Gff::FieldType::Dword64:
+        return field.uint64Value;
+
+    case Gff::FieldType::Float:
+        return field.floatValue;
+
+    case Gff::FieldType::Double:
+        return field.doubleValue;
+
+    case Gff::FieldType::CExoString:
+    case Gff::FieldType::ResRef:
+        return boost::json::string(field.strValue);
+
+    case Gff::FieldType::CExoLocString:
+        return boost::json::object({{"str", field.strValue}, {"loc", field.intValue}});
+    case Gff::FieldType::Void: {
+        boost::json::string str;
+        boost::algorithm::hex_lower(field.data, std::back_inserter(str));
+        return str;
+    }
+    case Gff::FieldType::Struct: {
+        assert(!field.children.empty() && "invalid struct field");
+        return serializeGff(*field.children.front());
+    }
+    case Gff::FieldType::List: {
+        boost::json::array arr;
+        for (const auto &child : field.children) {
+            arr.push_back(serializeGff(*child));
+        }
+        return arr;
+    }
+    case Gff::FieldType::Orientation: {
+        boost::json::array arr;
+        arr.push_back(field.quatValue[0]);
+        arr.push_back(field.quatValue[1]);
+        arr.push_back(field.quatValue[2]);
+        arr.push_back(field.quatValue[3]);
+        return arr;
+    }
+    case Gff::FieldType::Vector:
+        boost::json::array arr;
+        arr.push_back(field.vecValue[0]);
+        arr.push_back(field.vecValue[1]);
+        arr.push_back(field.vecValue[2]);
+        return arr;
+    }
+    assert(0 && "unhandled type");
+    return nullptr;
+}
+
+static boost::json::object serializeGff(const Gff &gff) {
+    boost::json::object tree;
+    for (const auto &field : gff.fields()) {
+        tree[field.label] = {{"type", serializeGffFieldType(field.type)}, {"value", serializeGffFieldValue(field)}};
+    }
+    return tree;
+}
+
+boost::json::object fromGff(const Gff &gff) {
+    boost::json::object obj;
+    if (const auto &signature = gff.signature()) {
+        obj["signature"] = *signature;
+    } else {
+        obj["signature"] = nullptr;
+    }
+
+    obj["gff"] = serializeGff(gff);
+    return obj;
+}
+
+} // namespace json
+} // namespace reone

--- a/src/libs/json/util.cpp
+++ b/src/libs/json/util.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/json/util.h"
+
+namespace reone {
+namespace json {
+
+static void printRecursive(std::ostream &os, const boost::json::value &jv, std::string &indent) {
+    switch (jv.kind()) {
+    case boost::json::kind::object: {
+        os << "{\n";
+        indent.append(4, ' ');
+        auto const &obj = jv.get_object();
+        if (!obj.empty()) {
+            auto it = obj.begin();
+            for (;;) {
+                os << indent << boost::json::serialize(it->key()) << " : ";
+                printRecursive(os, it->value(), indent);
+                if (++it == obj.end())
+                    break;
+                os << ",\n";
+            }
+        }
+        os << "\n";
+        indent.resize(indent.size() - 4);
+        os << indent << "}";
+        break;
+    }
+
+    case boost::json::kind::array: {
+        os << "[\n";
+        indent.append(4, ' ');
+        auto const &arr = jv.get_array();
+        if (!arr.empty()) {
+            auto it = arr.begin();
+            for (;;) {
+                os << indent;
+                printRecursive(os, *it, indent);
+                if (++it == arr.end())
+                    break;
+                os << ",\n";
+            }
+        }
+        os << "\n";
+        indent.resize(indent.size() - 4);
+        os << indent << "]";
+        break;
+    }
+    case boost::json::kind::string: {
+        os << boost::json::serialize(jv.get_string());
+        break;
+    }
+
+    case boost::json::kind::uint64:
+    case boost::json::kind::int64:
+    case boost::json::kind::double_: {
+        os << jv;
+        break;
+    }
+
+    case boost::json::kind::bool_: {
+        if (jv.get_bool())
+            os << "true";
+        else
+            os << "false";
+        break;
+    }
+
+    case boost::json::kind::null: {
+        os << "null";
+        break;
+    }
+    }
+
+    if (indent.empty())
+        os << "\n";
+}
+
+void print(std::ostream &os, const boost::json::value &jv, bool pretty) {
+    if (pretty) {
+        std::string indent;
+        printRecursive(os, jv, indent);
+        return;
+    }
+    os << boost::json::serialize(jv);
+}
+
+} // namespace json
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -175,3 +175,4 @@ add_library(resource STATIC ${RESOURCE_HEADERS} ${RESOURCE_SOURCES} ${CLANG_FORM
 set_target_properties(resource PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}$<$<CONFIG:Debug>:/debug>/lib)
 set_target_properties(resource PROPERTIES DEBUG_POSTFIX "d")
 target_precompile_headers(resource PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_link_libraries(resource PRIVATE movie graphics)

--- a/src/libs/resource/format/gffreader.cpp
+++ b/src/libs/resource/format/gffreader.cpp
@@ -25,7 +25,7 @@ namespace reone {
 namespace resource {
 
 void GffReader::load() {
-    _gff.skipBytes(8); // signature
+    std::string signature = _gff.readString(8);
 
     _structOffset = _gff.readUint32();
     _structCount = _gff.readUint32();
@@ -41,6 +41,7 @@ void GffReader::load() {
     _listIndicesCount = _gff.readUint32();
 
     _root = std::move(readStruct(0));
+    _root->setSignature(signature);
 }
 
 std::unique_ptr<Gff> GffReader::readStruct(int idx) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/format/txireader.cpp
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
+    ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dawriter.cpp
     ${TESTS_SOURCE_DIR}/resource/format/bifreader.cpp
@@ -99,7 +100,7 @@ set_target_properties(tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_D
 target_include_directories(tests PRIVATE ${GTEST_INCLUDE_DIRS})
 
 target_precompile_headers(tests PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
-target_link_libraries(tests PRIVATE tools GTest::gmock_main)
+target_link_libraries(tests PRIVATE tools json GTest::gmock_main)
 
 if(MSVC)
     target_compile_options(tests PRIVATE /bigobj)

--- a/test/json/gff.cpp
+++ b/test/json/gff.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/json/resource.h"
+#include "reone/json/util.h"
+#include "reone/resource/format/gffreader.h"
+#include "reone/system/stream/memoryinput.h"
+#include "reone/system/stringbuilder.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+static std::string gffData() {
+    return StringBuilder()
+        // header
+        .append("RES V3.2")
+        .append("\x38\x00\x00\x00", 4) // offset to structs
+        .append("\x04\x00\x00\x00", 4) // number of structs
+        .append("\x68\x00\x00\x00", 4) // offset to fields
+        .append("\x13\x00\x00\x00", 4) // number of fields
+        .append("\x4c\x01\x00\x00", 4) // offset to labels
+        .append("\x13\x00\x00\x00", 4) // number of labels
+        .append("\x7c\x02\x00\x00", 4) // offset to field data
+        .append("\x67\x00\x00\x00", 4) // size of field data
+        .append("\xe3\x02\x00\x00", 4) // offset to field indices
+        .append("\x40\x00\x00\x00", 4) // size of field indices
+        .append("\x23\x03\x00\x00", 4) // offset to list indices
+        .append("\x0c\x00\x00\x00", 4) // size of list indices
+        // structs
+        .append("\xff\xff\xff\xff", 4) // 0: type
+        .append("\x00\x00\x00\x00", 4) // 0: data offset
+        .append("\x10\x00\x00\x00", 4) // 0: field count
+        .append("\x01\x00\x00\x00", 4) // 1: type
+        .append("\x10\x00\x00\x00", 4) // 1: data offset
+        .append("\x01\x00\x00\x00", 4) // 1: field count
+        .append("\x02\x00\x00\x00", 4) // 2: type
+        .append("\x11\x00\x00\x00", 4) // 2: data offset
+        .append("\x01\x00\x00\x00", 4) // 2: field count
+        .append("\x03\x00\x00\x00", 4) // 3: type
+        .append("\x12\x00\x00\x00", 4) // 3: data offset
+        .append("\x01\x00\x00\x00", 4) // 3: field count
+        // fields
+        .append("\x00\x00\x00\x00", 4) // 0: type
+        .append("\x00\x00\x00\x00", 4) // 0: label index
+        .append("\x00\x00\x00\x00", 4) // 0: data
+        .append("\x05\x00\x00\x00", 4) // 1: type
+        .append("\x01\x00\x00\x00", 4) // 1: label index
+        .append("\x01\x00\x00\x00", 4) // 1: data
+        .append("\x04\x00\x00\x00", 4) // 2: type
+        .append("\x02\x00\x00\x00", 4) // 2: label index
+        .append("\x02\x00\x00\x00", 4) // 2: data
+        .append("\x07\x00\x00\x00", 4) // 3: type
+        .append("\x03\x00\x00\x00", 4) // 3: label index
+        .append("\x00\x00\x00\x00", 4) // 3: data
+        .append("\x06\x00\x00\x00", 4) // 4: type
+        .append("\x04\x00\x00\x00", 4) // 4: label index
+        .append("\x08\x00\x00\x00", 4) // 4: data
+        .append("\x08\x00\x00\x00", 4) // 5: type
+        .append("\x05\x00\x00\x00", 4) // 5: label index
+        .append("\x00\x00\x80\x3f", 4) // 5: data
+        .append("\x09\x00\x00\x00", 4) // 6: type
+        .append("\x06\x00\x00\x00", 4) // 6: label index
+        .append("\x10\x00\x00\x00", 4) // 6: data
+        .append("\x0a\x00\x00\x00", 4) // 7: type
+        .append("\x07\x00\x00\x00", 4) // 7: label index
+        .append("\x18\x00\x00\x00", 4) // 7: data
+        .append("\x0b\x00\x00\x00", 4) // 8: type
+        .append("\x08\x00\x00\x00", 4) // 8: label index
+        .append("\x20\x00\x00\x00", 4) // 8: data
+        .append("\x0c\x00\x00\x00", 4) // 9: type
+        .append("\x09\x00\x00\x00", 4) // 9: label index
+        .append("\x25\x00\x00\x00", 4) // 9: data
+        .append("\x0d\x00\x00\x00", 4) // 10: type
+        .append("\x0a\x00\x00\x00", 4) // 10: label index
+        .append("\x3d\x00\x00\x00", 4) // 10: data
+        .append("\x10\x00\x00\x00", 4) // 11: type
+        .append("\x0b\x00\x00\x00", 4) // 11: label index
+        .append("\x43\x00\x00\x00", 4) // 11: data
+        .append("\x11\x00\x00\x00", 4) // 12: type
+        .append("\x0c\x00\x00\x00", 4) // 12: label index
+        .append("\x53\x00\x00\x00", 4) // 12: data
+        .append("\x12\x00\x00\x00", 4) // 13: type
+        .append("\x0d\x00\x00\x00", 4) // 13: label index
+        .append("\x5f\x00\x00\x00", 4) // 13: data
+        .append("\x0e\x00\x00\x00", 4) // 14: type
+        .append("\x0e\x00\x00\x00", 4) // 14: label index
+        .append("\x01\x00\x00\x00", 4) // 14: data
+        .append("\x0f\x00\x00\x00", 4) // 15: type
+        .append("\x0f\x00\x00\x00", 4) // 15: label index
+        .append("\x00\x00\x00\x00", 4) // 15: data
+        .append("\x01\x00\x00\x00", 4) // 16: type
+        .append("\x10\x00\x00\x00", 4) // 16: label index
+        .append("\x01\x00\x00\x00", 4) // 16: data
+        .append("\x02\x00\x00\x00", 4) // 17: type
+        .append("\x11\x00\x00\x00", 4) // 17: label index
+        .append("\x02\x00\x00\x00", 4) // 17: data
+        .append("\x03\x00\x00\x00", 4) // 18: type
+        .append("\x12\x00\x00\x00", 4) // 18: label index
+        .append("\x03\x00\x00\x00", 4) // 18: data
+        // labels
+        .append("Byte\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Int\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Uint\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Int64\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Uint64\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Float\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Double\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("CExoString\x00\x00\x00\x00\x00\x00", 16)
+        .append("ResRef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("CExoLocString\x00\x00\x00", 16)
+        .append("Void\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Orientation\x00\x00\x00\x00\x00", 16)
+        .append("Vector\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("StrRef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Struct\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("List\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16)
+        .append("Struct1Char\x00\x00\x00\x00\x00", 16)
+        .append("Struct2Word\x00\x00\x00\x00\x00", 16)
+        .append("Struct3Short\x00\x00\x00\x00", 16)
+        // field data
+        .append("\x03\x00\x00\x00\x00\x00\x00\x00", 8)
+        .append("\x04\x00\x00\x00\x00\x00\x00\x00", 8)
+        .append("\x00\x00\x00\x00\x00\x00\xf0\x3f", 8)
+        .append("\x04\x00\x00\x00John", 8)
+        .append("\x04Jane", 5)
+        .append("\x14\x00\x00\x00\xff\xff\xff\xff\x01\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00Jill", 24)
+        .append("\x02\x00\x00\x00\xff\xff", 6)
+        .append("\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f", 16)
+        .append("\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f", 12)
+        .append("\x04\x00\x00\x00\x01\x00\x00\x00", 8)
+        // field indices
+        .append("\x00\x00\x00\x00", 4)
+        .append("\x01\x00\x00\x00", 4)
+        .append("\x02\x00\x00\x00", 4)
+        .append("\x03\x00\x00\x00", 4)
+        .append("\x04\x00\x00\x00", 4)
+        .append("\x05\x00\x00\x00", 4)
+        .append("\x06\x00\x00\x00", 4)
+        .append("\x07\x00\x00\x00", 4)
+        .append("\x08\x00\x00\x00", 4)
+        .append("\x09\x00\x00\x00", 4)
+        .append("\x0a\x00\x00\x00", 4)
+        .append("\x0b\x00\x00\x00", 4)
+        .append("\x0c\x00\x00\x00", 4)
+        .append("\x0d\x00\x00\x00", 4)
+        .append("\x0e\x00\x00\x00", 4)
+        .append("\x0f\x00\x00\x00", 4)
+        // list indices
+        .append("\x02\x00\x00\x00", 4)
+        .append("\x02\x00\x00\x00", 4)
+        .append("\x03\x00\x00\x00", 4)
+        .string();
+}
+
+static std::string jsonData() {
+    return StringBuilder()
+        .append("{\n")
+        .append("    \"signature\" : \"RES V3.2\",\n")
+        .append("    \"gff\" : {\n")
+        .append("        \"Byte\" : {\n")
+        .append("            \"type\" : \"Byte\",\n")
+        .append("            \"value\" : 0\n")
+        .append("        },\n")
+        .append("        \"Int\" : {\n")
+        .append("            \"type\" : \"Int\",\n")
+        .append("            \"value\" : 1\n")
+        .append("        },\n")
+        .append("        \"Uint\" : {\n")
+        .append("            \"type\" : \"Dword\",\n")
+        .append("            \"value\" : 2\n")
+        .append("        },\n")
+        .append("        \"Int64\" : {\n")
+        .append("            \"type\" : \"Int64\",\n")
+        .append("            \"value\" : 3\n")
+        .append("        },\n")
+        .append("        \"Uint64\" : {\n")
+        .append("            \"type\" : \"Dword64\",\n")
+        .append("            \"value\" : 4\n")
+        .append("        },\n")
+        .append("        \"Float\" : {\n")
+        .append("            \"type\" : \"Float\",\n")
+        .append("            \"value\" : 1E0\n")
+        .append("        },\n")
+        .append("        \"Double\" : {\n")
+        .append("            \"type\" : \"Double\",\n")
+        .append("            \"value\" : 1E0\n")
+        .append("        },\n")
+        .append("        \"CExoString\" : {\n")
+        .append("            \"type\" : \"CExoString\",\n")
+        .append("            \"value\" : \"John\"\n")
+        .append("        },\n")
+        .append("        \"ResRef\" : {\n")
+        .append("            \"type\" : \"ResRef\",\n")
+        .append("            \"value\" : \"Jane\"\n")
+        .append("        },\n")
+        .append("        \"CExoLocString\" : {\n")
+        .append("            \"type\" : \"CExoLocString\",\n")
+        .append("            \"value\" : {\n")
+        .append("                \"str\" : \"Jill\",\n")
+        .append("                \"loc\" : -1\n")
+        .append("            }\n")
+        .append("        },\n")
+        .append("        \"Void\" : {\n")
+        .append("            \"type\" : \"Void\",\n")
+        .append("            \"value\" : \"ffff\"\n")
+        .append("        },\n")
+        .append("        \"Orientation\" : {\n")
+        .append("            \"type\" : \"Orientation\",\n")
+        .append("            \"value\" : [\n")
+        .append("                1E0,\n")
+        .append("                1E0,\n")
+        .append("                1E0,\n")
+        .append("                1E0\n")
+        .append("            ]\n")
+        .append("        },\n")
+        .append("        \"Vector\" : {\n")
+        .append("            \"type\" : \"Vector\",\n")
+        .append("            \"value\" : [\n")
+        .append("                1E0,\n")
+        .append("                1E0,\n")
+        .append("                1E0\n")
+        .append("            ]\n")
+        .append("        },\n")
+        .append("        \"StrRef\" : {\n")
+        .append("            \"type\" : \"StrRef\",\n")
+        .append("            \"value\" : 1\n")
+        .append("        },\n")
+        .append("        \"Struct\" : {\n")
+        .append("            \"type\" : \"Struct\",\n")
+        .append("            \"value\" : {\n")
+        .append("                \"Struct1Char\" : {\n")
+        .append("                    \"type\" : \"Char\",\n")
+        .append("                    \"value\" : 1\n")
+        .append("                }\n")
+        .append("            }\n")
+        .append("        },\n")
+        .append("        \"List\" : {\n")
+        .append("            \"type\" : \"List\",\n")
+        .append("            \"value\" : [\n")
+        .append("                {\n")
+        .append("                    \"Struct2Word\" : {\n")
+        .append("                        \"type\" : \"Word\",\n")
+        .append("                        \"value\" : 2\n")
+        .append("                    }\n")
+        .append("                },\n")
+        .append("                {\n")
+        .append("                    \"Struct3Short\" : {\n")
+        .append("                        \"type\" : \"Short\",\n")
+        .append("                        \"value\" : 3\n")
+        .append("                    }\n")
+        .append("                }\n")
+        .append("            ]\n")
+        .append("        }\n")
+        .append("    }\n")
+        .append("}\n")
+        .string();
+}
+
+TEST(Json, fromGff) {
+    std::string data = gffData();
+    auto stream = MemoryInputStream(data);
+    auto reader = GffReader(stream);
+    reader.load();
+    auto gff = reader.root();
+
+    std::stringstream ss;
+    json::print(ss, json::fromGff(*gff));
+    ASSERT_EQ(ss.str(), jsonData());
+}

--- a/test/resource/format/gffreader.cpp
+++ b/test/resource/format/gffreader.cpp
@@ -183,6 +183,7 @@ TEST(GffReader, should_read_gff) {
     // then
 
     auto gff = reader.root();
+    EXPECT_EQ("RES V3.2", gff->signature());
     EXPECT_EQ(16ll, gff->fields().size());
     EXPECT_EQ(static_cast<int>(Gff::FieldType::Byte), static_cast<int>(gff->fields()[0].type));
     EXPECT_EQ(static_cast<int>(Gff::FieldType::Int), static_cast<int>(gff->fields()[1].type));


### PR DESCRIPTION
Added a new tool to convert from GFF binary to JSON text format. It takes 1 positional argument (file name) and outputs JSON to stdout.

GFF is used for a lot of game files, so it is useful to work with it in a text editor without relying on dedicated viewers like the reone toolkit.

The patch adds a new reone json library to have all JSON converters separate from other libraries. This is done primarily to limit a dependency on Boost.JSON just to this new library.