### PR TITLE
[game][gui] Improve party inventory and equipment UI

### DIFF
--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -208,6 +208,7 @@ private:
     void clearCandidateDescription();
     void updateCandidateDescription();
     void updateEquipment();
+    void updateK2LoadoutOverlayVisibility(bool visible);
     void updateItems();
     void updatePortraits();
     void activateSlot(Slot slot);

--- a/include/reone/game/gui/ingame/equip.h
+++ b/include/reone/game/gui/ingame/equip.h
@@ -208,6 +208,7 @@ private:
     void clearCandidateDescription();
     void updateCandidateDescription();
     void updateEquipment();
+    void tintK2LoadoutOverlay();
     void updateK2LoadoutOverlayVisibility(bool visible);
     void updateItems();
     void updatePortraits();

--- a/include/reone/game/gui/ingame/inventory.h
+++ b/include/reone/game/gui/ingame/inventory.h
@@ -39,6 +39,19 @@ namespace game {
 
 class Item;
 
+enum class InventoryFilter {
+    All,
+    New,
+    Quest,
+    Equippable,
+    Utility,
+    Useable,
+    Datapad,
+    Weapon,
+    Armor,
+    Misc
+};
+
 class InventoryMenu : public GameGUI {
 public:
     InventoryMenu(Game &game, ServicesView &services) :
@@ -83,12 +96,18 @@ private:
     };
 
     Controls _controls;
+    InventoryFilter _filter {InventoryFilter::All};
     int _selectedItemIdx {-1};
     std::vector<std::shared_ptr<Item>> _listedItems;
 
     void onGUILoaded() override;
     void configureItemsListBox();
+    void configureFilterControls();
     void refreshStats();
+    void advanceK1Filter();
+    void setFilter(InventoryFilter filter);
+    void updateFilterControls();
+    bool itemMatchesFilter(const Item &item) const;
     void updateItemDescription();
     void clearItemDescription();
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;

--- a/include/reone/game/gui/ingame/inventory.h
+++ b/include/reone/game/gui/ingame/inventory.h
@@ -37,6 +37,8 @@ class Texture;
 
 namespace game {
 
+class Item;
+
 class InventoryMenu : public GameGUI {
 public:
     InventoryMenu(Game &game, ServicesView &services) :
@@ -82,6 +84,7 @@ private:
 
     Controls _controls;
     int _selectedItemIdx {-1};
+    std::vector<std::shared_ptr<Item>> _listedItems;
 
     void onGUILoaded() override;
     void configureItemsListBox();

--- a/include/reone/game/gui/ingame/inventory.h
+++ b/include/reone/game/gui/ingame/inventory.h
@@ -29,6 +29,12 @@ class ListBox;
 
 } // namespace gui
 
+namespace graphics {
+
+class Texture;
+
+}
+
 namespace game {
 
 class InventoryMenu : public GameGUI {
@@ -39,6 +45,7 @@ public:
     }
 
     void refreshPortraits();
+    void refreshItems();
 
 private:
     struct Controls {
@@ -74,8 +81,13 @@ private:
     };
 
     Controls _controls;
+    int _selectedItemIdx {-1};
 
     void onGUILoaded() override;
+    void configureItemsListBox();
+    void updateItemDescription();
+    void clearItemDescription();
+    std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;
 
     void bindControls() {
         _controls.BTN_ALL = findControl<gui::Button>("BTN_ALL");

--- a/include/reone/game/gui/ingame/inventory.h
+++ b/include/reone/game/gui/ingame/inventory.h
@@ -88,6 +88,7 @@ private:
 
     void onGUILoaded() override;
     void configureItemsListBox();
+    void refreshStats();
     void updateItemDescription();
     void clearItemDescription();
     std::shared_ptr<graphics::Texture> getItemFrameTexture(int stackSize) const;

--- a/include/reone/game/itemdescription.h
+++ b/include/reone/game/itemdescription.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace reone {
+
+namespace game {
+
+class Item;
+struct ServicesView;
+
+std::vector<std::string> buildItemDescriptionLines(const Item &item, ServicesView &services);
+std::string joinItemDescriptionLines(const std::vector<std::string> &lines);
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -42,6 +42,17 @@ public:
         std::shared_ptr<audio::AudioClip> impactSound2;
     };
 
+    struct PropertyEntry {
+        uint8_t chanceAppear {0};
+        uint8_t costTable {0};
+        uint16_t costValue {0};
+        uint8_t paramTable {0};
+        uint8_t paramValue {0};
+        uint16_t propertyName {0};
+        uint16_t subtype {0};
+        uint8_t upgradeType {0};
+    };
+
     Item(
         uint32_t id,
         Game &game,
@@ -87,11 +98,13 @@ public:
     std::shared_ptr<graphics::Texture> icon() const { return _icon; }
     WeaponType weaponType() const { return _weaponType; }
     WeaponWield weaponWield() const { return _weaponWield; }
+    const std::string &description() const { return _description; }
     const std::string &descIdentified() const { return _descIdentified; }
     int baseItemType() const { return _baseItem; }
     int criticalThreat() const { return _criticalThreat; }
     int criticalHitMultiplier() const { return _criticalHitMultiplier; }
     std::optional<SpellType> activateSpell() const { return _activateSpell; }
+    const std::vector<PropertyEntry> &properties() const { return _properties; }
 
     void setDropable(bool dropable);
     void setStackSize(int size);
@@ -128,6 +141,7 @@ private:
     std::string _description;
     bool _stolen {false};
     std::optional<SpellType> _activateSpell;
+    std::vector<PropertyEntry> _properties;
 
     std::shared_ptr<audio::AudioSource> _audioSource;
 

--- a/include/reone/gui/control.h
+++ b/include/reone/gui/control.h
@@ -159,6 +159,7 @@ public:
     void setTextColor(glm::vec3 color);
     void setTextMessage(std::string text);
     void setTextFont(std::shared_ptr<graphics::Font> font);
+    void setTintBorderFill(bool tint) { _tintBorderFill = tint; }
     void setUseBorderColorOverride(bool use);
     void setVisible(bool visible);
 
@@ -215,6 +216,7 @@ protected:
     bool _disabled {false};
     bool _selected {false};
     bool _selectable {false};
+    bool _tintBorderFill {false};
     glm::vec3 _borderColorOverride {1.0f};
     bool _useBorderColorOverride {false};
     std::vector<std::string> _textLines;

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -86,6 +86,7 @@ public:
     const Item &getItemAt(int index) const;
 
     Control &protoItem() const { return *_protoItem; }
+    Control *protoItemOrNull() const { return _protoItem.get(); }
     Control &scrollBar() const { return *_scrollBar; }
     int selectedItemIndex() const { return _selectedItemIndex; }
 

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -184,6 +184,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/event.h
     ${GAME_INCLUDE_DIR}/footstepsounds.h
     ${GAME_INCLUDE_DIR}/game.h
+    ${GAME_INCLUDE_DIR}/itemdescription.h
     ${GAME_INCLUDE_DIR}/gui.h
     ${GAME_INCLUDE_DIR}/gui/actionbar.h
     ${GAME_INCLUDE_DIR}/gui/actionslot.h
@@ -453,6 +454,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/equipmentrules.cpp
     ${GAME_SOURCE_DIR}/footstepsounds.cpp
     ${GAME_SOURCE_DIR}/game.cpp
+    ${GAME_SOURCE_DIR}/itemdescription.cpp
     ${GAME_SOURCE_DIR}/gui/actionbar.cpp
     ${GAME_SOURCE_DIR}/gui/actionslot.cpp
     ${GAME_SOURCE_DIR}/gui/barkbubble.cpp

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -47,6 +47,14 @@ namespace game {
 
 static std::string g_attackIcon("i_attack");
 
+static void tintK2HUDMenuButton(const std::shared_ptr<Button> &button, const glm::vec3 &baseColor) {
+    if (!button) {
+        return;
+    }
+    button->setBorderColor(baseColor);
+    button->setTintBorderFill(true);
+}
+
 void HUD::preload(IGUI &gui) {
     gui.setResolution(800, 600);
     gui.setScaling(GUI::ScalingMode::PositionRelativeToCenter);
@@ -125,6 +133,14 @@ void HUD::onGUILoaded() {
 
     if (_game.isTSL()) {
         _controls.BTN_SWAPWEAPONS->setVisible(false);
+        tintK2HUDMenuButton(_controls.BTN_EQU, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_INV, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_CHAR, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_ABI, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_MSG, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_JOU, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_MAP, _baseColor);
+        tintK2HUDMenuButton(_controls.BTN_OPT, _baseColor);
     } else {
         _controls.LBL_COMBATBG1->setVisible(false);
         _controls.LBL_COMBATBG2->setVisible(false);

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -29,6 +29,14 @@ namespace reone {
 
 namespace game {
 
+static void tintK2TopNavigationIcon(const std::shared_ptr<ImageButton> &button, const glm::vec3 &baseColor) {
+    if (!button) {
+        return;
+    }
+    button->setBorderColor(baseColor);
+    button->setTintBorderFill(true);
+}
+
 void InGameMenu::preload(IGUI &gui) {
     if (_game.isTSL()) {
         gui.setResolution(800, 600);
@@ -37,6 +45,17 @@ void InGameMenu::preload(IGUI &gui) {
 
 void InGameMenu::onGUILoaded() {
     bindControls();
+
+    if (_game.isTSL()) {
+        tintK2TopNavigationIcon(_controls.LBLH_EQU, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_INV, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_CHA, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_ABI, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_MSG, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_JOU, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_MAP, _baseColor);
+        tintK2TopNavigationIcon(_controls.LBLH_OPT, _baseColor);
+    }
 
     // _controls.BTN_EQU->setVisible(false);
     // _controls.BTN_INV->setVisible(false);

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -200,6 +200,7 @@ void InGameMenu::updateTabButtons() {
 
 void InGameMenu::openInventory() {
     _inventory->refreshPortraits();
+    _inventory->refreshItems();
     changeTab(InGameMenuTab::Inventory);
 }
 

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -72,6 +72,13 @@ static std::unordered_map<Equipment::Slot, int32_t> g_slotStrRefs = {
 
 static int getInventorySlot(Equipment::Slot slot);
 
+static void enableBorderFillTint(const std::shared_ptr<Control> &control) {
+    if (!control) {
+        return;
+    }
+    control->setTintBorderFill(true);
+}
+
 static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
     if (!listBox) {
         return;
@@ -113,6 +120,7 @@ void Equipment::onGUILoaded() {
     _controls.LB_DESC->setVisible(false);
     _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LBL_CANTEQUIP->setVisible(false);
+    tintK2LoadoutOverlay();
     updateK2LoadoutOverlayVisibility(true);
 
     configureItemsListBox();
@@ -393,6 +401,20 @@ void Equipment::selectSlot(Slot slot) {
     if (noneSelected) {
         clearCandidateDescription();
     }
+}
+
+void Equipment::tintK2LoadoutOverlay() {
+    if (!_game.isTSL())
+        return;
+
+    // Preserve the muted K2 panel colours authored in equip_p.gui.
+    enableBorderFillTint(_controls.LBL_BACK1);
+    enableBorderFillTint(_controls.LBL_DEF_BACK);
+    enableBorderFillTint(_controls.LBL_BAR1);
+    enableBorderFillTint(_controls.LBL_BAR2);
+    enableBorderFillTint(_controls.LBL_BAR3);
+    enableBorderFillTint(_controls.LBL_BAR4);
+    enableBorderFillTint(_controls.LBL_BAR5);
 }
 
 void Equipment::updateK2LoadoutOverlayVisibility(bool visible) {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -105,6 +105,7 @@ void Equipment::onGUILoaded() {
     _controls.LB_DESC->setVisible(false);
     _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LBL_CANTEQUIP->setVisible(false);
+    updateK2LoadoutOverlayVisibility(true);
 
     configureItemsListBox();
 
@@ -366,6 +367,7 @@ void Equipment::selectSlot(Slot slot) {
 
     _controls.LB_DESC->setVisible(!noneSelected);
     _controls.LBL_SLOTNAME->setVisible(noneSelected);
+    updateK2LoadoutOverlayVisibility(noneSelected);
 
     if (!_game.isTSL()) {
         _controls.LBL_PORT_BORD->setVisible(noneSelected);
@@ -378,6 +380,35 @@ void Equipment::selectSlot(Slot slot) {
     if (noneSelected) {
         clearCandidateDescription();
     }
+}
+
+void Equipment::updateK2LoadoutOverlayVisibility(bool visible) {
+    if (!_game.isTSL())
+        return;
+
+    auto setVisible = [visible](auto &control) {
+        if (control) {
+            control->setVisible(visible);
+        }
+    };
+
+    // K2's normal loadout/stat art overlaps the candidate description panel.
+    setVisible(_controls.BTN_SWAPWEAPONS);
+    setVisible(_controls.LBL_ATKL);
+    setVisible(_controls.LBL_ATKR);
+    setVisible(_controls.LBL_ATTACKMOD);
+    setVisible(_controls.LBL_ATTACK_INFO);
+    setVisible(_controls.LBL_BACK1);
+    setVisible(_controls.LBL_DAMAGE);
+    setVisible(_controls.LBL_DAMTEXT);
+    setVisible(_controls.LBL_DEF);
+    setVisible(_controls.LBL_DEF_BACK);
+    setVisible(_controls.LBL_DEF_INFO);
+    setVisible(_controls.LBL_DEF_TEXT);
+    setVisible(_controls.LBL_SELECTTITLE);
+    setVisible(_controls.LBL_TOHIT);
+    setVisible(_controls.LBL_TOHITL);
+    setVisible(_controls.LBL_TOHITR);
 }
 
 void Equipment::activateSlot(Slot slot) {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -21,6 +21,7 @@
 #include "reone/game/equipmentrules.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/ingame.h"
+#include "reone/game/itemdescription.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/item.h"
 #include "reone/game/party.h"
@@ -211,12 +212,7 @@ void Equipment::updateCandidateDescription() {
     if (!itemObj)
         return;
 
-    std::string description(itemObj->localizedName());
-    if (!itemObj->descIdentified().empty()) {
-        description += "\n\n";
-        description += itemObj->descIdentified();
-    }
-    _controls.LB_DESC->addTextLinesAsItems(description);
+    _controls.LB_DESC->addTextLinesAsItems(joinItemDescriptionLines(buildItemDescriptionLines(*itemObj, _services)));
 }
 
 static int getInventorySlot(Equipment::Slot slot) {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -72,6 +72,14 @@ static std::unordered_map<Equipment::Slot, int32_t> g_slotStrRefs = {
 
 static int getInventorySlot(Equipment::Slot slot);
 
+static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
+    if (!listBox) {
+        return;
+    }
+    listBox->setBorderColor(baseColor);
+    listBox->setTintBorderFill(true);
+}
+
 void Equipment::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
@@ -170,6 +178,11 @@ void Equipment::configureItemsListBox() {
     auto &protoItem = _controls.LB_ITEMS->protoItem();
     protoItem.setBorderColor(_baseColor);
     protoItem.setHilightColor(_hilightColor);
+
+    if (_game.isTSL()) {
+        tintK2PanelFill(_controls.LB_ITEMS, _baseColor);
+        tintK2PanelFill(_controls.LB_DESC, _baseColor);
+    }
 }
 
 void Equipment::clearCandidateDescription() {

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -67,6 +67,13 @@ static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::
     listBox->setTintBorderFill(true);
 }
 
+static void enableBorderFillTint(const std::shared_ptr<Label> &label) {
+    if (!label) {
+        return;
+    }
+    label->setTintBorderFill(true);
+}
+
 struct BaseItemFilterInfo {
     std::optional<int> itemType;
     std::optional<int> storePanelSort;
@@ -269,6 +276,11 @@ void InventoryMenu::onGUILoaded() {
 
     configureItemsListBox();
     configureFilterControls();
+    if (_game.isTSL()) {
+        enableBorderFillTint(_controls.LBL_BAR1);
+        enableBorderFillTint(_controls.LBL_BAR2);
+        enableBorderFillTint(_controls.LBL_BAR6);
+    }
     if (_controls.LB_DESCRIPTION) {
         _controls.LB_DESCRIPTION->setProtoMatchContent(true);
     }

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -23,6 +23,7 @@
 
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
+#include "reone/game/itemdescription.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/item.h"
 #include "reone/game/party.h"
@@ -58,6 +59,9 @@ void InventoryMenu::onGUILoaded() {
     }
 
     configureItemsListBox();
+    if (_controls.LB_DESCRIPTION) {
+        _controls.LB_DESCRIPTION->setProtoMatchContent(true);
+    }
 
     if (!_game.isTSL()) {
         if (_controls.LBL_VIT) {
@@ -189,13 +193,8 @@ void InventoryMenu::updateItemDescription() {
         return;
     }
 
-    std::string description(itemObj->localizedName());
-    if (!itemObj->descIdentified().empty()) {
-        description += "\n\n";
-        description += itemObj->descIdentified();
-    }
     if (_controls.LB_DESCRIPTION) {
-        _controls.LB_DESCRIPTION->addTextLinesAsItems(description);
+        _controls.LB_DESCRIPTION->addTextLinesAsItems(joinItemDescriptionLines(buildItemDescriptionLines(*itemObj, _services)));
     }
 }
 

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -27,6 +27,8 @@
 #include "reone/game/object/creature.h"
 #include "reone/game/object/item.h"
 #include "reone/game/party.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/provider/2das.h"
 #include "reone/resource/provider/textures.h"
 
 #include <algorithm>
@@ -43,6 +45,8 @@ namespace reone {
 namespace game {
 
 static constexpr char kEquippedItemSuffix[] = " (equipped)";
+static constexpr char kK1InventoryTitlePrefix[] = "Party Inventory - ";
+static constexpr glm::vec3 kK2InventoryFilterSelectedColor {1.0f, 1.0f, 1.0f};
 
 static constexpr std::array<int, 9> kInventoryEquippedSlots {
     InventorySlots::head,
@@ -54,6 +58,187 @@ static constexpr std::array<int, 9> kInventoryEquippedSlots {
     InventorySlots::rightArm,
     InventorySlots::implant,
     InventorySlots::belt};
+
+struct BaseItemFilterInfo {
+    std::optional<int> itemType;
+    std::optional<int> storePanelSort;
+    std::optional<int> weaponType;
+};
+
+static BaseItemFilterInfo getBaseItemFilterInfo(ServicesView &services, const Item &item) {
+    BaseItemFilterInfo info;
+    auto baseItems = services.resource.twoDas.get("baseitems");
+    if (!baseItems) {
+        return info;
+    }
+
+    int baseItemType = item.baseItemType();
+    info.itemType = baseItems->getIntOpt(baseItemType, "itemtype");
+    info.storePanelSort = baseItems->getIntOpt(baseItemType, "storepanelsort");
+    info.weaponType = baseItems->getIntOpt(baseItemType, "weapontype");
+    return info;
+}
+
+static bool isDatapad(const Item &item, const BaseItemFilterInfo &baseItem) {
+    return baseItem.itemType == 24 || item.itemClass() == "i_datapad";
+}
+
+static bool isWeapon(const Item &item, const BaseItemFilterInfo &baseItem) {
+    if (item.weaponType() != WeaponType::None) {
+        return true;
+    }
+    if (baseItem.weaponType && *baseItem.weaponType != static_cast<int>(WeaponType::None)) {
+        return true;
+    }
+    if (baseItem.itemType) {
+        switch (*baseItem.itemType) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 39:
+        case 40:
+        case 41:
+            return true;
+        default:
+            break;
+        }
+    }
+    if (baseItem.storePanelSort) {
+        switch (*baseItem.storePanelSort) {
+        case 20:
+        case 25:
+        case 30:
+        case 35:
+        case 40:
+        case 45:
+            return true;
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
+static bool isArmor(const Item &item, const BaseItemFilterInfo &baseItem) {
+    return item.isEquippable() && !isWeapon(item, baseItem);
+}
+
+static bool isUseable(const Item &item, const BaseItemFilterInfo &baseItem) {
+    if (item.activateSpell()) {
+        return true;
+    }
+    if (!baseItem.storePanelSort) {
+        return false;
+    }
+
+    switch (*baseItem.storePanelSort) {
+    case 1:
+    case 50:
+        return true;
+    case 80:
+        return !isDatapad(item, baseItem);
+    default:
+        return false;
+    }
+}
+
+static bool isUtility(const Item &item, const BaseItemFilterInfo &baseItem) {
+    if (item.plotFlag() || isWeapon(item, baseItem) || isArmor(item, baseItem) || isUseable(item, baseItem)) {
+        return false;
+    }
+    if (isDatapad(item, baseItem)) {
+        return true;
+    }
+    if (baseItem.storePanelSort) {
+        switch (*baseItem.storePanelSort) {
+        case 2:
+        case 85:
+        case 90:
+        case 95:
+            return true;
+        default:
+            break;
+        }
+    }
+    if (baseItem.itemType) {
+        switch (*baseItem.itemType) {
+        case 27:
+        case 28:
+        case 29:
+        case 30:
+        case 42:
+        case 43:
+        case 46:
+        case 50:
+        case 51:
+            return true;
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
+static InventoryFilter nextK1Filter(InventoryFilter filter) {
+    switch (filter) {
+    case InventoryFilter::All:
+        return InventoryFilter::Quest;
+    case InventoryFilter::Quest:
+        return InventoryFilter::Equippable;
+    case InventoryFilter::Equippable:
+        return InventoryFilter::Utility;
+    case InventoryFilter::Utility:
+        return InventoryFilter::Useable;
+    case InventoryFilter::Useable:
+        return InventoryFilter::All;
+    default:
+        return InventoryFilter::All;
+    }
+}
+
+static std::string k1FilterTitle(InventoryFilter filter) {
+    switch (filter) {
+    case InventoryFilter::Quest:
+        return std::string(kK1InventoryTitlePrefix) + "Quest Items";
+    case InventoryFilter::Equippable:
+        return std::string(kK1InventoryTitlePrefix) + "Equippable";
+    case InventoryFilter::Utility:
+        return std::string(kK1InventoryTitlePrefix) + "Utility Items";
+    case InventoryFilter::Useable:
+        return std::string(kK1InventoryTitlePrefix) + "Useable Items";
+    case InventoryFilter::New:
+        return std::string(kK1InventoryTitlePrefix) + "New Items";
+    default:
+        return std::string(kK1InventoryTitlePrefix) + "All Items";
+    }
+}
+
+static std::string k1NextFilterAction(InventoryFilter filter) {
+    switch (nextK1Filter(filter)) {
+    case InventoryFilter::Quest:
+        return "Show Quest Items";
+    case InventoryFilter::Equippable:
+        return "Show Equippable";
+    case InventoryFilter::Utility:
+        return "Show Utility Items";
+    case InventoryFilter::Useable:
+        return "Show Useable Items";
+    default:
+        return "Show All Items";
+    }
+}
+
+static void updateK2FilterButton(const std::shared_ptr<Button> &button, bool selected, const glm::vec3 &baseColor) {
+    if (!button) {
+        return;
+    }
+
+    button->setSelected(selected);
+    button->setTextColor(selected ? kK2InventoryFilterSelectedColor : baseColor);
+}
 
 void InventoryMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
@@ -75,6 +260,7 @@ void InventoryMenu::onGUILoaded() {
     }
 
     configureItemsListBox();
+    configureFilterControls();
     if (_controls.LB_DESCRIPTION) {
         _controls.LB_DESCRIPTION->setProtoMatchContent(true);
     }
@@ -85,9 +271,6 @@ void InventoryMenu::onGUILoaded() {
         }
         if (_controls.BTN_CHANGE2) {
             _controls.BTN_CHANGE2->setSelectable(false);
-        }
-        if (_controls.BTN_QUESTITEMS) {
-            _controls.BTN_QUESTITEMS->setDisabled(true);
         }
     }
 }
@@ -108,6 +291,53 @@ void InventoryMenu::configureItemsListBox() {
         protoItem->setBorderColor(_baseColor);
         protoItem->setHilightColor(_hilightColor);
     }
+}
+
+void InventoryMenu::configureFilterControls() {
+    if (_game.isTSL()) {
+        if (_controls.BTN_ALL) {
+            _controls.BTN_ALL->setOnClick([this]() {
+                setFilter(InventoryFilter::All);
+            });
+        }
+        if (_controls.BTN_DATAPADS) {
+            _controls.BTN_DATAPADS->setOnClick([this]() {
+                setFilter(InventoryFilter::Datapad);
+            });
+        }
+        if (_controls.BTN_WEAPONS) {
+            _controls.BTN_WEAPONS->setOnClick([this]() {
+                setFilter(InventoryFilter::Weapon);
+            });
+        }
+        if (_controls.BTN_ARMOR) {
+            _controls.BTN_ARMOR->setOnClick([this]() {
+                setFilter(InventoryFilter::Armor);
+            });
+        }
+        if (_controls.BTN_USEABLE) {
+            _controls.BTN_USEABLE->setOnClick([this]() {
+                setFilter(InventoryFilter::Useable);
+            });
+        }
+        if (_controls.BTN_QUESTS) {
+            _controls.BTN_QUESTS->setOnClick([this]() {
+                setFilter(InventoryFilter::Quest);
+            });
+        }
+        if (_controls.BTN_MISC) {
+            _controls.BTN_MISC->setOnClick([this]() {
+                setFilter(InventoryFilter::Misc);
+            });
+        }
+    } else if (_controls.BTN_QUESTITEMS) {
+        _controls.BTN_QUESTITEMS->setDisabled(false);
+        _controls.BTN_QUESTITEMS->setOnClick([this]() {
+            advanceK1Filter();
+        });
+    }
+
+    updateFilterControls();
 }
 
 void InventoryMenu::refreshPortraits() {
@@ -166,6 +396,74 @@ void InventoryMenu::refreshStats() {
     }
 }
 
+void InventoryMenu::advanceK1Filter() {
+    setFilter(nextK1Filter(_filter));
+}
+
+void InventoryMenu::setFilter(InventoryFilter filter) {
+    if (_filter == filter) {
+        updateFilterControls();
+        return;
+    }
+    _filter = filter;
+    updateFilterControls();
+    refreshItems();
+}
+
+void InventoryMenu::updateFilterControls() {
+    if (_game.isTSL()) {
+        updateK2FilterButton(_controls.BTN_ALL, _filter == InventoryFilter::All, _baseColor);
+        updateK2FilterButton(_controls.BTN_DATAPADS, _filter == InventoryFilter::Datapad, _baseColor);
+        updateK2FilterButton(_controls.BTN_WEAPONS, _filter == InventoryFilter::Weapon, _baseColor);
+        updateK2FilterButton(_controls.BTN_ARMOR, _filter == InventoryFilter::Armor, _baseColor);
+        updateK2FilterButton(_controls.BTN_USEABLE, _filter == InventoryFilter::Useable, _baseColor);
+        updateK2FilterButton(_controls.BTN_QUESTS, _filter == InventoryFilter::Quest, _baseColor);
+        updateK2FilterButton(_controls.BTN_MISC, _filter == InventoryFilter::Misc, _baseColor);
+        return;
+    }
+
+    if (_controls.LBL_INV) {
+        _controls.LBL_INV->setTextMessage(k1FilterTitle(_filter));
+    }
+    if (_controls.BTN_QUESTITEMS) {
+        _controls.BTN_QUESTITEMS->setTextMessage(k1NextFilterAction(_filter));
+        _controls.BTN_QUESTITEMS->setDisabled(false);
+    }
+}
+
+bool InventoryMenu::itemMatchesFilter(const Item &item) const {
+    BaseItemFilterInfo baseItem(getBaseItemFilterInfo(_services, item));
+    switch (_filter) {
+    case InventoryFilter::All:
+        return true;
+    case InventoryFilter::New:
+        // New item tracking is not retained by the runtime inventory yet.
+        return false;
+    case InventoryFilter::Quest:
+        return item.plotFlag();
+    case InventoryFilter::Equippable:
+        return item.isEquippable();
+    case InventoryFilter::Utility:
+        return isUtility(item, baseItem);
+    case InventoryFilter::Useable:
+        return isUseable(item, baseItem);
+    case InventoryFilter::Datapad:
+        return isDatapad(item, baseItem);
+    case InventoryFilter::Weapon:
+        return isWeapon(item, baseItem);
+    case InventoryFilter::Armor:
+        return isArmor(item, baseItem);
+    case InventoryFilter::Misc:
+        return !item.plotFlag() &&
+               !isDatapad(item, baseItem) &&
+               !isWeapon(item, baseItem) &&
+               !isArmor(item, baseItem) &&
+               !isUseable(item, baseItem);
+    default:
+        return true;
+    }
+}
+
 void InventoryMenu::refreshItems() {
     if (!_controls.LB_ITEMS) {
         return;
@@ -184,7 +482,7 @@ void InventoryMenu::refreshItems() {
     if (activeCreature) {
         for (int slot : kInventoryEquippedSlots) {
             std::shared_ptr<Item> equipped(activeCreature->getEquippedItem(slot));
-            if (!equipped) {
+            if (!equipped || !itemMatchesFilter(*equipped)) {
                 continue;
             }
 
@@ -204,6 +502,9 @@ void InventoryMenu::refreshItems() {
 
     for (auto &item : player->items()) {
         if (!item || std::find(_listedItems.begin(), _listedItems.end(), item) != _listedItems.end()) {
+            continue;
+        }
+        if (!itemMatchesFilter(*item)) {
             continue;
         }
 

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -29,6 +29,9 @@
 #include "reone/game/party.h"
 #include "reone/resource/provider/textures.h"
 
+#include <algorithm>
+#include <array>
+
 using namespace reone::audio;
 
 using namespace reone::graphics;
@@ -38,6 +41,19 @@ using namespace reone::resource;
 namespace reone {
 
 namespace game {
+
+static constexpr char kEquippedItemSuffix[] = " (equipped)";
+
+static constexpr std::array<int, 9> kInventoryEquippedSlots {
+    InventorySlots::head,
+    InventorySlots::body,
+    InventorySlots::hands,
+    InventorySlots::rightWeapon,
+    InventorySlots::leftWeapon,
+    InventorySlots::leftArm,
+    InventorySlots::rightArm,
+    InventorySlots::implant,
+    InventorySlots::belt};
 
 void InventoryMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
@@ -124,6 +140,7 @@ void InventoryMenu::refreshItems() {
     }
 
     _controls.LB_ITEMS->clearItems();
+    _listedItems.clear();
     clearItemDescription();
 
     std::shared_ptr<Creature> player(_game.party().player());
@@ -131,7 +148,33 @@ void InventoryMenu::refreshItems() {
         return;
     }
 
+    std::shared_ptr<Creature> activeCreature(_game.party().getLeader());
+    if (activeCreature) {
+        for (int slot : kInventoryEquippedSlots) {
+            std::shared_ptr<Item> equipped(activeCreature->getEquippedItem(slot));
+            if (!equipped) {
+                continue;
+            }
+
+            ListBox::Item equippedItem;
+            equippedItem.tag = equipped->tag();
+            equippedItem.text = equipped->localizedName() + kEquippedItemSuffix;
+            equippedItem.iconTexture = equipped->icon();
+            equippedItem.iconFrame = getItemFrameTexture(equipped->stackSize());
+
+            if (equipped->stackSize() > 1) {
+                equippedItem.iconText = std::to_string(equipped->stackSize());
+            }
+            _controls.LB_ITEMS->addItem(std::move(equippedItem));
+            _listedItems.push_back(equipped);
+        }
+    }
+
     for (auto &item : player->items()) {
+        if (!item || std::find(_listedItems.begin(), _listedItems.end(), item) != _listedItems.end()) {
+            continue;
+        }
+
         ListBox::Item lbItem;
         lbItem.tag = item->tag();
         lbItem.text = item->localizedName();
@@ -142,6 +185,7 @@ void InventoryMenu::refreshItems() {
             lbItem.iconText = std::to_string(item->stackSize());
         }
         _controls.LB_ITEMS->addItem(std::move(lbItem));
+        _listedItems.push_back(item);
     }
 
     if (_controls.LB_ITEMS->getItemCount() > 0) {
@@ -172,23 +216,10 @@ void InventoryMenu::updateItemDescription() {
         _controls.LB_DESCRIPTION->clearItems();
     }
 
-    if (selectedItemIdx < 0 || selectedItemIdx >= _controls.LB_ITEMS->getItemCount()) {
-        return;
-    }
-
-    const ListBox::Item &lbItem = _controls.LB_ITEMS->getItemAt(selectedItemIdx);
-    std::shared_ptr<Creature> player(_game.party().player());
-    if (!player) {
-        return;
-    }
-
-    std::shared_ptr<Item> itemObj;
-    for (auto &playerItem : player->items()) {
-        if (playerItem->tag() == lbItem.tag) {
-            itemObj = playerItem;
-            break;
-        }
-    }
+    std::shared_ptr<Item> itemObj(
+        selectedItemIdx >= 0 && selectedItemIdx < static_cast<int>(_listedItems.size())
+            ? _listedItems[selectedItemIdx]
+            : nullptr);
     if (!itemObj) {
         return;
     }

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -32,7 +32,6 @@
 #include "reone/resource/provider/textures.h"
 
 #include <algorithm>
-#include <array>
 
 using namespace reone::audio;
 
@@ -48,16 +47,22 @@ static constexpr char kEquippedItemSuffix[] = " (equipped)";
 static constexpr char kK1InventoryTitlePrefix[] = "Party Inventory - ";
 static constexpr glm::vec3 kK2InventoryFilterSelectedColor {1.0f, 1.0f, 1.0f};
 
-static constexpr std::array<int, 9> kInventoryEquippedSlots {
-    InventorySlots::head,
-    InventorySlots::body,
-    InventorySlots::hands,
-    InventorySlots::rightWeapon,
-    InventorySlots::leftWeapon,
-    InventorySlots::leftArm,
-    InventorySlots::rightArm,
-    InventorySlots::implant,
-    InventorySlots::belt};
+static bool isInventoryListedEquipmentSlot(int slot) {
+    switch (slot) {
+    case InventorySlots::head:
+    case InventorySlots::body:
+    case InventorySlots::hands:
+    case InventorySlots::rightWeapon:
+    case InventorySlots::leftWeapon:
+    case InventorySlots::leftArm:
+    case InventorySlots::rightArm:
+    case InventorySlots::implant:
+    case InventorySlots::belt:
+        return true;
+    default:
+        return false;
+    }
+}
 
 static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
     if (!listBox) {
@@ -505,8 +510,11 @@ void InventoryMenu::refreshItems() {
 
     std::shared_ptr<Creature> activeCreature(_game.party().getLeader());
     if (activeCreature) {
-        for (int slot : kInventoryEquippedSlots) {
-            std::shared_ptr<Item> equipped(activeCreature->getEquippedItem(slot));
+        for (const auto &equipment : activeCreature->equipment()) {
+            if (!isInventoryListedEquipmentSlot(equipment.first)) {
+                continue;
+            }
+            std::shared_ptr<Item> equipped(equipment.second);
             if (!equipped || !itemMatchesFilter(*equipped)) {
                 continue;
             }

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -59,6 +59,14 @@ static constexpr std::array<int, 9> kInventoryEquippedSlots {
     InventorySlots::implant,
     InventorySlots::belt};
 
+static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
+    if (!listBox) {
+        return;
+    }
+    listBox->setBorderColor(baseColor);
+    listBox->setTintBorderFill(true);
+}
+
 struct BaseItemFilterInfo {
     std::optional<int> itemType;
     std::optional<int> storePanelSort;
@@ -278,6 +286,11 @@ void InventoryMenu::onGUILoaded() {
 void InventoryMenu::configureItemsListBox() {
     if (!_controls.LB_ITEMS) {
         return;
+    }
+
+    if (_game.isTSL()) {
+        tintK2PanelFill(_controls.LB_ITEMS, _baseColor);
+        tintK2PanelFill(_controls.LB_DESCRIPTION, _baseColor);
     }
 
     _controls.LB_ITEMS->setSelectionMode(ListBox::SelectionMode::OnClick);

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -24,7 +24,9 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
+#include "reone/game/object/item.h"
 #include "reone/game/party.h"
+#include "reone/resource/provider/textures.h"
 
 using namespace reone::audio;
 
@@ -40,18 +42,57 @@ void InventoryMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
 
-    _controls.LBL_CREDITS_VALUE->setVisible(false);
-    _controls.BTN_USEITEM->setDisabled(true);
-    _controls.BTN_EXIT->setOnClick([this]() {
-        _game.openInGame();
-    });
+    if (_controls.LBL_CREDITS_VALUE) {
+        _controls.LBL_CREDITS_VALUE->setVisible(false);
+    }
+    if (_controls.BTN_USEITEM) {
+        _controls.BTN_USEITEM->setDisabled(true);
+    }
+    if (_controls.BTN_EXIT) {
+        _controls.BTN_EXIT->setOnClick([this]() {
+            _game.openInGame();
+        });
+    }
+    if (_controls.BTN_ALL) {
+        _controls.BTN_ALL->setSelected(true);
+    }
+
+    configureItemsListBox();
 
     if (!_game.isTSL()) {
-        _controls.LBL_VIT->setVisible(false);
-        _controls.LBL_DEF->setVisible(false);
-        _controls.BTN_CHANGE1->setSelectable(false);
-        _controls.BTN_CHANGE2->setSelectable(false);
-        _controls.BTN_QUESTITEMS->setDisabled(true);
+        if (_controls.LBL_VIT) {
+            _controls.LBL_VIT->setVisible(false);
+        }
+        if (_controls.LBL_DEF) {
+            _controls.LBL_DEF->setVisible(false);
+        }
+        if (_controls.BTN_CHANGE1) {
+            _controls.BTN_CHANGE1->setSelectable(false);
+        }
+        if (_controls.BTN_CHANGE2) {
+            _controls.BTN_CHANGE2->setSelectable(false);
+        }
+        if (_controls.BTN_QUESTITEMS) {
+            _controls.BTN_QUESTITEMS->setDisabled(true);
+        }
+    }
+}
+
+void InventoryMenu::configureItemsListBox() {
+    if (!_controls.LB_ITEMS) {
+        return;
+    }
+
+    _controls.LB_ITEMS->setSelectionMode(ListBox::SelectionMode::OnClick);
+    _controls.LB_ITEMS->setRenderItemIconsForButtonProto(true);
+    _controls.LB_ITEMS->setPadding(5);
+    _controls.LB_ITEMS->setOnItemClick([this](const std::string &) {
+        updateItemDescription();
+    });
+
+    if (auto protoItem = _controls.LB_ITEMS->protoItemOrNull()) {
+        protoItem->setBorderColor(_baseColor);
+        protoItem->setHilightColor(_hilightColor);
     }
 }
 
@@ -71,6 +112,113 @@ void InventoryMenu::refreshPortraits() {
 
     _controls.BTN_CHANGE2->setBorderFill(partyMember2 ? partyMember2->portrait() : nullptr);
     _controls.BTN_CHANGE2->setHilightFill(partyMember2 ? partyMember2->portrait() : nullptr);
+}
+
+void InventoryMenu::refreshItems() {
+    if (!_controls.LB_ITEMS) {
+        return;
+    }
+
+    _controls.LB_ITEMS->clearItems();
+    clearItemDescription();
+
+    std::shared_ptr<Creature> player(_game.party().player());
+    if (!player) {
+        return;
+    }
+
+    for (auto &item : player->items()) {
+        ListBox::Item lbItem;
+        lbItem.tag = item->tag();
+        lbItem.text = item->localizedName();
+        lbItem.iconTexture = item->icon();
+        lbItem.iconFrame = getItemFrameTexture(item->stackSize());
+
+        if (item->stackSize() > 1) {
+            lbItem.iconText = std::to_string(item->stackSize());
+        }
+        _controls.LB_ITEMS->addItem(std::move(lbItem));
+    }
+
+    if (_controls.LB_ITEMS->getItemCount() > 0) {
+        _controls.LB_ITEMS->setSelectedItemIndex(0);
+        updateItemDescription();
+    }
+}
+
+void InventoryMenu::clearItemDescription() {
+    _selectedItemIdx = -1;
+    if (_controls.LB_DESCRIPTION) {
+        _controls.LB_DESCRIPTION->clearItems();
+    }
+}
+
+void InventoryMenu::updateItemDescription() {
+    if (!_controls.LB_ITEMS) {
+        return;
+    }
+
+    int selectedItemIdx = _controls.LB_ITEMS->selectedItemIndex();
+    if (selectedItemIdx == _selectedItemIdx) {
+        return;
+    }
+
+    _selectedItemIdx = selectedItemIdx;
+    if (_controls.LB_DESCRIPTION) {
+        _controls.LB_DESCRIPTION->clearItems();
+    }
+
+    if (selectedItemIdx < 0 || selectedItemIdx >= _controls.LB_ITEMS->getItemCount()) {
+        return;
+    }
+
+    const ListBox::Item &lbItem = _controls.LB_ITEMS->getItemAt(selectedItemIdx);
+    std::shared_ptr<Creature> player(_game.party().player());
+    if (!player) {
+        return;
+    }
+
+    std::shared_ptr<Item> itemObj;
+    for (auto &playerItem : player->items()) {
+        if (playerItem->tag() == lbItem.tag) {
+            itemObj = playerItem;
+            break;
+        }
+    }
+    if (!itemObj) {
+        return;
+    }
+
+    std::string description(itemObj->localizedName());
+    if (!itemObj->descIdentified().empty()) {
+        description += "\n\n";
+        description += itemObj->descIdentified();
+    }
+    if (_controls.LB_DESCRIPTION) {
+        _controls.LB_DESCRIPTION->addTextLinesAsItems(description);
+    }
+}
+
+std::shared_ptr<Texture> InventoryMenu::getItemFrameTexture(int stackSize) const {
+    std::string resRef;
+    if (_game.isTSL()) {
+        if (stackSize >= 100) {
+            resRef = "uibit_eqp_itm3";
+        } else if (stackSize > 1) {
+            resRef = "uibit_eqp_itm2";
+        } else {
+            resRef = "uibit_eqp_itm1";
+        }
+    } else {
+        if (stackSize >= 100) {
+            resRef = "lbl_hex_7";
+        } else if (stackSize > 1) {
+            resRef = "lbl_hex_6";
+        } else {
+            resRef = "lbl_hex_3";
+        }
+    }
+    return _services.resource.textures.get(resRef, TextureUsage::GUI);
 }
 
 } // namespace game

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -80,12 +80,6 @@ void InventoryMenu::onGUILoaded() {
     }
 
     if (!_game.isTSL()) {
-        if (_controls.LBL_VIT) {
-            _controls.LBL_VIT->setVisible(false);
-        }
-        if (_controls.LBL_DEF) {
-            _controls.LBL_DEF->setVisible(false);
-        }
         if (_controls.BTN_CHANGE1) {
             _controls.BTN_CHANGE1->setSelectable(false);
         }
@@ -117,6 +111,8 @@ void InventoryMenu::configureItemsListBox() {
 }
 
 void InventoryMenu::refreshPortraits() {
+    refreshStats();
+
     if (!!_game.isTSL())
         return;
 
@@ -132,6 +128,42 @@ void InventoryMenu::refreshPortraits() {
 
     _controls.BTN_CHANGE2->setBorderFill(partyMember2 ? partyMember2->portrait() : nullptr);
     _controls.BTN_CHANGE2->setHilightFill(partyMember2 ? partyMember2->portrait() : nullptr);
+}
+
+void InventoryMenu::refreshStats() {
+    if (_game.isTSL()) {
+        if (_controls.LBL_VIT) {
+            _controls.LBL_VIT->setTextMessage("");
+            _controls.LBL_VIT->setVisible(false);
+        }
+        if (_controls.LBL_DEF) {
+            _controls.LBL_DEF->setTextMessage("");
+            _controls.LBL_DEF->setVisible(false);
+        }
+        return;
+    }
+
+    std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+    if (!partyLeader) {
+        if (_controls.LBL_VIT) {
+            _controls.LBL_VIT->setTextMessage("");
+            _controls.LBL_VIT->setVisible(false);
+        }
+        if (_controls.LBL_DEF) {
+            _controls.LBL_DEF->setTextMessage("");
+            _controls.LBL_DEF->setVisible(false);
+        }
+        return;
+    }
+
+    if (_controls.LBL_VIT) {
+        _controls.LBL_VIT->setTextMessage(std::to_string(partyLeader->currentHitPoints()) + "/\n" + std::to_string(partyLeader->hitPoints()));
+        _controls.LBL_VIT->setVisible(true);
+    }
+    if (_controls.LBL_DEF) {
+        _controls.LBL_DEF->setTextMessage(std::to_string(partyLeader->getDefense()));
+        _controls.LBL_DEF->setVisible(true);
+    }
 }
 
 void InventoryMenu::refreshItems() {

--- a/src/libs/game/itemdescription.cpp
+++ b/src/libs/game/itemdescription.cpp
@@ -1,0 +1,1107 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/itemdescription.h"
+
+#include "reone/game/d20/feat.h"
+#include "reone/game/d20/feats.h"
+#include "reone/game/d20/skill.h"
+#include "reone/game/d20/skills.h"
+#include "reone/game/d20/spell.h"
+#include "reone/game/d20/spells.h"
+#include "reone/game/di/services.h"
+#include "reone/game/object/item.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/provider/2das.h"
+#include "reone/resource/strings.h"
+
+#include <iterator>
+#include <map>
+#include <regex>
+#include <set>
+
+using namespace reone::resource;
+
+namespace reone {
+
+namespace game {
+
+namespace {
+
+struct Section {
+    std::string title;
+    std::vector<std::string> lines;
+};
+
+struct RangeBonus {
+    int min {0};
+    int max {0};
+
+    bool empty() const {
+        return min == 0 && max == 0;
+    }
+
+    void add(const RangeBonus &other) {
+        min += other.min;
+        max += other.max;
+    }
+};
+
+struct DerivedProperties {
+    int attackModifier {0};
+    int defenseBonus {0};
+    int blasterBoltDeflection {0};
+    std::map<int, int> attributeBonuses;
+    std::map<std::string, RangeBonus> damageBonuses;
+    std::set<std::string> foldedDamageTypes;
+    RangeBonus massiveCriticals;
+    bool foldedDefenseBonus {false};
+};
+
+static std::string lowerASCII(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+static std::string trim(std::string value) {
+    auto begin = std::find_if(value.begin(), value.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    });
+    auto end = std::find_if(value.rbegin(), value.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base();
+    return begin < end ? std::string(begin, end) : std::string();
+}
+
+static std::string singleLine(std::string value) {
+    for (char &ch : value) {
+        if (ch == '\r' || ch == '\n' || ch == '\t') {
+            ch = ' ';
+        }
+    }
+
+    std::string result;
+    bool previousSpace = false;
+    for (char ch : value) {
+        bool space = std::isspace(static_cast<unsigned char>(ch));
+        if (space && previousSpace) {
+            continue;
+        }
+        result += space ? ' ' : ch;
+        previousSpace = space;
+    }
+    return trim(result);
+}
+
+static std::string titleFromRaw(std::string value) {
+    value = trim(value);
+    bool nextUpper = true;
+    for (char &ch : value) {
+        if (ch == '_' || ch == '-') {
+            ch = ' ';
+            nextUpper = true;
+        } else if (nextUpper) {
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+            nextUpper = false;
+        } else {
+            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+        }
+    }
+    return value;
+}
+
+static bool isDeletedCell(const std::string &value) {
+    return value.empty() || value == "****" || value == "*";
+}
+
+static std::optional<int> parseInt(const std::string &value) {
+    try {
+        size_t pos = 0;
+        int result = std::stoi(value, &pos, 0);
+        if (pos == value.size()) {
+            return result;
+        }
+    } catch (const std::exception &) {
+    }
+    return std::nullopt;
+}
+
+static std::optional<RangeBonus> parseRangeBonus(std::string value) {
+    value = trim(value);
+    if (value.empty()) {
+        return std::nullopt;
+    }
+
+    std::smatch match;
+    static const std::regex kDiceRegex("^([+-]?\\d+)\\s*d\\s*(\\d+)$", std::regex::icase);
+    if (std::regex_search(value, match, kDiceRegex)) {
+        int count = std::stoi(match[1].str());
+        int sides = std::stoi(match[2].str());
+        return RangeBonus {count, count * sides};
+    }
+
+    static const std::regex kRangeRegex("^([+-]?\\d+)\\s*-\\s*([+-]?\\d+)$");
+    if (std::regex_search(value, match, kRangeRegex)) {
+        return RangeBonus {std::stoi(match[1].str()), std::stoi(match[2].str())};
+    }
+
+    if (auto maybeValue = parseInt(value)) {
+        return RangeBonus {*maybeValue, *maybeValue};
+    }
+
+    static const std::regex kLooseIntRegex("([+-]?\\d+)");
+    if (std::regex_search(value, match, kLooseIntRegex)) {
+        int amount = std::stoi(match[1].str());
+        return RangeBonus {amount, amount};
+    }
+    return std::nullopt;
+}
+
+static std::optional<std::string> cell(
+    const TwoDA &twoDa,
+    int row,
+    const std::vector<std::string> &columns) {
+
+    if (row < 0 || row >= twoDa.getRowCount()) {
+        return std::nullopt;
+    }
+
+    std::unordered_map<std::string, int> columnIndices;
+    for (int i = 0; i < static_cast<int>(twoDa.columns().size()); ++i) {
+        columnIndices.insert(std::make_pair(lowerASCII(twoDa.columns()[i]), i));
+    }
+
+    for (auto &column : columns) {
+        auto it = columnIndices.find(lowerASCII(column));
+        if (it == columnIndices.end()) {
+            continue;
+        }
+        const std::string &value = twoDa.rows()[row].values[it->second];
+        if (!isDeletedCell(value)) {
+            return value;
+        }
+    }
+    return std::nullopt;
+}
+
+static std::string textFromCell(ServicesView &services, const std::string &raw) {
+    auto value = trim(raw);
+    if (auto maybeStrRef = parseInt(value)) {
+        std::string text(services.resource.strings.getText(*maybeStrRef));
+        if (!text.empty()) {
+            return text;
+        }
+    }
+    return titleFromRaw(value);
+}
+
+static std::shared_ptr<TwoDA> getTwoDA(ServicesView &services, const std::string &resRef) {
+    if (resRef.empty()) {
+        return nullptr;
+    }
+    return services.resource.twoDas.get(lowerASCII(resRef));
+}
+
+static std::string resolveRowText(ServicesView &services, const std::string &tableName, int row) {
+    auto twoDa = getTwoDA(services, tableName);
+    if (!twoDa) {
+        return "";
+    }
+
+    static const std::vector<std::string> kTextColumns {
+        "name",
+        "stringref",
+        "strref",
+        "labelstrref",
+        "gamestrref",
+        "description",
+        "desc"};
+
+    auto maybeTextCell = cell(*twoDa, row, kTextColumns);
+    if (maybeTextCell) {
+        return textFromCell(services, *maybeTextCell);
+    }
+
+    static const std::vector<std::string> kRawColumns {
+        "label",
+        "value"};
+
+    auto maybeRawCell = cell(*twoDa, row, kRawColumns);
+    return maybeRawCell ? titleFromRaw(*maybeRawCell) : "";
+}
+
+static std::string resolvePropertyDefText(ServicesView &services, int property, const std::vector<std::string> &columns) {
+    auto itemPropDef = services.resource.twoDas.get("itempropdef");
+    if (!itemPropDef) {
+        return "";
+    }
+    auto maybeCell = cell(*itemPropDef, property, columns);
+    return maybeCell ? textFromCell(services, *maybeCell) : "";
+}
+
+static std::string resolvePropertyDefResRef(ServicesView &services, int property, const std::vector<std::string> &columns) {
+    auto itemPropDef = services.resource.twoDas.get("itempropdef");
+    if (!itemPropDef) {
+        return "";
+    }
+    auto maybeCell = cell(*itemPropDef, property, columns);
+    return maybeCell ? lowerASCII(trim(*maybeCell)) : "";
+}
+
+static std::string resolveIndexedTableName(ServicesView &services, const std::string &tableName, int row) {
+    auto table = getTwoDA(services, tableName);
+    if (!table) {
+        return "";
+    }
+
+    static const std::vector<std::string> kResRefColumns {
+        "resref",
+        "tablename",
+        "table",
+        "name",
+        "label"};
+
+    auto maybeCell = cell(*table, row, kResRefColumns);
+    if (!maybeCell) {
+        return "";
+    }
+    std::string value(lowerASCII(trim(*maybeCell)));
+    if (auto maybeStrRef = parseInt(value)) {
+        std::string text(services.resource.strings.getText(*maybeStrRef));
+        if (!text.empty()) {
+            return lowerASCII(text);
+        }
+    }
+    return value;
+}
+
+static std::string resolveSubtype(ServicesView &services, const Item::PropertyEntry &property) {
+    std::string tableName(resolvePropertyDefResRef(
+        services,
+        property.propertyName,
+        {"subtyperesref", "subtype", "subtypetable", "subtyperes"}));
+    if (tableName.empty()) {
+        tableName = resolveIndexedTableName(services, "iprp_subtypes", property.subtype);
+    }
+    return resolveRowText(services, tableName, property.subtype);
+}
+
+static std::string resolveCost(ServicesView &services, const Item::PropertyEntry &property) {
+    std::string tableName(resolvePropertyDefResRef(
+        services,
+        property.propertyName,
+        {"costtableresref", "costtable", "costtableres"}));
+    if (tableName.empty()) {
+        tableName = resolveIndexedTableName(services, "iprp_costtable", property.costTable);
+    }
+    return resolveRowText(services, tableName, property.costValue);
+}
+
+static std::string resolveParam(ServicesView &services, const Item::PropertyEntry &property) {
+    std::string tableName(resolvePropertyDefResRef(
+        services,
+        property.propertyName,
+        {"param1resref", "param1table", "paramtableresref", "param1"}));
+    if (tableName.empty()) {
+        tableName = resolveIndexedTableName(services, "iprp_paramtable", property.paramTable);
+    }
+    return resolveRowText(services, tableName, property.paramValue);
+}
+
+static std::string itemPropertyName(ItemProperty property) {
+    switch (property) {
+    case ItemProperty::AbilityBonus:
+        return "Ability Bonus";
+    case ItemProperty::AcBonus:
+        return "Defense Bonus";
+    case ItemProperty::AcBonusVsAlignmentGroup:
+        return "Defense Bonus vs Alignment";
+    case ItemProperty::AcBonusVsDamageType:
+        return "Defense Bonus vs Damage";
+    case ItemProperty::AcBonusVsRacialGroup:
+        return "Defense Bonus vs Racial Group";
+    case ItemProperty::EnhancementBonus:
+        return "Enhancement Bonus";
+    case ItemProperty::AttackPenalty:
+        return "Attack Penalty";
+    case ItemProperty::BonusFeat:
+        return "Bonus Feat";
+    case ItemProperty::ActivateItem:
+        return "Activate Item";
+    case ItemProperty::DamageBonus:
+        return "Damage Bonus";
+    case ItemProperty::ImmunityDamageType:
+        return "Damage Immunity";
+    case ItemProperty::DamageReduction:
+        return "Damage Reduction";
+    case ItemProperty::DamageResistance:
+        return "Damage Resistance";
+    case ItemProperty::Immunity:
+        return "Immunity";
+    case ItemProperty::ImprovedSavingThrow:
+    case ItemProperty::ImprovedSavingThrowSpecific:
+        return "Saving Throw Bonus";
+    case ItemProperty::Keen:
+        return "Keen";
+    case ItemProperty::OnHitProperties:
+        return "On Hit";
+    case ItemProperty::Regeneration:
+        return "Regeneration";
+    case ItemProperty::SkillBonus:
+        return "Skill Bonus";
+    case ItemProperty::AttackBonus:
+        return "Attack Bonus";
+    case ItemProperty::UnlimitedAmmunition:
+        return "Unlimited Ammunition";
+    case ItemProperty::UseLimitationAlignmentGroup:
+        return "Use Limitation Alignment";
+    case ItemProperty::UseLimitationClass:
+        return "Use Limitation Class";
+    case ItemProperty::UseLimitationRacialType:
+        return "Use Limitation Racial Type";
+    case ItemProperty::TrueSeeing:
+        return "True Seeing";
+    case ItemProperty::MassiveCriticals:
+        return "Massive Criticals";
+    case ItemProperty::FreedomOfMovement:
+        return "Freedom Of Movement";
+    case ItemProperty::RegenerationForcePoints:
+        return "Regeneration Force Points";
+    case ItemProperty::BlasterBoltDeflectIncrease:
+        return "Blaster Bolt Deflection";
+    case ItemProperty::BlasterBoltDeflectDecrease:
+        return "Blaster Bolt Deflection Penalty";
+    case ItemProperty::UseLimitationFeat:
+        return "Use Limitation Feat";
+    default:
+        return "";
+    }
+}
+
+static std::string propertyDisplayName(ServicesView &services, int propertyName) {
+    std::string name(resolvePropertyDefText(
+        services,
+        propertyName,
+        {"name", "label", "stringref", "strref", "gamestrref"}));
+    if (!name.empty()) {
+        return name;
+    }
+
+    std::string enumName(itemPropertyName(static_cast<ItemProperty>(propertyName)));
+    return !enumName.empty() ? enumName : "Property " + std::to_string(propertyName);
+}
+
+static std::string signedValue(std::string value, bool positive = true) {
+    value = trim(value);
+    if (value.empty()) {
+        return "";
+    }
+    if (positive && value[0] != '+' && value[0] != '-' && parseInt(value)) {
+        return "+" + value;
+    }
+    if (!positive && value[0] != '-') {
+        return "-" + value;
+    }
+    return value;
+}
+
+static std::optional<RangeBonus> propertyCostRange(ServicesView &services, const Item::PropertyEntry &property) {
+    std::string cost(resolveCost(services, property));
+    if (!cost.empty()) {
+        return parseRangeBonus(cost);
+    }
+    if (property.costValue != 0) {
+        return RangeBonus {property.costValue, property.costValue};
+    }
+    return std::nullopt;
+}
+
+static std::optional<int> propertyCostInt(ServicesView &services, const Item::PropertyEntry &property) {
+    auto maybeRange = propertyCostRange(services, property);
+    if (!maybeRange || maybeRange->min != maybeRange->max) {
+        return std::nullopt;
+    }
+    return maybeRange->min;
+}
+
+static std::string formatSignedInt(int value) {
+    return signedValue(std::to_string(value), value >= 0);
+}
+
+static std::string formatRangeBonus(const RangeBonus &range) {
+    if (range.min == range.max) {
+        return formatSignedInt(range.min);
+    }
+    std::string sign = range.min >= 0 ? "+" : "";
+    return sign + std::to_string(range.min) + "-" + std::to_string(range.max);
+}
+
+static std::string abilityName(int ability) {
+    switch (static_cast<Ability>(ability)) {
+    case Ability::Strength:
+        return "Strength";
+    case Ability::Dexterity:
+        return "Dexterity";
+    case Ability::Constitution:
+        return "Constitution";
+    case Ability::Intelligence:
+        return "Intelligence";
+    case Ability::Wisdom:
+        return "Wisdom";
+    case Ability::Charisma:
+        return "Charisma";
+    default:
+        return "";
+    }
+}
+
+static std::string propertyDetailLine(
+    ServicesView &services,
+    const Item::PropertyEntry &property,
+    bool signedCost = false,
+    bool positive = true) {
+
+    std::vector<std::string> parts;
+
+    std::string subtype(resolveSubtype(services, property));
+    if (!subtype.empty()) {
+        parts.push_back(subtype);
+    }
+
+    std::string cost(resolveCost(services, property));
+    if (!cost.empty()) {
+        parts.push_back(signedCost ? signedValue(cost, positive) : cost);
+    } else if (property.costValue != 0) {
+        parts.push_back(signedCost ? signedValue(std::to_string(property.costValue), positive) : std::to_string(property.costValue));
+    }
+
+    std::string param(resolveParam(services, property));
+    if (!param.empty()) {
+        parts.push_back(param);
+    }
+
+    if (parts.empty()) {
+        return propertyDisplayName(services, property.propertyName);
+    }
+
+    std::string result;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i > 0) {
+            result += " ";
+        }
+        result += parts[i];
+    }
+    return result;
+}
+
+static std::string rawPropertyDetails(const Item::PropertyEntry &property) {
+    std::vector<std::string> parts {
+        "subtype " + std::to_string(property.subtype),
+        "cost table " + std::to_string(property.costTable),
+        "cost value " + std::to_string(property.costValue),
+        "param table " + std::to_string(property.paramTable),
+        "param value " + std::to_string(property.paramValue)};
+
+    std::string result;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += parts[i];
+    }
+    return result;
+}
+
+static std::string fallbackPropertyLine(ServicesView &services, const Item::PropertyEntry &property) {
+    std::string detail(propertyDetailLine(services, property));
+    std::string name(propertyDisplayName(services, property.propertyName));
+    if (detail.empty() || detail == name) {
+        detail = rawPropertyDetails(property);
+    }
+    return name + ": " + detail;
+}
+
+static std::string featName(ServicesView &services, int featIdx) {
+    auto feat = services.game.feats.get(static_cast<FeatType>(featIdx));
+    if (feat && !feat->name.empty()) {
+        return feat->name;
+    }
+    return resolveRowText(services, "feat", featIdx);
+}
+
+static std::string skillName(ServicesView &services, int skillIdx) {
+    auto skill = services.game.skills.get(static_cast<SkillType>(skillIdx));
+    if (skill && !skill->name.empty()) {
+        return skill->name;
+    }
+    return resolveRowText(services, "skills", skillIdx);
+}
+
+static std::string damageTypeName(int flags) {
+    if (flags == 0) {
+        return "";
+    }
+    if (flags == static_cast<int>(DamageType::Physical)) {
+        return "Physical";
+    }
+
+    std::vector<std::pair<int, std::string>> names {
+        {static_cast<int>(DamageType::Bludgeoning), "Bludgeoning"},
+        {static_cast<int>(DamageType::Piercing), "Piercing"},
+        {static_cast<int>(DamageType::Slashing), "Slashing"},
+        {static_cast<int>(DamageType::Universal), "Universal"},
+        {static_cast<int>(DamageType::Acid), "Acid"},
+        {static_cast<int>(DamageType::Cold), "Cold"},
+        {static_cast<int>(DamageType::LightSide), "Light Side"},
+        {static_cast<int>(DamageType::Electrical), "Electrical"},
+        {static_cast<int>(DamageType::Fire), "Fire"},
+        {static_cast<int>(DamageType::DarkSide), "Dark Side"},
+        {static_cast<int>(DamageType::Sonic), "Sonic"},
+        {static_cast<int>(DamageType::Ion), "Ion"},
+        {static_cast<int>(DamageType::Blaster), "Energy"}};
+
+    std::vector<std::string> parts;
+    for (auto &name : names) {
+        if ((flags & name.first) == name.first) {
+            parts.push_back(name.second);
+        }
+    }
+
+    std::string result;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i > 0) {
+            result += "/";
+        }
+        result += parts[i];
+    }
+    return result;
+}
+
+static std::optional<int> baseItemInt(ServicesView &services, const Item &item, const std::vector<std::string> &columns) {
+    auto baseItems = services.resource.twoDas.get("baseitems");
+    if (!baseItems) {
+        return std::nullopt;
+    }
+    auto maybeCell = cell(*baseItems, item.baseItemType(), columns);
+    if (!maybeCell) {
+        return std::nullopt;
+    }
+    return parseInt(*maybeCell);
+}
+
+static std::vector<int> baseItemInts(ServicesView &services, const Item &item, const std::vector<std::string> &columns) {
+    auto baseItems = services.resource.twoDas.get("baseitems");
+    if (!baseItems) {
+        return {};
+    }
+
+    std::vector<int> values;
+    for (auto &column : columns) {
+        auto maybeCell = cell(*baseItems, item.baseItemType(), {column});
+        if (!maybeCell) {
+            continue;
+        }
+        auto maybeValue = parseInt(*maybeCell);
+        if (maybeValue && *maybeValue > 0) {
+            values.push_back(*maybeValue);
+        }
+    }
+    return values;
+}
+
+static std::optional<bool> baseItemBool(ServicesView &services, const Item &item, const std::vector<std::string> &columns) {
+    auto baseItems = services.resource.twoDas.get("baseitems");
+    if (!baseItems) {
+        return std::nullopt;
+    }
+
+    auto maybeCell = cell(*baseItems, item.baseItemType(), columns);
+    if (!maybeCell) {
+        return std::nullopt;
+    }
+
+    std::string value(lowerASCII(trim(*maybeCell)));
+    if (value == "true" || value == "yes") {
+        return true;
+    }
+    if (value == "false" || value == "no") {
+        return false;
+    }
+    if (auto maybeValue = parseInt(value)) {
+        return *maybeValue != 0;
+    }
+    return std::nullopt;
+}
+
+static bool hasUpgradeHostMetadata(const Item &item) {
+    if (!item.isEquippable()) {
+        return false;
+    }
+    return std::any_of(item.properties().begin(), item.properties().end(), [](const Item::PropertyEntry &property) {
+        return property.upgradeType != 0;
+    });
+}
+
+static Section &sectionByTitle(std::vector<Section> &sections, const std::string &title) {
+    auto it = std::find_if(sections.begin(), sections.end(), [&title](const Section &section) {
+        return section.title == title;
+    });
+    if (it != sections.end()) {
+        return *it;
+    }
+    sections.push_back({title, {}});
+    return sections.back();
+}
+
+static std::string damageRange(int min, int max) {
+    return std::to_string(min) + "-" + std::to_string(max);
+}
+
+static std::string criticalThreatRange(const Item &item) {
+    int threatChances = std::clamp(item.criticalThreat(), 1, 20);
+    int startThreat = 21 - threatChances;
+    return std::to_string(startThreat) + "-20,x" + std::to_string(item.criticalHitMultiplier());
+}
+
+static std::string itemDescriptionText(const Item &item) {
+    std::string description(item.isIdentified() ? item.descIdentified() : item.description());
+    if (description.empty() && !item.descIdentified().empty()) {
+        description = item.descIdentified();
+    }
+    return description;
+}
+
+static bool isBalancedWeapon(ServicesView &services, const Item &item) {
+    if (auto maybeBalanced = baseItemBool(services, item, {"balanced", "isbalanced", "offhandbalanced"})) {
+        return *maybeBalanced;
+    }
+    if (auto maybeWeaponSize = baseItemInt(services, item, {"weaponsize", "weapon_size", "weapsize"})) {
+        return item.weaponType() != WeaponType::None && *maybeWeaponSize <= 1;
+    }
+    return item.weaponWield() == WeaponWield::BlasterPistol;
+}
+
+static void addBaseFacts(ServicesView &services, const Item &item, DerivedProperties &derived, std::vector<Section> &sections) {
+    Section featsRequired {"Feats Required"};
+    std::set<int> featIds;
+    for (int feat : baseItemInts(
+             services,
+             item,
+             {"reqfeat0", "reqfeat1", "reqfeat2", "reqfeat3", "reqfeat4", "reqfeat", "requiredfeat", "featrequired", "basefeat"})) {
+        featIds.insert(feat);
+    }
+    for (int feat : featIds) {
+        std::string name(featName(services, feat));
+        featsRequired.lines.push_back(!name.empty() ? singleLine(name) : std::to_string(feat));
+    }
+    sections.push_back(std::move(featsRequired));
+
+    Section baseFacts {""};
+    if (item.weaponType() != WeaponType::None && item.numDice() > 0 && item.dieToRoll() > 0) {
+        std::string type(damageTypeName(item.damageFlags()));
+        int minDamage = item.numDice();
+        int maxDamage = item.numDice() * item.dieToRoll();
+        if (!type.empty()) {
+            auto maybeDamageBonus = derived.damageBonuses.find(type);
+            if (maybeDamageBonus != derived.damageBonuses.end()) {
+                minDamage += maybeDamageBonus->second.min;
+                maxDamage += maybeDamageBonus->second.max;
+                derived.foldedDamageTypes.insert(type);
+            }
+        }
+
+        std::string line(damageRange(minDamage, maxDamage));
+        if (!type.empty()) {
+            line = type + ", " + line;
+        }
+        baseFacts.lines.push_back("Damage: " + line);
+    }
+
+    if (item.weaponType() != WeaponType::None && item.criticalThreat() > 0 && item.criticalHitMultiplier() > 0) {
+        std::string line("Critical Threat: " + criticalThreatRange(item));
+        if (!derived.massiveCriticals.empty()) {
+            line += " " + formatRangeBonus(derived.massiveCriticals);
+        }
+        baseFacts.lines.push_back(line);
+    }
+
+    if (item.weaponType() == WeaponType::Ranged && item.attackRange() > 0.0f) {
+        baseFacts.lines.push_back("Range: " + std::to_string(static_cast<int>(item.attackRange())) + "m");
+    }
+
+    if (auto maybeDefense = baseItemInt(services, item, {"baseac", "acbonus", "defbonus", "armorbonus", "armorclass"})) {
+        int defense = *maybeDefense + derived.defenseBonus;
+        derived.foldedDefenseBonus = true;
+        if (defense != 0) {
+            baseFacts.lines.push_back("Defense Bonus: " + formatSignedInt(defense));
+        }
+    }
+
+    if (isBalancedWeapon(services, item)) {
+        baseFacts.lines.push_back("Balanced: +2/+0 vs. two-weapon penalty if used in the off hand");
+    }
+
+    sections.push_back(std::move(baseFacts));
+}
+
+static void addPropertyLine(Section &section, const std::string &line) {
+    if (!line.empty()) {
+        section.lines.push_back(line);
+    }
+}
+
+static bool addSignedCost(ServicesView &services, const Item::PropertyEntry &property, int &target, bool positive = true) {
+    auto maybeValue = propertyCostInt(services, property);
+    if (!maybeValue) {
+        return false;
+    }
+    target += positive ? *maybeValue : -*maybeValue;
+    return true;
+}
+
+static void addDamageBonus(DerivedProperties &derived, const std::string &damageType, const RangeBonus &bonus) {
+    if (damageType.empty()) {
+        return;
+    }
+    derived.damageBonuses[damageType].add(bonus);
+}
+
+static void addAggregatedPropertyLines(const DerivedProperties &derived, std::vector<Section> &sections) {
+    Section scalar {""};
+
+    if (derived.attackModifier != 0) {
+        scalar.lines.push_back("Attack Modifier: " + formatSignedInt(derived.attackModifier));
+    }
+
+    if (!derived.foldedDefenseBonus && derived.defenseBonus != 0) {
+        scalar.lines.push_back("Defense Bonus: " + formatSignedInt(derived.defenseBonus));
+    }
+
+    if (derived.blasterBoltDeflection != 0) {
+        scalar.lines.push_back("Blaster Bolt Deflection: " + formatSignedInt(derived.blasterBoltDeflection));
+    }
+
+    for (auto &bonus : derived.damageBonuses) {
+        if (derived.foldedDamageTypes.count(bonus.first) > 0 || bonus.second.empty()) {
+            continue;
+        }
+        scalar.lines.push_back("Damage Bonus: " + bonus.first + " " + formatRangeBonus(bonus.second));
+    }
+
+    for (auto &bonus : derived.attributeBonuses) {
+        std::string name(abilityName(bonus.first));
+        if (!name.empty() && bonus.second != 0) {
+            scalar.lines.push_back(name + ": " + formatSignedInt(bonus.second));
+        }
+    }
+
+    sections.push_back(std::move(scalar));
+}
+
+static void addProperties(ServicesView &services, const Item &item, DerivedProperties &derived, std::vector<Section> &sections) {
+    Section requirements {"Requirements / Restrictions"};
+    Section attack {"Attack Modifier"};
+    Section damageBonus {"Damage Bonus"};
+    Section damageResistance {"Damage Resistance"};
+    Section damageImmunity {"Damage Immunity"};
+    Section immunity {"Immunity"};
+    Section saves {"Saves"};
+    Section skills {"Skills"};
+    Section attributes {"Attributes"};
+    Section regeneration {"Regeneration"};
+    Section featsGranted {"Feats Granted"};
+    Section activateItem {"Activate Item"};
+    Section onHit {""};
+    Section special {"Special / Properties"};
+
+    for (auto &property : item.properties()) {
+        ItemProperty type = static_cast<ItemProperty>(property.propertyName);
+        switch (type) {
+        case ItemProperty::AbilityBonus:
+        case ItemProperty::DecreasedAbilityScore: {
+            auto maybeValue = propertyCostInt(services, property);
+            if (maybeValue) {
+                derived.attributeBonuses[property.subtype] += type == ItemProperty::AbilityBonus ? *maybeValue : -*maybeValue;
+            } else {
+                addPropertyLine(attributes, propertyDetailLine(services, property, true, type == ItemProperty::AbilityBonus));
+            }
+            break;
+        }
+        case ItemProperty::AcBonus:
+        case ItemProperty::DecreasedAc:
+            if (!addSignedCost(services, property, derived.defenseBonus, type != ItemProperty::DecreasedAc)) {
+                addPropertyLine(sectionByTitle(sections, "Defense Bonus"), propertyDetailLine(services, property, true, type != ItemProperty::DecreasedAc));
+            }
+            break;
+        case ItemProperty::AcBonusVsAlignmentGroup:
+        case ItemProperty::AcBonusVsDamageType:
+        case ItemProperty::AcBonusVsRacialGroup:
+            addPropertyLine(sectionByTitle(sections, "Defense Bonus"), propertyDetailLine(services, property, true));
+            break;
+        case ItemProperty::EnhancementBonus:
+        case ItemProperty::AttackBonus:
+        case ItemProperty::AttackPenalty:
+        case ItemProperty::DecreasedAttackModifier:
+            if (!addSignedCost(
+                    services,
+                    property,
+                    derived.attackModifier,
+                    type != ItemProperty::AttackPenalty && type != ItemProperty::DecreasedAttackModifier)) {
+                addPropertyLine(attack, propertyDetailLine(
+                                            services,
+                                            property,
+                                            true,
+                                            type != ItemProperty::AttackPenalty && type != ItemProperty::DecreasedAttackModifier));
+            }
+            break;
+        case ItemProperty::EnhancementBonusVsAlignmentGroup:
+        case ItemProperty::EnhancementBonusVsRacialGroup:
+        case ItemProperty::AttackBonusVsAlignmentGroup:
+        case ItemProperty::AttackBonusVsRacialGroup:
+            addPropertyLine(attack, propertyDetailLine(services, property, true));
+            break;
+        case ItemProperty::DamageBonus:
+        case ItemProperty::ExtraMeleeDamageType:
+        case ItemProperty::ExtraRangedDamageType: {
+            std::string damageType(resolveSubtype(services, property));
+            auto maybeBonus = propertyCostRange(services, property);
+            if (!damageType.empty() && maybeBonus) {
+                addDamageBonus(derived, damageType, *maybeBonus);
+            } else {
+                addPropertyLine(damageBonus, propertyDetailLine(services, property, true));
+            }
+            break;
+        }
+        case ItemProperty::MassiveCriticals: {
+            auto maybeBonus = propertyCostRange(services, property);
+            if (maybeBonus) {
+                derived.massiveCriticals.add(*maybeBonus);
+            } else {
+                addPropertyLine(damageBonus, propertyDetailLine(services, property, true));
+            }
+            break;
+        }
+        case ItemProperty::DamageBonusVsAlignmentGroup:
+        case ItemProperty::DamageBonusVsRacialGroup:
+        case ItemProperty::MonsterDamage:
+            addPropertyLine(damageBonus, propertyDetailLine(services, property, true));
+            break;
+        case ItemProperty::ImmunityDamageType:
+            addPropertyLine(damageImmunity, propertyDetailLine(services, property));
+            break;
+        case ItemProperty::DamageReduction:
+        case ItemProperty::DamageResistance:
+            addPropertyLine(damageResistance, propertyDetailLine(services, property));
+            break;
+        case ItemProperty::Immunity:
+            addPropertyLine(immunity, propertyDetailLine(services, property));
+            break;
+        case ItemProperty::ImprovedSavingThrow:
+        case ItemProperty::ImprovedSavingThrowSpecific:
+        case ItemProperty::DecreasedSavingThrows:
+        case ItemProperty::DecreasedSavingThrowsSpecific:
+            addPropertyLine(saves, propertyDetailLine(
+                                       services,
+                                       property,
+                                       true,
+                                       type != ItemProperty::DecreasedSavingThrows && type != ItemProperty::DecreasedSavingThrowsSpecific));
+            break;
+        case ItemProperty::SkillBonus: {
+            std::string line(skillName(services, property.subtype));
+            std::string value(resolveCost(services, property));
+            if (!line.empty() && !value.empty()) {
+                line += ": " + signedValue(value);
+            }
+            addPropertyLine(skills, !line.empty() ? line : propertyDetailLine(services, property, true));
+            break;
+        }
+        case ItemProperty::DecreasedSkillModifier:
+            addPropertyLine(skills, propertyDetailLine(services, property, true, false));
+            break;
+        case ItemProperty::Regeneration:
+        case ItemProperty::RegenerationForcePoints:
+            addPropertyLine(regeneration, propertyDetailLine(services, property, true));
+            break;
+        case ItemProperty::BonusFeat: {
+            std::string name(featName(services, property.subtype));
+            addPropertyLine(featsGranted, !name.empty() ? name : propertyDetailLine(services, property));
+            break;
+        }
+        case ItemProperty::ActivateItem: {
+            auto spell = services.game.spells.get(static_cast<SpellType>(property.subtype));
+            if (spell && !spell->name.empty()) {
+                addPropertyLine(activateItem, spell->name);
+            } else {
+                addPropertyLine(activateItem, propertyDetailLine(services, property));
+            }
+            break;
+        }
+        case ItemProperty::OnHitProperties:
+        case ItemProperty::OnMonsterHit:
+            addPropertyLine(onHit, "On Hit: " + propertyDetailLine(services, property));
+            break;
+        case ItemProperty::BlasterBoltDeflectIncrease:
+        case ItemProperty::BlasterBoltDeflectDecrease:
+            if (!addSignedCost(services, property, derived.blasterBoltDeflection, type == ItemProperty::BlasterBoltDeflectIncrease)) {
+                addPropertyLine(special, fallbackPropertyLine(services, property));
+            }
+            break;
+        case ItemProperty::UseLimitationAlignmentGroup:
+        case ItemProperty::UseLimitationClass:
+        case ItemProperty::UseLimitationRacialType:
+        case ItemProperty::UseLimitationFeat:
+        case ItemProperty::LimitUseByGender:
+        case ItemProperty::LimitUseBySubrace:
+        case ItemProperty::LimitUseByPc:
+            addPropertyLine(requirements, fallbackPropertyLine(services, property));
+            break;
+        default:
+            addPropertyLine(special, fallbackPropertyLine(services, property));
+            break;
+        }
+    }
+
+    sections.insert(sections.begin(), std::move(requirements));
+    sections.push_back(std::move(attack));
+    sections.push_back(std::move(damageBonus));
+    sections.push_back(std::move(damageResistance));
+    sections.push_back(std::move(damageImmunity));
+    sections.push_back(std::move(immunity));
+    sections.push_back(std::move(saves));
+    sections.push_back(std::move(skills));
+    sections.push_back(std::move(attributes));
+    sections.push_back(std::move(regeneration));
+    sections.push_back(std::move(featsGranted));
+    sections.push_back(std::move(activateItem));
+    sections.push_back(std::move(onHit));
+    sections.push_back(std::move(special));
+}
+
+static bool shouldUseHeader(const Section &section) {
+    if (section.title.empty()) {
+        return false;
+    }
+    if (section.title == "Description") {
+        return true;
+    }
+    if (section.title == "Feats Required" ||
+        section.title == "Requirements / Restrictions" ||
+        section.title == "Skills" ||
+        section.title == "Attributes" ||
+        section.title == "Feats Granted" ||
+        section.title == "On Hit" ||
+        section.title == "Special / Properties") {
+        return true;
+    }
+    return section.lines.size() > 1;
+}
+
+static void appendSection(std::vector<std::string> &result, const Section &section) {
+    if (section.lines.empty()) {
+        return;
+    }
+    if (!result.empty()) {
+        result.push_back("");
+    }
+
+    if (section.title.empty()) {
+        for (auto &line : section.lines) {
+            if (!result.empty() && !result.back().empty()) {
+                result.push_back("");
+            }
+            result.push_back(line);
+        }
+        return;
+    }
+
+    if (shouldUseHeader(section)) {
+        result.push_back(section.title == "Description" ? section.title : section.title + ":");
+        result.insert(result.end(), section.lines.begin(), section.lines.end());
+        return;
+    }
+
+    if (section.lines.size() == 1) {
+        result.push_back(section.title + ": " + section.lines.front());
+        return;
+    }
+
+    result.push_back(section.title + ":");
+    result.insert(result.end(), section.lines.begin(), section.lines.end());
+}
+
+} // namespace
+
+std::vector<std::string> buildItemDescriptionLines(const Item &item, ServicesView &services) {
+    std::vector<std::string> result;
+    if (!item.localizedName().empty()) {
+        result.push_back(item.localizedName());
+    }
+
+    std::vector<Section> sections;
+    DerivedProperties derived;
+    std::vector<Section> propertySections;
+
+    // Upgradeable host templates can carry candidate/component properties in PropertiesList.
+    // Installed-upgrade-derived display needs active upgrade state, which Item does not expose yet.
+    bool renderProperties = !hasUpgradeHostMetadata(item);
+    if (renderProperties) {
+        addProperties(services, item, derived, propertySections);
+    }
+
+    addBaseFacts(services, item, derived, sections);
+
+    if (!propertySections.empty() && propertySections.front().title == "Requirements / Restrictions") {
+        auto insertPos = sections.size() > 1 ? sections.begin() + 1 : sections.end();
+        sections.insert(insertPos, std::move(propertySections.front()));
+        propertySections.erase(propertySections.begin());
+    }
+    if (renderProperties) {
+        addAggregatedPropertyLines(derived, sections);
+        sections.insert(
+            sections.end(),
+            std::make_move_iterator(propertySections.begin()),
+            std::make_move_iterator(propertySections.end()));
+    }
+
+    for (auto &section : sections) {
+        appendSection(result, section);
+    }
+
+    std::string description(itemDescriptionText(item));
+    if (!description.empty()) {
+        appendSection(result, {"Description", {description}});
+    }
+
+    return result;
+}
+
+std::string joinItemDescriptionLines(const std::vector<std::string> &lines) {
+    std::string result;
+    for (size_t i = 0; i < lines.size(); ++i) {
+        if (i > 0) {
+            result += "\n";
+        }
+        result += lines[i];
+    }
+    return result;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/itemdescription.cpp
+++ b/src/libs/game/itemdescription.cpp
@@ -546,11 +546,6 @@ static std::string damageTypeName(int flags) {
     if (flags == 0) {
         return "";
     }
-    // Physical is the aggregate damage type; keep it as one label instead of
-    // expanding its component bits.
-    if (flags == static_cast<int>(DamageType::Physical)) {
-        return "Physical";
-    }
 
     std::vector<std::pair<int, std::string>> names {
         {static_cast<int>(DamageType::Bludgeoning), "Bludgeoning"},

--- a/src/libs/game/itemdescription.cpp
+++ b/src/libs/game/itemdescription.cpp
@@ -29,6 +29,8 @@
 #include "reone/resource/provider/2das.h"
 #include "reone/resource/strings.h"
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 #include <iterator>
 #include <map>
 #include <regex>
@@ -71,13 +73,6 @@ struct DerivedProperties {
     RangeBonus massiveCriticals;
     bool foldedDefenseBonus {false};
 };
-
-static std::string lowerASCII(std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
-        return static_cast<char>(std::tolower(ch));
-    });
-    return value;
-}
 
 static std::string trim(std::string value) {
     auto begin = std::find_if(value.begin(), value.end(), [](unsigned char ch) {
@@ -165,8 +160,10 @@ static std::optional<RangeBonus> parseRangeBonus(std::string value) {
         return RangeBonus {*maybeValue, *maybeValue};
     }
 
-    static const std::regex kLooseIntRegex("([+-]?\\d+)");
-    if (std::regex_search(value, match, kLooseIntRegex)) {
+    // Exact numeric cells are handled above; this keeps free-form 2DA labels
+    // like "+2 bonus" readable.
+    static const std::regex kEmbeddedIntRegex("([+-]?\\d+)");
+    if (std::regex_search(value, match, kEmbeddedIntRegex)) {
         int amount = std::stoi(match[1].str());
         return RangeBonus {amount, amount};
     }
@@ -182,19 +179,11 @@ static std::optional<std::string> cell(
         return std::nullopt;
     }
 
-    std::unordered_map<std::string, int> columnIndices;
-    for (int i = 0; i < static_cast<int>(twoDa.columns().size()); ++i) {
-        columnIndices.insert(std::make_pair(lowerASCII(twoDa.columns()[i]), i));
-    }
-
-    for (auto &column : columns) {
-        auto it = columnIndices.find(lowerASCII(column));
-        if (it == columnIndices.end()) {
-            continue;
-        }
-        const std::string &value = twoDa.rows()[row].values[it->second];
-        if (!isDeletedCell(value)) {
-            return value;
+    for (const auto &column : columns) {
+        if (auto maybeValue = twoDa.getStringOpt(row, column)) {
+            if (!isDeletedCell(*maybeValue)) {
+                return maybeValue;
+            }
         }
     }
     return std::nullopt;
@@ -215,7 +204,7 @@ static std::shared_ptr<TwoDA> getTwoDA(ServicesView &services, const std::string
     if (resRef.empty()) {
         return nullptr;
     }
-    return services.resource.twoDas.get(lowerASCII(resRef));
+    return services.resource.twoDas.get(boost::to_lower_copy(resRef));
 }
 
 static std::string resolveRowText(ServicesView &services, const std::string &tableName, int row) {
@@ -261,7 +250,7 @@ static std::string resolvePropertyDefResRef(ServicesView &services, int property
         return "";
     }
     auto maybeCell = cell(*itemPropDef, property, columns);
-    return maybeCell ? lowerASCII(trim(*maybeCell)) : "";
+    return maybeCell ? boost::to_lower_copy(trim(*maybeCell)) : "";
 }
 
 static std::string resolveIndexedTableName(ServicesView &services, const std::string &tableName, int row) {
@@ -281,11 +270,11 @@ static std::string resolveIndexedTableName(ServicesView &services, const std::st
     if (!maybeCell) {
         return "";
     }
-    std::string value(lowerASCII(trim(*maybeCell)));
+    std::string value(boost::to_lower_copy(trim(*maybeCell)));
     if (auto maybeStrRef = parseInt(value)) {
         std::string text(services.resource.strings.getText(*maybeStrRef));
         if (!text.empty()) {
-            return lowerASCII(text);
+            return boost::to_lower_copy(text);
         }
     }
     return value;
@@ -557,6 +546,8 @@ static std::string damageTypeName(int flags) {
     if (flags == 0) {
         return "";
     }
+    // Physical is the aggregate damage type; keep it as one label instead of
+    // expanding its component bits.
     if (flags == static_cast<int>(DamageType::Physical)) {
         return "Physical";
     }
@@ -636,7 +627,7 @@ static std::optional<bool> baseItemBool(ServicesView &services, const Item &item
         return std::nullopt;
     }
 
-    std::string value(lowerASCII(trim(*maybeCell)));
+    std::string value(boost::to_lower_copy(trim(*maybeCell)));
     if (value == "true" || value == "yes") {
         return true;
     }

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -148,8 +148,19 @@ void Item::loadUTI(const resource::generated::UTI &uti) {
 
     loadAmmunitionType();
 
-    // TODO: load other properties
+    _properties.clear();
     for (const auto &utiProp : uti.PropertiesList) {
+        PropertyEntry entry;
+        entry.chanceAppear = utiProp.ChanceAppear;
+        entry.costTable = utiProp.CostTable;
+        entry.costValue = utiProp.CostValue;
+        entry.paramTable = utiProp.Param1;
+        entry.paramValue = utiProp.Param1Value;
+        entry.propertyName = utiProp.PropertyName;
+        entry.subtype = utiProp.Subtype;
+        entry.upgradeType = utiProp.UpgradeType;
+        _properties.push_back(entry);
+
         auto property = static_cast<ItemProperty>(utiProp.PropertyName);
         switch (property) {
         case ItemProperty::ActivateItem:

--- a/src/libs/gui/control.cpp
+++ b/src/libs/gui/control.cpp
@@ -257,7 +257,7 @@ void Control::renderBorder(const Border &border,
                 *border.fill,
                 {_extent.left + border.dimension + offset.x, _extent.top + border.dimension + offset.y},
                 {size.x - 2 * border.dimension, size.y - 2 * border.dimension},
-                glm::vec4(1.0f),
+                _tintBorderFill ? glm::vec4(color, 1.0f) : glm::vec4(1.0f),
                 uv);
         });
     }

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -31,6 +31,8 @@
 #include "reone/scene/render/pass.h"
 #include "reone/system/logutil.h"
 
+#include <sstream>
+
 using namespace reone::graphics;
 using namespace reone::resource;
 using namespace reone::scene;
@@ -61,11 +63,27 @@ void ListBox::addTextLinesAsItems(const std::string &text) {
     if (!_protoItem)
         return;
 
-    std::vector<std::string> lines(breakText(text, *_protoItem->text().font, getItemTextWidth()));
-    for (auto &line : lines) {
+    std::istringstream stream(text);
+    std::string logicalLine;
+    while (std::getline(stream, logicalLine)) {
+        std::vector<std::string> lines;
+        if (logicalLine.empty()) {
+            lines.push_back("");
+        } else {
+            lines = breakText(logicalLine, *_protoItem->text().font, getItemTextWidth());
+        }
+
+        for (auto &line : lines) {
+            Item item;
+            item.text = line;
+            item._textLines = std::vector<std::string> {line};
+            _items.push_back(std::move(item));
+        }
+    }
+
+    if (!text.empty() && text.back() == '\n') {
         Item item;
-        item.text = line;
-        item._textLines = std::vector<std::string> {line};
+        item._textLines = std::vector<std::string> {""};
         _items.push_back(std::move(item));
     }
 

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -42,6 +42,7 @@ namespace reone {
 namespace gui {
 
 static constexpr int kItemPadding = 3;
+static constexpr glm::vec3 kInvalidItemBorderColor {1.0f, 0.0f, 0.0f};
 
 void ListBox::clearItems() {
     _items.clear();
@@ -376,7 +377,10 @@ void ListBox::renderItemWithButtonProtoIcon(
 
     _protoItem->setExtent(textExtent);
     _protoItem->setTextLines(item._textLines);
+    _protoItem->setBorderColorOverride(kInvalidItemBorderColor);
+    _protoItem->setUseBorderColorOverride(item.invalid);
     _protoItem->render(screenSize, offset, pass);
+    _protoItem->setUseBorderColorOverride(false);
     _protoItem->setExtent(originalExtent);
 
     if (!item.iconFrame && !item.iconTexture)
@@ -388,7 +392,7 @@ void ListBox::renderItemWithButtonProtoIcon(
     if (item.iconFrame) {
         glm::vec3 frameColor(_protoItem->isSelected() ? _protoItem->hilight().color : _protoItem->border().color);
         if (item.invalid) {
-            frameColor = glm::vec3(1.0f, 0.0f, 0.0f);
+            frameColor = kInvalidItemBorderColor;
         }
         pass.drawImage(*item.iconFrame, iconPosition, iconSize, glm::vec4(frameColor, 1.0f));
     }


### PR DESCRIPTION
## Summary

Improves Party Inventory and Equipment UI parity across K1/K2.

### Party Inventory

- Populates the party inventory list.
- Adds shared item description formatting used by both Equipment and Party Inventory.
- Stacks stats of the same type rather than listing them sequentially
- Shows active character equipped items at the top of Party Inventory
- Shows K1 active character vitality/defense values.
- Adds K1/K2 inventory filtering.
- Preserves K2 Party Inventory stat area behavior where vanilla leaves it blank.

### Equipment

- Hides the K2 equipment loadout overlay while the item-selection panel is open.
- Improves invalid equipment candidate visuals so invalid rows outline both icon and text row.
- Preserves existing equipment legality/candidate rules.

### K2 UI tinting

- Adds opt-in border-fill tinting for GUI controls.
- Tints K2 HUD/menu icons and in-menu navigation icons.
- Tints K2 inventory/equipment list and description panel fills.
- Tints K2 equipment loadout overlay using GUI resource `BORDER.COLOR`.
- Tints K2 inventory filter bars using GUI resource colours.

## Notes

- K1 `New Items` filtering is intentionally deferred because runtime new-item/acquisition state is not currently retained.
- K1/K2 breathing/strobe effects (ie. flashing gold writing on select) are intentionally deferred to a later GUI update
- Inventory `Use Item` button behavior is intentionally left for a separate update
- Credits tally in Inventory not yet implemented
- Scrollbar should be able to be clicked and dragged, left for a separate update
- K1/K2 uses a .2da file to determine item list order.  This was left for a separate update
- No item ownership, equip legality, candidate filtering, item use, save/load, or gameplay stat formulas were changed.