### PR TITLE
[game] Implement EquipItemAction

### DIFF
--- a/src/libs/game/action/equipitem.cpp
+++ b/src/libs/game/action/equipitem.cpp
@@ -16,14 +16,20 @@
  */
 
 #include "reone/game/action/equipitem.h"
+#include "reone/game/object/creature.h"
 
 namespace reone {
 
 namespace game {
 
 void EquipItemAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    // TODO: implement
-
+    auto *creature = dyn_cast<Creature>(&actor);
+    if (!creature) {
+        complete();
+        return;
+    }
+    creature->equip(_inventorySlot, _item);
+    creature->playAnimation(CombatAnimation::Draw, creature->getWieldType());
     complete();
 }
 


### PR DESCRIPTION
`EquipItemAction` is used in cutscenes when a character draws a weapon (for example, Darth Bandon on Endar Spire).

`EquipItemAction` triggers only Draw animation for now. We can extend it later to use other animations for non-weapon equipment, and to play "ready" animation instead of transitioning to idle.