### PR TITLE
[game][gui] Implement level-up Feats selection

### DIFF
--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -46,6 +46,8 @@ public:
         _resRef = guiResRef("ftchrgen");
     }
 
+    void reset(bool levelUp);
+
 private:
     struct Controls {
         std::shared_ptr<gui::Button> BTN_ACCEPT;
@@ -67,6 +69,7 @@ private:
     Controls _controls;
 
     CharacterGeneration &_charGen;
+    int _points {0};
 
     void onGUILoaded() override;
 
@@ -86,6 +89,9 @@ private:
         _controls.STD_SELECTIONS_REMAINING_LBL = findControl<gui::Label>("STD_SELECTIONS_REMAINING_LBL");
         _controls.SUB_TITLE_LBL = findControl<gui::Label>("SUB_TITLE_LBL");
     }
+
+    void loadLevelUpCandidates();
+    void onFeatSelected(const std::string &feat);
 };
 
 } // namespace game

--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -21,6 +21,7 @@
 #include "reone/gui/control/label.h"
 #include "reone/gui/control/listbox.h"
 
+#include "../../types.h"
 #include "../../gui.h"
 
 namespace reone {
@@ -69,7 +70,10 @@ private:
     Controls _controls;
 
     CharacterGeneration &_charGen;
+    std::vector<FeatType> _candidates;
+    std::set<FeatType> _selectedFeats;
     int _points {0};
+    bool _levelUp {false};
 
     void onGUILoaded() override;
 
@@ -91,6 +95,9 @@ private:
     }
 
     void loadLevelUpCandidates();
+    void refreshControls();
+    void updateCharacter();
+    void toggleSelectedFeat(FeatType feat);
     void onFeatSelected(const std::string &feat);
 };
 

--- a/include/reone/game/gui/chargen/levelup.h
+++ b/include/reone/game/gui/chargen/levelup.h
@@ -79,6 +79,7 @@ private:
     CharacterGeneration &_charGen;
     int _step {0};
     bool _hasAttributes {false};
+    bool _hasFeats {false};
 
     void onGUILoaded() override;
 
@@ -103,6 +104,7 @@ private:
     }
 
     void doSetStep(int step);
