### PR TITLE
[scene][graphics] Fix TSL grass crash from missing secondary UVs

### DIFF
--- a/include/reone/graphics/mesh.h
+++ b/include/reone/graphics/mesh.h
@@ -254,6 +254,7 @@ public:
     std::vector<glm::vec3> faceVertexCoords(const Face &face) const;
     glm::vec2 faceUV1(const Face &face, const glm::vec3 &baryPosition) const;
     glm::vec2 faceUV2(const Face &face, const glm::vec3 &baryPosition) const;
+    std::optional<glm::vec2> tryFaceUV2(const Face &face, const glm::vec3 &baryPosition) const;
 
     int vertexCount() const { return _vertices.size(); }
     const std::vector<Face> &faces() const { return _faces; }

--- a/include/reone/graphics/mesh.h
+++ b/include/reone/graphics/mesh.h
@@ -253,7 +253,6 @@ public:
     std::vector<glm::vec3> vertexCoords() const;
     std::vector<glm::vec3> faceVertexCoords(const Face &face) const;
     glm::vec2 faceUV1(const Face &face, const glm::vec3 &baryPosition) const;
-    glm::vec2 faceUV2(const Face &face, const glm::vec3 &baryPosition) const;
     std::optional<glm::vec2> tryFaceUV2(const Face &face, const glm::vec3 &baryPosition) const;
 
     int vertexCount() const { return _vertices.size(); }

--- a/include/reone/scene/node/grass.h
+++ b/include/reone/scene/node/grass.h
@@ -70,6 +70,7 @@ private:
     std::vector<int> _grassFaces;
     std::stack<GrassClusterSceneNode *> _clusterPool;                          /**< pre-allocated pool of clusters */
     std::map<int, std::vector<GrassClusterSceneNode *>> _materializedClusters; /**< materialized clusters grouped by face */
+    bool _hasLightmapUV {true};
 };
 
 } // namespace scene

--- a/src/libs/graphics/mesh.cpp
+++ b/src/libs/graphics/mesh.cpp
@@ -277,10 +277,24 @@ glm::vec2 Mesh::faceUV1(const Face &face, const glm::vec3 &baryPosition) const {
 
 glm::vec2 Mesh::faceUV2(const Face &face, const glm::vec3 &baryPosition) const {
     checkNotEqual("UV offset", _vertexLayout.offUV2, 1);
+    auto uv = tryFaceUV2(face, baryPosition);
+    if (!uv) {
+        throw std::runtime_error("Face has no second UV channel");
+    }
+    return *uv;
+}
+
+std::optional<glm::vec2> Mesh::tryFaceUV2(const Face &face, const glm::vec3 &baryPosition) const {
+    if (_vertexLayout.offUV2 == -1) {
+        return std::nullopt;
+    }
     std::vector<glm::vec2> uv;
     uv.reserve(3);
     for (int i = 0; i < 3; ++i) {
         const auto &vertex = _vertices[face.vertices[i]];
+        if (!vertex.uv2) {
+            return std::nullopt;
+        }
         uv.push_back(*vertex.uv2);
     }
     return barycentricToCartesian(uv[0], uv[1], uv[2], baryPosition);

--- a/src/libs/graphics/mesh.cpp
+++ b/src/libs/graphics/mesh.cpp
@@ -275,15 +275,6 @@ glm::vec2 Mesh::faceUV1(const Face &face, const glm::vec3 &baryPosition) const {
     return barycentricToCartesian(uv[0], uv[1], uv[2], baryPosition);
 }
 
-glm::vec2 Mesh::faceUV2(const Face &face, const glm::vec3 &baryPosition) const {
-    checkNotEqual("UV offset", _vertexLayout.offUV2, 1);
-    auto uv = tryFaceUV2(face, baryPosition);
-    if (!uv) {
-        throw std::runtime_error("Face has no second UV channel");
-    }
-    return *uv;
-}
-
 std::optional<glm::vec2> Mesh::tryFaceUV2(const Face &face, const glm::vec3 &baryPosition) const {
     if (_vertexLayout.offUV2 == -1) {
         return std::nullopt;

--- a/src/libs/scene/node/grass.cpp
+++ b/src/libs/scene/node/grass.cpp
@@ -53,6 +53,9 @@ void GrassSceneNode::init() {
             continue;
         }
         _grassFaces.push_back(static_cast<int>(faceIdx));
+        if (!_aabbNode.mesh()->mesh->tryFaceUV2(face, glm::vec3(1.0f, 0.0f, 0.0f))) {
+            _hasLightmapUV = false;
+        }
     }
 
     // Pre-allocate grass clusters
@@ -127,7 +130,10 @@ void GrassSceneNode::update(float dt) {
             }
             glm::vec3 baryPosition(getRandomBarycentric());
             glm::vec3 position(barycentricToCartesian(verts[0], verts[1], verts[2], baryPosition));
-            glm::vec2 lightmapUV(mesh->faceUV2(face, baryPosition));
+            glm::vec2 lightmapUV {0.0f};
+            if (_hasLightmapUV) {
+                lightmapUV = *mesh->tryFaceUV2(face, baryPosition);
+            }
             auto cluster = _clusterPool.top();
             _clusterPool.pop();
             cluster->setLocalTransform(glm::translate(position));
@@ -144,7 +150,7 @@ void GrassSceneNode::renderLeafs(IRenderPass &pass, const std::vector<SceneNode 
         return;
     }
     std::optional<std::reference_wrapper<Texture>> lightmap;
-    if (!_aabbNode.mesh()->lightmap.empty()) {
+    if (_hasLightmapUV && !_aabbNode.mesh()->lightmap.empty()) {
         lightmap = *_resourceSvc.textures.get(_aabbNode.mesh()->lightmap, TextureUsage::Lightmap);
     }
     auto instances = std::vector<GrassInstance>(leafs.size());


### PR DESCRIPTION
## Summary

Fixes a Debug assertion/crash when warping into certain modules. Testing for this patch focused on the Telos modules.

WinDbg showed the crash path was:

`Mesh::faceUV2 -> GrassSceneNode::update -> SceneGraph::update -> Game::updateSceneGraph`

Some TSL grass meshes lack secondary UV/lightmap coordinates. The grass update path assumed UV2 was always present and dereferenced an empty `std::optional`.

This adds/uses a safe `Mesh::tryFaceUV2()` accessor and removes the unused throwing `Mesh::faceUV2()` wrapper. `GrassSceneNode` now disables grass lightmap usage when the mesh lacks UV2 data.

Verified:
- Debug `launcher`/`engine` build passes
- `tests.exe` passes: 150/150
- Fresh Debug Telos warps stay alive/responding: `203tel`, `204tel`, `220tel`, `231tel`, `233tel`
- Regression checked: `205tel`, `207tel`, `208tel`