### PR TITLE
[game][gui] Implement equipment screen logic

### DIFF
--- a/include/reone/game/equipmentrules.h
+++ b/include/reone/game/equipmentrules.h
@@ -54,6 +54,18 @@ struct EquipmentCandidateDecision {
     EquipmentCandidateReason reason {EquipmentCandidateReason::None};
 };
 
+enum class EquipmentSlotActivationReason {
+    None,
+    OffHandBlockedByTwoHandedMainHand
+};
+
+struct EquipmentSlotActivationDecision {
+    bool available {true};
+    int requestedSlot {-1};
+    int pairedSlot {-1};
+    EquipmentSlotActivationReason reason {EquipmentSlotActivationReason::None};
+};
+
 bool isMainHandWeaponSlot(int slot);
 bool isOffHandWeaponSlot(int slot);
 int getPairedMainHandSlot(int offHandSlot);
@@ -67,6 +79,10 @@ EquipmentCandidateDecision evaluateEquipmentCandidate(
     const Creature &creature,
     int requestedSlot,
     const Item *item);
+
+EquipmentSlotActivationDecision evaluateEquipmentSlotActivation(
+    const Creature &creature,
+    int requestedSlot);
 
 } // namespace game
 

--- a/include/reone/game/equipmentrules.h
+++ b/include/reone/game/equipmentrules.h
@@ -39,9 +39,10 @@ enum class EquipmentCandidateReason {
     NotEquippableInRequestedSlot,
     OffHandRequiresMainHand,
     TwoHandedInOffHand,
+    WeaponRequiresEmptyPairedSlot,
     IncompatibleWithMainHand,
     IncompatibleWithOffHand,
-    MainHandTwoHandedClearsOffHand
+    MainHandWeaponClearsOffHand
 };
 
 struct EquipmentCandidateDecision {
@@ -56,7 +57,7 @@ struct EquipmentCandidateDecision {
 
 enum class EquipmentSlotActivationReason {
     None,
-    OffHandBlockedByTwoHandedMainHand
+    OffHandBlockedByMainHandWeapon
 };
 
 struct EquipmentSlotActivationDecision {
@@ -73,6 +74,7 @@ int getPairedOffHandSlot(int mainHandSlot);
 
 bool isOneHandedWeapon(const Item &item);
 bool isTwoHandedWeapon(const Item &item);
+bool weaponRequiresEmptyPairedSlot(const Item &item);
 bool areWeaponsCompatible(const Item &mainHand, const Item &offHand);
 
 EquipmentCandidateDecision evaluateEquipmentCandidate(

--- a/include/reone/game/equipmentrules.h
+++ b/include/reone/game/equipmentrules.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace game {
+
+class Creature;
+class Item;
+
+enum class EquipmentCandidateAction {
+    None,
+    Equip,
+    EquipMainHandFromOffHand,
+    ClearSlot,
+    ClearMainHandAndOffHand,
+    EquipAndClearOffHand,
+    Reject
+};
+
+enum class EquipmentCandidateReason {
+    None,
+    NotEquippableInRequestedSlot,
+    OffHandRequiresMainHand,
+    TwoHandedInOffHand,
+    IncompatibleWithMainHand,
+    IncompatibleWithOffHand,
+    MainHandTwoHandedClearsOffHand
+};
+
+struct EquipmentCandidateDecision {
+    bool visible {false};
+    bool valid {false};
+    int requestedSlot {-1};
+    int actualSlot {-1};
+    int pairedSlot {-1};
+    EquipmentCandidateAction action {EquipmentCandidateAction::None};
+    EquipmentCandidateReason reason {EquipmentCandidateReason::None};
+};
+
+bool isMainHandWeaponSlot(int slot);
+bool isOffHandWeaponSlot(int slot);
+int getPairedMainHandSlot(int offHandSlot);
+int getPairedOffHandSlot(int mainHandSlot);
+
+bool isOneHandedWeapon(const Item &item);
+bool isTwoHandedWeapon(const Item &item);
+bool areWeaponsCompatible(const Item &mainHand, const Item &offHand);
+
+EquipmentCandidateDecision evaluateEquipmentCandidate(
+    const Creature &creature,
+    int requestedSlot,
+    const Item *item);
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -29,6 +29,7 @@ namespace reone {
 namespace game {
 
 class Creature;
+class Item;
 
 }
 
@@ -209,6 +210,7 @@ private:
     void updatePortraits();
     void activateSlot(Slot slot);
     void selectSlot(Slot slot);
+    int resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<Item> &item, const Creature &creature) const;
 
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;
     std::shared_ptr<graphics::Texture> getEmptySlotIcon(Slot slot) const;

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -211,6 +211,7 @@ private:
     void activateSlot(Slot slot);
     void selectSlot(Slot slot);
     int resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<Item> &item, const Creature &creature) const;
+    bool canEquipItemInSlot(int slot, const Item &item, const Creature &creature) const;
 
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;
     std::shared_ptr<graphics::Texture> getEmptySlotIcon(Slot slot) const;

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -63,6 +63,7 @@ public:
     }
 
     void update();
+    void update(float dt) override;
 
 private:
     static constexpr int kNumControlsBar = 5;
@@ -204,6 +205,8 @@ private:
     }
 
     void configureItemsListBox();
+    void clearCandidateDescription();
+    void updateCandidateDescription();
     void updateEquipment();
     void updateItems();
     void updatePortraits();

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -216,6 +216,8 @@ private:
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;
     std::shared_ptr<graphics::Texture> getEmptySlotIcon(Slot slot) const;
 
+    void confirmSelectedCandidate();
+    void confirmCandidateItem(const std::string &item);
     void onItemsListBoxItemClick(const std::string &item);
 };
 

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -137,6 +137,7 @@ private:
     InGameMenu &_inGameMenu;
 
     Slot _selectedSlot {Slot::None};
+    Slot _activeSlot {Slot::None};
     int _selectedItemIdx {-1};
 
     void onGUILoaded() override;
@@ -206,6 +207,7 @@ private:
     void updateEquipment();
     void updateItems();
     void updatePortraits();
+    void activateSlot(Slot slot);
     void selectSlot(Slot slot);
 
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -29,7 +29,6 @@ namespace reone {
 namespace game {
 
 class Creature;
-class Item;
 
 }
 
@@ -210,8 +209,6 @@ private:
     void updatePortraits();
     void activateSlot(Slot slot);
     void selectSlot(Slot slot);
-    int resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<Item> &item, const Creature &creature) const;
-    bool canEquipItemInSlot(int slot, const Item &item, const Creature &creature) const;
 
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;
     std::shared_ptr<graphics::Texture> getEmptySlotIcon(Slot slot) const;

--- a/include/reone/gui/control.h
+++ b/include/reone/gui/control.h
@@ -186,7 +186,7 @@ public:
 
     virtual bool handleMouseMotion(int x, int y);
     virtual bool handleMouseWheel(int x, int y);
-    virtual bool handleClick(int x, int y);
+    virtual bool handleClick(int x, int y, int clicks = 1);
 
     // END User input
 

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -77,6 +77,7 @@ public:
     void setExtentHeight(int height) override;
     void setSelectionMode(SelectionMode mode);
     void setProtoMatchContent(bool match);
+    void setRenderItemIconsForButtonProto(bool render);
 
     int getItemCount() const;
     const Item &getItemAt(int index) const;
@@ -101,6 +102,7 @@ private:
     int _selectedItemIndex {-1};
     int _itemMargin {0};
     bool _protoMatchContent {false}; /**< proto item height must match its content */
+    bool _renderItemIconsForButtonProto {false};
 
     // Event listeners
 
@@ -110,7 +112,14 @@ private:
 
     void updateItemSlots();
 
+    int getItemTextWidth() const;
     int getItemIndex(int y) const;
+    bool shouldRenderItemIconsForButtonProto() const;
+    void renderItemWithButtonProtoIcon(
+        const glm::ivec2 &screenSize,
+        const glm::ivec2 &offset,
+        const Item &item,
+        scene::IRenderPass &pass);
 };
 
 } // namespace gui

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -77,6 +77,7 @@ public:
     void setExtent(Extent extent) override;
     void setExtentHeight(int height) override;
     void setSelectionMode(SelectionMode mode);
+    void setSelectedItemIndex(int index);
     void setItemsInteractive(bool interactive);
     void setProtoMatchContent(bool match);
     void setRenderItemIconsForButtonProto(bool render);

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -38,6 +38,7 @@ public:
         std::string iconText;
         std::shared_ptr<graphics::Texture> iconTexture;
         std::shared_ptr<graphics::Texture> iconFrame;
