### PR TITLE
[resource] Support GVT and NFO savegame files

### DIFF
--- a/include/reone/json/resource.h
+++ b/include/reone/json/resource.h
@@ -23,11 +23,13 @@ namespace reone {
 
 namespace resource {
 class Gff;
+struct GVT;
 }
 
 namespace json {
 
 boost::json::object fromGff(const resource::Gff &gff);
+boost::json::object fromGvt(const resource::GVT &gvt);
 
 } // namespace json
 } // namespace reone

--- a/include/reone/resource/parser/gff/gvt.h
+++ b/include/reone/resource/parser/gff/gvt.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace resource {
+
+class Gff;
+
+struct GVT {
+    using Boolean = std::pair<std::string, bool>;
+    using Number = std::pair<std::string, int>;
+    using String = std::pair<std::string, std::string>;
+    using Location = std::pair<std::string, std::pair<glm::vec3, glm::vec3>>;
+
+    std::vector<Boolean> booleans;
+    std::vector<Number> numbers;
+    std::vector<String> strings;
+    std::vector<Location> locations;
+};
+
+GVT parseGVT(const Gff &gff);
+
+} // namespace resource
+} // namespace reone

--- a/include/reone/resource/parser/gff/nfo.h
+++ b/include/reone/resource/parser/gff/nfo.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace resource {
+
+class Gff;
+
+struct NFO {
+    std::string areaName;
+    std::string lastModule;
+    uint32_t timePlayed;
+    bool cheatUsed;
+    std::string savegameName;
+    uint32_t gameplayHint;
+    uint32_t storyHint;
+    std::string live1;
+    std::string live2;
+    std::string live3;
+    std::string live4;
+    std::string live5;
+    std::string live6;
+    uint32_t liveContent;
+    std::string portrait0;
+};
+
+NFO parseNFO(const Gff &gff);
+
+} // namespace resource
+} // namespace reone

--- a/src/apps/gff2json/main.cpp
+++ b/src/apps/gff2json/main.cpp
@@ -18,6 +18,7 @@
 #include "reone/json/resource.h"
 #include "reone/json/util.h"
 #include "reone/resource/format/gffreader.h"
+#include "reone/resource/parser/gff/gvt.h"
 #include "reone/system/stream/fileinput.h"
 
 using namespace reone;
@@ -25,14 +26,52 @@ using namespace reone::resource;
 
 using CmdArgs = boost::program_options::variables_map;
 
+enum class Kind {
+    Gff,
+    Gvt,
+};
+
+static std::optional<Kind> peekGffKind(FileInputStream &file) {
+    std::string magic;
+    magic.resize(3);
+    size_t readCount = file.read(&magic[0], magic.size());
+    file.seek(0, SeekOrigin::Begin);
+    if (magic.size() != readCount) {
+        return std::nullopt;
+    }
+
+    if (magic == "GVT") {
+        return Kind::Gvt;
+    }
+
+    return Kind::Gff;
+}
+
 static int run(const CmdArgs &args) {
     auto file = FileInputStream(args["input-file"].as<std::string>());
+    std::optional<Kind> kind = peekGffKind(file);
+    if (!kind) {
+        std::cerr << "unknown file type\n";
+        return -1;
+    }
+
     auto reader = GffReader(file);
     reader.load();
     std::shared_ptr<Gff> gff = reader.root();
 
-    boost::json::object json = json::fromGff(*gff);
-    json::print(std::cout, json);
+    boost::json::object obj;
+    switch (*kind) {
+    case Kind::Gff: {
+        obj = json::fromGff(*gff);
+        break;
+    }
+    case Kind::Gvt: {
+        obj = json::fromGvt(parseGVT(*gff));
+        break;
+    }
+    }
+
+    json::print(std::cout, obj);
     return 0;
 }
 