+    bool hasFeatChoices() const;
 };
 
 } // namespace game

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -299,6 +299,7 @@ void CharacterGeneration::openSkills() {
 }
 
 void CharacterGeneration::openFeats() {
+    _charGenFeats->reset(_type == Type::LevelUp);
     _controls.MODEL_LBL->setVisible(false);
     changeScreen(CharGenScreen::Feats);
 }

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -39,6 +39,7 @@ void CharGenFeats::onGUILoaded() {
 
     _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LB_FEATS->setSelectionMode(ListBox::SelectionMode::OnClick);
+    _controls.LB_FEATS->setRenderItemIconsForButtonProto(true);
     _controls.LB_FEATS->setOnItemClick([this](const std::string &item) {
         onFeatSelected(item);
     });
@@ -120,6 +121,9 @@ void CharGenFeats::toggleSelectedFeat(FeatType feat) {
     auto maybeSelectedFeat = _selectedFeats.find(feat);
     if (maybeSelectedFeat != _selectedFeats.end()) {
         _selectedFeats.erase(maybeSelectedFeat);
+    } else if (_points == 1) {
+        _selectedFeats.clear();
+        _selectedFeats.insert(feat);
     } else if (_selectedFeats.size() < static_cast<size_t>(_points)) {
         _selectedFeats.insert(feat);
     }

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -17,9 +17,12 @@
 
 #include "reone/game/gui/chargen/feats.h"
 
+#include "reone/game/d20/classes.h"
+#include "reone/game/d20/feats.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/chargen.h"
 #include "reone/gui/control/button.h"
+#include "reone/gui/control/listbox.h"
 
 using namespace reone::audio;
 
@@ -34,6 +37,11 @@ namespace game {
 void CharGenFeats::onGUILoaded() {
     bindControls();
 
+    _controls.LB_DESC->setProtoMatchContent(true);
+    _controls.LB_FEATS->setOnItemClick([this](const std::string &item) {
+        onFeatSelected(item);
+    });
+
     _controls.BTN_ACCEPT->setOnClick([this]() {
         _charGen.goToNextStep();
         _charGen.openSteps();
@@ -43,6 +51,54 @@ void CharGenFeats::onGUILoaded() {
     });
     _controls.BTN_SELECT->setDisabled(true);
     _controls.BTN_RECOMMENDED->setDisabled(true);
+}
+
+void CharGenFeats::reset(bool levelUp) {
+    _points = 0;
+    _controls.LB_FEATS->clearItems();
+    _controls.LB_DESC->clearItems();
+    _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage("0");
+
+    if (levelUp) {
+        loadLevelUpCandidates();
+    }
+
+    _controls.BTN_ACCEPT->setDisabled(levelUp && _points > 0);
+    _controls.BTN_SELECT->setDisabled(true);
+    _controls.BTN_RECOMMENDED->setDisabled(true);
+}
+
+void CharGenFeats::loadLevelUpCandidates() {
+    const CreatureAttributes &attributes = _charGen.character().attributes;
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
+
+    _points = _services.game.feats.getLevelUpChoiceCount(attributes, *clazz);
+    _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage(std::to_string(_points));
+
+    std::vector<FeatType> candidates(_services.game.feats.getLevelUpCandidates(attributes, *clazz));
+    for (auto featType : candidates) {
+        std::shared_ptr<Feat> feat(_services.game.feats.get(featType));
+        if (!feat) {
+            continue;
+        }
+
+        ListBox::Item item;
+        item.tag = std::to_string(static_cast<int>(featType));
+        item.text = feat->name;
+        item.iconTexture = feat->icon;
+        _controls.LB_FEATS->addItem(std::move(item));
+    }
+}
+
+void CharGenFeats::onFeatSelected(const std::string &feat) {
+    auto featType = static_cast<FeatType>(std::stoi(feat));
+    std::shared_ptr<Feat> featInfo(_services.game.feats.get(featType));
+    if (!featInfo) {
+        return;
+    }
+
+    _controls.LB_DESC->clearItems();
+    _controls.LB_DESC->addTextLinesAsItems(featInfo->description);
 }
 
 } // namespace game

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -38,32 +38,45 @@ void CharGenFeats::onGUILoaded() {
     bindControls();
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    _controls.LB_FEATS->setSelectionMode(ListBox::SelectionMode::OnClick);
     _controls.LB_FEATS->setOnItemClick([this](const std::string &item) {
         onFeatSelected(item);
     });
 
     _controls.BTN_ACCEPT->setOnClick([this]() {
+        if (_levelUp) {
+            if (_selectedFeats.size() != static_cast<size_t>(_points)) {
+                return;
+            }
+            updateCharacter();
+        }
         _charGen.goToNextStep();
         _charGen.openSteps();
     });
     _controls.BTN_BACK->setOnClick([this]() {
-        _charGen.openSteps();
+        _selectedFeats.clear();
+        if (_levelUp) {
+            _charGen.openSkills();
+        } else {
+            _charGen.openSteps();
+        }
     });
     _controls.BTN_SELECT->setDisabled(true);
     _controls.BTN_RECOMMENDED->setDisabled(true);
 }
 
 void CharGenFeats::reset(bool levelUp) {
+    _levelUp = levelUp;
     _points = 0;
-    _controls.LB_FEATS->clearItems();
+    _candidates.clear();
+    _selectedFeats.clear();
     _controls.LB_DESC->clearItems();
-    _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage("0");
 
     if (levelUp) {
         loadLevelUpCandidates();
     }
 
-    _controls.BTN_ACCEPT->setDisabled(levelUp && _points > 0);
+    refreshControls();
     _controls.BTN_SELECT->setDisabled(true);
     _controls.BTN_RECOMMENDED->setDisabled(true);
 }
@@ -73,10 +86,15 @@ void CharGenFeats::loadLevelUpCandidates() {
     std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
 
     _points = _services.game.feats.getLevelUpChoiceCount(attributes, *clazz);
-    _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage(std::to_string(_points));
+    _candidates = _services.game.feats.getLevelUpCandidates(attributes, *clazz);
+}
 
-    std::vector<FeatType> candidates(_services.game.feats.getLevelUpCandidates(attributes, *clazz));
-    for (auto featType : candidates) {
+void CharGenFeats::refreshControls() {
+    _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage(std::to_string(_points - static_cast<int>(_selectedFeats.size())));
+    _controls.BTN_ACCEPT->setDisabled(_levelUp && _selectedFeats.size() != static_cast<size_t>(_points));
+
+    _controls.LB_FEATS->clearItems();
+    for (auto featType : _candidates) {
         std::shared_ptr<Feat> feat(_services.game.feats.get(featType));
         if (!feat) {
             continue;
@@ -84,10 +102,28 @@ void CharGenFeats::loadLevelUpCandidates() {
 
         ListBox::Item item;
         item.tag = std::to_string(static_cast<int>(featType));
-        item.text = feat->name;
+        item.text = (_selectedFeats.count(featType) > 0 ? "* " : "") + feat->name;
         item.iconTexture = feat->icon;
         _controls.LB_FEATS->addItem(std::move(item));
     }
+}
+
+void CharGenFeats::updateCharacter() {
+    Character character(_charGen.character());
+    for (auto feat : _selectedFeats) {
+        character.attributes.addFeat(feat);
+    }
+    _charGen.setCharacter(std::move(character));
+}
+
+void CharGenFeats::toggleSelectedFeat(FeatType feat) {
+    auto maybeSelectedFeat = _selectedFeats.find(feat);
+    if (maybeSelectedFeat != _selectedFeats.end()) {
+        _selectedFeats.erase(maybeSelectedFeat);
+    } else if (_selectedFeats.size() < static_cast<size_t>(_points)) {
+        _selectedFeats.insert(feat);
+    }
+    refreshControls();
 }
 
 void CharGenFeats::onFeatSelected(const std::string &feat) {
@@ -99,6 +135,10 @@ void CharGenFeats::onFeatSelected(const std::string &feat) {
 
     _controls.LB_DESC->clearItems();
     _controls.LB_DESC->addTextLinesAsItems(featInfo->description);
+
+    if (_levelUp) {
+        toggleSelectedFeat(featType);
+    }
 }
 
 } // namespace game

--- a/src/libs/game/gui/chargen/levelup.cpp
+++ b/src/libs/game/gui/chargen/levelup.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/gui/chargen/levelup.h"
 
+#include "reone/game/d20/classes.h"
+#include "reone/game/d20/feats.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/chargen.h"
 #include "reone/gui/control/button.h"
@@ -46,6 +48,9 @@ void LevelUpMenu::onGUILoaded() {
     _controls.BTN_STEPNAME2->setOnClick([this]() {
         _charGen.openSkills();
     });
+    _controls.BTN_STEPNAME3->setOnClick([this]() {
+        _charGen.openFeats();
+    });
     _controls.BTN_STEPNAME5->setOnClick([this]() {
         _charGen.finish();
     });
@@ -54,17 +59,18 @@ void LevelUpMenu::onGUILoaded() {
 void LevelUpMenu::reset() {
     int nextLevel = _charGen.character().attributes.getAggregateLevel() + 1;
     _hasAttributes = nextLevel % 4 == 0;
+    _hasFeats = hasFeatChoices();
 
-    // TODO: feats and Force Powers are not yet implemented
+    // TODO: Force Powers are not yet implemented
 
     _controls.LBL_1->setVisible(_hasAttributes);
-    _controls.LBL_3->setVisible(false);
+    _controls.LBL_3->setVisible(_hasFeats);
     _controls.LBL_4->setVisible(false);
     _controls.LBL_NUM1->setVisible(_hasAttributes);
-    _controls.LBL_NUM3->setVisible(false);
+    _controls.LBL_NUM3->setVisible(_hasFeats);
     _controls.LBL_NUM4->setVisible(false);
     _controls.BTN_STEPNAME1->setVisible(_hasAttributes);
-    _controls.BTN_STEPNAME3->setVisible(false);
+    _controls.BTN_STEPNAME3->setVisible(_hasFeats);
     _controls.BTN_STEPNAME4->setVisible(false);
 }
 
@@ -74,6 +80,9 @@ void LevelUpMenu::goToNextStep() {
         doSetStep(1);
         break;
     case 1:
+        doSetStep(_hasFeats ? 2 : 4);
+        break;
+    case 2:
         doSetStep(4);
         break;
     default:
@@ -116,6 +125,12 @@ void LevelUpMenu::doSetStep(int step) {
     _controls.BTN_STEPNAME3->setSelected(_step == 2);
     _controls.BTN_STEPNAME4->setSelected(_step == 3);
     _controls.BTN_STEPNAME5->setSelected(_step == 4);
+}
+
+bool LevelUpMenu::hasFeatChoices() const {
+    const CreatureAttributes &attributes = _charGen.character().attributes;
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
+    return _services.game.feats.getLevelUpChoiceCount(attributes, *clazz) > 0;
 }
 
 } // namespace game


### PR DESCRIPTION
## Summary

Implements the level-up Feats selection flow.

- routes level-up through the Feats page when discretionary feat choices are due
- displays D20-filtered feat candidates with icons and descriptions
- supports selecting/deselecting feats
- supports single-choice replacement
- enables Accept only when the required number of feats is selected
- applies selected feats to the transient level-up character before Finish

## Notes

- consumes the merged feat candidate helper APIs
- keeps `Finish` as the commit point to the party leader
- does not implement auto-granted feats
- does not implement character-creation Feats parity
- does not change save/load, journal, inventory, character sheet, or combat feat activation