### PR TITLE
[scene] Support multi-level walkmeshes

### DIFF
--- a/include/reone/graphics/walkmesh.h
+++ b/include/reone/graphics/walkmesh.h
@@ -48,6 +48,7 @@ public:
         const glm::vec3 &origin,
         const glm::vec3 &dir,
         float maxDistance,
+        bool ignoreBackface,
         float &outDistance) const;
 
     bool contains(const glm::vec2 &point) const;
@@ -75,6 +76,7 @@ private:
         const glm::vec3 &origin,
         const glm::vec3 &dir,
         float maxDistance,
+        bool ignoreBackface,
         float &outDistance) const;
 
     bool raycastFace(
@@ -83,6 +85,7 @@ private:
         const glm::vec3 &origin,
         const glm::vec3 &dir,
         float maxDistance,
+        bool ignoreBackface,
         float &outDistance) const;
 
     friend class BwmReader;

--- a/include/reone/scene/graph.h
+++ b/include/reone/scene/graph.h
@@ -57,6 +57,8 @@ struct ResourceServices;
 
 namespace scene {
 
+static constexpr float kElevationTestZ = 1024.0f;
+
 struct Collision;
 
 class IAnimationEventListener;
@@ -72,7 +74,7 @@ public:
 
     virtual void clear() = 0;
 
-    virtual bool testElevation(const glm::vec2 &position, Collision &outCollision) const = 0;
+    virtual bool testElevation(const glm::vec3 &position, Collision &outCollision) const = 0;
     virtual bool testLineOfSight(const glm::vec3 &origin, const glm::vec3 &dest, Collision &outCollision) const = 0;
     virtual bool testWalk(const glm::vec3 &origin, const glm::vec3 &dest, const IUser *excludeUser, Collision &outCollision) const = 0;
 
@@ -240,7 +242,7 @@ public:
 
     // Collision detection and object picking
 
-    bool testElevation(const glm::vec2 &position, Collision &outCollision) const override;
+    bool testElevation(const glm::vec3 &position, Collision &outCollision) const override;
     bool testLineOfSight(const glm::vec3 &origin, const glm::vec3 &dest, Collision &outCollision) const override;
     bool testWalk(const glm::vec3 &origin, const glm::vec3 &dest, const IUser *excludeUser, Collision &outCollision) const override;
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -421,7 +421,7 @@ void Area::loadPTH() {
     for (size_t i = 0; i < path->points.size(); ++i) {
         const Path::Point &point = path->points[i];
         Collision collision;
-        if (!sceneGraph.testElevation(glm::vec2(point.x, point.y), collision)) {
+        if (!sceneGraph.testElevation(glm::vec3(point.x, point.y, scene::kElevationTestZ), collision)) {
             warn(str(boost::format("Point %d elevation not found") % i));
             continue;
         }

--- a/src/libs/graphics/walkmesh.cpp
+++ b/src/libs/graphics/walkmesh.cpp
@@ -69,8 +69,10 @@ const Walkmesh::Face *Walkmesh::raycastAABB(
     std::stack<AABB *> aabbs;
     aabbs.push(_rootAabb.get());
 
-    auto invDir = 1.0f / dir;
+    outDistance = std::numeric_limits<float>::max();
+    const Face *result = nullptr;
 
+    auto invDir = 1.0f / dir;
     while (!aabbs.empty()) {
         auto aabb = aabbs.top();
         aabbs.pop();
@@ -79,8 +81,10 @@ const Walkmesh::Face *Walkmesh::raycastAABB(
         if (aabb->faceIdx != -1) {
             const Face &face = _faces[aabb->faceIdx];
             if (raycastFace(surfaces, face, origin, dir, maxDistance, ignoreBackface, distance)) {
-                outDistance = distance;
-                return &face;
+                if (distance < outDistance) {
+                    result = &face;
+                    outDistance = distance;
+                }
             }
             continue;
         }
@@ -99,7 +103,7 @@ const Walkmesh::Face *Walkmesh::raycastAABB(
         }
     }
 
-    return nullptr;
+    return result;
 }
 
 bool Walkmesh::raycastFace(

--- a/src/libs/graphics/walkmesh.cpp
+++ b/src/libs/graphics/walkmesh.cpp
@@ -26,11 +26,12 @@ const Walkmesh::Face *Walkmesh::raycast(
     const glm::vec3 &origin,
     const glm::vec3 &dir,
     float maxDistance,
+    bool ignoreBackface,
     float &outDistance) const {
 
     // For area walkmeshes, find intersection via AABB tree
     if (_rootAabb) {
-        return raycastAABB(surfaces, origin, dir, maxDistance, outDistance);
+        return raycastAABB(surfaces, origin, dir, maxDistance, ignoreBackface, outDistance);
     }
 
     // For placeable and door walkmeshes, test all faces for intersection
@@ -38,9 +39,10 @@ const Walkmesh::Face *Walkmesh::raycast(
     float minDistance = std::numeric_limits<float>::max();
     std::optional<std::reference_wrapper<const Face>> intersected;
     for (auto &face : _faces) {
-        if (!raycastFace(surfaces, face, origin, dir, maxDistance, distance)) {
+        if (!raycastFace(surfaces, face, origin, dir, maxDistance, ignoreBackface, distance)) {
             continue;
         }
+
         if (distance < minDistance) {
             minDistance = distance;
             intersected = face;
@@ -59,6 +61,7 @@ const Walkmesh::Face *Walkmesh::raycastAABB(
     const glm::vec3 &origin,
     const glm::vec3 &dir,
     float maxDistance,
+    bool ignoreBackface,
     float &outDistance) const {
 
     float distance = 0.0f;
@@ -75,7 +78,7 @@ const Walkmesh::Face *Walkmesh::raycastAABB(
         // Test ray/face intersection for tree leafs
         if (aabb->faceIdx != -1) {
             const Face &face = _faces[aabb->faceIdx];
-            if (raycastFace(surfaces, face, origin, dir, maxDistance, distance)) {
+            if (raycastFace(surfaces, face, origin, dir, maxDistance, ignoreBackface, distance)) {
                 outDistance = distance;
                 return &face;
             }
@@ -105,6 +108,7 @@ bool Walkmesh::raycastFace(
     const glm::vec3 &origin,
     const glm::vec3 &dir,
     float maxDistance,
+    bool ignoreBackface,
     float &outDistance) const {
 
     if (surfaces.count(face.material) == 0) {
@@ -119,6 +123,9 @@ bool Walkmesh::raycastFace(
     float distance = 0.0f;
 
     if (glm::intersectRayTriangle(origin, dir, p0, p1, p2, baryPosition, distance) && distance > 0.0f && distance < maxDistance) {
+        if (ignoreBackface && glm::dot(face.normal, dir) > 0) {
+            return false;
+        }
         outDistance = distance;
         return true;
     }

--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -51,7 +51,6 @@ static constexpr int kMaxFlareLights = 4;
 static constexpr int kMaxSoundCount = 4;
 
 static constexpr float kShadowFadeSpeed = 2.0f;
-static constexpr float kElevationTestZ = 1024.0f;
 
 static constexpr float kLightRadiusBias = 64.0f;
 
@@ -764,13 +763,12 @@ std::vector<LightSceneNode *> SceneGraph::computeClosestLights(int count, const 
     return lights;
 }
 
-bool SceneGraph::testElevation(const glm::vec2 &position, Collision &outCollision) const {
+bool SceneGraph::testElevation(const glm::vec3 &position, Collision &outCollision) const {
     static glm::vec3 down(0.0f, 0.0f, -1.0f);
 
     bool walkable = false;
     float minDistance = std::numeric_limits<float>::max();
-
-    glm::vec3 origin {position, kElevationTestZ};
+    glm::vec3 origin {position.x, position.y, position.z + 0.1f};
     for (auto &root : _walkmeshRoots) {
         if (!root->isEnabled()) {
             continue;

--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -783,7 +783,7 @@ bool SceneGraph::testElevation(const glm::vec2 &position, Collision &outCollisio
         }
         auto objSpaceOrigin = glm::vec3(root->absoluteTransformInverse() * glm::vec4(origin, 1.0f));
         float distance = 0.0f;
-        auto face = root->walkmesh().raycast(_walkcheckSurfaces, objSpaceOrigin, down, 2.0f * kElevationTestZ, distance);
+        auto face = root->walkmesh().raycast(_walkcheckSurfaces, objSpaceOrigin, down, 2.0f * kElevationTestZ, /*ignoreBackface=*/true, distance);
         if (!face || distance >= minDistance) {
             continue;
         }
@@ -827,7 +827,7 @@ bool SceneGraph::testLineOfSight(const glm::vec3 &origin, const glm::vec3 &dest,
             dirLocal = root->absoluteTransformInverse() * glm::vec4 {dir, 0.0f};
         }
         float distance = 0.0f;
-        auto face = root->walkmesh().raycast(_lineOfSightSurfaces, originLocal, dirLocal, maxDistance, distance);
+        auto face = root->walkmesh().raycast(_lineOfSightSurfaces, originLocal, dirLocal, maxDistance, /*ignoreBackface=*/false, distance);
         if (!face || distance > minDistance) {
             continue;
         }
@@ -860,7 +860,7 @@ bool SceneGraph::testWalk(const glm::vec3 &origin, const glm::vec3 &dest, const 
         glm::vec3 objSpaceOrigin(root->absoluteTransformInverse() * glm::vec4(origin, 1.0f));
         glm::vec3 objSpaceDir(root->absoluteTransformInverse() * glm::vec4(dir, 0.0f));
         float distance = 0.0f;
-        auto face = root->walkmesh().raycast(_walkcheckSurfaces, objSpaceOrigin, objSpaceDir, kMaxCollisionDistanceWalk, distance);
+        auto face = root->walkmesh().raycast(_walkcheckSurfaces, objSpaceOrigin, objSpaceDir, kMaxCollisionDistanceWalk, /*ignoreBackface=*/false, distance);
         if (!face || distance > maxDistance || distance > minDistance) {
             continue;
         }

--- a/test/graphics/walkmesh.cpp
+++ b/test/graphics/walkmesh.cpp
@@ -47,7 +47,7 @@ TEST(Walkmesh, should_find_ray_walkmesh_intersection__intersection_from_close) {
 
     // when
     float distance = -1.0f;
-    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 1.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, distance);
+    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 1.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/false, distance);
 
     // then
     EXPECT_TRUE(static_cast<bool>(face));
@@ -80,7 +80,7 @@ TEST(Walkmesh, should_find_ray_walkmesh_intersection__intersection_from_far) {
 
     // when
     float distance = -1.0f;
-    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 20.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, distance);
+    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 20.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/false, distance);
 
     // then
     EXPECT_TRUE(!static_cast<bool>(face));
@@ -111,8 +111,51 @@ TEST(Walkmesh, should_find_ray_walkmesh_intersection__no_intersection) {
 
     // when
     float distance = -1.0f;
-    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 1.0f), glm::vec3(1.0f, 0.0f, 0.0f), 10.0f, distance);
+    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(-0.5f, 0.25, 1.0f), glm::vec3(1.0f, 0.0f, 0.0f), 10.0f, /*ignoreBackface=*/false, distance);
 
     // then
     EXPECT_TRUE(!static_cast<bool>(face));
+}
+
+TEST(Walkmesh, should_find_ray_walkmesh_intersection__ignore_backface) {
+    // given
+    auto walkmesh = Walkmesh();
+
+    // Bottom triangle (facing up)
+    walkmesh.add(Walkmesh::Face {0, 0, std::vector<glm::vec3> {glm::vec3(-1.0f, -1.0f, 0.0f), glm::vec3(1.0f, -1.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f)}, glm::vec3(0.0f, 0.0f, 1.0f)});
+
+    // Top triangle (facing down)
+    walkmesh.add(Walkmesh::Face {1, 0, std::vector<glm::vec3> {glm::vec3(-1.0f, -1.0f, 1.0f), glm::vec3(1.0f, -1.0f, 1.0f), glm::vec3(0.0f, 1.0f, 1.0f)}, glm::vec3(0.0f, 0.0f, -1.0f)});
+
+    // Root AABB covers both triangles.
+    auto rootAabb = std::make_shared<Walkmesh::AABB>();
+    rootAabb->value = AABB(glm::vec3(-1.0f, -1.0f, -0.2f), glm::vec3(1.0f, 1.0f, 1.2f));
+
+    // Bottom AABB covers the bottom triangle.
+    rootAabb->right = std::make_shared<Walkmesh::AABB>();
+    rootAabb->right->value = AABB(glm::vec3(-1.0f, -1.0f, -0.2f), glm::vec3(1.0f, 1.0f, 0.2f));
+    rootAabb->right->faceIdx = 0;
+
+    // Top AABB covers the top triangle.
+    rootAabb->left = std::make_shared<Walkmesh::AABB>();
+    rootAabb->left->value = AABB(glm::vec3(-1.0f, -1.0f, 0.8f), glm::vec3(1.0f, 1.0f, 1.2f));
+    rootAabb->left->faceIdx = 1;
+
+    walkmesh.setRootAABB(rootAabb);
+
+    // When ignoreBackface is false, we should hit the top face first
+    // regardless of its orientation (normal is up or down).
+    float distance = -1.0f;
+    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(0.0f, 0.0f, 2.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/false, distance);
+    EXPECT_TRUE(face);
+    EXPECT_EQ(1, face->index);
+    EXPECT_NEAR(1.0f, distance, 1e-5);
+
+    // When ignoreBackface is true, we should ignore the top face and
+    // hit the bottom face.
+    distance = -1.0f;
+    face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(0.0f, 0.0f, 2.0f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/true, distance);
+    EXPECT_TRUE(face);
+    EXPECT_EQ(0, face->index);
+    EXPECT_NEAR(2.0f, distance, 1e-5);
 }

--- a/test/graphics/walkmesh.cpp
+++ b/test/graphics/walkmesh.cpp
@@ -159,3 +159,45 @@ TEST(Walkmesh, should_find_ray_walkmesh_intersection__ignore_backface) {
     EXPECT_EQ(0, face->index);
     EXPECT_NEAR(2.0f, distance, 1e-5);
 }
+
+TEST(Walkmesh, should_find_ray_walkmesh_intersection__multi_level) {
+    // given
+    auto walkmesh = Walkmesh();
+
+    // Bottom triangle (facing up)
+    walkmesh.add(Walkmesh::Face {0, 0, std::vector<glm::vec3> {glm::vec3(-1.0f, -1.0f, 0.0f), glm::vec3(1.0f, -1.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f)}, glm::vec3(0.0f, 0.0f, 1.0f)});
+
+    // Top triangle (facing up)
+    walkmesh.add(Walkmesh::Face {1, 0, std::vector<glm::vec3> {glm::vec3(-1.0f, -1.0f, 1.0f), glm::vec3(1.0f, -1.0f, 1.0f), glm::vec3(0.0f, 1.0f, 1.0f)}, glm::vec3(0.0f, 0.0f, 1.0f)});
+
+    auto rootAabb = std::make_shared<Walkmesh::AABB>();
+    rootAabb->value = AABB(glm::vec3(-1.0f, -1.0f, -0.2f), glm::vec3(1.0f, 1.0f, 1.2f));
+
+    // Bottom AABB
+    rootAabb->right = std::make_shared<Walkmesh::AABB>();
+    rootAabb->right->value = AABB(glm::vec3(-1.0f, -1.0f, -0.2f), glm::vec3(1.0f, 1.0f, 0.2f));
+    rootAabb->right->faceIdx = 0;
+
+    // Top AABB
+    rootAabb->left = std::make_shared<Walkmesh::AABB>();
+    rootAabb->left->value = AABB(glm::vec3(-1.0f, -1.0f, 0.8f), glm::vec3(1.0f, 1.0f, 1.2f));
+    rootAabb->left->faceIdx = 1;
+
+    walkmesh.setRootAABB(rootAabb);
+
+    // With both triangles are facing up, we should pick the one
+    // closer to the origin.
+    float distance = -1.0f;
+    auto face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(0.0f, 0.0f, 1.1f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/true, distance);
+    EXPECT_TRUE(face);
+    EXPECT_EQ(1, face->index);
+    EXPECT_NEAR(0.1f, distance, 1e-5);
+
+    // Now move the origin closer to the bottom triangle. Raycast
+    // should pick it instead of the top triangle.
+    distance = -1.0f;
+    face = walkmesh.raycast(std::set<uint32_t> {0}, glm::vec3(0.0f, 0.0f, 0.2f), glm::vec3(0.0f, 0.0f, -1.0f), 10.0f, /*ignoreBackface=*/true, distance);
+    EXPECT_TRUE(face);
+    EXPECT_EQ(0, face->index);
+    EXPECT_NEAR(0.2f, distance, 1e-5);
+}


### PR DESCRIPTION
There are two kinds of multi-level walkmeshes that we now support:
1. Mesh with a top plane facing down, and the bottom plane facing up.
2. Mesh with both planes facing up, and both may be walkable.

The first case is present in the original game and causes issue #128.
The second case is an extra feature that reone supports compared to the original engine.
It allows to make a walkable "bridge" with a walkable path under the bridge.

Please see individual commit messages for more details.