### PR TITLE
[gui] Fix K1 computer GUI background

### DIFF
--- a/include/reone/game/gui/computer.h
+++ b/include/reone/game/gui/computer.h
@@ -97,6 +97,7 @@ private:
 
     void configureMessage();
     void configureReplies();
+    void hideK1StaticBands();
 
     void setMessage(std::string message) override;
     void setReplyLines(std::vector<std::string> lines) override;

--- a/src/libs/game/gui/computer.cpp
+++ b/src/libs/game/gui/computer.cpp
@@ -29,6 +29,12 @@ namespace reone {
 
 namespace game {
 
+static void setVisible(const std::shared_ptr<Label> &control, bool visible) {
+    if (control) {
+        control->setVisible(visible);
+    }
+}
+
 void ComputerGUI::preload(IGUI &gui) {
     gui.setScaling(GUI::ScalingMode::Stretch);
 
@@ -41,6 +47,7 @@ void ComputerGUI::onGUILoaded() {
     bindControls();
     configureMessage();
     configureReplies();
+    hideK1StaticBands();
 }
 
 void ComputerGUI::configureMessage() {
@@ -57,6 +64,18 @@ void ComputerGUI::configureReplies() {
         int replyIdx = stoi(item);
         pickReply(replyIdx);
     });
+}
+
+void ComputerGUI::hideK1StaticBands() {
+    if (_game.isTSL()) {
+        return;
+    }
+
+    // K1 computer.gui ships static band overlays that duplicate the terminal background in reone.
+    setVisible(_controls.LBL_STATIC1, false);
+    setVisible(_controls.LBL_STATIC2, false);
+    setVisible(_controls.LBL_STATIC3, false);
+    setVisible(_controls.LBL_STATIC4, false);
 }
 
 void ComputerGUI::setMessage(std::string message) {


### PR DESCRIPTION
## Summary

Fixes tiling of console textures in the K1 Computer GUI.

K1 terminal and damaged-droid repair interactions both use `ComputerGUI` with `computer.gui`. Manual suppression testing showed the repeated bands came from the K1 `LBL_STATIC1` through `LBL_STATIC4` controls.

This hides those static band controls for K1 ComputerGUI only.

## Notes

- K2 `computer_p.gui` is unchanged.
- Terminal command logic is unchanged.
- Repair/droid logic is unchanged.
- Dialogue/script behavior is unchanged.
- Global GUI rendering and `FILLSTYLE` handling are unchanged.
- GUI assets/layout files are unchanged.