### PR TITLE
[script] Implement SwitchPlayerCharacter

### DIFF
--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -69,6 +69,7 @@ public:
     bool isMember(int npc) const;
     bool isMember(const Object &object) const;
 
+    std::shared_ptr<Creature> getMemberByNPC(int npc) const;
     std::shared_ptr<Creature> getMember(int index) const;
     int getNPCByMemberIndex(int index) const;
 
@@ -81,6 +82,7 @@ public:
 
     bool isMemberAvailable(int npc) const;
 
+    std::shared_ptr<Creature> getOrCreateAvailableMember(int npc);
     const std::string &getAvailableMember(int npc) const;
 
     // END Available members
@@ -96,6 +98,7 @@ private:
 
     std::shared_ptr<Creature> _player;
     std::map<int, std::string> _availableMembers;
+    std::map<int, std::shared_ptr<Creature>> _materializedMembers;
     std::vector<Member> _members;
     bool _solo {false};
 

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -82,7 +82,7 @@ public:
 
     bool isMemberAvailable(int npc) const;
 
-    std::shared_ptr<Creature> getOrCreateAvailableMember(int npc);
+    std::shared_ptr<Creature> createAvailableMember(int npc);
     const std::string &getAvailableMember(int npc) const;
 
     // END Available members
@@ -98,7 +98,6 @@ private:
 
     std::shared_ptr<Creature> _player;
     std::map<int, std::string> _availableMembers;
-    std::map<int, std::shared_ptr<Creature>> _materializedMembers;
     std::vector<Member> _members;
     bool _solo {false};
 

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -67,7 +67,6 @@ bool Party::removeAvailableMember(int npc) {
     auto maybeMember = _availableMembers.find(npc);
     if (maybeMember != _availableMembers.end()) {
         _availableMembers.erase(maybeMember);
-        _materializedMembers.erase(npc);
         return true;
     }
     return false;
@@ -113,12 +112,7 @@ const std::string &Party::getAvailableMember(int npc) const {
     return _availableMembers.find(npc)->second;
 }
 
-std::shared_ptr<Creature> Party::getOrCreateAvailableMember(int npc) {
-    auto maybeMaterialized = _materializedMembers.find(npc);
-    if (maybeMaterialized != _materializedMembers.end()) {
-        return maybeMaterialized->second;
-    }
-
+std::shared_ptr<Creature> Party::createAvailableMember(int npc) {
     auto maybeBlueprint = _availableMembers.find(npc);
     if (maybeBlueprint == _availableMembers.end()) {
         return nullptr;
@@ -129,7 +123,6 @@ std::shared_ptr<Creature> Party::getOrCreateAvailableMember(int npc) {
     creature->setFaction(Faction::Friendly1);
     creature->setImmortal(true);
 
-    _materializedMembers.insert(std::make_pair(npc, creature));
     return creature;
 }
 

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -67,6 +67,7 @@ bool Party::removeAvailableMember(int npc) {
     auto maybeMember = _availableMembers.find(npc);
     if (maybeMember != _availableMembers.end()) {
         _availableMembers.erase(maybeMember);
+        _materializedMembers.erase(npc);
         return true;
     }
     return false;
@@ -112,8 +113,37 @@ const std::string &Party::getAvailableMember(int npc) const {
     return _availableMembers.find(npc)->second;
 }
 
+std::shared_ptr<Creature> Party::getOrCreateAvailableMember(int npc) {
+    auto maybeMaterialized = _materializedMembers.find(npc);
+    if (maybeMaterialized != _materializedMembers.end()) {
+        return maybeMaterialized->second;
+    }
+
+    auto maybeBlueprint = _availableMembers.find(npc);
+    if (maybeBlueprint == _availableMembers.end()) {
+        return nullptr;
+    }
+
+    auto creature = _game.newCreature();
+    creature->loadFromBlueprint(maybeBlueprint->second);
+    creature->setFaction(Faction::Friendly1);
+    creature->setImmortal(true);
+
+    _materializedMembers.insert(std::make_pair(npc, creature));
+    return creature;
+}
+
 std::shared_ptr<Creature> Party::getMember(int index) const {
     return _members.size() > index ? _members[index].creature : nullptr;
+}
+
+std::shared_ptr<Creature> Party::getMemberByNPC(int npc) const {
+    for (auto &member : _members) {
+        if (member.npc == npc) {
+            return member.creature;
+        }
+    }
+    return nullptr;
 }
 
 int Party::getNPCByMemberIndex(int index) const {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -208,7 +208,42 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("SwitchPlayerCharacter");
+    Party &party = ctx.game.party();
+    if (party.getMemberByNPC(nNPC)) {
+        party.setPartyLeader(nNPC);
+        return Variable::ofInt(1);
+    }
+
+    std::shared_ptr<Creature> creature;
+    if (nNPC == kNpcPlayer) {
+        creature = party.player();
+    } else {
+        creature = party.getOrCreateAvailableMember(nNPC);
+    }
+    if (!creature) {
+        warn("Party: NPC not found: " + std::to_string(nNPC));
+        return Variable::ofInt(0);
+    }
+
+    auto currentLeader = party.getLeader();
+    glm::vec3 position(currentLeader ? currentLeader->position() : creature->position());
+    float facing = currentLeader ? currentLeader->getFacing() : creature->getFacing();
+
+    auto module = ctx.game.module();
+    auto area = module ? module->area() : nullptr;
+    if (area) {
+        area->unloadParty();
+    }
+
+    party.clear();
+    party.addMember(nNPC, creature);
+
+    if (area) {
+        area->loadParty(position, facing);
+        area->onPartyLeaderMoved(true);
+        area->update3rdPersonCameraFacing();
+    }
+    return Variable::ofInt(1);
 }
 
 static Variable SetTime(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -218,7 +218,7 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
     if (nNPC == kNpcPlayer) {
         creature = party.player();
     } else {
-        creature = party.getOrCreateAvailableMember(nNPC);
+        creature = party.createAvailableMember(nNPC);
     }
     if (!creature) {
         warn("Party: NPC not found: " + std::to_string(nNPC));


### PR DESCRIPTION
## Summary

Implements the `SwitchPlayerCharacter(int nNPC)` script routine.

This supports scripted story-control sequences where the game temporarily switches control to a specific party/NPC slot. KOTOR 2 uses this in the prologue to switch control to T3-M4:

- `AddAvailableNPCByTemplate(8, "p_t3m4")`
- `SwitchPlayerCharacter(8)`

The implementation is general and does not hardcode K2, the prologue, T3, module names, dialog names, or template resrefs.

## Behavior

- `SwitchPlayerCharacter(-1)` restores the generated/player character.
- If the requested NPC is already an active party member, it switches the party leader.
- If the requested NPC is available from `AddAvailableNPCByTemplate`, it materializes that template once and switches control to it.
- The generated player is preserved for later restoration.
- Unknown or missing NPC indices fail safely with a warning.