### PR TITLE
[game] Add bash support for locked inventory placeables

### DIFF
--- a/include/reone/game/object/placeable.h
+++ b/include/reone/game/object/placeable.h
@@ -50,16 +50,24 @@ public:
     void loadFromGIT(const resource::generated::GIT_Placeable_List &git);
     void loadFromBlueprint(const std::string &resRef);
 
+    void damage(int amount, uint32_t damager) override;
+
     bool hasInventory() const { return _hasInventory; }
     bool isSelectable() const override { return _usable; }
     bool isUsable() const { return _usable; }
+    bool isLocked() const { return _locked; }
+    bool isKeyRequired() const { return _keyRequired; }
+    bool isNotBlastable() const { return _notBlastable; }
 
     int appearance() const { return _appearance; }
     Faction faction() const { return _faction; }
     std::shared_ptr<scene::WalkmeshSceneNode> walkmesh() const { return _walkmesh; }
 
+    void setLocked(bool locked) { _locked = locked; }
+
     // Scripts
 
+    void onOpen(uint32_t triggererId);
     void runOnUsed(std::shared_ptr<Object> usedBy);
     void runOnInvDisturbed(std::shared_ptr<Object> triggerrer);
 
@@ -79,6 +87,7 @@ private:
     int _fortitude {0};
     bool _partyInteract {false};
     bool _static {false};
+    bool _notBlastable {false};
 
     std::shared_ptr<scene::WalkmeshSceneNode> _walkmesh;
 
@@ -102,6 +111,8 @@ private:
 
     void loadUTP(const resource::generated::UTP &utp);
     void loadTransformFromGIT(const resource::generated::GIT_Placeable_List &git);
+    void runDamagedScript(uint32_t damagerId);
+    void runDeathScript(uint32_t damagerId);
 
     void updateTransform() override;
 };

--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -19,6 +19,7 @@
 #include "reone/game/object.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/door.h"
+#include "reone/game/object/placeable.h"
 
 namespace reone {
 
@@ -45,6 +46,28 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
     door.setLocked(false);
     door.open();
     door.onOpen(actor.id());
+
+    return true;
+}
+
+bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt) {
+    if (actor.type() == ObjectType::Creature) {
+        auto &creature = static_cast<Creature &>(actor);
+        bool reached = creature.navigateTo(placeable.position(), true, distance, dt);
+        if (!reached) {
+            return false;
+        }
+        creature.face(placeable);
+        creature.playAnimation(AnimationType::LoopingUnlockDoor);
+    }
+
+    // FIXME: wait for animation to play
+
+    if (placeable.isKeyRequired()) {
+        return true;
+    }
+
+    placeable.setLocked(false);
 
     return true;
 }