--- a/src/libs/json/CMakeLists.txt
+++ b/src/libs/json/CMakeLists.txt
@@ -22,6 +22,7 @@ set(JSON_HEADERS
 
 set(JSON_SOURCES
     ${JSON_SOURCE_DIR}/gff.cpp
+    ${JSON_SOURCE_DIR}/gvt.cpp
     ${JSON_SOURCE_DIR}/util.cpp)
 
 add_library(json STATIC ${JSON_HEADERS} ${JSON_SOURCES} ${CLANG_FORMAT_PATH})

--- a/src/libs/json/gvt.cpp
+++ b/src/libs/json/gvt.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/parser/gff/gvt.h"
+#include "reone/json/resource.h"
+#include <boost/algorithm/hex.hpp>
+
+using namespace reone::resource;
+
+namespace reone {
+namespace json {
+
+static boost::json::object serializeGvt(const resource::GVT &gvt) {
+    boost::json::object booleans;
+    for (const GVT::Boolean &b : gvt.booleans) {
+        booleans[b.first] = b.second;
+    }
+
+    boost::json::object numbers;
+    for (const GVT::Number &num : gvt.numbers) {
+        numbers[num.first] = num.second;
+    }
+
+    boost::json::object strings;
+    for (const GVT::String &str : gvt.strings) {
+        strings[str.first] = str.second;
+    }
+
+    boost::json::object locations;
+    for (const GVT::Location &loc : gvt.locations) {
+        glm::vec3 pos = loc.second.first;
+        glm::vec3 rot = loc.second.second;
+
+        boost::json::object jloc;
+        jloc["position"] = {pos.x, pos.y, pos.z};
+        jloc["rotation"] = {rot.x, rot.y, rot.z};
+        locations[loc.first] = jloc;
+    }
+
+    return {{"booleans", booleans}, {"numbers", numbers}, {"strings", strings}, {"locations", locations}};
+}
+
+boost::json::object fromGvt(const resource::GVT &gvt) {
+    boost::json::object obj;
+    obj["signature"] = "GVT V3.2";
+    obj["gvt"] = serializeGvt(gvt);
+    return obj;
+}
+
+} // namespace json
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -62,6 +62,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/parser/gff/dlg.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/git.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/gui.h
+    ${RESOURCE_INCLUDE_DIR}/parser/gff/gvt.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/ifo.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/pth.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/utc.h
@@ -138,6 +139,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/parser/gff/dlg.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/git.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/gui.cpp
+    ${RESOURCE_SOURCE_DIR}/parser/gff/gvt.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/ifo.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/pth.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/utc.cpp

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -64,6 +64,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/parser/gff/gui.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/gvt.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/ifo.h
+    ${RESOURCE_INCLUDE_DIR}/parser/gff/nfo.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/pth.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/utc.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/utd.h
@@ -141,6 +142,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/parser/gff/gui.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/gvt.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/ifo.cpp
+    ${RESOURCE_SOURCE_DIR}/parser/gff/nfo.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/pth.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/utc.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/utd.cpp

--- a/src/libs/resource/parser/gff/gvt.cpp
+++ b/src/libs/resource/parser/gff/gvt.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/parser/gff/gvt.h"
+
+#include "reone/resource/gff.h"
+#include "reone/system/binaryreader.h"
+#include "reone/system/exception/endofstream.h"
+#include "reone/system/stream/memoryinput.h"
+#include "reone/system/types.h"
+
+namespace reone {
+namespace resource {
+
+static bool parseBooleans(const Gff &gff, std::vector<GVT::Boolean> &result) {
+    ByteBuffer bytes = gff.getData("ValBoolean");
+    auto names = gff.getList("CatBoolean");
+    result.reserve(names.size());
+
+    size_t i = 0;
+    for (const std::shared_ptr<Gff> &name : names) {
+        size_t byteIndex = i / 8;
+        size_t bitIndex = i % 8;
+        i += 1;
+
+        if (byteIndex >= bytes.size()) {
+            return false;
+        }
+
+        // Bits are packed MSB first.
+        bool value = (bytes[byteIndex] >> (7 - bitIndex)) & 0x1;
+        result.push_back({name->getString("Name"), value});
+    }
+    return true;
+}
+
+static bool parseNumbers(const Gff &gff, std::vector<GVT::Number> &result) {
+    ByteBuffer bytes = gff.getData("ValNumber");
+    auto names = gff.getList("CatNumber");
+    result.reserve(names.size());
+
+    size_t i = 0;
+    for (const std::shared_ptr<Gff> &name : names) {
+        if (i >= bytes.size()) {
+            return false;
+        }
+        int value = bytes[i++];
+        result.push_back({name->getString("Name"), value});
+    }
+    return true;
+}
+
+static bool parseStrings(const Gff &gff, std::vector<GVT::String> &result) {
+    auto names = gff.getList("CatString");
+    auto values = gff.getList("ValString");
+    result.reserve(names.size());
+
+    size_t i = 0;
+    for (const std::shared_ptr<Gff> &name : names) {
+        if (i >= values.size()) {
+            return false;
+        }
+        const std::shared_ptr<Gff> &value = values[i++];
+        result.push_back({name->getString("Name"), value->getString("String")});
+    }
+    return true;
+}
+
+static bool parseLocations(const Gff &gff, std::vector<GVT::Location> &result) {
+    auto names = gff.getList("CatLocation");
+    ByteBuffer values = gff.getData("ValString");
+    MemoryInputStream stream(values);
+    BinaryReader reader(stream);
+
+    result.reserve(names.size());
+
+    for (const std::shared_ptr<Gff> &name : names) {
+        float fv[6];
+        for (int i = 0; i < 6; ++i) {
+            try {
+                fv[i] = reader.readFloat();
+            } catch (EndOfStreamException &e) {
+                return false;
+            }
+        }
+        glm::vec3 pos(fv[0], fv[1], fv[2]);
+        glm::vec3 rot(fv[3], fv[4], fv[5]);
+        result.push_back({name->getString("Name"), {pos, rot}});
+    }
+    return true;
+}
+
+GVT parseGVT(const Gff &gff) {
+    GVT gvt;
+
+    parseBooleans(gff, gvt.booleans);
+    parseNumbers(gff, gvt.numbers);
+    parseStrings(gff, gvt.strings);
+    parseLocations(gff, gvt.locations);
+
+    return gvt;
+}
+
+} // namespace resource
+} // namespace reone

--- a/src/libs/resource/parser/gff/nfo.cpp
+++ b/src/libs/resource/parser/gff/nfo.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/parser/gff/nfo.h"
+
+#include "reone/resource/gff.h"
+
+namespace reone {
+namespace resource {
+
+NFO parseNFO(const Gff &gff) {
+    NFO nfo;
+
+    nfo.areaName = gff.getString("AREANAME");
+    nfo.lastModule = gff.getString("LASTMODULE");
+    nfo.timePlayed = gff.getUint("TIMEPLAYED");
+    nfo.cheatUsed = gff.getBool("CHEATUSED");
+    nfo.savegameName = gff.getString("SAVEGAMENAME");
+    nfo.gameplayHint = gff.getUint("GAMEPLAYHINT");
+    nfo.storyHint = gff.getUint("STORYHINT");
+    nfo.live1 = gff.getString("LIVE1");
+    nfo.live2 = gff.getString("LIVE2");
+    nfo.live3 = gff.getString("LIVE3");
+    nfo.live4 = gff.getString("LIVE4");
+    nfo.live5 = gff.getString("LIVE5");
+    nfo.live6 = gff.getString("LIVE6");
+    nfo.liveContent = gff.getUint("LIVECONTENT");
+    nfo.portrait0 = gff.getString("PORTRAIT0");
+
+    return nfo;
+}
+
+} // namespace resource
+} // namespace reone


### PR DESCRIPTION
This patchset adds support for 2 GFF files that are required to load a savegame:
  - GVT contains global variables: booleans, integers, strings and locations.
  - NFO contains metadata about the save: what module to load, information for GUIs, etc.

GVT is a bit difficult to read, so the last patch extends gff2json to emit GVT in a more human-readable way.

See individual commit messages for more details.