+        bool invalid {false};
 
         std::vector<std::string> _textLines;
     };

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -67,7 +67,7 @@ public:
     void load(const resource::generated::GUI_BASECONTROL &gui, bool protoItem) override;
     bool handleMouseMotion(int x, int y) override;
     bool handleMouseWheel(int x, int y) override;
-    bool handleClick(int x, int y) override;
+    bool handleClick(int x, int y, int clicks = 1) override;
     void render(const glm::ivec2 &screenSize, const glm::ivec2 &offset, scene::IRenderPass &pass) override;
     void stretch(float x, float y, int mask) override;
 
@@ -92,6 +92,7 @@ public:
     // Event listeners
 
     void setOnItemClick(std::function<void(const std::string &)> fn) { _onItemClick = std::move(fn); }
+    void setOnItemDoubleClick(std::function<void(const std::string &)> fn) { _onItemDoubleClick = std::move(fn); }
 
     // END Event listeners
 
@@ -111,6 +112,7 @@ private:
     // Event listeners
 
     std::function<void(const std::string &)> _onItemClick;
+    std::function<void(const std::string &)> _onItemDoubleClick;
 
     // END Event listeners
 

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -77,6 +77,7 @@ public:
     void setExtent(Extent extent) override;
     void setExtentHeight(int height) override;
     void setSelectionMode(SelectionMode mode);
+    void setItemsInteractive(bool interactive);
     void setProtoMatchContent(bool match);
     void setRenderItemIconsForButtonProto(bool render);
 
@@ -102,6 +103,7 @@ private:
     int _itemOffset {0};
     int _selectedItemIndex {-1};
     int _itemMargin {0};
+    bool _itemsInteractive {true};
     bool _protoMatchContent {false}; /**< proto item height must match its content */
     bool _renderItemIconsForButtonProto {false};
 

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -180,6 +180,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/effect/visual.h
     ${GAME_INCLUDE_DIR}/effect/vpregenmodifier.h
     ${GAME_INCLUDE_DIR}/effect/whirlwind.h
+    ${GAME_INCLUDE_DIR}/equipmentrules.h
     ${GAME_INCLUDE_DIR}/event.h
     ${GAME_INCLUDE_DIR}/footstepsounds.h
     ${GAME_INCLUDE_DIR}/game.h
@@ -449,6 +450,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/effect/vpregenmodifier.cpp
     ${GAME_SOURCE_DIR}/effect/whirlwind.cpp
     ${GAME_SOURCE_DIR}/effect.cpp
+    ${GAME_SOURCE_DIR}/equipmentrules.cpp
     ${GAME_SOURCE_DIR}/footstepsounds.cpp
     ${GAME_SOURCE_DIR}/game.cpp
     ${GAME_SOURCE_DIR}/gui/actionbar.cpp

--- a/src/libs/game/equipmentrules.cpp
+++ b/src/libs/game/equipmentrules.cpp
@@ -70,6 +70,17 @@ bool areWeaponsCompatible(const Item &mainHand, const Item &offHand) {
            mainHand.weaponType() != WeaponType::None;
 }
 
