### PR TITLE
[game] Clear stunt mode during module party placement

### DIFF
--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -41,6 +41,7 @@ public:
     void update(float dt) override;
 
     void start(const std::shared_ptr<resource::Dialog> &dialog, const std::shared_ptr<Object> &owner);
+    void cleanupForModuleTransition();
 
     CameraType getCamera(int &cameraId) const;
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -491,6 +491,10 @@ bool Game::handleMouseButtonUp(const input::MouseButtonEvent &event) {
 void Game::loadModule(const std::string &name, std::string entry) {
     info("Loading module '" + name + "'");
 
+    if (_screen == Screen::Conversation && _conversation) {
+        _conversation->cleanupForModuleTransition();
+    }
+
     withLoadingScreen("load_" + name, [this, &name, &entry]() {
         loadInGameMenus();
 

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -120,6 +120,18 @@ void Conversation::finish() {
 void Conversation::onFinish() {
 }
 
+void Conversation::cleanupForModuleTransition() {
+    if (!_dialog) {
+        return;
+    }
+    if (_currentVoice) {
+        _currentVoice->stop();
+        _currentVoice.reset();
+    }
+    _lipAnimation.reset();
+    onFinish();
+}
+
 void Conversation::loadEntry(int index, bool start) {
     debug("Load entry " + std::to_string(index), LogChannel::Conversation);
     _currentEntry = &_dialog->getEntry(index);

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -604,9 +604,6 @@ void Area::loadParty(const glm::vec3 &position, float facing, bool fromSave) {
     for (int i = 0; i < party.getSize(); ++i) {
         auto member = party.getMember(i);
         if (!fromSave) {
-            if (member->isStuntMode()) {
-                member->stopStuntMode();
-            }
             member->setPosition(position);
             member->setFacing(facing);
         }

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -604,6 +604,9 @@ void Area::loadParty(const glm::vec3 &position, float facing, bool fromSave) {
     for (int i = 0; i < party.getSize(); ++i) {
         auto member = party.getMember(i);
         if (!fromSave) {
+            if (member->isStuntMode()) {
+                member->stopStuntMode();
+            }
             member->setPosition(position);
             member->setFacing(facing);
         }


### PR DESCRIPTION
## Summary

Fixes one cause of the Endar Spire -> STUNT_00 -> Taris hideout black-space/camera issue: stale stunt mode surviving into fresh module party placement.

The transition reaches the correct module and correct IFO/default entry. The player is logically placed at the valid `tar_m02af` apartment entry, but if stunt mode remains active, `Object::updateTransform()` skips scene-node updates. This can leave the rendered scene node / camera target stale even though the logical player coordinates are correct, causing the player/camera to appear in the skybox/backdrop.

This clears stale stunt mode for party members during fresh `Area::loadParty` placement before applying the new module position/facing.

This does not attempt to fix unrelated door/trigger return transitions or remaining cutscene staging issues.

## Classification

Shared-engine fix.

## What changed

- In `Area::loadParty()`, when loading fresh party placement, clear stunt mode before `setPosition` / `setFacing`.
- No waypoint resolution, IFO fallback, `landObject`, camera, or transition logic changed.
- No module-specific or coordinate-specific workaround.
- Save-load semantics are left unchanged because `fromSave=true` intentionally preserves saved state.

## Verification

- Manual clean repro: Endar Spire -> STUNT_00 -> `tar_m02af` -> Carth wake-up dialogue now renders correctly inside the apartment.
- Debug engine build passed.
- RelWithDebInfo engine build passed.
- `git diff --check` passed, with only existing CRLF normalization warnings.