### PR TITLE
[script] Return -1 for missing stacked items

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -4143,13 +4143,21 @@ static Variable GetCurrentStealthXP(const std::vector<Variable> &args, const Rou
 static Variable GetNumStackedItems(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     if (args.empty() || args[0].type != VariableType::Object) {
-        return Variable::ofInt(0);
+        return Variable::ofInt(-1);
     }
 
     // Transform
-    auto object = ctx.game.getObjectById(args[0].objectId);
+    uint32_t objectId = args[0].objectId;
+    if (objectId == kObjectSelf) {
+        if (const Variable *caller = ctx.execution.findArg(ArgKind::Caller)) {
+            objectId = caller->objectId;
+        } else {
+            objectId = kObjectInvalid;
+        }
+    }
+    auto object = ctx.game.getObjectById(objectId);
     if (!object || object->type() != ObjectType::Item) {
-        return Variable::ofInt(0);
+        return Variable::ofInt(-1);
     }
     auto item = std::static_pointer_cast<Item>(object);
 


### PR DESCRIPTION
## Summary

This was an error in the initial implementation of `GetNumStackedItems`  returning `0` instead of `-1`.  Updates `GetNumStackedItems` so that invalid, missing, or non-item objects return `-1` instead of `0`.

This keeps valid item behavior unchanged: valid item objects still return `stackSize()`.

## Behavior

- valid item object: returns `stackSize()`
- invalid/missing object: returns `-1`
- non-item object: returns `-1`
- `OBJECT_SELF` follows the existing caller-resolution pattern before lookup; if it resolves to no caller or a non-item, returns `-1`