### PR TITLE
[game] Parse feat metadata as decimal

### DIFF
--- a/src/libs/game/d20/feats.cpp
+++ b/src/libs/game/d20/feats.cpp
@@ -46,11 +46,11 @@ void Feats::init() {
         std::string name(_strings.getText(feats->getInt(row, "name", -1)));
         std::string description(_strings.getText(feats->getInt(row, "description", -1)));
         std::shared_ptr<Texture> icon(_textures.get(feats->getString(row, "icon"), TextureUsage::GUI));
-        uint32_t minCharLevel = feats->getHexInt(row, "mincharlevel");
-        auto preReqFeat1 = static_cast<FeatType>(feats->getHexInt(row, "prereqfeat1"));
-        auto preReqFeat2 = static_cast<FeatType>(feats->getHexInt(row, "prereqfeat2"));
-        auto successor = static_cast<FeatType>(feats->getHexInt(row, "successor"));
-        uint32_t pips = feats->getHexInt(row, "pips");
+        uint32_t minCharLevel = feats->getInt(row, "mincharlevel");
+        auto preReqFeat1 = static_cast<FeatType>(feats->getInt(row, "prereqfeat1"));
+        auto preReqFeat2 = static_cast<FeatType>(feats->getInt(row, "prereqfeat2"));
+        auto successor = static_cast<FeatType>(feats->getInt(row, "successor"));
+        uint32_t pips = feats->getInt(row, "pips");
 
         auto feat = std::make_shared<Feat>();
         feat->name = std::move(name);


### PR DESCRIPTION
## Summary

Parses decimal-valued feat metadata fields in `feat.2da` as decimal rather than hexadecimal.

## Behaviour

Updates parsing for:

- `mincharlevel`
- `prereqfeat1`
- `prereqfeat2`
- `successor`
- `pips`

These fields contain decimal row IDs / values in K1/K2 resources. Parsing them as hex caused values such as `14`, `19`, and `81` to become incorrect feat IDs.

## Impact

Fixes feat prerequisite and chain metadata used by level-up feat selection/display logic.  Feats for test that were used were Implant feat tree and Critical strike.  Observed behaviour with this patch:

- Implant Level 2 unlocking after Implant Level 1
- Implant Level 3 requiring Implant Levels 1 and 2
- Critical Strike → Improved Critical Strike → Master Critical Strike chain linkage