### PR TITLE
[game] Initial support for loading a savegame

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -137,6 +137,7 @@ public:
     std::shared_ptr<Module> module() const { return _module; }
     CameraType cameraType() const { return _cameraType; }
     const std::set<std::string> &moduleNames() const { return _moduleNames; }
+    const std::set<std::string> &saveNames() const { return _saveNames; }
 
     void initLocalServices();
     void setSceneSurfaces();
@@ -190,10 +191,14 @@ public:
     /**
      * @param entry waypoint tag to spawn at, or empty string to spawn at default location
      */
-    void loadModule(const std::string &name, std::string entry = "");
+    void loadModule(const std::string &name, std::string entry = "", bool fromSave = false);
 
     void scheduleModuleTransition(const std::string &moduleName, const std::string &entry);
     void scheduleModuleTransitionWithMovies(const std::string &moduleName, const std::string &entry, std::vector<std::string> movies);
+
+    // Load a savegame. Name must be one of savegame directores returned by
+    // ResourceDirector::saveNames().
+    void loadGame(std::string_view name);
 
     // END Module loading
 
@@ -350,6 +355,7 @@ private:
     CameraType _cameraType {CameraType::ThirdPerson};
     bool _paused {false};
     std::set<std::string> _moduleNames;
+    std::set<std::string> _saveNames;
     bool _quitRequested {false};
     bool _relativeMouseMode {false};
 
@@ -414,6 +420,7 @@ private:
     void stopMovement();
 
     void loadDefaultParty();
+    bool loadParty();
     void loadNextModule();
     void playMusic(const std::string &resRef);
     void toggleInGameCameraType();
@@ -538,6 +545,8 @@ private:
     void consoleAddOrRemoveSpell(const ConsoleArgs &tokens);
     void consoleCastSpellAtObject(const ConsoleArgs &tokens);
     void consoleOpenCloseDoor(const ConsoleArgs &tokens);
+    void consoleListGames(const ConsoleArgs &tokens);
+    void consoleLoadGame(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -50,8 +50,10 @@ public:
 
     virtual void init() = 0;
     virtual void onModuleLoad(const std::string &name) = 0;
+    virtual void onGameLoad(std::string_view name) = 0;
 
     virtual std::set<std::string> moduleNames() = 0;
+    virtual std::set<std::string> saveNames() = 0;
 };
 
 class ResourceDirector : public IResourceDirector, boost::noncopyable {
@@ -82,8 +84,10 @@ public:
 
     void init() override;
     void onModuleLoad(const std::string &name) override;
+    void onGameLoad(std::string_view name) override;
 
     std::set<std::string> moduleNames() override;
+    std::set<std::string> saveNames() override;
 
 private:
     GameID _gameId;
@@ -98,8 +102,13 @@ private:
     IResources &_resources;
     IScripts &_scripts;
 
+    // Set when a savegame is loaded.
+    std::optional<std::filesystem::path> _savegamePath;
+
     void loadGlobalResources();
     void loadModuleResources(const std::string &name);
+    void loadSaveGameResources(std::string_view name);
+
     void loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
     void loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
 };

--- a/include/reone/system/fileutil.h
+++ b/include/reone/system/fileutil.h
@@ -19,7 +19,7 @@
 
 namespace reone {
 
-std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, const std::string &relPath);
-std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, const std::string &relPath);
+std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath);
+std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath);
 
 } // namespace reone

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -50,6 +50,8 @@
 #include "reone/resource/format/erfreader.h"
 #include "reone/resource/format/erfwriter.h"
 #include "reone/resource/format/gffwriter.h"
+#include "reone/resource/parser/gff/gvt.h"
+#include "reone/resource/parser/gff/nfo.h"
 #include "reone/resource/provider/2das.h"
 #include "reone/resource/provider/audioclips.h"
 #include "reone/resource/provider/cursors.h"
