### PR TITLE
[tool] Add unerf tool to extract ERF or MOD files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(BUILD_LAUNCHER "build launcher application" ON)
 option(BUILD_TOOLKIT "build toolkit application" ON)
 option(BUILD_DATAMINER "build dataminer application" ON)
 option(BUILD_GFF2JSON "build gff2json application" ON)
+option(BUILD_UNERF "build unerf application" ON)
 
 option(ENABLE_MOVIE "enable movie playback" ON)
 option(ENABLE_ASAN "enable address sanitizer" OFF)
@@ -124,6 +125,10 @@ endif()
 
 if(BUILD_GFF2JSON)
     add_subdirectory(src/apps/gff2json) # gff2json application
+endif()
+
+if(BUILD_UNERF)
+    add_subdirectory(src/apps/unerf) # unpack ERF files
 endif()
 
 if(BUILD_TESTS)

--- a/src/apps/unerf/CMakeLists.txt
+++ b/src/apps/unerf/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The reone project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(UNERF_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/apps/unerf)
+
+set(UNERF_HEADERS)
+
+set(UNERF_SOURCES
+    ${UNERF_SOURCE_DIR}/main.cpp)
+
+add_executable(unerf ${UNERF_SOURCES} ${UNERF_HEADERS} ${CLANG_FORMAT_PATH})
+set_target_properties(unerf PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}$<$<CONFIG:Debug>:/debug>/bin)
+target_precompile_headers(unerf PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_link_libraries(unerf PRIVATE resource system ${Boost_PROGRAM_OPTIONS_LIBRARY})
+

--- a/src/apps/unerf/main.cpp
+++ b/src/apps/unerf/main.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/format/erfreader.h"
+#include "reone/resource/id.h"
+#include "reone/system/stream/fileinput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+// Writer a file from an ERF container into the current directory.
+static void extract(ResourceId id, IInputStream &file, size_t size) {
+    std::string name = id.string();
+    std::ofstream outs(name, std::ios::binary);
+    while (size--) {
+        outs.put(file.readByte());
+    }
+}
+
+// Extract all files from an ERF container and write them to the current
+// directory.
+static void extractAll(IInputStream &file) {
+    ErfReader erf(file);
+    erf.load();
+
+    for (size_t i = 0; i < erf.keys().size(); ++i) {
+        auto &key = erf.keys()[i];
+        auto &res = erf.resources()[i];
+
+        file.seek(res.offset, SeekOrigin::Begin);
+        extract(key.resId, file, res.size);
+    }
+}
+
+using CmdArgs = boost::program_options::variables_map;
+
+static int run(const CmdArgs &args) {
+    auto file = FileInputStream(args["input-file"].as<std::string>());
+    extractAll(file);
+    return 0;
+}
+
+static void parseOptions(int argc, char **argv, CmdArgs &vars) {
+    using namespace boost::program_options;
+    options_description description;
+    description.add_options()("input-file", value<std::string>()->required());
+
+    positional_options_description positional;
+    positional.add("input-file", 1);
+
+    basic_command_line_parser parser(argc, argv);
+    store(parser.options(description).positional(positional).run(),
+          vars, /*utf8=*/true);
+}
+
+int main(int argc, char **argv) {
+    try {
+        CmdArgs args;
+        parseOptions(argc, argv, args);
+        return run(args);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return -1;
+    }
+}

--- a/src/apps/unerf/main.cpp
+++ b/src/apps/unerf/main.cpp
@@ -22,7 +22,7 @@
 using namespace reone;
 using namespace reone::resource;
 
-// Writer a file from an ERF container into the current directory.
+// Write a file from an ERF container into the current directory.
 static void extract(ResourceId id, IInputStream &file, size_t size) {
     std::string name = id.string();
     std::ofstream outs(name, std::ios::binary);


### PR DESCRIPTION
The tool takes 1 positional argument (a file name) for an ERF or MOD file and extracts its content into the current directory as separate files.

ERF files are archives that contain game resources. They are used to bundle together module files and savegame data.

Savegame ERF files (savegame.sav) can contain other ERF files inside, but this tool is not recursive.

unerf is a replacement for (now legacy) ErfTool, but with a simpler command line interface.