### PR TITLE
[script] Support DLG script parameters and stacked item counts

### DIFF
--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -104,7 +104,10 @@ private:
 
     int indexOfFirstActive(const std::vector<resource::Dialog::EntryReplyLink> &links);
 
-    bool evaluateCondition(const std::string &scriptResRef);
+    bool isLinkActive(const resource::Dialog::EntryReplyLink &link);
+    bool evaluateCondition(const std::string &scriptResRef, const resource::Dialog::EntryReplyLink::ConditionParams &params);
+    void runScript(const std::string &scriptResRef, const resource::Dialog::EntryReply::ActionParams &params);
+    void runScripts(const resource::Dialog::EntryReply &node);
 
     virtual void setMessage(std::string message) = 0;
 

--- a/include/reone/resource/dialog.h
+++ b/include/reone/resource/dialog.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "types.h"
 
 namespace reone {
@@ -34,8 +36,19 @@ struct Dialog {
     };
 
     struct EntryReplyLink {
+        struct ConditionParams {
+            std::array<int, 5> ints {0, 0, 0, 0, 0};
+            std::string str;
+        };
+
         int index {0};
         std::string active;
+        std::string active2;
+        bool notActive {false};
+        bool notActive2 {false};
+        int logic {0};
+        ConditionParams params;
+        ConditionParams params2;
     };
 
     struct ParticipantAnimation {
@@ -44,12 +57,20 @@ struct Dialog {
     };
 
     struct EntryReply {
+        struct ActionParams {
+            std::array<int, 5> ints {0, 0, 0, 0, 0};
+            std::string str;
+        };
+
         std::string speaker;
         std::string text;
         std::string voResRef;
         std::string script;
+        std::string script2;
         std::string sound;
         std::string listener;
+        ActionParams actionParams;
+        ActionParams actionParams2;
         int delay {0};
         int waitFlags {0};
         int cameraId {-1};

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -106,6 +106,12 @@ enum class ArgKind {
     SpellId,
     SpellLocation,
     ObjectsInShape,
+    ScriptParam1,
+    ScriptParam2,
+    ScriptParam3,
+    ScriptParam4,
+    ScriptParam5,
+    ScriptStringParam,
 };
 
 struct Argument {

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -46,6 +46,35 @@ static constexpr float kDefaultEntryDuration = 3.0f;
 
 static bool g_allEntriesSkippable = false;
 
+static script::ArgKind getScriptParamArgKind(size_t index) {
+    switch (index) {
+    case 0:
+        return script::ArgKind::ScriptParam1;
+    case 1:
+        return script::ArgKind::ScriptParam2;
+    case 2:
+        return script::ArgKind::ScriptParam3;
+    case 3:
+        return script::ArgKind::ScriptParam4;
+    case 4:
+    default:
+        return script::ArgKind::ScriptParam5;
+    }
+}
+
+template <typename Params>
+static std::vector<script::Argument> makeScriptArgs(uint32_t callerId, const Params &params) {
+    std::vector<script::Argument> args;
+    if (callerId) {
+        args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(callerId));
+    }
+    for (size_t i = 0; i < params.ints.size(); ++i) {
+        args.emplace_back(getScriptParamArgKind(i), script::Variable::ofInt(params.ints[i]));
+    }
+    args.emplace_back(script::ArgKind::ScriptStringParam, script::Variable::ofString(params.str));
+    return args;
+}
+
 void Conversation::start(const std::shared_ptr<Dialog> &dialog, const std::shared_ptr<Object> &owner) {
     debug("Start " + dialog->resRef, LogChannel::Conversation);
 
@@ -95,15 +124,53 @@ void Conversation::loadStartEntry() {
 
 int Conversation::indexOfFirstActive(const std::vector<Dialog::EntryReplyLink> &links) {
     for (auto &link : links) {
-        if (link.active.empty() || evaluateCondition(link.active)) {
+        if (isLinkActive(link)) {
             return link.index;
         }
     }
     return -1;
 }
 
-bool Conversation::evaluateCondition(const std::string &scriptResRef) {
-    return _game.scriptRunner().run(scriptResRef, _owner->id()) != 0;
+bool Conversation::isLinkActive(const Dialog::EntryReplyLink &link) {
+    std::optional<bool> active;
+    if (!link.active.empty()) {
+        active = evaluateCondition(link.active, link.params);
+        if (link.notActive) {
+            active = !active.value();
+        }
+    }
+    std::optional<bool> active2;
+    if (!link.active2.empty()) {
+        active2 = evaluateCondition(link.active2, link.params2);
+        if (link.notActive2) {
+            active2 = !active2.value();
+        }
+    }
+    if (!active && !active2) {
+        return true;
+    }
+    if (!active) {
+        return active2.value();
+    }
+    if (!active2) {
+        return active.value();
+    }
+    return link.logic == 1 ? active.value() || active2.value() : active.value() && active2.value();
+}
+
+bool Conversation::evaluateCondition(const std::string &scriptResRef, const Dialog::EntryReplyLink::ConditionParams &params) {
+    return _game.scriptRunner().run(scriptResRef, makeScriptArgs(_owner ? _owner->id() : 0, params)) != 0;
+}
+
+void Conversation::runScript(const std::string &scriptResRef, const Dialog::EntryReply::ActionParams &params) {
+    if (!scriptResRef.empty()) {
+        _game.scriptRunner().run(scriptResRef, makeScriptArgs(_owner ? _owner->id() : 0, params));
+    }
+}
+
+void Conversation::runScripts(const Dialog::EntryReply &node) {
+    runScript(node.script, node.actionParams);
+    runScript(node.script2, node.actionParams2);
 }
 
 void Conversation::finish() {
@@ -155,10 +222,8 @@ void Conversation::loadEntry(int index, bool start) {
         return;
     }
 
-    // Run entry script
-    if (!_currentEntry->script.empty()) {
-        _game.scriptRunner().run(_currentEntry->script, _owner->id());
-    }
+    // Run entry scripts
+    runScripts(*_currentEntry);
 
     if (_autoSkip) {
         if (std::optional<bool> skip = _autoSkip->trySkipEntry()) {
@@ -229,7 +294,7 @@ void Conversation::scheduleEndOfEntry() {
 void Conversation::loadReplies() {
     _replies.clear();
     for (auto &link : _currentEntry->replies) {
-        if (link.active.empty() || evaluateCondition(link.active)) {
+        if (isLinkActive(link)) {
             _replies.push_back(&_dialog->getReply(link.index));
         }
     }
@@ -258,10 +323,8 @@ void Conversation::pickReply(int index) {
     debug("Pick reply " + std::to_string(index), LogChannel::Conversation);
     const Dialog::EntryReply &reply = *_replies[index];
 
-    // Run reply script
-    if (!reply.script.empty()) {
-        _game.scriptRunner().run(reply.script, _owner->id());
-    }
+    // Run reply scripts
+    runScripts(reply);
 
     int entryIdx = indexOfFirstActive(reply.entries);
     if (entryIdx == -1) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -4142,12 +4142,19 @@ static Variable GetCurrentStealthXP(const std::vector<Variable> &args, const Rou
 
 static Variable GetNumStackedItems(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
-    auto oItem = getObject(args, 0, ctx);
+    if (args.empty() || args[0].type != VariableType::Object) {
+        return Variable::ofInt(0);
+    }
 
     // Transform
+    auto object = ctx.game.getObjectById(args[0].objectId);
+    if (!object || object->type() != ObjectType::Item) {
+        return Variable::ofInt(0);
+    }
+    auto item = std::static_pointer_cast<Item>(object);
 
     // Execute
-    throw RoutineNotImplementedException("GetNumStackedItems");
+    return Variable::ofInt(item->stackSize());
 }
 
 static Variable SurrenderToEnemies(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -6043,9 +6050,29 @@ static Variable GetScriptParameter(const std::vector<Variable> &args, const Rout
     auto nIndex = getInt(args, 0);
 
     // Transform
+    const Variable *param = nullptr;
+    switch (nIndex) {
+    case 1:
+        param = ctx.execution.findArg(ArgKind::ScriptParam1);
+        break;
+    case 2:
+        param = ctx.execution.findArg(ArgKind::ScriptParam2);
+        break;
+    case 3:
+        param = ctx.execution.findArg(ArgKind::ScriptParam3);
+        break;
+    case 4:
+        param = ctx.execution.findArg(ArgKind::ScriptParam4);
+        break;
+    case 5:
+        param = ctx.execution.findArg(ArgKind::ScriptParam5);
+        break;
+    default:
+        break;
+    }
 
     // Execute
-    throw RoutineNotImplementedException("GetScriptParameter");
+    return Variable::ofInt(param ? param->intValue : 0);
 }
 
 static Variable SetFadeUntilScript(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -6515,7 +6542,8 @@ static Variable ModifyWillSavingThrowBase(const std::vector<Variable> &args, con
 
 static Variable GetScriptStringParameter(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetScriptStringParameter");
+    const Variable *param = ctx.execution.findArg(ArgKind::ScriptStringParam);
+    return Variable::ofString(param ? param->strValue : "");
 }
 
 static Variable GetObjectPersonalSpace(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/resource/provider/dialogs.cpp
+++ b/src/libs/resource/provider/dialogs.cpp
@@ -63,6 +63,14 @@ Dialog::EntryReplyLink Dialogs::getEntryReplyLink(const resource::generated::DLG
     Dialog::EntryReplyLink link;
     link.index = dlg.Index;
     link.active = dlg.Active;
+    link.active2 = dlg.Active2;
+    link.notActive = dlg.Not != 0;
+    link.notActive2 = dlg.Not2 != 0;
+    link.logic = dlg.Logic;
+    link.params.ints = {dlg.Param1, dlg.Param2, dlg.Param3, dlg.Param4, dlg.Param5};
+    link.params.str = dlg.ParamStrA;
+    link.params2.ints = {dlg.Param1b, dlg.Param2b, dlg.Param3b, dlg.Param4b, dlg.Param5b};
+    link.params2.str = dlg.ParamStrB;
 
     return link;
 }
@@ -75,8 +83,13 @@ Dialog::EntryReply Dialogs::getEntryReply(const resource::generated::DLG_EntryRe
     entry.text = strRef == -1 ? "" : _strings.getText(strRef);
     entry.voResRef = dlg.VO_ResRef;
     entry.script = dlg.Script;
+    entry.script2 = dlg.Script2;
     entry.sound = dlg.Sound;
     entry.listener = dlg.Listener;
+    entry.actionParams.ints = {dlg.ActionParam1, dlg.ActionParam2, dlg.ActionParam3, dlg.ActionParam4, dlg.ActionParam5};
+    entry.actionParams.str = dlg.ActionParamStrA;
+    entry.actionParams2.ints = {dlg.ActionParam1b, dlg.ActionParam2b, dlg.ActionParam3b, dlg.ActionParam4b, dlg.ActionParam5b};
+    entry.actionParams2.str = dlg.ActionParamStrB;
     entry.delay = dlg.Delay;
     entry.waitFlags = dlg.WaitFlags;
     entry.cameraId = dlg.CameraID;

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -193,6 +193,18 @@ const char *argKindToString(ArgKind kind) {
         return "SpellLocation";
     case ArgKind::ObjectsInShape:
         return "ObjectsInShape";
+    case ArgKind::ScriptParam1:
+        return "ScriptParam1";
+    case ArgKind::ScriptParam2:
+        return "ScriptParam2";
+    case ArgKind::ScriptParam3:
+        return "ScriptParam3";
+    case ArgKind::ScriptParam4:
+        return "ScriptParam4";
+    case ArgKind::ScriptParam5:
+        return "ScriptParam5";
+    case ArgKind::ScriptStringParam:
+        return "ScriptStringParam";
     }
 
     throw std::logic_error("Unsupported arg kind: " +
@@ -285,6 +297,24 @@ Argument Argument::fromString(std::string str) {
         auto location = std::make_shared<game::Location>(position, facing);
         return {ArgKind::SpellLocation, Variable::ofLocation(std::move(location))};
     }
+    if (kind == "ScriptParam1") {
+        return {ArgKind::ScriptParam1, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "ScriptParam2") {
+        return {ArgKind::ScriptParam2, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "ScriptParam3") {
+        return {ArgKind::ScriptParam3, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "ScriptParam4") {
+        return {ArgKind::ScriptParam4, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "ScriptParam5") {
+        return {ArgKind::ScriptParam5, Variable::ofInt(std::stoi(value))};
+    }
+    if (kind == "ScriptStringParam") {
+        return {ArgKind::ScriptStringParam, Variable::ofString(value)};
+    }
 
     throw std::logic_error("Unsupported arg kind: " + kind);
 }
@@ -317,6 +347,23 @@ void Argument::verify() {
     case ArgKind::SpellId: {
         if (var.type != VariableType::Int) {
             throw std::invalid_argument(toString() + ": expected an integer");
+        }
+        return;
+    }
+    case ArgKind::ScriptParam1:
+    case ArgKind::ScriptParam2:
+    case ArgKind::ScriptParam3:
+    case ArgKind::ScriptParam4:
+    case ArgKind::ScriptParam5: {
+        if (var.type != VariableType::Int) {
+            throw std::invalid_argument(toString() + ": expected an integer");
+        }
+        return;
+    }
+
+    case ArgKind::ScriptStringParam: {
+        if (var.type != VariableType::String) {
+            throw std::invalid_argument(toString() + ": expected a string");
         }
         return;
     }


### PR DESCRIPTION
## Summary

Adds DLG script parameter support and implements stacked item counts for scripts.

This preserves and passes DLG condition/action metadata so dialogue scripts can use their configured parameters:

- `Active2`
- `Not` / `Not2`
- `Logic`
- `Param1`-`Param5`
- `Param1b`-`Param5b`
- `ParamStrA` / `ParamStrB`
- `Script2` action execution

Also implements:

- `GetScriptParameter`
- `GetScriptStringParameter`
- `GetNumStackedItems`

## Why

Some vanilla computer/repair dialogues depend on DLG script parameters and item stack counts. For example, the K2 prologue comm panel slice option is present in the DLG, but requires parameterized condition/action scripts and computer-spike stack checks before it appears and works correctly.

## Notes

- No hardcoded K2 prologue, console, spike, door, or module logic.
- No GUI/layout changes.
- No `SwitchPlayerCharacter` changes.
- No `StartConversationAction` changes.
- No `DialogCamera` changes in this branch.

## Validation

- Manual K2 prologue smoke:
  - spike can be looted
  - comm panel slice option appears
  - slice path opens/unlocks progression
  - default logoff still works
- Manual K1 Endar Spire smoke:
  - player can loot parts / spikes
  - these parts can be 'spent' at the security panel / droid 
  - slice path results in desired actions, droid can be reactivated