### PR TITLE
[game] Add level-up feat candidate rules

### DIFF
--- a/include/reone/game/d20/class.h
+++ b/include/reone/game/d20/class.h
@@ -70,6 +70,8 @@ public:
     int hitdie() const { return _hitdie; }
     const CreatureAttributes &defaultAttributes() const { return _defaultAttributes; }
     int skillPointBase() const { return _skillPointBase; }
+    int getFeatGain(int level) const;
+    bool isFeatSelectable(FeatType feat) const { return _selectableFeats.count(feat) > 0; }
 
 private:
     ClassType _type;
@@ -79,7 +81,9 @@ private:
     CreatureAttributes _defaultAttributes;
     int _skillPointBase {0};
     std::unordered_set<SkillType> _classSkills;
+    std::unordered_set<FeatType> _selectableFeats;
     std::unordered_map<int, SavingThrows> _savingThrowsByLevel;
+    std::unordered_map<int, int> _featGainsByLevel;
     std::vector<int> _attackBonuses;
 
     // Services
@@ -94,6 +98,8 @@ private:
     void loadClassSkills(const std::string &skillsTable);
     void loadSavingThrows(const std::string &savingThrowTable);
     void loadAttackBonuses(const std::string &attackBonusTable);
+    void loadSelectableFeats(const std::string &featsPrefix);
+    void loadFeatGains(const std::string &featGainPrefix);
 };
 
 } // namespace game

