### PR TITLE
[game] Set position and facing for objects created by scripts

### DIFF
--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1032,6 +1032,11 @@ std::shared_ptr<Object> Area::createObject(ObjectType type, const std::string &b
         return nullptr;
     }
 
+    if (location) {
+        object->setPosition(location->position());
+        object->setFacing(location->facing());
+    }
+
     add(object);
 
     auto creature = std::dynamic_pointer_cast<Creature>(object);


### PR DESCRIPTION
Scripts use `CreateObject` routine to change modules, and can specify a location for created objects.

On Taris North Appartments (`tar_m02ad`), `CreateObject` is used to spawn a backpack with Sith disguise uniform. Without a location, the backpack spawned at 0 and was not accessible.