+static int getCandidateEquipSlot(int requestedSlot) {
+    switch (requestedSlot) {
+    case InventorySlots::rightWeapon2:
+        return InventorySlots::rightWeapon;
+    case InventorySlots::leftWeapon2:
+        return InventorySlots::leftWeapon;
+    default:
+        return requestedSlot;
+    }
+}
+
 static int resolveActualEquipSlot(int requestedSlot, const Item &item, const Creature &creature) {
     if (!isOffHandWeaponSlot(requestedSlot))
         return requestedSlot;
@@ -78,7 +89,7 @@ static int resolveActualEquipSlot(int requestedSlot, const Item &item, const Cre
     if (creature.getEquippedItem(mainHandSlot) || creature.getEquippedItem(requestedSlot))
         return requestedSlot;
 
-    return isOneHandedWeapon(item) && item.isEquippable(mainHandSlot) ? mainHandSlot : requestedSlot;
+    return isOneHandedWeapon(item) && item.isEquippable(getCandidateEquipSlot(mainHandSlot)) ? mainHandSlot : requestedSlot;
 }
 
 EquipmentSlotActivationDecision evaluateEquipmentSlotActivation(
@@ -122,7 +133,7 @@ EquipmentCandidateDecision evaluateEquipmentCandidate(
         return result;
     }
 
-    if (!item->isEquippable(requestedSlot)) {
+    if (!item->isEquippable(getCandidateEquipSlot(requestedSlot))) {
         result.action = EquipmentCandidateAction::Reject;
         result.reason = EquipmentCandidateReason::NotEquippableInRequestedSlot;
         return result;

--- a/src/libs/game/equipmentrules.cpp
+++ b/src/libs/game/equipmentrules.cpp
@@ -81,6 +81,26 @@ static int resolveActualEquipSlot(int requestedSlot, const Item &item, const Cre
     return isOneHandedWeapon(item) && item.isEquippable(mainHandSlot) ? mainHandSlot : requestedSlot;
 }
 
+EquipmentSlotActivationDecision evaluateEquipmentSlotActivation(
+    const Creature &creature,
+    int requestedSlot) {
+
+    EquipmentSlotActivationDecision result;
+    result.requestedSlot = requestedSlot;
+
+    if (!isOffHandWeaponSlot(requestedSlot))
+        return result;
+
+    result.pairedSlot = getPairedMainHandSlot(requestedSlot);
+    auto mainHand = creature.getEquippedItem(result.pairedSlot);
+    if (mainHand && isTwoHandedWeapon(*mainHand)) {
+        result.available = false;
+        result.reason = EquipmentSlotActivationReason::OffHandBlockedByTwoHandedMainHand;
+    }
+
+    return result;
+}
+
 EquipmentCandidateDecision evaluateEquipmentCandidate(
     const Creature &creature,
     int requestedSlot,

--- a/src/libs/game/equipmentrules.cpp
+++ b/src/libs/game/equipmentrules.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/equipmentrules.h"
+
+#include "reone/game/object/creature.h"
+#include "reone/game/object/item.h"
+#include "reone/game/types.h"
+
+namespace reone {
+
+namespace game {
+
+bool isMainHandWeaponSlot(int slot) {
+    return slot == InventorySlots::rightWeapon || slot == InventorySlots::rightWeapon2;
+}
+
+bool isOffHandWeaponSlot(int slot) {
+    return slot == InventorySlots::leftWeapon || slot == InventorySlots::leftWeapon2;
+}
+
+int getPairedMainHandSlot(int offHandSlot) {
+    return offHandSlot == InventorySlots::leftWeapon2 ? InventorySlots::rightWeapon2 : InventorySlots::rightWeapon;
+}
+
+int getPairedOffHandSlot(int mainHandSlot) {
+    return mainHandSlot == InventorySlots::rightWeapon2 ? InventorySlots::leftWeapon2 : InventorySlots::leftWeapon;
+}
+
+bool isOneHandedWeapon(const Item &item) {
+    switch (item.weaponWield()) {
+    case WeaponWield::StunBaton:
+    case WeaponWield::SingleSword:
+    case WeaponWield::BlasterPistol:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isTwoHandedWeapon(const Item &item) {
+    switch (item.weaponWield()) {
+    case WeaponWield::DoubleBladedSword:
+    case WeaponWield::BlasterRifle:
+    case WeaponWield::HeavyWeapon:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool areWeaponsCompatible(const Item &mainHand, const Item &offHand) {
+    return isOneHandedWeapon(mainHand) &&
+           isOneHandedWeapon(offHand) &&
+           mainHand.weaponType() == offHand.weaponType() &&
+           mainHand.weaponType() != WeaponType::None;
+}
+
+static int resolveActualEquipSlot(int requestedSlot, const Item &item, const Creature &creature) {
+    if (!isOffHandWeaponSlot(requestedSlot))
+        return requestedSlot;
+
+    int mainHandSlot = getPairedMainHandSlot(requestedSlot);
+    if (creature.getEquippedItem(mainHandSlot) || creature.getEquippedItem(requestedSlot))
+        return requestedSlot;
+
+    return isOneHandedWeapon(item) && item.isEquippable(mainHandSlot) ? mainHandSlot : requestedSlot;
+}
+
+EquipmentCandidateDecision evaluateEquipmentCandidate(
+    const Creature &creature,
+    int requestedSlot,
+    const Item *item) {
+
+    EquipmentCandidateDecision result;
+    result.requestedSlot = requestedSlot;
+    result.actualSlot = requestedSlot;
+
+    if (!item) {
+        result.visible = true;
+        result.valid = true;
+        if (isMainHandWeaponSlot(requestedSlot)) {
+            result.pairedSlot = getPairedOffHandSlot(requestedSlot);
+            result.action = EquipmentCandidateAction::ClearMainHandAndOffHand;
+        } else {
+            result.action = EquipmentCandidateAction::ClearSlot;
+        }
+        return result;
+    }
+
+    if (!item->isEquippable(requestedSlot)) {
+        result.action = EquipmentCandidateAction::Reject;
+        result.reason = EquipmentCandidateReason::NotEquippableInRequestedSlot;
+        return result;
+    }
+
+    result.visible = true;
+    result.actualSlot = resolveActualEquipSlot(requestedSlot, *item, creature);
+    result.valid = true;
+    result.action = result.actualSlot != requestedSlot ? EquipmentCandidateAction::EquipMainHandFromOffHand : EquipmentCandidateAction::Equip;
+
+    if (isOffHandWeaponSlot(result.actualSlot)) {
+        if (isTwoHandedWeapon(*item)) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::TwoHandedInOffHand;
+            return result;
+        }
+
+        result.pairedSlot = getPairedMainHandSlot(result.actualSlot);
+        auto mainHand = creature.getEquippedItem(result.pairedSlot);
+        if (!mainHand) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::OffHandRequiresMainHand;
+            return result;
+        }
+
+        if (isTwoHandedWeapon(*mainHand)) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::IncompatibleWithMainHand;
+            return result;
+        }
+
+        if (!areWeaponsCompatible(*mainHand, *item)) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::IncompatibleWithMainHand;
+        }
+        return result;
+    }
+
+    if (isMainHandWeaponSlot(result.actualSlot)) {
+        result.pairedSlot = getPairedOffHandSlot(result.actualSlot);
+        auto offHand = creature.getEquippedItem(result.pairedSlot);
+        if (!offHand)
+            return result;
+
+        if (isTwoHandedWeapon(*item)) {
+            result.action = EquipmentCandidateAction::EquipAndClearOffHand;
+            result.reason = EquipmentCandidateReason::MainHandTwoHandedClearsOffHand;
+            return result;
+        }
+
+        if (!areWeaponsCompatible(*item, *offHand)) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::IncompatibleWithOffHand;
+        }
+    }
+
+    return result;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/equipmentrules.cpp
+++ b/src/libs/game/equipmentrules.cpp
@@ -63,9 +63,15 @@ bool isTwoHandedWeapon(const Item &item) {
     }
 }
 
+bool weaponRequiresEmptyPairedSlot(const Item &item) {
+    return isTwoHandedWeapon(item) || item.weaponWield() == WeaponWield::StunBaton;
+}
+
 bool areWeaponsCompatible(const Item &mainHand, const Item &offHand) {
     return isOneHandedWeapon(mainHand) &&
            isOneHandedWeapon(offHand) &&
+           !weaponRequiresEmptyPairedSlot(mainHand) &&
+           !weaponRequiresEmptyPairedSlot(offHand) &&
            mainHand.weaponType() == offHand.weaponType() &&
            mainHand.weaponType() != WeaponType::None;
 }
@@ -104,9 +110,9 @@ EquipmentSlotActivationDecision evaluateEquipmentSlotActivation(
 
     result.pairedSlot = getPairedMainHandSlot(requestedSlot);
     auto mainHand = creature.getEquippedItem(result.pairedSlot);
-    if (mainHand && isTwoHandedWeapon(*mainHand)) {
+    if (mainHand && weaponRequiresEmptyPairedSlot(*mainHand)) {
         result.available = false;
-        result.reason = EquipmentSlotActivationReason::OffHandBlockedByTwoHandedMainHand;
+        result.reason = EquipmentSlotActivationReason::OffHandBlockedByMainHandWeapon;
     }
 
     return result;
@@ -151,6 +157,12 @@ EquipmentCandidateDecision evaluateEquipmentCandidate(
             result.reason = EquipmentCandidateReason::TwoHandedInOffHand;
             return result;
         }
+        if (weaponRequiresEmptyPairedSlot(*item)) {
+            result.valid = false;
+            result.action = EquipmentCandidateAction::Reject;
+            result.reason = EquipmentCandidateReason::WeaponRequiresEmptyPairedSlot;
+            return result;
+        }
 
         result.pairedSlot = getPairedMainHandSlot(result.actualSlot);
         auto mainHand = creature.getEquippedItem(result.pairedSlot);
@@ -161,7 +173,7 @@ EquipmentCandidateDecision evaluateEquipmentCandidate(
             return result;
         }
 
-        if (isTwoHandedWeapon(*mainHand)) {
+        if (weaponRequiresEmptyPairedSlot(*mainHand)) {
             result.valid = false;
             result.action = EquipmentCandidateAction::Reject;
             result.reason = EquipmentCandidateReason::IncompatibleWithMainHand;
@@ -182,9 +194,9 @@ EquipmentCandidateDecision evaluateEquipmentCandidate(
         if (!offHand)
             return result;
 
-        if (isTwoHandedWeapon(*item)) {
+        if (weaponRequiresEmptyPairedSlot(*item)) {
             result.action = EquipmentCandidateAction::EquipAndClearOffHand;
-            result.reason = EquipmentCandidateReason::MainHandTwoHandedClearsOffHand;
+            result.reason = EquipmentCandidateReason::MainHandWeaponClearsOffHand;
             return result;
         }
 

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -251,7 +251,9 @@ void Equipment::selectSlot(Slot slot) {
 
     for (auto &lbl : _lblInv) {
         lbl.second->setVisible(noneSelected);
-        lbl.second->setVisible(noneSelected);
+    }
+    for (auto &btn : _btnInv) {
+        btn.second->setVisible(noneSelected);
     }
 
     _controls.LB_DESC->setVisible(!noneSelected);

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -115,16 +115,19 @@ void Equipment::onGUILoaded() {
     });
 
     for (auto &slotButton : _btnInv) {
-        slotButton.second->setOnClick([&]() {
-            selectSlot(slotButton.first);
+        auto slot = slotButton.first;
+        slotButton.second->setOnClick([this, slot]() {
+            selectSlot(slot);
         });
-        slotButton.second->setOnSelectionChanged([&](bool selected) {
+        slotButton.second->setOnSelectionChanged([this, slot](bool selected) {
             if (!selected)
                 return;
 
+            activateSlot(slot);
+
             std::string slotDesc;
 
-            auto maybeStrRef = g_slotStrRefs.find(slotButton.first);
+            auto maybeStrRef = g_slotStrRefs.find(slot);
             if (maybeStrRef != g_slotStrRefs.end()) {
                 slotDesc = _services.resource.strings.getText(maybeStrRef->second);
             }
@@ -176,7 +179,7 @@ static int getInventorySlot(Equipment::Slot slot) {
 }
 
 void Equipment::onItemsListBoxItemClick(const std::string &item) {
-    if (_selectedSlot == Slot::None)
+    if (_activeSlot == Slot::None)
         return;
 
     std::shared_ptr<Creature> player(_game.party().player());
@@ -189,7 +192,7 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
             }
         }
     }
-    int slot = getInventorySlot(_selectedSlot);
+    int slot = getInventorySlot(_activeSlot);
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
     std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
 
@@ -261,6 +264,11 @@ void Equipment::selectSlot(Slot slot) {
     }
     _selectedSlot = slot;
 
+    activateSlot(slot);
+}
+
+void Equipment::activateSlot(Slot slot) {
+    _activeSlot = slot;
     updateItems();
 }
 
@@ -349,7 +357,7 @@ std::shared_ptr<Texture> Equipment::getEmptySlotIcon(Slot slot) const {
 void Equipment::updateItems() {
     _controls.LB_ITEMS->clearItems();
 
-    if (_selectedSlot != Slot::None) {
+    if (_activeSlot != Slot::None) {
         ListBox::Item lbItem;
         lbItem.tag = "[none]";
         lbItem.text = _services.resource.strings.getText(kStrRefNone);
@@ -361,11 +369,11 @@ void Equipment::updateItems() {
     std::shared_ptr<Creature> player(_game.party().player());
 
     for (auto &item : player->items()) {
-        if (_selectedSlot == Slot::None) {
+        if (_activeSlot == Slot::None) {
             if (!item->isEquippable())
                 continue;
         } else {
-            int slot = getInventorySlot(_selectedSlot);
+            int slot = getInventorySlot(_activeSlot);
             if (!item->isEquippable(slot))
                 continue;
         }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -178,6 +178,51 @@ static int getInventorySlot(Equipment::Slot slot) {
     }
 }
 
+static bool isMainHandWeaponSlot(int slot) {
+    return slot == InventorySlots::rightWeapon || slot == InventorySlots::rightWeapon2;
+}
+
+static bool isOffHandWeaponSlot(int slot) {
+    return slot == InventorySlots::leftWeapon || slot == InventorySlots::leftWeapon2;
+}
+
+static int getPairedMainHandSlot(int offHandSlot) {
+    return offHandSlot == InventorySlots::leftWeapon2 ? InventorySlots::rightWeapon2 : InventorySlots::rightWeapon;
+}
+
+static int getPairedOffHandSlot(int mainHandSlot) {
+    return mainHandSlot == InventorySlots::rightWeapon2 ? InventorySlots::leftWeapon2 : InventorySlots::leftWeapon;
+}
+
+static bool isOneHandedWeapon(const Item &item) {
+    switch (item.weaponWield()) {
+    case WeaponWield::StunBaton:
+    case WeaponWield::SingleSword:
+    case WeaponWield::BlasterPistol:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool isTwoHandedWeapon(const Item &item) {
+    switch (item.weaponWield()) {
+    case WeaponWield::DoubleBladedSword:
+    case WeaponWield::BlasterRifle:
+    case WeaponWield::HeavyWeapon:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool areWeaponsCompatible(const Item &mainHand, const Item &offHand) {
+    return isOneHandedWeapon(mainHand) &&
+           isOneHandedWeapon(offHand) &&
+           mainHand.weaponType() == offHand.weaponType() &&
+           mainHand.weaponType() != WeaponType::None;
+}
+
 void Equipment::onItemsListBoxItemClick(const std::string &item) {
     if (_activeSlot == Slot::None)
         return;
@@ -196,10 +241,20 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
     int slot = resolveActualEquipSlot(getInventorySlot(_activeSlot), itemObj, *partyLeader);
     std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
 
-    if (equipped != itemObj) {
+    if (itemObj && !canEquipItemInSlot(slot, *itemObj, *partyLeader))
+        return;
+
+    bool clearPairedOffHand = !itemObj && isMainHandWeaponSlot(slot);
+    std::shared_ptr<Item> pairedOffHand(clearPairedOffHand ? partyLeader->getEquippedItem(getPairedOffHandSlot(slot)) : nullptr);
+
+    if (equipped != itemObj || pairedOffHand) {
         if (equipped) {
             partyLeader->unequip(equipped);
             player->addItem(equipped);
+        }
+        if (pairedOffHand) {
+            partyLeader->unequip(pairedOffHand);
+            player->addItem(pairedOffHand);
         }
         if (itemObj) {
             bool last;
@@ -298,6 +353,32 @@ int Equipment::resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<I
     default:
         return requestedSlot;
     }
+}
+
+bool Equipment::canEquipItemInSlot(int slot, const Item &item, const Creature &creature) const {
+    if (isOffHandWeaponSlot(slot)) {
+        if (isTwoHandedWeapon(item))
+            return false;
+
+        auto mainHand = creature.getEquippedItem(getPairedMainHandSlot(slot));
+        if (!mainHand)
+            return false;
+
+        return areWeaponsCompatible(*mainHand, item);
+    }
+
+    if (isMainHandWeaponSlot(slot)) {
+        auto offHand = creature.getEquippedItem(getPairedOffHandSlot(slot));
+        if (!offHand)
+            return true;
+
+        if (isTwoHandedWeapon(item))
+            return false;
+
+        return areWeaponsCompatible(item, *offHand);
+    }
+
+    return true;
 }
 
 void Equipment::updateEquipment() {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -300,11 +300,15 @@ void Equipment::confirmCandidateItem(const std::string &item) {
             bool last;
             if (player->removeItem(itemObj, last)) {
                 if (last) {
-                    partyLeader->equip(slot, itemObj);
+                    if (!partyLeader->equip(slot, itemObj)) {
+                        player->addItem(itemObj);
+                    }
                 } else {
                     std::shared_ptr<Item> clonedItem = _game.newItem();
                     clonedItem->loadFromBlueprint(itemObj->blueprintResRef());
-                    partyLeader->equip(slot, clonedItem);
+                    if (!partyLeader->equip(slot, clonedItem)) {
+                        player->addItem(itemObj);
+                    }
                 }
             }
         }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -140,6 +140,7 @@ void Equipment::onGUILoaded() {
 }
 
 void Equipment::configureItemsListBox() {
+    _controls.LB_ITEMS->setItemsInteractive(false);
     _controls.LB_ITEMS->setRenderItemIconsForButtonProto(true);
     _controls.LB_ITEMS->setPadding(5);
     _controls.LB_ITEMS->setOnItemClick([this](const std::string &item) {
@@ -225,7 +226,7 @@ static int getInventorySlot(Equipment::Slot slot) {
 }
 
 void Equipment::onItemsListBoxItemClick(const std::string &item) {
-    if (_activeSlot == Slot::None)
+    if (_selectedSlot == Slot::None)
         return;
 
     std::shared_ptr<Creature> player(_game.party().player());
@@ -239,7 +240,7 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
         }
     }
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
-    EquipmentCandidateDecision decision(evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_activeSlot), itemObj.get()));
+    EquipmentCandidateDecision decision(evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_selectedSlot), itemObj.get()));
     if (!decision.valid)
         return;
 
@@ -342,6 +343,7 @@ void Equipment::selectSlot(Slot slot) {
 
 void Equipment::activateSlot(Slot slot) {
     _activeSlot = slot;
+    _controls.LB_ITEMS->setItemsInteractive(_selectedSlot != Slot::None);
     clearCandidateDescription();
     updateItems();
 }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -250,7 +250,10 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
                               decision.action == EquipmentCandidateAction::EquipAndClearOffHand;
     std::shared_ptr<Item> pairedOffHand(clearPairedOffHand ? partyLeader->getEquippedItem(decision.pairedSlot) : nullptr);
 
-    if (equipped != itemObj || pairedOffHand) {
+    bool clearAction = decision.action == EquipmentCandidateAction::ClearSlot ||
+                       decision.action == EquipmentCandidateAction::ClearMainHandAndOffHand;
+    bool equipmentChanged = equipped != itemObj || pairedOffHand;
+    if (equipmentChanged) {
         if (equipped) {
             partyLeader->unequip(equipped);
             player->addItem(equipped);
@@ -271,6 +274,8 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
                 }
             }
         }
+    }
+    if (equipmentChanged || clearAction) {
         updateEquipment();
         selectSlot(Slot::None);
     }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -38,6 +38,7 @@ namespace reone {
 namespace game {
 
 static constexpr int kStrRefNone = 363;
+static constexpr int kStrRefBlockedByTwoHandedMainHand = 42344;
 static constexpr char kNoneItemTag[] = "[none]";
 static constexpr char kEquippedItemTag[] = "[equipped]";
 static constexpr char kEquippedItemSuffix[] = " (equipped)";
@@ -124,6 +125,14 @@ void Equipment::onGUILoaded() {
     for (auto &slotButton : _btnInv) {
         auto slot = slotButton.first;
         slotButton.second->setOnClick([this, slot]() {
+            std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+            auto activation = evaluateEquipmentSlotActivation(*partyLeader, getInventorySlot(slot));
+            if (!activation.available) {
+                _controls.LBL_CANTEQUIP->setTextMessage(_services.resource.strings.getText(kStrRefBlockedByTwoHandedMainHand));
+                _controls.LBL_CANTEQUIP->setVisible(true);
+                return;
+            }
+
             selectSlot(slot);
         });
         slotButton.second->setOnSelectionChanged([this, slot](bool selected) {
@@ -372,6 +381,8 @@ void Equipment::selectSlot(Slot slot) {
 void Equipment::activateSlot(Slot slot) {
     _activeSlot = slot;
     _controls.LB_ITEMS->setItemsInteractive(_selectedSlot != Slot::None);
+    _controls.LBL_CANTEQUIP->setTextMessage("");
+    _controls.LBL_CANTEQUIP->setVisible(false);
     clearCandidateDescription();
     updateItems();
     updateCandidateDescription();
@@ -464,8 +475,11 @@ void Equipment::updateItems() {
     clearCandidateDescription();
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
     std::shared_ptr<Item> equipped;
+    int activeInventorySlot = -1;
 
     if (_activeSlot != Slot::None) {
+        activeInventorySlot = getInventorySlot(_activeSlot);
+
         ListBox::Item lbItem;
         lbItem.tag = kNoneItemTag;
         lbItem.text = _services.resource.strings.getText(kStrRefNone);
@@ -474,7 +488,11 @@ void Equipment::updateItems() {
 
         _controls.LB_ITEMS->addItem(std::move(lbItem));
 
-        equipped = partyLeader->getEquippedItem(getInventorySlot(_activeSlot));
+        auto activation = evaluateEquipmentSlotActivation(*partyLeader, activeInventorySlot);
+        if (!activation.available)
+            return;
+
+        equipped = partyLeader->getEquippedItem(activeInventorySlot);
         if (equipped) {
             ListBox::Item equippedItem;
             equippedItem.tag = kEquippedItemTag;
@@ -500,7 +518,7 @@ void Equipment::updateItems() {
             if (!item->isEquippable())
                 continue;
         } else {
-            decision = evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_activeSlot), item.get());
+            decision = evaluateEquipmentCandidate(*partyLeader, activeInventorySlot, item.get());
             hasDecision = true;
             if (!decision.visible)
                 continue;

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -38,6 +38,9 @@ namespace reone {
 namespace game {
 
 static constexpr int kStrRefNone = 363;
+static constexpr char kNoneItemTag[] = "[none]";
+static constexpr char kEquippedItemTag[] = "[equipped]";
+static constexpr char kEquippedItemSuffix[] = " (equipped)";
 
 static std::unordered_map<Equipment::Slot, std::string> g_slotNames = {
     {Equipment::Slot::Implant, "IMPLANT"},
@@ -64,6 +67,8 @@ static std::unordered_map<Equipment::Slot, int32_t> g_slotStrRefs = {
     {Equipment::Slot::WeapR, 31379},
     {Equipment::Slot::WeapL2, 31378},
     {Equipment::Slot::WeapR2, 31379}};
+
+static int getInventorySlot(Equipment::Slot slot);
 
 void Equipment::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
@@ -174,15 +179,20 @@ void Equipment::updateCandidateDescription() {
         return;
 
     const ListBox::Item &lbItem = _controls.LB_ITEMS->getItemAt(selectedItemIdx);
-    if (lbItem.tag == "[none]")
+    if (lbItem.tag == kNoneItemTag)
         return;
 
     std::shared_ptr<Item> itemObj;
-    std::shared_ptr<Creature> player(_game.party().player());
-    for (auto &playerItem : player->items()) {
-        if (playerItem->tag() == lbItem.tag) {
-            itemObj = playerItem;
-            break;
+    if (lbItem.tag == kEquippedItemTag) {
+        std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+        itemObj = partyLeader->getEquippedItem(getInventorySlot(_selectedSlot));
+    } else {
+        std::shared_ptr<Creature> player(_game.party().player());
+        for (auto &playerItem : player->items()) {
+            if (playerItem->tag() == lbItem.tag) {
+                itemObj = playerItem;
+                break;
+            }
         }
     }
     if (!itemObj)
@@ -228,10 +238,12 @@ static int getInventorySlot(Equipment::Slot slot) {
 void Equipment::onItemsListBoxItemClick(const std::string &item) {
     if (_selectedSlot == Slot::None)
         return;
+    if (item == kEquippedItemTag)
+        return;
 
     std::shared_ptr<Creature> player(_game.party().player());
     std::shared_ptr<Item> itemObj;
-    if (item != "[none]") {
+    if (item != kNoneItemTag) {
         for (auto &playerItem : player->items()) {
             if (playerItem->tag() == item) {
                 itemObj = playerItem;
@@ -434,19 +446,37 @@ void Equipment::updateItems() {
     _controls.LB_ITEMS->clearItems();
     clearCandidateDescription();
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+    std::shared_ptr<Item> equipped;
 
     if (_activeSlot != Slot::None) {
         ListBox::Item lbItem;
-        lbItem.tag = "[none]";
+        lbItem.tag = kNoneItemTag;
         lbItem.text = _services.resource.strings.getText(kStrRefNone);
         lbItem.iconTexture = _services.resource.textures.get("inone", TextureUsage::GUI);
         lbItem.iconFrame = getItemFrameTexture(1);
 
         _controls.LB_ITEMS->addItem(std::move(lbItem));
+
+        equipped = partyLeader->getEquippedItem(getInventorySlot(_activeSlot));
+        if (equipped) {
+            ListBox::Item equippedItem;
+            equippedItem.tag = kEquippedItemTag;
+            equippedItem.text = equipped->localizedName() + kEquippedItemSuffix;
+            equippedItem.iconTexture = equipped->icon();
+            equippedItem.iconFrame = getItemFrameTexture(equipped->stackSize());
+
+            if (equipped->stackSize() > 1) {
+                equippedItem.iconText = std::to_string(equipped->stackSize());
+            }
+            _controls.LB_ITEMS->addItem(std::move(equippedItem));
+        }
     }
     std::shared_ptr<Creature> player(_game.party().player());
 
     for (auto &item : player->items()) {
+        if (item == equipped)
+            continue;
+
         EquipmentCandidateDecision decision;
         bool hasDecision = false;
         if (_activeSlot == Slot::None) {
@@ -471,6 +501,9 @@ void Equipment::updateItems() {
             lbItem.iconText = std::to_string(item->stackSize());
         }
         _controls.LB_ITEMS->addItem(std::move(lbItem));
+    }
+    if (_selectedSlot != Slot::None) {
+        _controls.LB_ITEMS->setSelectedItemIndex(equipped ? 1 : 0);
     }
 }
 

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -135,13 +135,13 @@ void Equipment::onGUILoaded() {
 }
 
 void Equipment::configureItemsListBox() {
-    _controls.LB_ITEMS->changeProtoItemType(ControlType::ImageButton);
+    _controls.LB_ITEMS->setRenderItemIconsForButtonProto(true);
     _controls.LB_ITEMS->setPadding(5);
     _controls.LB_ITEMS->setOnItemClick([this](const std::string &item) {
         onItemsListBoxItemClick(item);
     });
 
-    auto &protoItem = static_cast<ImageButton &>(_controls.LB_ITEMS->protoItem());
+    auto &protoItem = _controls.LB_ITEMS->protoItem();
     protoItem.setBorderColor(_baseColor);
     protoItem.setHilightColor(_hilightColor);
 }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -110,7 +110,7 @@ void Equipment::onGUILoaded() {
         if (_selectedSlot == Slot::None) {
             _game.openInGame();
         } else {
-            selectSlot(Slot::None);
+            confirmSelectedCandidate();
         }
     });
     _controls.BTN_BACK->setOnClick([this]() {
@@ -146,10 +146,14 @@ void Equipment::onGUILoaded() {
 
 void Equipment::configureItemsListBox() {
     _controls.LB_ITEMS->setItemsInteractive(false);
+    _controls.LB_ITEMS->setSelectionMode(ListBox::SelectionMode::OnClick);
     _controls.LB_ITEMS->setRenderItemIconsForButtonProto(true);
     _controls.LB_ITEMS->setPadding(5);
     _controls.LB_ITEMS->setOnItemClick([this](const std::string &item) {
         onItemsListBoxItemClick(item);
+    });
+    _controls.LB_ITEMS->setOnItemDoubleClick([this](const std::string &item) {
+        confirmSelectedCandidate();
     });
 
     auto &protoItem = _controls.LB_ITEMS->protoItem();
@@ -235,7 +239,15 @@ static int getInventorySlot(Equipment::Slot slot) {
     }
 }
 
-void Equipment::onItemsListBoxItemClick(const std::string &item) {
+void Equipment::confirmSelectedCandidate() {
+    int selectedItemIdx = _controls.LB_ITEMS->selectedItemIndex();
+    if (selectedItemIdx < 0 || selectedItemIdx >= _controls.LB_ITEMS->getItemCount())
+        return;
+
+    confirmCandidateItem(_controls.LB_ITEMS->getItemAt(selectedItemIdx).tag);
+}
+
+void Equipment::confirmCandidateItem(const std::string &item) {
     if (_selectedSlot == Slot::None)
         return;
     if (item == kEquippedItemTag)
@@ -292,6 +304,10 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
         updateEquipment();
         selectSlot(Slot::None);
     }
+}
+
+void Equipment::onItemsListBoxItemClick(const std::string &item) {
+    updateCandidateDescription();
 }
 
 void Equipment::update() {
@@ -358,6 +374,7 @@ void Equipment::activateSlot(Slot slot) {
     _controls.LB_ITEMS->setItemsInteractive(_selectedSlot != Slot::None);
     clearCandidateDescription();
     updateItems();
+    updateCandidateDescription();
 }
 
 void Equipment::updateEquipment() {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -18,6 +18,7 @@
 #include "reone/game/gui/ingame/equip.h"
 
 #include "reone/game/di/services.h"
+#include "reone/game/equipmentrules.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/ingame.h"
 #include "reone/game/object/creature.h"
@@ -178,51 +179,6 @@ static int getInventorySlot(Equipment::Slot slot) {
     }
 }
 
-static bool isMainHandWeaponSlot(int slot) {
-    return slot == InventorySlots::rightWeapon || slot == InventorySlots::rightWeapon2;
-}
-
-static bool isOffHandWeaponSlot(int slot) {
-    return slot == InventorySlots::leftWeapon || slot == InventorySlots::leftWeapon2;
-}
-
-static int getPairedMainHandSlot(int offHandSlot) {
-    return offHandSlot == InventorySlots::leftWeapon2 ? InventorySlots::rightWeapon2 : InventorySlots::rightWeapon;
-}
-
-static int getPairedOffHandSlot(int mainHandSlot) {
-    return mainHandSlot == InventorySlots::rightWeapon2 ? InventorySlots::leftWeapon2 : InventorySlots::leftWeapon;
-}
-
-static bool isOneHandedWeapon(const Item &item) {
-    switch (item.weaponWield()) {
-    case WeaponWield::StunBaton:
-    case WeaponWield::SingleSword:
-    case WeaponWield::BlasterPistol:
-        return true;
-    default:
-        return false;
-    }
-}
-
-static bool isTwoHandedWeapon(const Item &item) {
-    switch (item.weaponWield()) {
-    case WeaponWield::DoubleBladedSword:
-    case WeaponWield::BlasterRifle:
-    case WeaponWield::HeavyWeapon:
-        return true;
-    default:
-        return false;
-    }
-}
-
-static bool areWeaponsCompatible(const Item &mainHand, const Item &offHand) {
-    return isOneHandedWeapon(mainHand) &&
-           isOneHandedWeapon(offHand) &&
-           mainHand.weaponType() == offHand.weaponType() &&
-           mainHand.weaponType() != WeaponType::None;
-}
-
 void Equipment::onItemsListBoxItemClick(const std::string &item) {
     if (_activeSlot == Slot::None)
         return;
@@ -238,14 +194,16 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
         }
     }
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
-    int slot = resolveActualEquipSlot(getInventorySlot(_activeSlot), itemObj, *partyLeader);
-    std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
-
-    if (itemObj && !canEquipItemInSlot(slot, *itemObj, *partyLeader))
+    EquipmentCandidateDecision decision(evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_activeSlot), itemObj.get()));
+    if (!decision.valid)
         return;
 
-    bool clearPairedOffHand = !itemObj && isMainHandWeaponSlot(slot);
-    std::shared_ptr<Item> pairedOffHand(clearPairedOffHand ? partyLeader->getEquippedItem(getPairedOffHandSlot(slot)) : nullptr);
+    int slot = decision.actualSlot;
+    std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
+
+    bool clearPairedOffHand = decision.action == EquipmentCandidateAction::ClearMainHandAndOffHand ||
+                              decision.action == EquipmentCandidateAction::EquipAndClearOffHand;
+    std::shared_ptr<Item> pairedOffHand(clearPairedOffHand ? partyLeader->getEquippedItem(decision.pairedSlot) : nullptr);
 
     if (equipped != itemObj || pairedOffHand) {
         if (equipped) {
@@ -327,58 +285,6 @@ void Equipment::selectSlot(Slot slot) {
 void Equipment::activateSlot(Slot slot) {
     _activeSlot = slot;
     updateItems();
-}
-
-int Equipment::resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<Item> &item, const Creature &creature) const {
-    if (!item)
-        return requestedSlot;
-
-    int mainHandSlot = -1;
-    if (requestedSlot == InventorySlots::leftWeapon) {
-        mainHandSlot = InventorySlots::rightWeapon;
-    } else if (requestedSlot == InventorySlots::leftWeapon2) {
-        mainHandSlot = InventorySlots::rightWeapon2;
-    } else {
-        return requestedSlot;
-    }
-
-    if (creature.getEquippedItem(mainHandSlot) || creature.getEquippedItem(requestedSlot))
-        return requestedSlot;
-
-    switch (item->weaponWield()) {
-    case WeaponWield::StunBaton:
-    case WeaponWield::SingleSword:
-    case WeaponWield::BlasterPistol:
-        return item->isEquippable(mainHandSlot) ? mainHandSlot : requestedSlot;
-    default:
-        return requestedSlot;
-    }
-}
-
-bool Equipment::canEquipItemInSlot(int slot, const Item &item, const Creature &creature) const {
-    if (isOffHandWeaponSlot(slot)) {
-        if (isTwoHandedWeapon(item))
-            return false;
-
-        auto mainHand = creature.getEquippedItem(getPairedMainHandSlot(slot));
-        if (!mainHand)
-            return false;
-
-        return areWeaponsCompatible(*mainHand, item);
-    }
-
-    if (isMainHandWeaponSlot(slot)) {
-        auto offHand = creature.getEquippedItem(getPairedOffHandSlot(slot));
-        if (!offHand)
-            return true;
-
-        if (isTwoHandedWeapon(item))
-            return false;
-
-        return areWeaponsCompatible(item, *offHand);
-    }
-
-    return true;
 }
 
 void Equipment::updateEquipment() {
@@ -479,12 +385,15 @@ void Equipment::updateItems() {
     std::shared_ptr<Creature> player(_game.party().player());
 
     for (auto &item : player->items()) {
+        EquipmentCandidateDecision decision;
+        bool hasDecision = false;
         if (_activeSlot == Slot::None) {
             if (!item->isEquippable())
                 continue;
         } else {
-            int slot = getInventorySlot(_activeSlot);
-            if (!item->isEquippable(slot))
+            decision = evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_activeSlot), item.get());
+            hasDecision = true;
+            if (!decision.visible)
                 continue;
         }
         ListBox::Item lbItem;
@@ -492,11 +401,9 @@ void Equipment::updateItems() {
         lbItem.text = item->localizedName();
         lbItem.iconTexture = item->icon();
         lbItem.iconFrame = getItemFrameTexture(item->stackSize());
-        lbItem.invalid = _activeSlot != Slot::None &&
-                         !canEquipItemInSlot(
-                             resolveActualEquipSlot(getInventorySlot(_activeSlot), item, *partyLeader),
-                             *item,
-                             *partyLeader);
+        if (hasDecision) {
+            lbItem.invalid = !decision.valid;
+        }
 
         if (item->stackSize() > 1) {
             lbItem.iconText = std::to_string(item->stackSize());

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -259,8 +259,10 @@ void Equipment::confirmSelectedCandidate() {
 void Equipment::confirmCandidateItem(const std::string &item) {
     if (_selectedSlot == Slot::None)
         return;
-    if (item == kEquippedItemTag)
+    if (item == kEquippedItemTag) {
+        selectSlot(Slot::None);
         return;
+    }
 
     std::shared_ptr<Creature> player(_game.party().player());
     std::shared_ptr<Item> itemObj;
@@ -549,9 +551,21 @@ void Equipment::updateItems() {
 std::shared_ptr<Texture> Equipment::getItemFrameTexture(int stackSize) const {
     std::string resRef;
     if (_game.isTSL()) {
-        resRef = stackSize > 1 ? "uibit_eqp_itm3" : "uibit_eqp_itm1";
+        if (stackSize >= 100) {
+            resRef = "uibit_eqp_itm3";
+        } else if (stackSize > 1) {
+            resRef = "uibit_eqp_itm2";
+        } else {
+            resRef = "uibit_eqp_itm1";
+        }
     } else {
-        resRef = stackSize > 1 ? "lbl_hex_7" : "lbl_hex_3";
+        if (stackSize >= 100) {
+            resRef = "lbl_hex_7";
+        } else if (stackSize > 1) {
+            resRef = "lbl_hex_6";
+        } else {
+            resRef = "lbl_hex_3";
+        }
     }
     return _services.resource.textures.get(resRef, TextureUsage::GUI);
 }

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -192,8 +192,8 @@ void Equipment::onItemsListBoxItemClick(const std::string &item) {
             }
         }
     }
-    int slot = getInventorySlot(_activeSlot);
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+    int slot = resolveActualEquipSlot(getInventorySlot(_activeSlot), itemObj, *partyLeader);
     std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
 
     if (equipped != itemObj) {
@@ -270,6 +270,32 @@ void Equipment::selectSlot(Slot slot) {
 void Equipment::activateSlot(Slot slot) {
     _activeSlot = slot;
     updateItems();
+}
+
+int Equipment::resolveActualEquipSlot(int requestedSlot, const std::shared_ptr<Item> &item, const Creature &creature) const {
+    if (!item)
+        return requestedSlot;
+
+    int mainHandSlot = -1;
+    if (requestedSlot == InventorySlots::leftWeapon) {
+        mainHandSlot = InventorySlots::rightWeapon;
+    } else if (requestedSlot == InventorySlots::leftWeapon2) {
+        mainHandSlot = InventorySlots::rightWeapon2;
+    } else {
+        return requestedSlot;
+    }
+
+    if (creature.getEquippedItem(mainHandSlot) || creature.getEquippedItem(requestedSlot))
+        return requestedSlot;
+
+    switch (item->weaponWield()) {
+    case WeaponWield::StunBaton:
+    case WeaponWield::SingleSword:
+    case WeaponWield::BlasterPistol:
+        return item->isEquippable(mainHandSlot) ? mainHandSlot : requestedSlot;
+    default:
+        return requestedSlot;
+    }
 }
 
 void Equipment::updateEquipment() {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -96,6 +96,7 @@ void Equipment::onGUILoaded() {
     // _controls.btnCharLeft->setVisible(false);
     // _controls.btnCharRight->setVisible(false);
     _controls.LB_DESC->setVisible(false);
+    _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LBL_CANTEQUIP->setVisible(false);
 
     configureItemsListBox();
@@ -148,6 +149,50 @@ void Equipment::configureItemsListBox() {
     auto &protoItem = _controls.LB_ITEMS->protoItem();
     protoItem.setBorderColor(_baseColor);
     protoItem.setHilightColor(_hilightColor);
+}
+
+void Equipment::clearCandidateDescription() {
+    _selectedItemIdx = -1;
+    _controls.LB_DESC->clearItems();
+}
+
+void Equipment::updateCandidateDescription() {
+    if (_selectedSlot == Slot::None) {
+        clearCandidateDescription();
+        return;
+    }
+
+    int selectedItemIdx = _controls.LB_ITEMS->selectedItemIndex();
+    if (selectedItemIdx == _selectedItemIdx)
+        return;
+
+    _selectedItemIdx = selectedItemIdx;
+    _controls.LB_DESC->clearItems();
+
+    if (selectedItemIdx < 0 || selectedItemIdx >= _controls.LB_ITEMS->getItemCount())
+        return;
+
+    const ListBox::Item &lbItem = _controls.LB_ITEMS->getItemAt(selectedItemIdx);
+    if (lbItem.tag == "[none]")
+        return;
+
+    std::shared_ptr<Item> itemObj;
+    std::shared_ptr<Creature> player(_game.party().player());
+    for (auto &playerItem : player->items()) {
+        if (playerItem->tag() == lbItem.tag) {
+            itemObj = playerItem;
+            break;
+        }
+    }
+    if (!itemObj)
+        return;
+
+    std::string description(itemObj->localizedName());
+    if (!itemObj->descIdentified().empty()) {
+        description += "\n\n";
+        description += itemObj->descIdentified();
+    }
+    _controls.LB_DESC->addTextLinesAsItems(description);
 }
 
 static int getInventorySlot(Equipment::Slot slot) {
@@ -245,6 +290,11 @@ void Equipment::update() {
     _controls.LBL_DEF->setTextMessage(std::to_string(partyLeader->getDefense()));
 }
 
+void Equipment::update(float dt) {
+    GameGUI::update(dt);
+    updateCandidateDescription();
+}
+
 void Equipment::updatePortraits() {
     if (_game.isTSL())
         return;
@@ -280,10 +330,14 @@ void Equipment::selectSlot(Slot slot) {
     _selectedSlot = slot;
 
     activateSlot(slot);
+    if (noneSelected) {
+        clearCandidateDescription();
+    }
 }
 
 void Equipment::activateSlot(Slot slot) {
     _activeSlot = slot;
+    clearCandidateDescription();
     updateItems();
 }
 
@@ -371,6 +425,7 @@ std::shared_ptr<Texture> Equipment::getEmptySlotIcon(Slot slot) const {
 
 void Equipment::updateItems() {
     _controls.LB_ITEMS->clearItems();
+    clearCandidateDescription();
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
 
     if (_activeSlot != Slot::None) {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -465,6 +465,7 @@ std::shared_ptr<Texture> Equipment::getEmptySlotIcon(Slot slot) const {
 
 void Equipment::updateItems() {
     _controls.LB_ITEMS->clearItems();
+    std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
 
     if (_activeSlot != Slot::None) {
         ListBox::Item lbItem;
@@ -491,6 +492,11 @@ void Equipment::updateItems() {
         lbItem.text = item->localizedName();
         lbItem.iconTexture = item->icon();
         lbItem.iconFrame = getItemFrameTexture(item->stackSize());
+        lbItem.invalid = _activeSlot != Slot::None &&
+                         !canEquipItemInSlot(
+                             resolveActualEquipSlot(getInventorySlot(_activeSlot), item, *partyLeader),
+                             *item,
+                             *partyLeader);
 
         if (item->stackSize() > 1) {
             lbItem.iconText = std::to_string(item->stackSize());

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -72,6 +72,17 @@ static const std::string g_maskHookNode("gogglehook");
 static const std::string g_rightHandNode("rhand");
 static const std::string g_leftHandNode("lhand");
 
+static int getEquipabilitySlot(int slot) {
+    switch (slot) {
+    case InventorySlots::rightWeapon2:
+        return InventorySlots::rightWeapon;
+    case InventorySlots::leftWeapon2:
+        return InventorySlots::leftWeapon;
+    default:
+        return slot;
+    }
+}
+
 void Creature::Path::selectNextPoint() {
     size_t pointCount = points.size();
     if (pointIdx < pointCount) {
@@ -349,7 +360,7 @@ bool Creature::equip(const std::string &resRef) {
 }
 
 bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
-    if (!item->isEquippable(slot)) {
+    if (!item->isEquippable(getEquipabilitySlot(slot))) {
         return false;
     }
 

--- a/src/libs/gui/control.cpp
+++ b/src/libs/gui/control.cpp
@@ -181,7 +181,7 @@ bool Control::handleMouseWheel(int x, int y) {
     return true;
 }
 
-bool Control::handleClick(int x, int y) {
+bool Control::handleClick(int x, int y, int clicks) {
     if (_onClick) {
         _onClick();
     }

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -166,7 +166,7 @@ void ListBox::updateItemSlots() {
     }
 }
 
-bool ListBox::handleClick(int x, int y) {
+bool ListBox::handleClick(int x, int y, int clicks) {
     if (!_itemsInteractive)
         return false;
 
@@ -179,6 +179,9 @@ bool ListBox::handleClick(int x, int y) {
     }
     if (_onItemClick) {
         _onItemClick(_items[itemIdx].tag);
+    }
+    if (clicks > 1 && _onItemDoubleClick) {
+        _onItemDoubleClick(_items[itemIdx].tag);
     }
 
     return true;

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -348,7 +348,8 @@ void ListBox::renderItemWithButtonProtoIcon(
     glm::ivec2 iconSize(originalExtent.height, originalExtent.height);
 
     if (item.iconFrame) {
-        pass.drawImage(*item.iconFrame, iconPosition, iconSize, glm::vec4(_protoItem->border().color, 1.0f));
+        glm::vec3 frameColor(item.invalid ? glm::vec3(1.0f, 0.0f, 0.0f) : _protoItem->border().color);
+        pass.drawImage(*item.iconFrame, iconPosition, iconSize, glm::vec4(frameColor, 1.0f));
     }
     if (item.iconTexture) {
         pass.drawImage(*item.iconTexture, iconPosition, iconSize);

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -28,6 +28,7 @@
 #include "reone/gui/gui.h"
 #include "reone/resource/gff.h"
 #include "reone/resource/resources.h"
+#include "reone/scene/render/pass.h"
 #include "reone/system/logutil.h"
 
 using namespace reone::graphics;
@@ -50,7 +51,7 @@ void ListBox::addItem(Item &&item) {
     if (!_protoItem)
         return;
 
-    item._textLines = breakText(item.text, *_protoItem->text().font, _protoItem->extent().width);
+    item._textLines = breakText(item.text, *_protoItem->text().font, getItemTextWidth());
     _items.push_back(item);
 
     updateItemSlots();
@@ -60,7 +61,7 @@ void ListBox::addTextLinesAsItems(const std::string &text) {
     if (!_protoItem)
         return;
 
-    std::vector<std::string> lines(breakText(text, *_protoItem->text().font, _protoItem->extent().width));
+    std::vector<std::string> lines(breakText(text, *_protoItem->text().font, getItemTextWidth()));
     for (auto &line : lines) {
         Item item;
         item.text = line;
@@ -207,6 +208,8 @@ void ListBox::render(const glm::ivec2 &screenSize,
         auto imageButton = std::dynamic_pointer_cast<ImageButton>(_protoItem);
         if (imageButton) {
             imageButton->render(itemOffset, item._textLines, item.iconText, item.iconTexture, item.iconFrame, pass);
+        } else if (shouldRenderItemIconsForButtonProto()) {
+            renderItemWithButtonProtoIcon(screenSize, itemOffset, item, pass);
         } else {
             _protoItem->setTextLines(item._textLines);
             _protoItem->render(screenSize, itemOffset, pass);
@@ -287,6 +290,69 @@ void ListBox::setSelectionMode(SelectionMode mode) {
 
 void ListBox::setProtoMatchContent(bool match) {
     _protoMatchContent = match;
+}
+
+void ListBox::setRenderItemIconsForButtonProto(bool render) {
+    _renderItemIconsForButtonProto = render;
+
+    if (!_protoItem)
+        return;
+
+    for (auto &item : _items) {
+        item._textLines = breakText(item.text, *_protoItem->text().font, getItemTextWidth());
+    }
+    updateItemSlots();
+}
+
+int ListBox::getItemTextWidth() const {
+    if (!_protoItem)
+        return 0;
+
+    int width = _protoItem->extent().width;
+    if (shouldRenderItemIconsForButtonProto()) {
+        width -= _protoItem->extent().height;
+        if (width < 0) {
+            width = 0;
+        }
+    }
+    return width;
+}
+
+bool ListBox::shouldRenderItemIconsForButtonProto() const {
+    return _renderItemIconsForButtonProto && static_cast<bool>(std::dynamic_pointer_cast<Button>(_protoItem));
+}
+
+void ListBox::renderItemWithButtonProtoIcon(
+    const glm::ivec2 &screenSize,
+    const glm::ivec2 &offset,
+    const Item &item,
+    IRenderPass &pass) {
+
+    Control::Extent originalExtent(_protoItem->extent());
+    Control::Extent textExtent(originalExtent);
+    textExtent.left += originalExtent.height;
+    textExtent.width -= originalExtent.height;
+    if (textExtent.width < 0) {
+        textExtent.width = 0;
+    }
+
+    _protoItem->setExtent(textExtent);
+    _protoItem->setTextLines(item._textLines);
+    _protoItem->render(screenSize, offset, pass);
+    _protoItem->setExtent(originalExtent);
+
+    if (!item.iconFrame && !item.iconTexture)
+        return;
+
+    glm::ivec2 iconPosition(offset.x + originalExtent.left, offset.y + originalExtent.top);
+    glm::ivec2 iconSize(originalExtent.height, originalExtent.height);
+
+    if (item.iconFrame) {
+        pass.drawImage(*item.iconFrame, iconPosition, iconSize, glm::vec4(_protoItem->border().color, 1.0f));
+    }
+    if (item.iconTexture) {
+        pass.drawImage(*item.iconTexture, iconPosition, iconSize);
+    }
 }
 
 const ListBox::Item &ListBox::getItemAt(int index) const {

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -91,7 +91,7 @@ void ListBox::load(const resource::generated::GUI_BASECONTROL &gui, bool protoIt
 }
 
 bool ListBox::handleMouseMotion(int x, int y) {
-    if (_selectionMode == SelectionMode::OnHover) {
+    if (_itemsInteractive && _selectionMode == SelectionMode::OnHover) {
         _selectedItemIndex = getItemIndex(y);
     }
     return false;
@@ -167,6 +167,9 @@ void ListBox::updateItemSlots() {
 }
 
 bool ListBox::handleClick(int x, int y) {
+    if (!_itemsInteractive)
+        return false;
+
     int itemIdx = getItemIndex(y);
     if (itemIdx == -1)
         return false;
@@ -286,6 +289,13 @@ void ListBox::changeProtoItemType(ControlType type) {
 
 void ListBox::setSelectionMode(SelectionMode mode) {
     _selectionMode = mode;
+}
+
+void ListBox::setItemsInteractive(bool interactive) {
+    _itemsInteractive = interactive;
+    if (!interactive) {
+        clearSelection();
+    }
 }
 
 void ListBox::setProtoMatchContent(bool match) {

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -327,7 +327,9 @@ int ListBox::getItemTextWidth() const {
 
     int width = _protoItem->extent().width;
     if (shouldRenderItemIconsForButtonProto()) {
-        width -= _protoItem->extent().height;
+        // Button-proto item icons render in a square gutter sized from the row height.
+        int itemIconWidth = _protoItem->extent().height;
+        width -= itemIconWidth;
         if (width < 0) {
             width = 0;
         }
@@ -346,9 +348,10 @@ void ListBox::renderItemWithButtonProtoIcon(
     IRenderPass &pass) {
 
     Control::Extent originalExtent(_protoItem->extent());
+    int itemIconWidth = originalExtent.height;
     Control::Extent textExtent(originalExtent);
-    textExtent.left += originalExtent.height;
-    textExtent.width -= originalExtent.height;
+    textExtent.left += itemIconWidth;
+    textExtent.width -= itemIconWidth;
     if (textExtent.width < 0) {
         textExtent.width = 0;
     }
@@ -362,14 +365,23 @@ void ListBox::renderItemWithButtonProtoIcon(
         return;
 
     glm::ivec2 iconPosition(offset.x + originalExtent.left, offset.y + originalExtent.top);
-    glm::ivec2 iconSize(originalExtent.height, originalExtent.height);
+    glm::ivec2 iconSize(itemIconWidth, originalExtent.height);
 
     if (item.iconFrame) {
-        glm::vec3 frameColor(item.invalid ? glm::vec3(1.0f, 0.0f, 0.0f) : _protoItem->border().color);
+        glm::vec3 frameColor(_protoItem->isSelected() ? _protoItem->hilight().color : _protoItem->border().color);
+        if (item.invalid) {
+            frameColor = glm::vec3(1.0f, 0.0f, 0.0f);
+        }
         pass.drawImage(*item.iconFrame, iconPosition, iconSize, glm::vec4(frameColor, 1.0f));
     }
     if (item.iconTexture) {
         pass.drawImage(*item.iconTexture, iconPosition, iconSize);
+    }
+    if (!item.iconText.empty() && _protoItem->text().font) {
+        glm::vec3 position(0.0f);
+        position.x = static_cast<float>(iconPosition.x + iconSize.x);
+        position.y = static_cast<float>(iconPosition.y + iconSize.y - 0.5f * _protoItem->text().font->height());
+        _protoItem->text().font->render(item.iconText, position, _protoItem->text().color, TextGravity::LeftCenter);
     }
 }
 

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -291,6 +291,10 @@ void ListBox::setSelectionMode(SelectionMode mode) {
     _selectionMode = mode;
 }
 
+void ListBox::setSelectedItemIndex(int index) {
+    _selectedItemIndex = index >= 0 && index < getItemCount() ? index : -1;
+}
+
 void ListBox::setItemsInteractive(bool interactive) {
     _itemsInteractive = interactive;
     if (!interactive) {

--- a/src/libs/gui/gui.cpp
+++ b/src/libs/gui/gui.cpp
@@ -177,7 +177,7 @@ bool GUI::handle(const input::Event &event) {
             if (control) {
                 debug("Control clicked: " + control->get().tag(), LogChannel::GUI);
                 onClick(control->get().tag());
-                return control->get().handleClick(ctrlCoords.x, ctrlCoords.y);
+                return control->get().handleClick(ctrlCoords.x, ctrlCoords.y, event.button.clicks);
             }
         }
         break;


### PR DESCRIPTION
## Summary

Improves equipment candidate selection and display.  Both K1 and K2 present shared logic for equipment tab behaviour (this works even with two configs in K2, as there is no way to call it in K1).  The below is consistent with K1 with separate GUI update to come:

- show item icons in equipment candidate rows
- filter equipment candidates by hovered/selected slot
- separate hover preview from interactive chooser mode
- add shared equipment candidate rule evaluation for visibility, validity, action, and slot activation
- reject incompatible weapon pairings before equipment/inventory mutation
- support off-hand-to-main-hand routing for empty-hand one-handed weapon selection
- clear off-hand when equipping a two-handed main-hand weapon
- block off-hand slot selection while a two-handed main-hand weapon is equipped
- support K2 secondary weapon configuration slots
- restore inventory item if an equip attempt fails after inventory removal
- mark invalid candidates with a red icon frame
- show the currently equipped item under `[none]`
- show candidate item descriptions while choosing equipment
- change chooser flow so click selects, OK confirms, and double-click confirms

## Notes / Omissions

- Equipment rules are expressed in inventory-slot terms for K1/K2 sharing.
- GUI remains responsible for layout, icons, red-frame presentation, descriptions, hover/selected state, and confirmation flow.
- Double-click support reuses the existing `MouseButtonEvent.clicks` value and is opt-in for `ListBox`.
- This does not add proficiency/restriction checks, item effects, or stat recalculation.
- Exact visual parity for selected-row breathing/yellow text borders, invalid red text borders, localized `(equipped)`, and ghosted paired two-handed off-hand display is left as follow-up work.

## Tests

- Release build
- `tests.exe`: 150 tests passed
- Manual K1 equipment regression
- Basic K2 equipment smoke