--- a/include/reone/game/d20/feats.h
+++ b/include/reone/game/d20/feats.h
@@ -33,6 +33,9 @@ class Textures;
 
 namespace game {
 
+class CreatureAttributes;
+class CreatureClass;
+
 class IFeats {
 public:
     virtual ~IFeats() = default;
@@ -40,6 +43,9 @@ public:
     virtual void init() = 0;
 
     virtual std::shared_ptr<Feat> get(FeatType type) const = 0;
+    virtual int getLevelUpChoiceCount(const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
+    virtual bool isLevelUpCandidate(FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
+    virtual std::vector<FeatType> getLevelUpCandidates(const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
 };
 
 class Feats : public IFeats, boost::noncopyable {
@@ -56,6 +62,9 @@ public:
     void init() override;
 
     std::shared_ptr<Feat> get(FeatType type) const override;
+    int getLevelUpChoiceCount(const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
+    bool isLevelUpCandidate(FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
+    std::vector<FeatType> getLevelUpCandidates(const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
 
 private:
     std::unordered_map<FeatType, std::shared_ptr<Feat>> _feats;

--- a/src/libs/game/d20/class.cpp
+++ b/src/libs/game/d20/class.cpp
@@ -30,6 +30,19 @@ namespace reone {
 namespace game {
 
 static const char kSkillsTwoDAResRef[] = "skills";
+static const char kFeatTwoDAResRef[] = "feat";
+static const char kFeatGainTwoDAResRef[] = "featgain";
+
+static bool hasColumn(const TwoDA &twoDa, const std::string &column) {
+    return std::find(twoDa.columns().begin(), twoDa.columns().end(), column) != twoDa.columns().end();
+}
+
+static std::optional<int> getLevel(const TwoDA &twoDa, int row) {
+    if (auto level = twoDa.getIntOpt(row, "label")) {
+        return level;
+    }
+    return twoDa.getIntOpt(row, "level");
+}
 
 void CreatureClass::load(const TwoDA &twoDa, int row) {
     _name = _strings.getText(twoDa.getInt(row, "name"));
@@ -53,6 +66,12 @@ void CreatureClass::load(const TwoDA &twoDa, int row) {
 
     std::string attackBonusTable(boost::to_lower_copy(twoDa.getString(row, "attackbonustable")));
     loadAttackBonuses(attackBonusTable);
+
+    std::string featsPrefix(boost::to_lower_copy(twoDa.getString(row, "featstable")));
+    loadSelectableFeats(featsPrefix);
+
+    std::string featGainPrefix(boost::to_lower_copy(twoDa.getString(row, "featgain")));
+    loadFeatGains(featGainPrefix);
 }
 
 void CreatureClass::loadClassSkills(const std::string &skillsTable) {
@@ -85,6 +104,44 @@ void CreatureClass::loadAttackBonuses(const std::string &attackBonusTable) {
     }
 }
 
+void CreatureClass::loadSelectableFeats(const std::string &featsPrefix) {
+    if (featsPrefix.empty()) {
+        return;
+    }
+
+    std::shared_ptr<TwoDA> feats(_twoDas.get(kFeatTwoDAResRef));
+    std::string listColumn(featsPrefix + "_list");
+    if (!feats || !hasColumn(*feats, listColumn)) {
+        return;
+    }
+
+    for (int row = 0; row < feats->getRowCount(); ++row) {
+        int listValue = feats->getInt(row, listColumn, 4);
+        if (listValue == 0 || listValue == 1) {
+            _selectableFeats.insert(static_cast<FeatType>(row));
+        }
+    }
+}
+
+void CreatureClass::loadFeatGains(const std::string &featGainPrefix) {
+    if (featGainPrefix.empty()) {
+        return;
+    }
+
+    std::shared_ptr<TwoDA> featGain(_twoDas.get(kFeatGainTwoDAResRef));
+    std::string regularGainColumn(featGainPrefix + "_reg");
+    if (!featGain || !hasColumn(*featGain, regularGainColumn)) {
+        return;
+    }
+
+    for (int row = 0; row < featGain->getRowCount(); ++row) {
+        auto level = getLevel(*featGain, row);
+        if (level) {
+            _featGainsByLevel.insert(std::make_pair(*level, featGain->getInt(row, regularGainColumn, 0)));
+        }
+    }
+}
+
 bool CreatureClass::isClassSkill(SkillType skill) const {
     return _classSkills.count(skill) > 0;
 }
@@ -102,6 +159,11 @@ int CreatureClass::getAttackBonus(int level) const {
         throw std::out_of_range(str(boost::format("Level out of range: %d/%d") % level % static_cast<int>(_attackBonuses.size())));
     }
     return _attackBonuses[level - 1];
+}
+
+int CreatureClass::getFeatGain(int level) const {
+    auto maybeFeatGain = _featGainsByLevel.find(level);
+    return maybeFeatGain != _featGainsByLevel.end() ? maybeFeatGain->second : 0;
 }
 
 } // namespace game

--- a/src/libs/game/d20/feats.cpp
+++ b/src/libs/game/d20/feats.cpp
@@ -22,12 +22,19 @@
 #include "reone/resource/provider/textures.h"
 #include "reone/resource/strings.h"
 
+#include "reone/game/d20/attributes.h"
+#include "reone/game/d20/class.h"
+
 using namespace reone::graphics;
 using namespace reone::resource;
 
 namespace reone {
 
 namespace game {
+
+static bool isValidFeat(FeatType type) {
+    return type != FeatType::Invalid;
+}
 
 void Feats::init() {
     std::shared_ptr<TwoDA> feats(_twoDas.get("feat"));
@@ -61,6 +68,47 @@ void Feats::init() {
 std::shared_ptr<Feat> Feats::get(FeatType type) const {
     auto it = _feats.find(type);
     return it != _feats.end() ? it->second : nullptr;
+}
+
+int Feats::getLevelUpChoiceCount(const CreatureAttributes &attributes, const CreatureClass &clazz) const {
+    int nextClassLevel = attributes.getClassLevel(clazz.type()) + 1;
+    return clazz.getFeatGain(nextClassLevel);
+}
+
+bool Feats::isLevelUpCandidate(FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz) const {
+    if (!isValidFeat(type) || attributes.hasFeat(type) || !clazz.isFeatSelectable(type)) {
+        return false;
+    }
+
+    std::shared_ptr<Feat> feat(get(type));
+    if (!feat) {
+        return false;
+    }
+
+    int nextCharacterLevel = attributes.getAggregateLevel() + 1;
+    if (nextCharacterLevel < static_cast<int>(feat->minCharLevel)) {
+        return false;
+    }
+
+    if (isValidFeat(feat->preReqFeat1) && !attributes.hasFeat(feat->preReqFeat1)) {
+        return false;
+    }
+    if (isValidFeat(feat->preReqFeat2) && !attributes.hasFeat(feat->preReqFeat2)) {
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<FeatType> Feats::getLevelUpCandidates(const CreatureAttributes &attributes, const CreatureClass &clazz) const {
+    std::vector<FeatType> result;
+    for (auto &feat : _feats) {
+        if (isLevelUpCandidate(feat.first, attributes, clazz)) {
+            result.push_back(feat.first);
+        }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
 }
 
 } // namespace game

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -55,6 +55,9 @@ class MockFeats : public IFeats, boost::noncopyable {
 public:
     MOCK_METHOD(void, init, (), (override));
     MOCK_METHOD(std::shared_ptr<Feat>, get, (FeatType type), (const override));
+    MOCK_METHOD(int, getLevelUpChoiceCount, (const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
+    MOCK_METHOD(bool, isLevelUpCandidate, (FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
+    MOCK_METHOD(std::vector<FeatType>, getLevelUpCandidates, (const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
 };
 
 class MockFootstepSounds : public IFootstepSounds, boost::noncopyable {


### PR DESCRIPTION
## Summary

Adds resource-driven helper rules for level-up feat choice counts and candidate filtering.

This reads KOTOR/K2 feat acquisition data from shared 2DA tables:

- `classes.2da featstable` -> `<prefix>_list` in `feat.2da`
- `classes.2da featgain` -> `<prefix>_reg` in `featgain.2da`

## Behavior

- Determines discretionary feat choice count for a class level.
- Determines whether a feat is selectable for a class.
- Provides reusable level-up feat candidate filtering.
- Excludes invalid feats, already-owned feats, non-selectable class feats, feats above current character level, and feats whose explicit prerequisites are missing.

## Scope

- No Feats GUI page.
- No LevelUpMenu step wiring.
- No selected feat application.
- No auto-granted feat application.
- No Force Powers.
- No save/load changes.
- No character sheet, journal, inventory, or combat feat activation changes.