### PR TITLE
[script][game] Support custom dialogue tokens

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -321,6 +321,9 @@ public:
     const std::map<std::string, int> &globalNumbers() const { return _globalNumbers; }
     const std::map<std::string, std::shared_ptr<Location>> &globalLocations() const { return _globalLocations; }
 
+    void setCustomToken(int token, std::string value);
+    std::string substituteCustomTokens(std::string str) const;
+
     void setGlobalBoolean(const std::string &name, bool value);
     void setGlobalLocation(const std::string &name, const std::shared_ptr<Location> &location);
     void setGlobalNumber(const std::string &name, int value);
@@ -418,6 +421,7 @@ private:
     std::map<std::string, bool> _globalBooleans;
     std::map<std::string, int> _globalNumbers;
     std::map<std::string, std::shared_ptr<Location>> _globalLocations;
+    std::map<int, std::string> _customTokens;
 
     // END Global variables
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -17,6 +17,9 @@
 
 #include "reone/game/game.h"
 
+#include <cctype>
+#include <exception>
+
 #include "reone/audio/context.h"
 #include "reone/audio/di/services.h"
 #include "reone/audio/mixer.h"
@@ -598,6 +601,7 @@ void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
     _globalBooleans.clear();
     _globalNumbers.clear();
     _globalLocations.clear();
+    _customTokens.clear();
 
     for (auto &[name, value] : gvt.strings) {
         setGlobalString(name, value);
@@ -1238,6 +1242,40 @@ std::string Game::getGlobalString(const std::string &name) const {
 std::shared_ptr<Location> Game::getGlobalLocation(const std::string &name) const {
     auto it = _globalLocations.find(name);
     return it != _globalLocations.end() ? it->second : nullptr;
+}
+
+void Game::setCustomToken(int token, std::string value) {
+    _customTokens[token] = std::move(value);
+}
+
+std::string Game::substituteCustomTokens(std::string str) const {
+    size_t start = 0;
+    while ((start = str.find("<CUSTOM", start)) != std::string::npos) {
+        size_t digitsStart = start + 7;
+        size_t digitsEnd = digitsStart;
+        while (digitsEnd < str.size() && std::isdigit(static_cast<unsigned char>(str[digitsEnd]))) {
+            ++digitsEnd;
+        }
+        if (digitsEnd == digitsStart || digitsEnd >= str.size() || str[digitsEnd] != '>') {
+            start = digitsStart;
+            continue;
+        }
+        int token = 0;
+        try {
+            token = std::stoi(str.substr(digitsStart, digitsEnd - digitsStart));
+        } catch (const std::exception &) {
+            start = digitsEnd + 1;
+            continue;
+        }
+        auto it = _customTokens.find(token);
+        if (it == _customTokens.end()) {
+            start = digitsEnd + 1;
+            continue;
+        }
+        str.replace(start, digitsEnd - start + 1, it->second);
+        start += it->second.size();
+    }
+    return str;
 }
 
 void Game::setGlobalBoolean(const std::string &name, bool value) {

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -203,7 +203,8 @@ void Conversation::loadEntry(int index, bool start) {
     debug("Load entry " + std::to_string(index), LogChannel::Conversation);
     _currentEntry = &_dialog->getEntry(index);
 
-    setMessage(_currentEntry->text);
+    std::string entryText(_game.substituteCustomTokens(_currentEntry->text));
+    setMessage(entryText);
     loadReplies();
     loadVoiceOver();
     scheduleEndOfEntry();
@@ -216,7 +217,7 @@ void Conversation::loadEntry(int index, bool start) {
         oneLiner = reply.text.empty() && reply.entries.empty();
     }
     if (oneLiner) {
-        _game.setBarkBubbleText(_currentEntry->text, _entryDuration);
+        _game.setBarkBubbleText(std::move(entryText), _entryDuration);
         debug("Dialog: finish (one-liner)");
         finish();
         return;
@@ -305,15 +306,15 @@ void Conversation::loadReplies() {
     refreshReplies();
 }
 
-static std::string getReplyText(const Dialog::EntryReply &reply, int index) {
-    return str(boost::format("%d. %s") % (index + 1) % (reply.text.empty() ? "[empty]" : reply.text));
+static std::string getReplyText(const Dialog::EntryReply &reply, int index, const Game &game) {
+    return str(boost::format("%d. %s") % (index + 1) % (reply.text.empty() ? "[empty]" : game.substituteCustomTokens(reply.text)));
 }
 
 void Conversation::refreshReplies() {
     std::vector<std::string> lines;
     if (!_autoPickFirstReply) {
         for (size_t i = 0; i < _replies.size(); ++i) {
-            lines.push_back(getReplyText(*_replies[i], static_cast<int>(i)));
+            lines.push_back(getReplyText(*_replies[i], static_cast<int>(i), _game));
         }
     }
     setReplyLines(std::move(lines));

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2685,7 +2685,8 @@ static Variable SetCustomToken(const std::vector<Variable> &args, const RoutineC
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("SetCustomToken");
+    ctx.game.setCustomToken(nCustomTokenNumber, std::move(sTokenValue));
+    return Variable::ofNull();
 }
 
 static Variable GetHasFeat(const std::vector<Variable> &args, const RoutineContext &ctx) {


### PR DESCRIPTION
## Summary

Implements support for custom dialogue tokens set by scripts.

This adds `SetCustomToken(int, string)`, stores custom token values on `Game`, and substitutes `<CUSTOMn>` / `<CUSTOMnn>` tokens at conversation display time.

## Behavior

- `SetCustomToken(n, value)` stores the custom token value
- `<CUSTOM1>` resolves token 1
- `<CUSTOM01>` also resolves token 1
- missing or unset custom tokens remain unchanged
- malformed custom tokens remain unchanged
- non-custom tokens such as `<FullName>`, `<FirstName>`, `<LastName>`, and `<abutton>` are unaffected
- custom tokens are cleared on `Game::loadGame()` to avoid stale runtime token values leaking across saves