--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -52,12 +52,12 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
 
 bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt) {
     if (auto *creature = dyn_cast<Creature>(&actor)) {
-        bool reached = creature.navigateTo(placeable.position(), true, distance, dt);
+        bool reached = creature->navigateTo(placeable.position(), true, distance, dt);
         if (!reached) {
             return false;
         }
-        creature.face(placeable);
-        creature.playAnimation(AnimationType::LoopingUnlockDoor);
+        creature->face(placeable);
+        creature->playAnimation(AnimationType::LoopingUnlockDoor);
     }
 
     // FIXME: wait for animation to play

--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -51,7 +51,7 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
 }
 
 bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt) {
-    if (actor.type() == ObjectType::Creature) {
+    if (auto *creature = dyn_cast<Creature>(&actor)) {
         auto &creature = static_cast<Creature &>(actor);
         bool reached = creature.navigateTo(placeable.position(), true, distance, dt);
         if (!reached) {

--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -52,7 +52,6 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
 
 bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt) {
     if (auto *creature = dyn_cast<Creature>(&actor)) {
-        auto &creature = static_cast<Creature &>(actor);
         bool reached = creature.navigateTo(placeable.position(), true, distance, dt);
         if (!reached) {
             return false;

--- a/src/libs/game/action/commonactions.h
+++ b/src/libs/game/action/commonactions.h
@@ -23,10 +23,15 @@ namespace game {
 
 class Door;
 class Object;
+class Placeable;
 
 // Move an actor to a door, unlock and open it. Returns true when this action is
 // complete.
 bool unlockDoor(Door &door, Object &actor, float distance, float dt);
+
+// Move an actor to a placeable and unlock it. Returns true when this action is
+// complete.
+bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt);
 
 } // namespace game
 

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -20,6 +20,7 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
+#include "reone/game/object/placeable.h"
 
 namespace reone {
 
@@ -29,6 +30,12 @@ void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, f
     if (!_object || !isa<Creature>(actor)) {
         complete();
         return;
+    }
+    if (auto placeable = std::dynamic_pointer_cast<Placeable>(_object)) {
+        if (placeable->isLocked()) {
+            complete();
+            return;
+        }
     }
 
     auto &creatureActor = cast<Creature>(actor);

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -31,7 +31,7 @@ void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, f
         complete();
         return;
     }
-    if (auto placeable = std::dynamic_pointer_cast<Placeable>(_object)) {
+    if (auto placeable = dyn_cast<Placeable>(_object)) {
         if (placeable->isLocked()) {
             complete();
             return;

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -31,7 +31,7 @@ void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, f
         complete();
         return;
     }
-    if (auto placeable = dyn_cast<Placeable>(_object)) {
+    if (auto *placeable = dyn_cast<Placeable>(_object.get())) {
         if (placeable->isLocked()) {
             complete();
             return;

--- a/src/libs/game/action/useskill.cpp
+++ b/src/libs/game/action/useskill.cpp
@@ -21,6 +21,7 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
+#include "reone/game/object/placeable.h"
 #include "reone/game/script/runner.h"
 #include "reone/system/logutil.h"
 
@@ -31,9 +32,24 @@ namespace game {
 void UseSkillAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     switch (_skill) {
     case SkillType::Security: {
-        if (_target && _target->type() == ObjectType::Door) {
+        if (!_target) {
+            warn("ActionExecutor: unsupported Security target: null");
+            complete();
+            return;
+        }
+        if (_target->type() == ObjectType::Door) {
             Door &door = static_cast<Door &>(*_target);
             if (unlockDoor(door, actor, kDefaultMaxObjectDistance, dt)) {
+                complete();
+            }
+            return;
+        }
+        if (_target->type() == ObjectType::Placeable) {
+            auto &placeable = static_cast<Placeable &>(*_target);
+            if (unlockPlaceable(placeable, actor, kDefaultMaxObjectDistance, dt)) {
+                if (placeable.hasInventory() && !placeable.isLocked()) {
+                    _game.openContainer(_target);
+                }
                 complete();
             }
             return;

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -382,7 +382,7 @@ std::vector<ContextAction> Module::getContextActions(const std::shared_ptr<Objec
         break;
     }
     case ObjectType::Placeable: {
-        auto placeable = std::static_pointer_cast<Placeable>(object);
+        auto placeable = cast<Placeable>(object);
         auto leader = _game.party().getLeader();
         if (canBashPlaceable(*placeable, *leader, _services.game.reputes)) {
             actions.push_back(ContextAction(ActionType::AttackObject));

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -50,6 +50,24 @@ static bool canBashDoor(const Door &door, const Creature &actor, const IReputes 
            (door.hitPoints() > 0 || door.currentHitPoints() > 0);
 }
 
+static bool canUseSecurityOnPlaceable(const Placeable &placeable, const Creature &actor) {
+    return placeable.hasInventory() &&
+           placeable.isLocked() &&
+           !placeable.isKeyRequired() &&
+           actor.attributes().hasSkill(SkillType::Security);
+}
+
+static bool canBashPlaceable(const Placeable &placeable, const Creature &actor, const IReputes &reputes) {
+    return placeable.hasInventory() &&
+           placeable.isLocked() &&
+           placeable.isSelectable() &&
+           !placeable.isDead() &&
+           !placeable.plotFlag() &&
+           !placeable.isNotBlastable() &&
+           reputes.getIsEnemy(actor.faction(), placeable.faction()) &&
+           (placeable.hitPoints() > 0 || placeable.currentHitPoints() > 0);
+}
+
 void Module::load(std::string name, const Gff &ifo, bool fromSave) {
     _name = std::move(name);
 
@@ -271,7 +289,9 @@ void Module::onPlaceableClick(const std::shared_ptr<Placeable> &placeable) {
 
     if (placeable->hasInventory()) {
         partyLeader->clearAllActions();
-        partyLeader->addAction(_game.newAction<OpenContainerAction>(placeable));
+        if (!placeable->isLocked()) {
+            partyLeader->addAction(_game.newAction<OpenContainerAction>(placeable));
+        }
     } else if (!placeable->conversation().empty()) {
         partyLeader->clearAllActions();
         partyLeader->addAction(_game.newAction<StartConversationAction>(placeable, placeable->conversation()));
@@ -357,6 +377,17 @@ std::vector<ContextAction> Module::getContextActions(const std::shared_ptr<Objec
             actions.push_back(ContextAction(ActionType::AttackObject));
         }
         if (door->isLocked() && !door->isKeyRequired() && leader->attributes().hasSkill(SkillType::Security)) {
+            actions.push_back(ContextAction(SkillType::Security));
+        }
+        break;
+    }
+    case ObjectType::Placeable: {
+        auto placeable = std::static_pointer_cast<Placeable>(object);
+        auto leader = _game.party().getLeader();
+        if (canBashPlaceable(*placeable, *leader, _services.game.reputes)) {
+            actions.push_back(ContextAction(ActionType::AttackObject));
+        }
+        if (canUseSecurityOnPlaceable(*placeable, *leader)) {
             actions.push_back(ContextAction(SkillType::Security));
         }
         break;

--- a/src/libs/game/object/placeable.cpp
+++ b/src/libs/game/object/placeable.cpp
@@ -17,6 +17,9 @@
 
 #include "reone/game/object/placeable.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/script/runner.h"
@@ -86,6 +89,45 @@ void Placeable::loadTransformFromGIT(const resource::generated::GIT_Placeable_Li
     updateTransform();
 }
 
+void Placeable::damage(int amount, uint32_t damager) {
+    if (_dead || _plot || _notBlastable) {
+        return;
+    }
+    if (amount <= 0) {
+        return;
+    }
+
+    int currentHitPoints = _currentHitPoints > 0 ? _currentHitPoints : _hitPoints;
+    if (amount == std::numeric_limits<int>::max()) {
+        _currentHitPoints = isMinOneHP() ? 1 : 0;
+    } else {
+        _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, currentHitPoints - amount);
+    }
+
+    damager = damager ? damager : script::kObjectInvalid;
+    runDamagedScript(damager);
+
+    if (_currentHitPoints > 0) {
+        return;
+    }
+
+    _dead = true;
+    _locked = false;
+    _open = true;
+    onOpen(damager);
+    runDeathScript(damager);
+}
+
+void Placeable::onOpen(uint32_t triggererId) {
+    if (_onOpen.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(
+        _onOpen,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastOpenedBy, Variable::ofObject(triggererId)}});
+}
+
 void Placeable::runOnUsed(std::shared_ptr<Object> usedBy) {
     if (_onUsed.empty()) {
         return;
@@ -116,6 +158,28 @@ void Placeable::runOnInvDisturbed(std::shared_ptr<Object> triggerrer) {
     _game.scriptRunner().run(_onInvDisturbed, args);
 }
 
+void Placeable::runDamagedScript(uint32_t damagerId) {
+    if (_onDamaged.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(
+        _onDamaged,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastAttacker, Variable::ofObject(damagerId)},
+         {script::ArgKind::LastDamager, Variable::ofObject(damagerId)}});
+}
+
+void Placeable::runDeathScript(uint32_t damagerId) {
+    if (_onDeath.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(
+        _onDeath,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::LastAttacker, Variable::ofObject(damagerId)},
+         {script::ArgKind::LastDamager, Variable::ofObject(damagerId)}});
+}
+
 void Placeable::loadUTP(const resource::generated::UTP &utp) {
     _tag = boost::to_lower_copy(utp.Tag);
     _name = _services.resource.strings.getText(utp.LocName.first);
@@ -139,6 +203,7 @@ void Placeable::loadUTP(const resource::generated::UTP &utp) {
     _partyInteract = utp.PartyInteract;
     _static = utp.Static;
     _usable = utp.Useable;
+    _notBlastable = utp.NotBlastable;
 
     _onClosed = boost::to_lower_copy(utp.OnClosed);
     _onDamaged = boost::to_lower_copy(utp.OnDamaged); // always empty, but could be useful


### PR DESCRIPTION
## Summary

Adds bash support for locked inventory placeables/containers.

Locked inventory placeables can now expose Bash where eligible, take bash damage, and become accessible after successful bash resolution. Locked containers no longer open directly before Security/bash succeeds.

## What changed

- Added placeable bash damage handling similar to door bash.
- Locked inventory placeables can expose Bash and Security context actions when eligible.
- OpenContainer no longer bypasses locked inventory placeables.
- Security can unlock locked inventory placeables and then open the container.
- Bash success unlocks/opens the placeable so the container can be accessed.

## Script/event behavior

- Bash damage fires `OnDamaged`.
- If bash destroys the placeable, it unlocks/opens and fires `OnOpen` before `OnDeath`.
- Bash destruction routes through `onOpen(damager)` before `OnDeath`, matching the previous door-bash review feedback.
- `OnDeath` only fires when HP reaches zero.
- `OnUsed` is not fired by bash, because bash is an attack rather than direct use.
- This PR does not broaden ordinary Security/container-open script semantics beyond the bash path.

## Verification

- Debug engine build passed.
- `tests.exe` passed, 150/150.
- `git diff --check` passed, with only existing CRLF conversion warnings.