### PR TITLE
[resource] Support savegame containers

### DIFF
--- a/include/reone/resource/container/erf.h
+++ b/include/reone/resource/container/erf.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include "reone/system/stream/fileinput.h"
-
 #include "../container.h"
+#include "utils.h"
 
 namespace reone {
 
@@ -27,9 +26,8 @@ namespace resource {
 
 class ErfResourceContainer : public IResourceContainer, boost::noncopyable {
 public:
-    ErfResourceContainer(std::filesystem::path path) :
-        _path(std::move(path)) {
-    }
+    ErfResourceContainer(Storage storage) :
+        _storage(std::move(storage)) {}
 
     void init();
 
@@ -48,8 +46,7 @@ private:
         uint32_t fileSize {0};
     };
 
-    std::filesystem::path _path;
-    std::unique_ptr<FileInputStream> _erf;
+    Storage _storage;
 
     std::unordered_set<ResourceId> _resourceIds;
     std::unordered_map<ResourceId, Resource> _idToResource;

--- a/include/reone/resource/container/utils.h
+++ b/include/reone/resource/container/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,42 +18,33 @@
 #pragma once
 
 #include "reone/system/stream/fileinput.h"
-
-#include "../container.h"
-#include "utils.h"
+#include "reone/system/stream/memoryinput.h"
 
 namespace reone {
 
 namespace resource {
 
-class RimResourceContainer : public IResourceContainer, boost::noncopyable {
+class Storage {
 public:
-    RimResourceContainer(Storage storage) :
-        _storage(std::move(storage)) {}
+    Storage(std::filesystem::path path) :
+        _path(path), _file(std::make_unique<FileInputStream>(_path)) {}
+    Storage(ByteBuffer buffer) :
+        _buffer(buffer), _mem(std::make_unique<MemoryInputStream>(_buffer)) {}
 
-    void init();
-
-    // IResourceContainer
-
-    std::optional<ByteBuffer> findResourceData(const ResourceId &id) override;
-
-    const std::unordered_set<ResourceId> &resourceIds() const override { return _resourceIds; }
-
-    // END IResourceContainer
+    IInputStream &stream() {
+        assert((_file || _mem) && "uninitialized storage");
+        if (_file) {
+            return *_file;
+        }
+        return *_mem;
+    }
 
 private:
-    struct Resource {
-        ResourceId id;
-        uint32_t offset {0};
-        uint32_t fileSize {0};
-    };
-
-    Storage _storage;
-
-    std::unordered_set<ResourceId> _resourceIds;
-    std::unordered_map<ResourceId, Resource> _idToResource;
+    std::filesystem::path _path;
+    std::unique_ptr<FileInputStream> _file;
+    ByteBuffer _buffer;
+    std::unique_ptr<MemoryInputStream> _mem;
 };
 
 } // namespace resource
-
 } // namespace reone

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "resources.h"
 #include "types.h"
 
 namespace reone {
@@ -99,6 +100,8 @@ private:
 
     void loadGlobalResources();
     void loadModuleResources(const std::string &name);
+    void loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
+    void loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
 };
 
 } // namespace resource

--- a/include/reone/resource/resource.h
+++ b/include/reone/resource/resource.h
@@ -25,7 +25,6 @@ namespace resource {
 
 struct Resource {
     ByteBuffer data;
-    bool local {false};
 };
 
 } // namespace resource

--- a/include/reone/resource/resources.h
+++ b/include/reone/resource/resources.h
@@ -27,12 +27,18 @@ namespace reone {
 
 namespace resource {
 
-struct ResourceContainerLocalPair {
-    std::unique_ptr<IResourceContainer> provider;
-    bool local {false};
+enum class ContainerKind {
+    Global,
+    Local,
+    Save,
 };
 
-using ResourceContainerList = std::list<ResourceContainerLocalPair>;
+struct ResourceContainerPair {
+    std::unique_ptr<IResourceContainer> provider;
+    ContainerKind kind;
+};
+
+using ResourceContainerList = std::list<ResourceContainerPair>;
 
 class IResources {
 public:
@@ -40,12 +46,13 @@ public:
 
     virtual void clear() = 0;
     virtual void clearLocal() = 0;
+    virtual void clearSave() = 0;
 
-    virtual void addKEY(const std::filesystem::path &path) = 0;
-    virtual void addERF(const std::filesystem::path &path, bool local = false) = 0;
-    virtual void addRIM(const std::filesystem::path &path, bool local = false) = 0;
     virtual void addEXE(const std::filesystem::path &path) = 0;
-    virtual void addFolder(const std::filesystem::path &path) = 0;
+    virtual void addKEY(const std::filesystem::path &path) = 0;
+    virtual void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
+    virtual void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
+    virtual void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
 
     virtual Resource get(const ResourceId &id) = 0;
     virtual std::optional<Resource> find(const ResourceId &id) = 0;
@@ -58,21 +65,29 @@ public:
     }
 
     void clearLocal() override {
-        auto toErase = std::remove_if(_containers.begin(), _containers.end(), [](auto &pair) {
-            return pair.local;
+        clearSome(ContainerKind::Local);
+    }
+
+    void clearSave() override {
+        clearSome(ContainerKind::Save);
+    }
+
+    void clearSome(ContainerKind kind) {
+        auto toErase = std::remove_if(_containers.begin(), _containers.end(), [kind](auto &pair) {
+            return pair.kind == kind;
         });
         _containers.erase(toErase, _containers.end());
     }
 
-    void add(std::unique_ptr<IResourceContainer> provider, bool local = false) {
-        _containers.push_front(ResourceContainerLocalPair {std::move(provider), local});
+    void add(std::unique_ptr<IResourceContainer> provider, ContainerKind kind = ContainerKind::Global) {
+        _containers.push_front(ResourceContainerPair {std::move(provider), kind});
     }
 
-    void addKEY(const std::filesystem::path &path) override;
-    void addERF(const std::filesystem::path &path, bool local = false) override;
-    void addRIM(const std::filesystem::path &path, bool local = false) override;
     void addEXE(const std::filesystem::path &path) override;
-    void addFolder(const std::filesystem::path &path) override;
+    void addKEY(const std::filesystem::path &path) override;
+    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
 
     Resource get(const ResourceId &id) override;
     std::optional<Resource> find(const ResourceId &id) override;

--- a/include/reone/resource/resources.h
+++ b/include/reone/resource/resources.h
@@ -51,7 +51,9 @@ public:
     virtual void addEXE(const std::filesystem::path &path) = 0;
     virtual void addKEY(const std::filesystem::path &path) = 0;
     virtual void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
+    virtual void addMemERF(ByteBuffer buffer, ContainerKind kind) = 0;
     virtual void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
+    virtual void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) = 0;
     virtual void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
 
     virtual Resource get(const ResourceId &id) = 0;
@@ -86,7 +88,9 @@ public:
     void addEXE(const std::filesystem::path &path) override;
     void addKEY(const std::filesystem::path &path) override;
     void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
     void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
     void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
 
     Resource get(const ResourceId &id) override;

--- a/src/libs/resource/container/erf.cpp
+++ b/src/libs/resource/container/erf.cpp
@@ -24,9 +24,7 @@ namespace reone {
 namespace resource {
 
 void ErfResourceContainer::init() {
-    _erf = std::make_unique<FileInputStream>(_path);
-
-    auto reader = ErfReader(*_erf);
+    auto reader = ErfReader(_storage.stream());
     reader.load();
 
     auto &keys = reader.keys();
@@ -54,8 +52,9 @@ std::optional<ByteBuffer> ErfResourceContainer::findResourceData(const ResourceI
     ByteBuffer buf;
     buf.resize(resource.fileSize);
 
-    _erf->seek(resource.offset, SeekOrigin::Begin);
-    _erf->read(&buf[0], buf.size());
+    IInputStream &erf = _storage.stream();
+    erf.seek(resource.offset, SeekOrigin::Begin);
+    erf.read(&buf[0], buf.size());
 
     return buf;
 }

--- a/src/libs/resource/container/rim.cpp
+++ b/src/libs/resource/container/rim.cpp
@@ -25,9 +25,7 @@ namespace reone {
 namespace resource {
 
 void RimResourceContainer::init() {
-    _rim = std::make_unique<FileInputStream>(_path);
-
-    auto reader = RimReader(*_rim);
+    auto reader = RimReader(_storage.stream());
     reader.load();
 
     for (auto &rimResource : reader.resources()) {
@@ -52,8 +50,9 @@ std::optional<ByteBuffer> RimResourceContainer::findResourceData(const ResourceI
     ByteBuffer buf;
     buf.resize(resource.fileSize);
 
-    _rim->seek(resource.offset, SeekOrigin::Begin);
-    _rim->read(&buf[0], buf.size());
+    IInputStream &rim = _storage.stream();
+    rim.seek(resource.offset, SeekOrigin::Begin);
+    rim.read(&buf[0], buf.size());
 
     return buf;
 }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -179,15 +179,15 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     auto &resources = _resources;
     auto rimPath = findFileIgnoreCase(*modulesPath, name + ".rim");
     if (rimPath) {
-        resources.addRIM(*rimPath, true);
+        resources.addRIM(*rimPath, ContainerKind::Local);
     }
     auto rimsPath = findFileIgnoreCase(*modulesPath, name + "_s.rim");
     if (rimsPath) {
-        resources.addRIM(*rimsPath, true);
+        resources.addRIM(*rimsPath, ContainerKind::Local);
     }
     auto modPath = findFileIgnoreCase(*modulesPath, name + ".mod");
     if (modPath) {
-        resources.addERF(*modPath, true);
+        resources.addERF(*modPath, ContainerKind::Local);
     }
     if (!rimPath && !rimsPath && !modPath) {
         throw ResourceNotFoundException("Module archives not found: " + name);
@@ -197,14 +197,14 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     if (lipsPath) {
         auto locModPath = findFileIgnoreCase(*lipsPath, name + "_loc.mod");
         if (locModPath) {
-            resources.addERF(*locModPath, true);
+            resources.addERF(*locModPath, ContainerKind::Local);
         }
     }
 
     if (_gameId == GameID::TSL) {
         auto dlgErfPath = findFileIgnoreCase(*modulesPath, name + "_dlg.erf");
         if (dlgErfPath) {
-            resources.addERF(*dlgErfPath, true);
+            resources.addERF(*dlgErfPath, ContainerKind::Local);
         }
     }
 }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -171,41 +171,55 @@ void ResourceDirector::loadGlobalResources() {
 }
 
 void ResourceDirector::loadModuleResources(const std::string &name) {
-    auto modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
+    std::optional<std::filesystem::path> modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
     if (!modulesPath) {
         throw ResourceNotFoundException("Modules directory not found");
     }
 
-    auto &resources = _resources;
-    auto rimPath = findFileIgnoreCase(*modulesPath, name + ".rim");
-    if (rimPath) {
-        resources.addRIM(*rimPath, ContainerKind::Local);
-    }
-    auto rimsPath = findFileIgnoreCase(*modulesPath, name + "_s.rim");
-    if (rimsPath) {
-        resources.addRIM(*rimsPath, ContainerKind::Local);
-    }
-    auto modPath = findFileIgnoreCase(*modulesPath, name + ".mod");
-    if (modPath) {
-        resources.addERF(*modPath, ContainerKind::Local);
-    }
-    if (!rimPath && !rimsPath && !modPath) {
-        throw ResourceNotFoundException("Module archives not found: " + name);
-    }
-
-    auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName);
-    if (lipsPath) {
-        auto locModPath = findFileIgnoreCase(*lipsPath, name + "_loc.mod");
-        if (locModPath) {
-            resources.addERF(*locModPath, ContainerKind::Local);
-        }
-    }
+    loadRIM(*modulesPath, name, ContainerKind::Local);
+    loadRIM(*modulesPath, name + "_s", ContainerKind::Local);
+    loadERF(*modulesPath, name, ContainerKind::Local);
+    loadERF(*modulesPath, name + "_loc", ContainerKind::Local);
 
     if (_gameId == GameID::TSL) {
-        auto dlgErfPath = findFileIgnoreCase(*modulesPath, name + "_dlg.erf");
-        if (dlgErfPath) {
-            resources.addERF(*dlgErfPath, ContainerKind::Local);
-        }
+        loadERF(*modulesPath, name + "_dlg", ContainerKind::Local);
+    }
+}
+
+void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {
+    // Try to find a module with the same name in already loaded resources.
+    // Same idea as in loadERF.
+    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Res));
+    if (res) {
+        _resources.addMemRIM(res->data, kind);
+        return;
+    }
+
+    if (auto rimPath = findFileIgnoreCase(path, name + ".rim")) {
+        _resources.addRIM(*rimPath, kind);
+    }
+}
+
+void ResourceDirector::loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {
+    // Try to find a module with the same name in already loaded resources.
+    //
+    // This allows us to support savegame archives: savegame.sav is an ERF
+    // archive that contains ERF modules. When loading from a save game we add
+    // savegame.sav ERF container. Module lookups resolve to modules from this
+    // container, and fall back to filesystem search if the module is not in the
+    // save archive.
+    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Mod));
+    if (res) {
+        _resources.addMemERF(res->data, kind);
+        return;
+    }
+
+    if (auto modPath = findFileIgnoreCase(path, name + ".mod")) {
+        _resources.addERF(*modPath, kind);
+    }
+
+    if (auto erfPath = findFileIgnoreCase(path, name + ".erf")) {
+        _resources.addERF(*erfPath, kind);
     }
 }
 

--- a/src/libs/resource/provider/cursors.cpp
+++ b/src/libs/resource/provider/cursors.cpp
@@ -105,7 +105,7 @@ std::vector<uint32_t> Cursors::getCursorNamesFromCursorGroup(uint32_t name) {
 }
 
 std::shared_ptr<Texture> Cursors::newTextureFromCursor(uint32_t name) {
-    auto [data, _] = _resources.get(ResourceId(std::to_string(name), ResType::Cursor));
+    auto [data] = _resources.get(ResourceId(std::to_string(name), ResType::Cursor));
     auto stream = MemoryInputStream(data);
 
     CurReader cur(stream);

--- a/src/libs/resource/resources.cpp
+++ b/src/libs/resource/resources.cpp
@@ -40,8 +40,20 @@ void Resources::addERF(const std::filesystem::path &path, ContainerKind kind) {
     _containers.push_front(ResourceContainerPair {std::move(provider), kind});
 }
 
+void Resources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
+    auto provider = std::make_unique<ErfResourceContainer>(std::move(buffer));
+    provider->init();
+    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+}
+
 void Resources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
     auto provider = std::make_unique<RimResourceContainer>(path);
+    provider->init();
+    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+}
+
+void Resources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
+    auto provider = std::make_unique<RimResourceContainer>(buffer);
     provider->init();
     _containers.push_front(ResourceContainerPair {std::move(provider), kind});
 }

--- a/src/libs/resource/resources.cpp
+++ b/src/libs/resource/resources.cpp
@@ -31,31 +31,31 @@ namespace resource {
 void Resources::addKEY(const std::filesystem::path &path) {
     auto provider = std::make_unique<KeyBifResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerLocalPair {std::move(provider), false});
+    _containers.push_front(ResourceContainerPair {std::move(provider), ContainerKind::Global});
 }
 
-void Resources::addERF(const std::filesystem::path &path, bool local) {
+void Resources::addERF(const std::filesystem::path &path, ContainerKind kind) {
     auto provider = std::make_unique<ErfResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerLocalPair {std::move(provider), local});
+    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
 }
 
-void Resources::addRIM(const std::filesystem::path &path, bool local) {
+void Resources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
     auto provider = std::make_unique<RimResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerLocalPair {std::move(provider), local});
+    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
 }
 
 void Resources::addEXE(const std::filesystem::path &path) {
     auto provider = std::make_unique<ExeResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerLocalPair {std::move(provider), false});
+    _containers.push_front(ResourceContainerPair {std::move(provider), ContainerKind::Global});
 }
 
-void Resources::addFolder(const std::filesystem::path &path) {
+void Resources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
     auto provider = std::make_unique<FolderResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerLocalPair {std::move(provider), false});
+    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
 }
 
 Resource Resources::get(const ResourceId &id) {
@@ -67,10 +67,10 @@ Resource Resources::get(const ResourceId &id) {
 }
 
 std::optional<Resource> Resources::find(const ResourceId &id) {
-    for (auto &[provider, local] : _containers) {
+    for (auto &[provider, kind] : _containers) {
         auto data = provider->findResourceData(id);
         if (data) {
-            return Resource {*data, local};
+            return Resource {*data};
         }
     }
     return std::nullopt;

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -56,11 +56,12 @@ class MockResources : public IResources, boost::noncopyable {
 public:
     MOCK_METHOD(void, clear, (), (override));
     MOCK_METHOD(void, clearLocal, (), (override));
-    MOCK_METHOD(void, addKEY, (const std::filesystem::path &path), (override));
-    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, bool local), (override));
-    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, bool local), (override));
+    MOCK_METHOD(void, clearSave, (), (override));
     MOCK_METHOD(void, addEXE, (const std::filesystem::path &path), (override));
-    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path), (override));
+    MOCK_METHOD(void, addKEY, (const std::filesystem::path &path), (override));
+    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ContainerKind kind), (override));
+    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ContainerKind kind), (override));
+    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ContainerKind kind), (override));
 
     MOCK_METHOD(Resource, get, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, find, (const ResourceId &id), (override));

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -60,7 +60,9 @@ public:
     MOCK_METHOD(void, addEXE, (const std::filesystem::path &path), (override));
     MOCK_METHOD(void, addKEY, (const std::filesystem::path &path), (override));
     MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ContainerKind kind), (override));
+    MOCK_METHOD(void, addMemERF, (ByteBuffer buffer, ContainerKind kind), (override));
     MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ContainerKind kind), (override));
+    MOCK_METHOD(void, addMemRIM, (ByteBuffer buffer, ContainerKind kind), (override));
     MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ContainerKind kind), (override));
 
     MOCK_METHOD(Resource, get, (const ResourceId &id), (override));


### PR DESCRIPTION
Refactored the resource subsystem to support savegame containers:
- Added support for nested ERF containers.
- Introduced a new "scope" for savegame containers in addition to local and global scopes.

Please see individual commit messages for more details.
Note that this patch does not add any actual savegame loading yet. This is a subject of a follow-up patch.