@@ -215,6 +217,7 @@ void Game::init() {
     setCursorType(CursorType::Default);
 
     _moduleNames = _services.resource.director.moduleNames();
+    _saveNames = _services.resource.director.saveNames();
 
     playVideo("legal");
     openMainMenu();
@@ -261,6 +264,8 @@ void Game::initConsole() {
     registerConsoleCommand("castspellatobject", "cast spell at object", &Game::consoleCastSpellAtObject);
     registerConsoleCommand("opendoor", "open a selected door object", &Game::consoleOpenCloseDoor);
     registerConsoleCommand("closedoor", "close a selected door object", &Game::consoleOpenCloseDoor);
+    registerConsoleCommand("listgames", "list savegames", &Game::consoleListGames);
+    registerConsoleCommand("loadgame", "load a savegame", &Game::consoleLoadGame);
 }
 
 void Game::initLocalServices() {
@@ -488,14 +493,14 @@ bool Game::handleMouseButtonUp(const input::MouseButtonEvent &event) {
     return false;
 }
 
-void Game::loadModule(const std::string &name, std::string entry) {
+void Game::loadModule(const std::string &name, std::string entry, bool fromSave) {
     info("Loading module '" + name + "'");
 
     if (_screen == Screen::Conversation && _conversation) {
         _conversation->cleanupForModuleTransition();
     }
 
-    withLoadingScreen("load_" + name, [this, &name, &entry]() {
+    withLoadingScreen("load_" + name, [this, &name, &entry, fromSave]() {
         loadInGameMenus();
 
         try {
@@ -526,15 +531,17 @@ void Game::loadModule(const std::string &name, std::string entry) {
                     throw ResourceNotFoundException("Module IFO not found");
                 }
 
-                _module->load(name, *ifo);
+                _module->load(name, *ifo, fromSave);
                 _loadedModules.insert(std::make_pair(name, _module));
             }
 
             if (_party.isEmpty()) {
-                loadDefaultParty();
+                if (!loadParty()) {
+                    loadDefaultParty();
+                }
             }
 
-            _module->loadParty(entry);
+            _module->loadParty(entry, fromSave);
 
             info("Module '" + name + "' loaded successfully");
 
@@ -552,6 +559,69 @@ void Game::loadModule(const std::string &name, std::string entry) {
             error("Failed loading module '" + name + "': " + std::string(e.what()));
         }
     });
+}
+
+void Game::loadGame(std::string_view name) {
+    info(str(boost::format("Loading savegame '%s'") % name));
+
+    _services.resource.director.onGameLoad(name);
+    std::shared_ptr<Gff> globalVars(_services.resource.gffs.get("globalvars", ResType::Res));
+    if (!globalVars) {
+        throw ResourceNotFoundException("globalvars.res not found");
+    }
+
+    GVT gvt = resource::parseGVT(*globalVars);
+    _globalStrings.clear();
+    _globalBooleans.clear();
+    _globalNumbers.clear();
+    _globalLocations.clear();
+
+    for (auto &[name, value] : gvt.strings) {
+        setGlobalString(name, value);
+    }
+
+    for (auto &[name, value] : gvt.booleans) {
+        setGlobalBoolean(name, value);
+    }
+
+    for (auto &[name, value] : gvt.numbers) {
+        setGlobalNumber(name, value);
+    }
+
+    for (auto &[name, value] : gvt.locations) {
+        auto &[pos, rot] = value;
+        float facing = glm::half_pi<float>() - glm::atan(rot.x, rot.y);
+        setGlobalLocation(name, std::make_shared<Location>(pos, facing));
+    }
+
+    std::shared_ptr<Gff> saveInfo(_services.resource.gffs.get("savenfo", ResType::Res));
+    if (!saveInfo) {
+        throw ResourceNotFoundException("saveinfo.res not found");
+    }
+
+    NFO nfo = resource::parseNFO(*saveInfo);
+    loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
+}
+
+bool Game::loadParty() {
+    std::shared_ptr<Gff> ifo(_services.resource.gffs.get("module", ResType::Ifo));
+    if (!ifo) {
+        throw ResourceNotFoundException("module.ifo not found");
+    }
+
+    const auto &players = ifo->getList("Mod_PlayerList");
+    if (players.empty()) {
+        return false;
+    }
+
+    std::shared_ptr<Creature> player = newCreature();
+    _objectById.insert(std::make_pair(player->id(), player));
+    player->deserialize(*players.front());
+    player->setTag(kObjectTagPlayer);
+    _party.addMember(kNpcPlayer, player);
+    _party.setPlayer(player);
+
+    return true;
 }
 
 void Game::loadDefaultParty() {
@@ -1992,6 +2062,31 @@ void Game::consoleOpenCloseDoor(const ConsoleArgs &args) {
         target->close();
         // There is no Door::onClose yet
     }
+}
+
+void Game::consoleListGames(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 0, 0, "");
+
+    std::stringstream ss;
+    unsigned index = 0;
+    const char *newline = "";
+    for (const std::string &name : _saveNames) {
+        ss << newline << "[" << index++ << "] " << name;
+        newline = "\n";
+    }
+    _console.printLine(ss.str());
+}
+
+void Game::consoleLoadGame(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 1, 1, "save_id");
+    size_t id = *args.get<size_t>(1);
+    const auto &_saveNames = _services.resource.director.saveNames();
+    if (id >= _saveNames.size()) {
+        throw std::runtime_error("Invalid savegame id");
+    }
+    auto name = _saveNames.begin();
+    std::advance(name, id);
+    loadGame(*name);
 }
 
 } // namespace game

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -47,6 +47,7 @@ static constexpr char kSoundsDirectoryName[] = "streamsounds";
 static constexpr char kWavesDirectoryName[] = "streamwaves";
 static constexpr char kVoiceDirectoryName[] = "streamvoice";
 static constexpr char kModulesDirectoryName[] = "modules";
+static constexpr char kSavesDirectoryName[] = "saves";
 static constexpr char kLipsDirectoryName[] = "lips";
 static constexpr char kOverrideDirectoryName[] = "override";
 
@@ -82,6 +83,11 @@ void ResourceDirector::onModuleLoad(const std::string &name) {
     loadModuleResources(name);
 }
 
+void ResourceDirector::onGameLoad(std::string_view name) {
+    _resources.clearSave();
+    loadSaveGameResources(name);
+}
+
 std::set<std::string> ResourceDirector::moduleNames() {
     auto moduleNames = std::set<std::string>();
     auto modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
@@ -96,6 +102,18 @@ std::set<std::string> ResourceDirector::moduleNames() {
         }
     }
     return moduleNames;
+}
+
+std::set<std::string> ResourceDirector::saveNames() {
+    auto names = std::set<std::string>();
+    auto savesPath = findFileIgnoreCase(_gamePath, kSavesDirectoryName);
+    if (!savesPath) {
+        throw ResourceNotFoundException("Saves directory not found");
+    }
+    for (auto &entry : std::filesystem::directory_iterator(*savesPath)) {
+        names.insert(boost::to_lower_copy(entry.path().filename().string()));
+    }
+    return names;
 }
 
 void ResourceDirector::loadGlobalResources() {
@@ -184,6 +202,30 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     if (_gameId == GameID::TSL) {
         loadERF(*modulesPath, name + "_dlg", ContainerKind::Local);
     }
+}
+
+void ResourceDirector::loadSaveGameResources(std::string_view name) {
+    auto allSavesPath = findFileIgnoreCase(_gamePath, kSavesDirectoryName);
+    if (!allSavesPath) {
+        throw ResourceNotFoundException("Saves directory not found");
+    }
+
+    auto savePath = findFileIgnoreCase(*allSavesPath, name);
+    if (!savePath) {
+        throw ResourceNotFoundException(str(boost::format("Save directory not found: %s") % name));
+    }
+
+    // Add savegame directory itself, so we can load globalvars.res
+    // partytable.res and savenfo.res.
+    _resources.addFolder(*savePath);
+
+    _savegamePath = findFileIgnoreCase(*savePath, "savegame.sav");
+    if (!_savegamePath) {
+        throw ResourceNotFoundException("savegame.sav not found");
+    }
+
+    // Add savegame resource archive.
+    _resources.addERF(*_savegamePath);
 }
 
 void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {

--- a/src/libs/system/fileutil.cpp
+++ b/src/libs/system/fileutil.cpp
@@ -21,7 +21,7 @@
 
 namespace reone {
 
-std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, const std::string &relPath) {
+std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
     std::vector<std::string> tokens;
     boost::split(tokens, relPath, boost::is_any_of("/"), boost::token_compress_on);
 
@@ -39,7 +39,7 @@ std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, const 
     throw FileNotFoundException((dir / relPath).string());
 }
 
-std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, const std::string &relPath) {
+std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
     std::vector<std::string> tokens;
     boost::split(tokens, relPath, boost::is_any_of("/"), boost::token_compress_on);
 

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -176,7 +176,9 @@ class MockResourceDirector : public IResourceDirector, boost::noncopyable {
 public:
     MOCK_METHOD(void, init, (), (override));
     MOCK_METHOD(void, onModuleLoad, (const std::string &name), (override));
+    MOCK_METHOD(void, onGameLoad, (std::string_view name), (override));
     MOCK_METHOD(std::set<std::string>, moduleNames, (), (override));
+    MOCK_METHOD(std::set<std::string>, saveNames, (), (override));
 };
 
 class TestResourceModule : boost::noncopyable {


### PR DESCRIPTION
Savegame load process:

  - Add savegame resources and containers to `ResourceManager`. When a savegame is loaded,
  `ResourceManager` resolves module loads to savegame files instead of global game files.

  - Load global variables from `globalvars.res`.

  - Find the name of the module we need to load in `saveinfo.res`.

  - Load the module with `fromSave=true` to skip calling onEntry scripts.

GUIs are not implemented yet, but the patch adds 2 new console commands:

  - `listgames` displays an enumerated list of all found savegames.
  - `loadgame index` loads a savegame.

Known issues:

  - Doors and placables are not loaded from savegame modules. These objects have all their
  properties "inlined" into module GFFs, but the engine currently only handles template references
  and position/rotation. Creature and Item objects are already changed to accommodate this design,
  but other objects are left for follow-up patches.

  - Transition between modules (or reloading a savegame) is still not fully finalized. We may not
  need to run onExit scripts, for example. Loading a module still calls render() as part of the
  update() routine. These issues will also be addressed by follow-up patches.


Please ignore the first 6 commits. These are reviewed separately in #115, #116, and #112.
