### PR TITLE
[resource] Load lips ERF for a module

### DIFF
--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -199,6 +199,10 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     loadERF(*modulesPath, name, ContainerKind::Local);
     loadERF(*modulesPath, name + "_loc", ContainerKind::Local);
 
+    if (auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName)) {
+        loadERF(*lipsPath, name + "_loc", ContainerKind::Local);
+    }
+
     if (_gameId == GameID::TSL) {
         loadERF(*modulesPath, name + "_dlg", ContainerKind::Local);
     }


### PR DESCRIPTION
Fixed a regression from 6f3319451 "[resource] Support nested ERF containers".
Lips movement in dialogs was broken because we did not load these extra ERF modules.