### PR TITLE
[gui] Implement level-up Feats icon-chain presentation

### DIFF
--- a/include/reone/game/d20/class.h
+++ b/include/reone/game/d20/class.h
@@ -71,7 +71,11 @@ public:
     const CreatureAttributes &defaultAttributes() const { return _defaultAttributes; }
     int skillPointBase() const { return _skillPointBase; }
     int getFeatGain(int level) const;
-    bool isFeatSelectable(FeatType feat) const { return _selectableFeats.count(feat) > 0; }
+    int getFeatListValue(FeatType feat) const;
+    bool isFeatSelectable(FeatType feat) const {
+        int listValue = getFeatListValue(feat);
+        return listValue == 0 || listValue == 1;
+    }
 
 private:
     ClassType _type;
@@ -81,7 +85,7 @@ private:
     CreatureAttributes _defaultAttributes;
     int _skillPointBase {0};
     std::unordered_set<SkillType> _classSkills;
-    std::unordered_set<FeatType> _selectableFeats;
+    std::unordered_map<FeatType, int> _featListValues;
     std::unordered_map<int, SavingThrows> _savingThrowsByLevel;
     std::unordered_map<int, int> _featGainsByLevel;
     std::vector<int> _attackBonuses;
@@ -98,7 +102,7 @@ private:
     void loadClassSkills(const std::string &skillsTable);
     void loadSavingThrows(const std::string &savingThrowTable);
     void loadAttackBonuses(const std::string &attackBonusTable);
-    void loadSelectableFeats(const std::string &featsPrefix);
+    void loadFeatListValues(const std::string &featsPrefix);
     void loadFeatGains(const std::string &featGainPrefix);
 };
 

--- a/include/reone/game/d20/feats.h
+++ b/include/reone/game/d20/feats.h
@@ -36,6 +36,21 @@ namespace game {
 class CreatureAttributes;
 class CreatureClass;
 
+enum class FeatAvailability {
+    Owned,
+    Selectable,
+    LockedMinLevel,
+    LockedMissingPrerequisite
+};
+
+struct FeatDisplayEntry {
+    FeatType type {FeatType::Invalid};
+    FeatAvailability availability {FeatAvailability::Owned};
+    FeatType chainRoot {FeatType::Invalid};
+    int tier {0};
+    int visualIndex {0};
+};
+
 class IFeats {
 public:
     virtual ~IFeats() = default;
@@ -46,6 +61,7 @@ public:
     virtual int getLevelUpChoiceCount(const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
     virtual bool isLevelUpCandidate(FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
     virtual std::vector<FeatType> getLevelUpCandidates(const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
+    virtual std::vector<FeatDisplayEntry> getLevelUpDisplayEntries(const CreatureAttributes &attributes, const CreatureClass &clazz) const = 0;
 };
 
 class Feats : public IFeats, boost::noncopyable {
@@ -65,6 +81,7 @@ public:
     int getLevelUpChoiceCount(const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
     bool isLevelUpCandidate(FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
     std::vector<FeatType> getLevelUpCandidates(const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
+    std::vector<FeatDisplayEntry> getLevelUpDisplayEntries(const CreatureAttributes &attributes, const CreatureClass &clazz) const override;
 
 private:
     std::unordered_map<FeatType, std::shared_ptr<Feat>> _feats;

--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -103,6 +103,7 @@ private:
     void refreshSelectionControls();
     void refreshIconChain();
     void refreshIconChainSelection();
+    void refreshIconChainLinks();
     void refreshListBox();
     void updateCharacter();
     void toggleSelectedFeat(FeatType feat);

--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -30,6 +30,7 @@ namespace reone {
 namespace gui {
 
 class Button;
+class IconChain;
 
 }
 
@@ -60,6 +61,7 @@ private:
         std::shared_ptr<gui::Label> LBL_BAR1;
         std::shared_ptr<gui::Label> LBL_BAR2;
         std::shared_ptr<gui::Label> LBL_NAME;
+        std::shared_ptr<gui::IconChain> ICONCHAIN_FEATS;
         std::shared_ptr<gui::ListBox> LB_DESC;
         std::shared_ptr<gui::ListBox> LB_FEATS;
         std::shared_ptr<gui::Label> MAIN_TITLE_LBL;
@@ -97,8 +99,14 @@ private:
 
     void loadLevelUpDisplayEntries();
     void refreshControls();
+    void refreshSelectionControls();
+    void refreshIconChain();
+    void refreshIconChainSelection();
+    void refreshListBox();
     void updateCharacter();
     void toggleSelectedFeat(FeatType feat);
+    void showFeatDescription(FeatType feat);
+    void onFeatFocused(const std::string &feat);
     void onFeatSelected(const std::string &feat);
 };
 

--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -21,6 +21,7 @@
 #include "reone/gui/control/label.h"
 #include "reone/gui/control/listbox.h"
 
+#include "../../d20/feats.h"
 #include "../../types.h"
 #include "../../gui.h"
 
@@ -70,7 +71,7 @@ private:
     Controls _controls;
 
     CharacterGeneration &_charGen;
-    std::vector<FeatType> _candidates;
+    std::vector<FeatDisplayEntry> _displayEntries;
     std::set<FeatType> _selectedFeats;
     int _points {0};
     bool _levelUp {false};
@@ -94,7 +95,7 @@ private:
         _controls.SUB_TITLE_LBL = findControl<gui::Label>("SUB_TITLE_LBL");
     }
 
-    void loadLevelUpCandidates();
+    void loadLevelUpDisplayEntries();
     void refreshControls();
     void updateCharacter();
     void toggleSelectedFeat(FeatType feat);

--- a/include/reone/game/gui/chargen/feats.h
+++ b/include/reone/game/gui/chargen/feats.h
@@ -75,6 +75,7 @@ private:
     CharacterGeneration &_charGen;
     std::vector<FeatDisplayEntry> _displayEntries;
     std::set<FeatType> _selectedFeats;
+    std::string _defaultFeatNameText;
     int _points {0};
     bool _levelUp {false};
 
@@ -106,8 +107,10 @@ private:
     void updateCharacter();
     void toggleSelectedFeat(FeatType feat);
     void showFeatDescription(FeatType feat);
+    void resetFocusedFeatName();
     void onFeatFocused(const std::string &feat);
-    void onFeatSelected(const std::string &feat);
+    void onFeatActivated(const std::string &feat);
+    void activateFocusedFeat();
 };
 
 } // namespace game

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -40,6 +40,11 @@ public:
         bool selected {false};
     };
 
+    struct Link {
+        std::string sourceTag;
+        std::string targetTag;
+    };
+
     struct CellStyle {
         struct BorderColors {
             glm::vec3 locked {1.0f};
@@ -56,9 +61,11 @@ public:
         };
 
         std::shared_ptr<graphics::Texture> backgroundTexture;
+        std::shared_ptr<graphics::Texture> linkTexture;
         std::shared_ptr<Border> itemBorder;
         std::shared_ptr<BorderColors> borderColors;
         std::shared_ptr<FocusedBorderColors> focusedBorderColors;
+        glm::ivec2 linkSize {0};
         int iconSize {0};
         bool dimLockedBackground {false};
         bool drawItemBorderFill {true};
@@ -82,6 +89,8 @@ public:
 
     void clearItems();
     void addItem(Item item);
+    void clearLinks();
+    void addLink(Link link);
     void setItemSelected(const std::string &tag, bool selected);
     const Item *focusedItem() const;
 
@@ -110,6 +119,7 @@ public:
 
 private:
     std::vector<Item> _items;
+    std::vector<Link> _links;
     int _columnCount {0};
     int _cellSize {0};
     glm::ivec2 _cellSpacing {0};
@@ -138,6 +148,7 @@ private:
     int getVisibleRowCount() const;
     int getMaxRow() const;
     int getItemIndex(int x, int y) const;
+    const Item *findItem(const std::string &tag) const;
     void clearFocusedItem();
     Extent getItemExtent(const Item &item) const;
     Extent getItemIconExtent(const Extent &itemExtent) const;
@@ -147,6 +158,10 @@ private:
     glm::vec4 getItemIconColor(const Item &item) const;
     std::optional<glm::vec3> getFocusedBorderColor(const Item &item, bool focused) const;
     float getFocusedBorderPulseFactor() const;
+    void renderLink(
+        const Link &link,
+        const glm::ivec2 &offset,
+        scene::IRenderPass &pass) const;
     void renderItemBorder(
         const Item &item,
         bool focused,

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -40,6 +40,31 @@ public:
         bool selected {false};
     };
 
+    struct CellStyle {
+        struct BorderColors {
+            glm::vec3 locked {1.0f};
+            glm::vec3 selectable {1.0f};
+            glm::vec3 owned {1.0f};
+            glm::vec3 selected {1.0f};
+        };
+
+        struct FocusedBorderColors {
+            glm::vec3 locked {1.0f};
+            glm::vec3 selectable {1.0f};
+            glm::vec3 owned {1.0f};
+            glm::vec3 selected {1.0f};
+        };
+
+        std::shared_ptr<graphics::Texture> backgroundTexture;
+        std::shared_ptr<Border> itemBorder;
+        std::shared_ptr<BorderColors> borderColors;
+        std::shared_ptr<FocusedBorderColors> focusedBorderColors;
+        int iconSize {0};
+        bool dimLockedBackground {false};
+        bool drawItemBorderFill {true};
+        bool onlyDrawItemBorderWhenBright {false};
+    };
+
     IconChain(
         IGUI &gui,
         scene::ISceneGraphs &sceneGraphs,
@@ -63,12 +88,17 @@ public:
     bool handleMouseMotion(int x, int y) override;
     bool handleMouseWheel(int x, int y) override;
     bool handleClick(int x, int y, int clicks = 1) override;
+    void update(float dt) override;
     void render(const glm::ivec2 &screenSize, const glm::ivec2 &offset, scene::IRenderPass &pass) override;
     void setSelected(bool selected) override;
 
     void setColumnCount(int count);
     void setCellSize(int size);
     void setCellSpacing(int x, int y);
+    void setCellOrigin(int x, int y);
+    void setCellStep(int x, int y);
+    void setRowOffsets(std::vector<int> offsets);
+    void setCellStyle(CellStyle style);
 
     // Event listeners
 
@@ -83,8 +113,13 @@ private:
     int _columnCount {0};
     int _cellSize {0};
     glm::ivec2 _cellSpacing {0};
+    glm::ivec2 _cellOrigin {-1};
+    glm::ivec2 _cellStep {0};
+    std::vector<int> _rowOffsets;
+    CellStyle _cellStyle;
     int _rowOffset {0};
     int _focusedItemIndex {-1};
+    float _focusedBorderPulsePhase {0.0f};
 
     // Event listeners
 
@@ -96,14 +131,29 @@ private:
 
     bool hasValidPosition(const Item &item) const;
     bool isItemVisible(const Extent &extent) const;
+    int getCellOriginX() const;
+    int getCellOriginY() const;
+    int getCellStepX() const;
+    int getCellStepY() const;
     int getVisibleRowCount() const;
     int getMaxRow() const;
     int getItemIndex(int x, int y) const;
     void clearFocusedItem();
     Extent getItemExtent(const Item &item) const;
+    Extent getItemIconExtent(const Extent &itemExtent) const;
+    bool isItemBright(const Item &item) const;
+    glm::vec4 getCellBackgroundColor(const Item &item) const;
     glm::vec3 getItemBorderColor(const Item &item, bool focused) const;
     glm::vec4 getItemIconColor(const Item &item) const;
+    std::optional<glm::vec3> getFocusedBorderColor(const Item &item, bool focused) const;
+    float getFocusedBorderPulseFactor() const;
     void renderItemBorder(
+        const Item &item,
+        bool focused,
+        const Extent &extent,
+        const glm::ivec2 &offset,
+        scene::IRenderPass &pass);
+    void renderFocusedBorder(
         const Item &item,
         bool focused,
         const Extent &extent,

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -57,6 +57,7 @@ public:
 
     void clearItems();
     void addItem(Item item);
+    void setItemSelected(const std::string &tag, bool selected);
 
     bool handleMouseMotion(int x, int y) override;
     bool handleMouseWheel(int x, int y) override;

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "../control.h"
+
+namespace reone {
+
+namespace gui {
+
+class IconChain : public Control {
+public:
+    enum class State {
+        Owned,
+        Selectable,
+        Locked
+    };
+
+    struct Item {
+        std::string tag;
+        int row {0};
+        int column {0};
+        std::shared_ptr<graphics::Texture> iconTexture;
+        State state {State::Owned};
+        bool selected {false};
+    };
+
+    IconChain(
+        IGUI &gui,
+        scene::ISceneGraphs &sceneGraphs,
+        graphics::GraphicsServices &graphicsSvc,
+        resource::ResourceServices &resourceSvc) :
+        Control(
+            gui,
+            ControlType::IconChain,
+            sceneGraphs,
+            graphicsSvc,
+            resourceSvc) {
+
+        _selectable = true;
+    }
+
+    void clearItems();
+    void addItem(Item item);
+
+    bool handleMouseMotion(int x, int y) override;
+    bool handleMouseWheel(int x, int y) override;
+    bool handleClick(int x, int y, int clicks = 1) override;
+    void render(const glm::ivec2 &screenSize, const glm::ivec2 &offset, scene::IRenderPass &pass) override;
+    void setSelected(bool selected) override;
+
+    void setColumnCount(int count);
+    void setCellSize(int size);
+    void setCellSpacing(int x, int y);
+
+    // Event listeners
+
+    void setOnItemFocus(std::function<void(const std::string &)> fn) { _onItemFocus = std::move(fn); }
+    void setOnItemClick(std::function<void(const std::string &)> fn) { _onItemClick = std::move(fn); }
+
+    // END Event listeners
+
+private:
+    std::vector<Item> _items;
+    int _columnCount {0};
+    int _cellSize {0};
+    glm::ivec2 _cellSpacing {0};
+    int _rowOffset {0};
+    int _focusedItemIndex {-1};
+
+    // Event listeners
+
+    std::function<void(const std::string &)> _onItemFocus;
+    std::function<void(const std::string &)> _onItemClick;
+
+    // END Event listeners
+
+    bool hasValidPosition(const Item &item) const;
+    bool isItemVisible(const Extent &extent) const;
+    int getVisibleRowCount() const;
+    int getMaxRow() const;
+    int getItemIndex(int x, int y) const;
+    Extent getItemExtent(const Item &item) const;
+    glm::vec3 getItemBorderColor(const Item &item, bool focused) const;
+    glm::vec4 getItemIconColor(const Item &item) const;
+    void renderItemBorder(
+        const Item &item,
+        bool focused,
+        const Extent &extent,
+        const glm::ivec2 &offset,
+        scene::IRenderPass &pass);
+};
+
+} // namespace gui
+
+} // namespace reone

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -58,6 +58,7 @@ public:
     void clearItems();
     void addItem(Item item);
     void setItemSelected(const std::string &tag, bool selected);
+    const Item *focusedItem() const;
 
     bool handleMouseMotion(int x, int y) override;
     bool handleMouseWheel(int x, int y) override;
@@ -72,7 +73,8 @@ public:
     // Event listeners
 
     void setOnItemFocus(std::function<void(const std::string &)> fn) { _onItemFocus = std::move(fn); }
-    void setOnItemClick(std::function<void(const std::string &)> fn) { _onItemClick = std::move(fn); }
+    void setOnItemFocusCleared(std::function<void()> fn) { _onItemFocusCleared = std::move(fn); }
+    void setOnItemDoubleClick(std::function<void(const std::string &)> fn) { _onItemDoubleClick = std::move(fn); }
 
     // END Event listeners
 
@@ -87,7 +89,8 @@ private:
     // Event listeners
 
     std::function<void(const std::string &)> _onItemFocus;
-    std::function<void(const std::string &)> _onItemClick;
+    std::function<void()> _onItemFocusCleared;
+    std::function<void(const std::string &)> _onItemDoubleClick;
 
     // END Event listeners
 
@@ -96,6 +99,7 @@ private:
     int getVisibleRowCount() const;
     int getMaxRow() const;
     int getItemIndex(int x, int y) const;
+    void clearFocusedItem();
     Extent getItemExtent(const Item &item) const;
     glm::vec3 getItemBorderColor(const Item &item, bool focused) const;
     glm::vec4 getItemIconColor(const Item &item) const;

--- a/include/reone/gui/types.h
+++ b/include/reone/gui/types.h
@@ -31,7 +31,8 @@ enum class ControlType {
     Slider = 8,
     ScrollBar = 9,
     ProgressBar = 10,
-    ListBox = 11
+    ListBox = 11,
+    IconChain = 12
 };
 
 } // namespace gui

--- a/src/libs/game/d20/class.cpp
+++ b/src/libs/game/d20/class.cpp
@@ -68,7 +68,7 @@ void CreatureClass::load(const TwoDA &twoDa, int row) {
     loadAttackBonuses(attackBonusTable);
 
     std::string featsPrefix(boost::to_lower_copy(twoDa.getString(row, "featstable")));
-    loadSelectableFeats(featsPrefix);
+    loadFeatListValues(featsPrefix);
 
     std::string featGainPrefix(boost::to_lower_copy(twoDa.getString(row, "featgain")));
     loadFeatGains(featGainPrefix);
@@ -104,7 +104,7 @@ void CreatureClass::loadAttackBonuses(const std::string &attackBonusTable) {
     }
 }
 
-void CreatureClass::loadSelectableFeats(const std::string &featsPrefix) {
+void CreatureClass::loadFeatListValues(const std::string &featsPrefix) {
     if (featsPrefix.empty()) {
         return;
     }
@@ -117,9 +117,7 @@ void CreatureClass::loadSelectableFeats(const std::string &featsPrefix) {
 
     for (int row = 0; row < feats->getRowCount(); ++row) {
         int listValue = feats->getInt(row, listColumn, 4);
-        if (listValue == 0 || listValue == 1) {
-            _selectableFeats.insert(static_cast<FeatType>(row));
-        }
+        _featListValues.insert(std::make_pair(static_cast<FeatType>(row), listValue));
     }
 }
 
@@ -164,6 +162,11 @@ int CreatureClass::getAttackBonus(int level) const {
 int CreatureClass::getFeatGain(int level) const {
     auto maybeFeatGain = _featGainsByLevel.find(level);
     return maybeFeatGain != _featGainsByLevel.end() ? maybeFeatGain->second : 0;
+}
+
+int CreatureClass::getFeatListValue(FeatType feat) const {
+    auto maybeFeatListValue = _featListValues.find(feat);
+    return maybeFeatListValue != _featListValues.end() ? maybeFeatListValue->second : 4;
 }
 
 } // namespace game

--- a/src/libs/game/d20/feats.cpp
+++ b/src/libs/game/d20/feats.cpp
@@ -36,6 +36,182 @@ static bool isValidFeat(FeatType type) {
     return type != FeatType::Invalid;
 }
 
+static bool isManualFeatListValue(int value) {
+    return value == 0 || value == 1;
+}
+
+static bool hasPrerequisite(const Feat &feat, FeatType prerequisite) {
+    return feat.preReqFeat1 == prerequisite || feat.preReqFeat2 == prerequisite;
+}
+
+static std::vector<FeatType> getValidPrerequisites(
+    const Feat &feat,
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats) {
+
+    std::vector<FeatType> result;
+    if (isValidFeat(feat.preReqFeat1) && feats.count(feat.preReqFeat1) > 0) {
+        result.push_back(feat.preReqFeat1);
+    }
+    if (isValidFeat(feat.preReqFeat2) && feats.count(feat.preReqFeat2) > 0) {
+        result.push_back(feat.preReqFeat2);
+    }
+    return result;
+}
+
+static bool dependsOn(
+    FeatType type,
+    FeatType prerequisite,
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats,
+    std::set<FeatType> &visited) {
+
+    if (!visited.insert(type).second) {
+        return false;
+    }
+
+    auto maybeFeat = feats.find(type);
+    if (maybeFeat == feats.end()) {
+        return false;
+    }
+
+    for (auto directPrerequisite : getValidPrerequisites(*maybeFeat->second, feats)) {
+        if (directPrerequisite == prerequisite ||
+            dependsOn(directPrerequisite, prerequisite, feats, visited)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool dependsOn(
+    FeatType type,
+    FeatType prerequisite,
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats) {
+
+    std::set<FeatType> visited;
+    return dependsOn(type, prerequisite, feats, visited);
+}
+
+static bool isCoherentSuccessor(
+    const Feat &parent,
+    FeatType parentType,
+    const Feat &child,
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats) {
+
+    if (hasPrerequisite(child, parentType)) {
+        return true;
+    }
+
+    auto childPrerequisites = getValidPrerequisites(child, feats);
+    return childPrerequisites.empty() && child.pips == parent.pips + 1;
+}
+
+static std::optional<FeatType> getPrerequisiteParent(
+    const Feat &feat,
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats) {
+
+    auto prerequisites = getValidPrerequisites(feat, feats);
+    if (prerequisites.size() == 1) {
+        return prerequisites.front();
+    }
+    if (prerequisites.size() != 2) {
+        return std::nullopt;
+    }
+
+    if (dependsOn(prerequisites[0], prerequisites[1], feats)) {
+        return prerequisites[0];
+    }
+    if (dependsOn(prerequisites[1], prerequisites[0], feats)) {
+        return prerequisites[1];
+    }
+    return std::nullopt;
+}
+
+static std::unordered_map<FeatType, FeatType> getDisplayParents(
+    const std::unordered_map<FeatType, std::shared_ptr<Feat>> &feats) {
+
+    std::unordered_map<FeatType, std::vector<FeatType>> successorParents;
+    for (auto &feat : feats) {
+        if (!isValidFeat(feat.second->successor) || feats.count(feat.second->successor) == 0) {
+            continue;
+        }
+
+        const Feat &child = *feats.at(feat.second->successor);
+        if (isCoherentSuccessor(*feat.second, feat.first, child, feats)) {
+            successorParents[feat.second->successor].push_back(feat.first);
+        }
+    }
+
+    std::unordered_map<FeatType, FeatType> result;
+    for (auto &feat : feats) {
+        auto maybeSuccessorParents = successorParents.find(feat.first);
+        if (maybeSuccessorParents != successorParents.end() && maybeSuccessorParents->second.size() == 1) {
+            result.insert({feat.first, maybeSuccessorParents->second.front()});
+            continue;
+        }
+
+        auto prerequisiteParent = getPrerequisiteParent(*feat.second, feats);
+        if (prerequisiteParent) {
+            result.insert({feat.first, *prerequisiteParent});
+        }
+    }
+    return result;
+}
+
+static FeatType getChainRoot(
+    FeatType type,
+    const std::unordered_map<FeatType, FeatType> &parents) {
+
+    FeatType result = type;
+    std::set<FeatType> visited;
+    while (visited.insert(result).second) {
+        auto maybeParent = parents.find(result);
+        if (maybeParent == parents.end()) {
+            break;
+        }
+        result = maybeParent->second;
+    }
+    return result;
+}
+
+static int getVisualIndex(
+    FeatType type,
+    const std::unordered_map<FeatType, FeatType> &parents) {
+
+    int result = 0;
+    FeatType current = type;
+    std::set<FeatType> visited;
+    while (visited.insert(current).second) {
+        auto maybeParent = parents.find(current);
+        if (maybeParent == parents.end()) {
+            break;
+        }
+        ++result;
+        current = maybeParent->second;
+    }
+    return result;
+}
+
+static bool hasOwnedChainMember(
+    FeatType type,
+    const CreatureAttributes &attributes,
+    const std::unordered_map<FeatType, FeatType> &parents) {
+
+    FeatType current = type;
+    std::set<FeatType> visited;
+    while (visited.insert(current).second) {
+        if (attributes.hasFeat(current)) {
+            return true;
+        }
+
+        auto maybeParent = parents.find(current);
+        if (maybeParent == parents.end()) {
+            break;
+        }
+        current = maybeParent->second;
+    }
+    return false;
+}
+
 void Feats::init() {
     std::shared_ptr<TwoDA> feats(_twoDas.get("feat"));
     if (!feats) {
@@ -108,6 +284,59 @@ std::vector<FeatType> Feats::getLevelUpCandidates(const CreatureAttributes &attr
         }
     }
     std::sort(result.begin(), result.end());
+    return result;
+}
+
+std::vector<FeatDisplayEntry> Feats::getLevelUpDisplayEntries(const CreatureAttributes &attributes, const CreatureClass &clazz) const {
+    auto parents = getDisplayParents(_feats);
+
+    std::vector<FeatDisplayEntry> result;
+    for (auto &feat : _feats) {
+        FeatType chainRoot = getChainRoot(feat.first, parents);
+
+        bool owned = attributes.hasFeat(feat.first);
+        int listValue = clazz.getFeatListValue(feat.first);
+        bool chainVisible = clazz.isFeatSelectable(chainRoot);
+        bool manualFeatVisible = isManualFeatListValue(listValue) &&
+                                 (chainVisible || hasOwnedChainMember(feat.first, attributes, parents));
+        bool visible = owned || manualFeatVisible;
+        if (!visible) {
+            continue;
+        }
+
+        FeatAvailability availability = FeatAvailability::Owned;
+        if (owned) {
+            availability = FeatAvailability::Owned;
+        } else if (isManualFeatListValue(listValue)) {
+            int nextCharacterLevel = attributes.getAggregateLevel() + 1;
+            if (nextCharacterLevel < static_cast<int>(feat.second->minCharLevel)) {
+                availability = FeatAvailability::LockedMinLevel;
+            } else if ((isValidFeat(feat.second->preReqFeat1) && !attributes.hasFeat(feat.second->preReqFeat1)) ||
+                       (isValidFeat(feat.second->preReqFeat2) && !attributes.hasFeat(feat.second->preReqFeat2))) {
+                availability = FeatAvailability::LockedMissingPrerequisite;
+            } else {
+                availability = FeatAvailability::Selectable;
+            }
+        }
+
+        FeatDisplayEntry entry;
+        entry.type = feat.first;
+        entry.availability = availability;
+        entry.chainRoot = chainRoot;
+        entry.tier = static_cast<int>(feat.second->pips);
+        entry.visualIndex = getVisualIndex(feat.first, parents);
+        result.push_back(std::move(entry));
+    }
+
+    std::sort(result.begin(), result.end(), [](const auto &left, const auto &right) {
+        if (left.chainRoot != right.chainRoot) {
+            return static_cast<int>(left.chainRoot) < static_cast<int>(right.chainRoot);
+        }
+        if (left.visualIndex != right.visualIndex) {
+            return left.visualIndex < right.visualIndex;
+        }
+        return static_cast<int>(left.type) < static_cast<int>(right.type);
+    });
     return result;
 }
 

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -39,9 +39,12 @@ namespace game {
 static constexpr int kFeatIconCellSize = 40;
 static constexpr int kFeatIconColumnCount = 3;
 static constexpr int kFeatIconSize = 32;
+static constexpr int kK1FeatArrowSize = 32;
+static constexpr int kTSLFeatArrowSize = 32;
 static constexpr int kK1VisibleFeatRows = 5;
 static constexpr int kTSLVisibleFeatRows = 7;
 static constexpr char kK1FeatCellFill[] = "lbl_indent";
+static constexpr char kK1FeatArrow[] = "lbl_skarr";
 static constexpr char kK1FeatCellBorderCorner[] = "border2d";
 static constexpr char kK1FeatCellBorderEdge[] = "border1d";
 static constexpr int kK1FeatCellBorderDimension = 8;
@@ -53,6 +56,44 @@ static constexpr glm::vec3 kTSLLockedFeatBorderColor {0.698039f, 0.0f, 0.0f};
 static constexpr glm::vec3 kTSLSelectableFeatBorderColor {0.05098f, 0.34902f, 0.270588f};
 static constexpr glm::vec3 kTSLOwnedFeatBorderColor {0.101961f, 0.698039f, 0.54902f};
 static constexpr glm::vec3 kTSLSelectedFeatBorderColor {1.0f};
+static constexpr char kTSLFeatArrow[] = "uibit_abi_arrow";
+
+static std::map<FeatType, glm::ivec2> getFeatIconPositions(
+    const std::vector<FeatDisplayEntry> &entries) {
+
+    std::map<FeatType, int> chainRowCounts;
+    std::vector<FeatType> chainRoots;
+    for (auto &entry : entries) {
+        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
+        int wrappedRowCount = entry.visualIndex / kFeatIconColumnCount + 1;
+
+        auto maybeChainRows = chainRowCounts.insert({chainRoot, wrappedRowCount});
+        if (maybeChainRows.second) {
+            chainRoots.push_back(chainRoot);
+        } else {
+            maybeChainRows.first->second = std::max(maybeChainRows.first->second, wrappedRowCount);
+        }
+    }
+
+    std::map<FeatType, int> chainRowBases;
+    int nextRow = 0;
+    for (auto chainRoot : chainRoots) {
+        chainRowBases.insert({chainRoot, nextRow});
+        nextRow += chainRowCounts.at(chainRoot);
+    }
+
+    std::map<FeatType, glm::ivec2> result;
+    for (auto &entry : entries) {
+        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
+        result.insert({
+            entry.type,
+            {
+                entry.visualIndex % kFeatIconColumnCount,
+                chainRowBases.at(chainRoot) + entry.visualIndex / kFeatIconColumnCount
+            }});
+    }
+    return result;
+}
 
 void CharGenFeats::onGUILoaded() {
     bindControls();
@@ -105,6 +146,10 @@ void CharGenFeats::onGUILoaded() {
         cellStyle.backgroundTexture = _services.resource.textures.get(
             kK1FeatCellFill,
             TextureUsage::GUI);
+        cellStyle.linkTexture = _services.resource.textures.get(
+            kK1FeatArrow,
+            TextureUsage::GUI);
+        cellStyle.linkSize = {kK1FeatArrowSize, kK1FeatArrowSize};
         cellStyle.itemBorder = std::make_shared<Control::Border>();
         cellStyle.itemBorder->corner = _services.resource.textures.get(
             kK1FeatCellBorderCorner,
@@ -123,6 +168,10 @@ void CharGenFeats::onGUILoaded() {
         cellStyle.focusedBorderColors->selected = kK1FeatBorderGreen;
         cellStyle.onlyDrawItemBorderWhenBright = true;
     } else {
+        cellStyle.linkTexture = _services.resource.textures.get(
+            kTSLFeatArrow,
+            TextureUsage::GUI);
+        cellStyle.linkSize = {kTSLFeatArrowSize, kTSLFeatArrowSize};
         cellStyle.borderColors = std::make_shared<IconChain::CellStyle::BorderColors>();
         cellStyle.borderColors->locked = kTSLLockedFeatBorderColor;
         cellStyle.borderColors->selectable = kTSLSelectableFeatBorderColor;
@@ -230,26 +279,7 @@ void CharGenFeats::refreshIconChain() {
 
     _controls.ICONCHAIN_FEATS->setColumnCount(kFeatIconColumnCount);
 
-    std::map<FeatType, int> chainRowCounts;
-    std::vector<FeatType> chainRoots;
-    for (auto &entry : _displayEntries) {
-        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
-        int wrappedRowCount = entry.visualIndex / kFeatIconColumnCount + 1;
-
-        auto maybeChainRows = chainRowCounts.insert({chainRoot, wrappedRowCount});
-        if (maybeChainRows.second) {
-            chainRoots.push_back(chainRoot);
-        } else {
-            maybeChainRows.first->second = std::max(maybeChainRows.first->second, wrappedRowCount);
-        }
-    }
-
-    std::map<FeatType, int> chainRowBases;
-    int nextRow = 0;
-    for (auto chainRoot : chainRoots) {
-        chainRowBases.insert({chainRoot, nextRow});
-        nextRow += chainRowCounts.at(chainRoot);
-    }
+    auto itemPositions = getFeatIconPositions(_displayEntries);
 
     for (auto &entry : _displayEntries) {
         std::shared_ptr<Feat> feat(_services.game.feats.get(entry.type));
@@ -257,12 +287,10 @@ void CharGenFeats::refreshIconChain() {
             continue;
         }
 
-        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
-
         IconChain::Item item;
         item.tag = std::to_string(static_cast<int>(entry.type));
-        item.row = chainRowBases.at(chainRoot) + entry.visualIndex / kFeatIconColumnCount;
-        item.column = entry.visualIndex % kFeatIconColumnCount;
+        item.column = itemPositions.at(entry.type).x;
+        item.row = itemPositions.at(entry.type).y;
         item.iconTexture = feat->icon;
         item.selected = _selectedFeats.count(entry.type) > 0;
         switch (entry.availability) {
@@ -279,6 +307,8 @@ void CharGenFeats::refreshIconChain() {
         }
         _controls.ICONCHAIN_FEATS->addItem(std::move(item));
     }
+
+    refreshIconChainLinks();
 }
 
 void CharGenFeats::refreshIconChainSelection() {
@@ -290,6 +320,58 @@ void CharGenFeats::refreshIconChainSelection() {
         _controls.ICONCHAIN_FEATS->setItemSelected(
             std::to_string(static_cast<int>(entry.type)),
             _selectedFeats.count(entry.type) > 0);
+    }
+
+    refreshIconChainLinks();
+}
+
+void CharGenFeats::refreshIconChainLinks() {
+    _controls.ICONCHAIN_FEATS->clearLinks();
+    if (!_levelUp) {
+        return;
+    }
+
+    CreatureAttributes effectiveAttributes(_charGen.character().attributes);
+    for (auto feat : _selectedFeats) {
+        effectiveAttributes.addFeat(feat);
+    }
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(effectiveAttributes.getEffectiveClass()));
+    auto itemPositions = getFeatIconPositions(_displayEntries);
+
+    for (size_t i = 1; i < _displayEntries.size(); ++i) {
+        const FeatDisplayEntry &source = _displayEntries[i - 1];
+        const FeatDisplayEntry &target = _displayEntries[i];
+        FeatType sourceChainRoot = source.chainRoot != FeatType::Invalid ? source.chainRoot : source.type;
+        FeatType targetChainRoot = target.chainRoot != FeatType::Invalid ? target.chainRoot : target.type;
+        if (sourceChainRoot != targetChainRoot ||
+            target.visualIndex != source.visualIndex + 1) {
+            continue;
+        }
+
+        auto sourcePosition = itemPositions.find(source.type);
+        auto targetPosition = itemPositions.find(target.type);
+        if (sourcePosition == itemPositions.end() ||
+            targetPosition == itemPositions.end() ||
+            sourcePosition->second.y != targetPosition->second.y ||
+            targetPosition->second.x != sourcePosition->second.x + 1) {
+            continue;
+        }
+
+        bool sourceEffectivelyOwned = effectiveAttributes.hasFeat(source.type);
+        bool targetEffectivelyOwned = effectiveAttributes.hasFeat(target.type);
+        bool targetSelectable = clazz &&
+                                _services.game.feats.isLevelUpCandidate(
+                                    target.type,
+                                    effectiveAttributes,
+                                    *clazz);
+        if (!sourceEffectivelyOwned || (!targetEffectivelyOwned && !targetSelectable)) {
+            continue;
+        }
+
+        IconChain::Link link;
+        link.sourceTag = std::to_string(static_cast<int>(source.type));
+        link.targetTag = std::to_string(static_cast<int>(target.type));
+        _controls.ICONCHAIN_FEATS->addLink(std::move(link));
     }
 }
 

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -22,6 +22,7 @@
 #include "reone/game/game.h"
 #include "reone/game/gui/chargen.h"
 #include "reone/gui/control/button.h"
+#include "reone/gui/control/iconchain.h"
 #include "reone/gui/control/listbox.h"
 
 using namespace reone::audio;
@@ -34,8 +35,31 @@ namespace reone {
 
 namespace game {
 
+static constexpr int kFeatIconCellSize = 48;
+static constexpr int kFeatIconCellSpacingX = 8;
+static constexpr int kFeatIconCellSpacingY = 8;
+static constexpr int kFeatIconColumnCount = 3;
+
 void CharGenFeats::onGUILoaded() {
     bindControls();
+
+    auto iconChainControl = std::shared_ptr<Control>(_gui->newControl(ControlType::IconChain, "ICONCHAIN_FEATS"));
+    _controls.ICONCHAIN_FEATS = std::static_pointer_cast<IconChain>(iconChainControl);
+    _controls.ICONCHAIN_FEATS->setExtent(_controls.LB_FEATS->extent());
+    _controls.ICONCHAIN_FEATS->setPadding(_controls.LB_FEATS->padding());
+    _controls.ICONCHAIN_FEATS->setBorder(_controls.LB_FEATS->border());
+    _controls.ICONCHAIN_FEATS->setHilight(_controls.LB_FEATS->border());
+    _controls.ICONCHAIN_FEATS->setHilightColor(_hilightColor);
+    _controls.ICONCHAIN_FEATS->setCellSize(kFeatIconCellSize);
+    _controls.ICONCHAIN_FEATS->setCellSpacing(kFeatIconCellSpacingX, kFeatIconCellSpacingY);
+    _controls.ICONCHAIN_FEATS->setVisible(false);
+    _controls.ICONCHAIN_FEATS->setOnItemFocus([this](const std::string &item) {
+        onFeatFocused(item);
+    });
+    _controls.ICONCHAIN_FEATS->setOnItemClick([this](const std::string &item) {
+        onFeatSelected(item);
+    });
+    _gui->addControlToBack(_controls.ICONCHAIN_FEATS);
 
     _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LB_FEATS->setSelectionMode(ListBox::SelectionMode::OnClick);
@@ -91,9 +115,90 @@ void CharGenFeats::loadLevelUpDisplayEntries() {
 }
 
 void CharGenFeats::refreshControls() {
+    refreshSelectionControls();
+    refreshIconChain();
+    refreshListBox();
+}
+
+void CharGenFeats::refreshSelectionControls() {
     _controls.STD_REMAINING_SELECTIONS_LBL->setTextMessage(std::to_string(_points - static_cast<int>(_selectedFeats.size())));
     _controls.BTN_ACCEPT->setDisabled(_levelUp && _selectedFeats.size() != static_cast<size_t>(_points));
+}
 
+void CharGenFeats::refreshIconChain() {
+    _controls.ICONCHAIN_FEATS->clearItems();
+    _controls.ICONCHAIN_FEATS->setVisible(_levelUp);
+    if (!_levelUp) {
+        return;
+    }
+
+    _controls.ICONCHAIN_FEATS->setColumnCount(kFeatIconColumnCount);
+
+    std::map<FeatType, int> chainRowCounts;
+    std::vector<FeatType> chainRoots;
+    for (auto &entry : _displayEntries) {
+        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
+        int wrappedRowCount = entry.visualIndex / kFeatIconColumnCount + 1;
+
+        auto maybeChainRows = chainRowCounts.insert({chainRoot, wrappedRowCount});
+        if (maybeChainRows.second) {
+            chainRoots.push_back(chainRoot);
+        } else {
+            maybeChainRows.first->second = std::max(maybeChainRows.first->second, wrappedRowCount);
+        }
+    }
+
+    std::map<FeatType, int> chainRowBases;
+    int nextRow = 0;
+    for (auto chainRoot : chainRoots) {
+        chainRowBases.insert({chainRoot, nextRow});
+        nextRow += chainRowCounts.at(chainRoot);
+    }
+
+    for (auto &entry : _displayEntries) {
+        std::shared_ptr<Feat> feat(_services.game.feats.get(entry.type));
+        if (!feat) {
+            continue;
+        }
+
+        FeatType chainRoot = entry.chainRoot != FeatType::Invalid ? entry.chainRoot : entry.type;
+
+        IconChain::Item item;
+        item.tag = std::to_string(static_cast<int>(entry.type));
+        item.row = chainRowBases.at(chainRoot) + entry.visualIndex / kFeatIconColumnCount;
+        item.column = entry.visualIndex % kFeatIconColumnCount;
+        item.iconTexture = feat->icon;
+        item.selected = _selectedFeats.count(entry.type) > 0;
+        switch (entry.availability) {
+        case FeatAvailability::Owned:
+            item.state = IconChain::State::Owned;
+            break;
+        case FeatAvailability::Selectable:
+            item.state = IconChain::State::Selectable;
+            break;
+        case FeatAvailability::LockedMinLevel:
+        case FeatAvailability::LockedMissingPrerequisite:
+            item.state = IconChain::State::Locked;
+            break;
+        }
+        _controls.ICONCHAIN_FEATS->addItem(std::move(item));
+    }
+}
+
+void CharGenFeats::refreshIconChainSelection() {
+    if (!_levelUp) {
+        return;
+    }
+
+    for (auto &entry : _displayEntries) {
+        _controls.ICONCHAIN_FEATS->setItemSelected(
+            std::to_string(static_cast<int>(entry.type)),
+            _selectedFeats.count(entry.type) > 0);
+    }
+}
+
+void CharGenFeats::refreshListBox() {
+    _controls.LB_FEATS->setVisible(!_levelUp);
     _controls.LB_FEATS->clearItems();
     for (auto &entry : _displayEntries) {
         std::shared_ptr<Feat> feat(_services.game.feats.get(entry.type));
@@ -148,18 +253,27 @@ void CharGenFeats::toggleSelectedFeat(FeatType feat) {
     } else if (_selectedFeats.size() < static_cast<size_t>(_points)) {
         _selectedFeats.insert(feat);
     }
-    refreshControls();
+    refreshSelectionControls();
+    refreshIconChainSelection();
 }
 
-void CharGenFeats::onFeatSelected(const std::string &feat) {
-    auto featType = static_cast<FeatType>(std::stoi(feat));
-    std::shared_ptr<Feat> featInfo(_services.game.feats.get(featType));
+void CharGenFeats::showFeatDescription(FeatType feat) {
+    std::shared_ptr<Feat> featInfo(_services.game.feats.get(feat));
     if (!featInfo) {
         return;
     }
 
     _controls.LB_DESC->clearItems();
     _controls.LB_DESC->addTextLinesAsItems(featInfo->description);
+}
+
+void CharGenFeats::onFeatFocused(const std::string &feat) {
+    showFeatDescription(static_cast<FeatType>(std::stoi(feat)));
+}
+
+void CharGenFeats::onFeatSelected(const std::string &feat) {
+    auto featType = static_cast<FeatType>(std::stoi(feat));
+    showFeatDescription(featType);
 
     auto maybeDisplayEntry = std::find_if(
         _displayEntries.begin(), _displayEntries.end(),

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -42,6 +42,7 @@ static constexpr int kFeatIconColumnCount = 3;
 
 void CharGenFeats::onGUILoaded() {
     bindControls();
+    _defaultFeatNameText = _controls.LBL_NAME->text().text;
 
     auto iconChainControl = std::shared_ptr<Control>(_gui->newControl(ControlType::IconChain, "ICONCHAIN_FEATS"));
     _controls.ICONCHAIN_FEATS = std::static_pointer_cast<IconChain>(iconChainControl);
@@ -56,8 +57,11 @@ void CharGenFeats::onGUILoaded() {
     _controls.ICONCHAIN_FEATS->setOnItemFocus([this](const std::string &item) {
         onFeatFocused(item);
     });
-    _controls.ICONCHAIN_FEATS->setOnItemClick([this](const std::string &item) {
-        onFeatSelected(item);
+    _controls.ICONCHAIN_FEATS->setOnItemFocusCleared([this]() {
+        resetFocusedFeatName();
+    });
+    _controls.ICONCHAIN_FEATS->setOnItemDoubleClick([this](const std::string &item) {
+        onFeatActivated(item);
     });
     _gui->addControlToBack(_controls.ICONCHAIN_FEATS);
 
@@ -65,7 +69,10 @@ void CharGenFeats::onGUILoaded() {
     _controls.LB_FEATS->setSelectionMode(ListBox::SelectionMode::OnClick);
     _controls.LB_FEATS->setRenderItemIconsForButtonProto(true);
     _controls.LB_FEATS->setOnItemClick([this](const std::string &item) {
-        onFeatSelected(item);
+        onFeatFocused(item);
+    });
+    _controls.LB_FEATS->setOnItemDoubleClick([this](const std::string &item) {
+        onFeatActivated(item);
     });
 
     _controls.BTN_ACCEPT->setOnClick([this]() {
@@ -86,6 +93,9 @@ void CharGenFeats::onGUILoaded() {
             _charGen.openSteps();
         }
     });
+    _controls.BTN_SELECT->setOnClick([this]() {
+        activateFocusedFeat();
+    });
     _controls.BTN_SELECT->setDisabled(true);
     _controls.BTN_RECOMMENDED->setDisabled(true);
 }
@@ -96,6 +106,7 @@ void CharGenFeats::reset(bool levelUp) {
     _displayEntries.clear();
     _selectedFeats.clear();
     _controls.LB_DESC->clearItems();
+    resetFocusedFeatName();
 
     if (levelUp) {
         loadLevelUpDisplayEntries();
@@ -263,15 +274,21 @@ void CharGenFeats::showFeatDescription(FeatType feat) {
         return;
     }
 
+    _controls.LBL_NAME->setTextMessage(featInfo->name);
     _controls.LB_DESC->clearItems();
     _controls.LB_DESC->addTextLinesAsItems(featInfo->description);
 }
 
-void CharGenFeats::onFeatFocused(const std::string &feat) {
-    showFeatDescription(static_cast<FeatType>(std::stoi(feat)));
+void CharGenFeats::resetFocusedFeatName() {
+    _controls.LBL_NAME->setTextMessage(_defaultFeatNameText);
 }
 
-void CharGenFeats::onFeatSelected(const std::string &feat) {
+void CharGenFeats::onFeatFocused(const std::string &feat) {
+    showFeatDescription(static_cast<FeatType>(std::stoi(feat)));
+    _controls.BTN_SELECT->setDisabled(!_levelUp);
+}
+
+void CharGenFeats::onFeatActivated(const std::string &feat) {
     auto featType = static_cast<FeatType>(std::stoi(feat));
     showFeatDescription(featType);
 
@@ -283,6 +300,14 @@ void CharGenFeats::onFeatSelected(const std::string &feat) {
         maybeDisplayEntry->availability == FeatAvailability::Selectable) {
         toggleSelectedFeat(featType);
     }
+}
+
+void CharGenFeats::activateFocusedFeat() {
+    const IconChain::Item *item = _controls.ICONCHAIN_FEATS->focusedItem();
+    if (!item) {
+        return;
+    }
+    onFeatActivated(item->tag);
 }
 
 } // namespace game

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -69,12 +69,12 @@ void CharGenFeats::onGUILoaded() {
 void CharGenFeats::reset(bool levelUp) {
     _levelUp = levelUp;
     _points = 0;
-    _candidates.clear();
+    _displayEntries.clear();
     _selectedFeats.clear();
     _controls.LB_DESC->clearItems();
 
     if (levelUp) {
-        loadLevelUpCandidates();
+        loadLevelUpDisplayEntries();
     }
 
     refreshControls();
@@ -82,12 +82,12 @@ void CharGenFeats::reset(bool levelUp) {
     _controls.BTN_RECOMMENDED->setDisabled(true);
 }
 
-void CharGenFeats::loadLevelUpCandidates() {
+void CharGenFeats::loadLevelUpDisplayEntries() {
     const CreatureAttributes &attributes = _charGen.character().attributes;
     std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
 
     _points = _services.game.feats.getLevelUpChoiceCount(attributes, *clazz);
-    _candidates = _services.game.feats.getLevelUpCandidates(attributes, *clazz);
+    _displayEntries = _services.game.feats.getLevelUpDisplayEntries(attributes, *clazz);
 }
 
 void CharGenFeats::refreshControls() {
@@ -95,15 +95,36 @@ void CharGenFeats::refreshControls() {
     _controls.BTN_ACCEPT->setDisabled(_levelUp && _selectedFeats.size() != static_cast<size_t>(_points));
 
     _controls.LB_FEATS->clearItems();
-    for (auto featType : _candidates) {
-        std::shared_ptr<Feat> feat(_services.game.feats.get(featType));
+    for (auto &entry : _displayEntries) {
+        std::shared_ptr<Feat> feat(_services.game.feats.get(entry.type));
         if (!feat) {
             continue;
         }
 
+        std::string availabilityText;
+        switch (entry.availability) {
+        case FeatAvailability::Owned:
+            availabilityText = "[OWNED] ";
+            break;
+        case FeatAvailability::Selectable:
+            availabilityText = "[CAN PICK] ";
+            break;
+        case FeatAvailability::LockedMinLevel:
+            availabilityText = "[LOCKED: level] ";
+            break;
+        case FeatAvailability::LockedMissingPrerequisite:
+            availabilityText = "[LOCKED: prereq] ";
+            break;
+        }
+
+        std::string tierIndent;
+        if (entry.tier > 1) {
+            tierIndent = std::string(static_cast<size_t>(entry.tier - 1) * 2, ' ');
+        }
+
         ListBox::Item item;
-        item.tag = std::to_string(static_cast<int>(featType));
-        item.text = (_selectedFeats.count(featType) > 0 ? "* " : "") + feat->name;
+        item.tag = std::to_string(static_cast<int>(entry.type));
+        item.text = tierIndent + (_selectedFeats.count(entry.type) > 0 ? "* " : "") + availabilityText + feat->name;
         item.iconTexture = feat->icon;
         _controls.LB_FEATS->addItem(std::move(item));
     }
@@ -140,7 +161,12 @@ void CharGenFeats::onFeatSelected(const std::string &feat) {
     _controls.LB_DESC->clearItems();
     _controls.LB_DESC->addTextLinesAsItems(featInfo->description);
 
-    if (_levelUp) {
+    auto maybeDisplayEntry = std::find_if(
+        _displayEntries.begin(), _displayEntries.end(),
+        [&featType](auto &entry) { return entry.type == featType; });
+    if (_levelUp &&
+        maybeDisplayEntry != _displayEntries.end() &&
+        maybeDisplayEntry->availability == FeatAvailability::Selectable) {
         toggleSelectedFeat(featType);
     }
 }

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -24,6 +24,7 @@
 #include "reone/gui/control/button.h"
 #include "reone/gui/control/iconchain.h"
 #include "reone/gui/control/listbox.h"
+#include "reone/resource/provider/textures.h"
 
 using namespace reone::audio;
 
@@ -35,10 +36,23 @@ namespace reone {
 
 namespace game {
 
-static constexpr int kFeatIconCellSize = 48;
-static constexpr int kFeatIconCellSpacingX = 8;
-static constexpr int kFeatIconCellSpacingY = 8;
+static constexpr int kFeatIconCellSize = 40;
 static constexpr int kFeatIconColumnCount = 3;
+static constexpr int kFeatIconSize = 32;
+static constexpr int kK1VisibleFeatRows = 5;
+static constexpr int kTSLVisibleFeatRows = 7;
+static constexpr char kK1FeatCellFill[] = "lbl_indent";
+static constexpr char kK1FeatCellBorderCorner[] = "border2d";
+static constexpr char kK1FeatCellBorderEdge[] = "border1d";
+static constexpr int kK1FeatCellBorderDimension = 8;
+static constexpr glm::vec3 kK1FeatBorderGreen {0.278431f, 0.921569f, 0.105882f};
+static constexpr glm::vec3 kK1FeatBorderGreenDim = 0.7f * kK1FeatBorderGreen;
+static constexpr glm::vec3 kK1FeatBorderGold {0.980392f, 1.0f, 0.0f};
+static constexpr glm::vec3 kK1FeatBorderRed {0.698039f, 0.0f, 0.0f};
+static constexpr glm::vec3 kTSLLockedFeatBorderColor {0.698039f, 0.0f, 0.0f};
+static constexpr glm::vec3 kTSLSelectableFeatBorderColor {0.05098f, 0.34902f, 0.270588f};
+static constexpr glm::vec3 kTSLOwnedFeatBorderColor {0.101961f, 0.698039f, 0.54902f};
+static constexpr glm::vec3 kTSLSelectedFeatBorderColor {1.0f};
 
 void CharGenFeats::onGUILoaded() {
     bindControls();
@@ -49,10 +63,81 @@ void CharGenFeats::onGUILoaded() {
     _controls.ICONCHAIN_FEATS->setExtent(_controls.LB_FEATS->extent());
     _controls.ICONCHAIN_FEATS->setPadding(_controls.LB_FEATS->padding());
     _controls.ICONCHAIN_FEATS->setBorder(_controls.LB_FEATS->border());
-    _controls.ICONCHAIN_FEATS->setHilight(_controls.LB_FEATS->border());
-    _controls.ICONCHAIN_FEATS->setHilightColor(_hilightColor);
+    if (!_game.isTSL()) {
+        _controls.ICONCHAIN_FEATS->setHilight(_controls.LB_FEATS->border());
+        _controls.ICONCHAIN_FEATS->setHilightColor(_hilightColor);
+    }
+    _controls.ICONCHAIN_FEATS->setTintBorderFill(_game.isTSL());
     _controls.ICONCHAIN_FEATS->setCellSize(kFeatIconCellSize);
-    _controls.ICONCHAIN_FEATS->setCellSpacing(kFeatIconCellSpacingX, kFeatIconCellSpacingY);
+    auto &featListExtent = _controls.LB_FEATS->extent();
+    auto &featProtoExtent = _controls.LB_FEATS->protoItem().extent();
+    int featContentInsetY = featProtoExtent.top - featListExtent.top;
+    int featOriginY = featContentInsetY;
+    int featRowStep = featProtoExtent.height;
+    if (!_game.isTSL()) {
+        int featContentHeight = featListExtent.height - 2 * featContentInsetY;
+        int remainingHeight = featContentHeight - kK1VisibleFeatRows * kFeatIconCellSize;
+        int featGapCount = kK1VisibleFeatRows + 1;
+        int featRowGap = (remainingHeight + featGapCount / 2) / featGapCount;
+        featOriginY += featRowGap;
+        featRowStep = kFeatIconCellSize + featRowGap;
+    } else {
+        int featFillInsetY = _controls.LB_FEATS->border().dimension;
+        int featFillHeight = featListExtent.height - 2 * featFillInsetY;
+        int featRowRange = featFillHeight - kFeatIconCellSize;
+        int featGapCount = kTSLVisibleFeatRows - 1;
+        std::vector<int> featRowOffsets;
+        featRowOffsets.reserve(kTSLVisibleFeatRows);
+        for (int row = 0; row < kTSLVisibleFeatRows; ++row) {
+            featRowOffsets.push_back(
+                featFillInsetY + (row * featRowRange + featGapCount / 2) / featGapCount);
+        }
+        _controls.ICONCHAIN_FEATS->setRowOffsets(std::move(featRowOffsets));
+    }
+    _controls.ICONCHAIN_FEATS->setCellOrigin(
+        featProtoExtent.left - featListExtent.left,
+        featOriginY);
+    _controls.ICONCHAIN_FEATS->setCellStep(
+        (featProtoExtent.width - kFeatIconCellSize) / (kFeatIconColumnCount - 1),
+        featRowStep);
+    IconChain::CellStyle cellStyle;
+    if (!_game.isTSL()) {
+        cellStyle.backgroundTexture = _services.resource.textures.get(
+            kK1FeatCellFill,
+            TextureUsage::GUI);
+        cellStyle.itemBorder = std::make_shared<Control::Border>();
+        cellStyle.itemBorder->corner = _services.resource.textures.get(
+            kK1FeatCellBorderCorner,
+            TextureUsage::GUI);
+        cellStyle.itemBorder->edge = _services.resource.textures.get(
+            kK1FeatCellBorderEdge,
+            TextureUsage::GUI);
+        cellStyle.itemBorder->dimension = kK1FeatCellBorderDimension;
+        cellStyle.borderColors = std::make_shared<IconChain::CellStyle::BorderColors>();
+        cellStyle.borderColors->owned = kK1FeatBorderGreenDim;
+        cellStyle.borderColors->selected = kK1FeatBorderGreen;
+        cellStyle.focusedBorderColors = std::make_shared<IconChain::CellStyle::FocusedBorderColors>();
+        cellStyle.focusedBorderColors->locked = kK1FeatBorderRed;
+        cellStyle.focusedBorderColors->selectable = kK1FeatBorderGold;
+        cellStyle.focusedBorderColors->owned = kK1FeatBorderGreen;
+        cellStyle.focusedBorderColors->selected = kK1FeatBorderGreen;
+        cellStyle.onlyDrawItemBorderWhenBright = true;
+    } else {
+        cellStyle.borderColors = std::make_shared<IconChain::CellStyle::BorderColors>();
+        cellStyle.borderColors->locked = kTSLLockedFeatBorderColor;
+        cellStyle.borderColors->selectable = kTSLSelectableFeatBorderColor;
+        cellStyle.borderColors->owned = kTSLOwnedFeatBorderColor;
+        cellStyle.borderColors->selected = kTSLSelectedFeatBorderColor;
+        cellStyle.focusedBorderColors = std::make_shared<IconChain::CellStyle::FocusedBorderColors>();
+        cellStyle.focusedBorderColors->locked = kTSLLockedFeatBorderColor;
+        cellStyle.focusedBorderColors->selectable = kTSLSelectableFeatBorderColor;
+        cellStyle.focusedBorderColors->owned = kTSLOwnedFeatBorderColor;
+        cellStyle.focusedBorderColors->selected = kTSLSelectedFeatBorderColor;
+    }
+    cellStyle.iconSize = kFeatIconSize;
+    cellStyle.dimLockedBackground = !_game.isTSL();
+    cellStyle.drawItemBorderFill = !_game.isTSL();
+    _controls.ICONCHAIN_FEATS->setCellStyle(std::move(cellStyle));
     _controls.ICONCHAIN_FEATS->setVisible(false);
     _controls.ICONCHAIN_FEATS->setOnItemFocus([this](const std::string &item) {
         onFeatFocused(item);

--- a/src/libs/gui/CMakeLists.txt
+++ b/src/libs/gui/CMakeLists.txt
@@ -19,6 +19,7 @@ set(GUI_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/libs/gui)
 set(GUI_HEADERS
     ${GUI_INCLUDE_DIR}/control.h
     ${GUI_INCLUDE_DIR}/control/button.h
+    ${GUI_INCLUDE_DIR}/control/iconchain.h
     ${GUI_INCLUDE_DIR}/control/imagebutton.h
     ${GUI_INCLUDE_DIR}/control/label.h
     ${GUI_INCLUDE_DIR}/control/listbox.h
@@ -37,6 +38,7 @@ set(GUI_HEADERS
 
 set(GUI_SOURCES
     ${GUI_SOURCE_DIR}/control.cpp
+    ${GUI_SOURCE_DIR}/control/iconchain.cpp
     ${GUI_SOURCE_DIR}/control/imagebutton.cpp
     ${GUI_SOURCE_DIR}/control/listbox.cpp
     ${GUI_SOURCE_DIR}/control/progressbar.cpp

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -25,8 +25,10 @@ namespace reone {
 
 namespace gui {
 
-static constexpr glm::vec3 kLockedItemColor {0.45f};
+static constexpr glm::vec3 kDarkItemColor {0.45f};
 static constexpr glm::vec3 kSelectedItemColor {1.0f};
+static constexpr float kFocusedBorderPulseCyclesPerSecond = 1.0f;
+static constexpr float kFocusedBorderPulseMinFactor = 0.55f;
 
 void IconChain::clearItems() {
     _items.clear();
@@ -89,6 +91,12 @@ bool IconChain::handleClick(int x, int y, int clicks) {
     return true;
 }
 
+void IconChain::update(float dt) {
+    Control::update(dt);
+    _focusedBorderPulsePhase += dt * kFocusedBorderPulseCyclesPerSecond;
+    _focusedBorderPulsePhase -= std::floor(_focusedBorderPulsePhase);
+}
+
 void IconChain::render(const glm::ivec2 &screenSize,
                        const glm::ivec2 &offset,
                        IRenderPass &pass) {
@@ -110,15 +118,25 @@ void IconChain::render(const glm::ivec2 &screenSize,
         }
 
         bool focused = static_cast<int>(i) == _focusedItemIndex;
-        renderItemBorder(item, focused, itemExtent, offset, pass);
-
-        if (item.iconTexture) {
+        if (_cellStyle.backgroundTexture) {
             pass.drawImage(
-                *item.iconTexture,
+                *_cellStyle.backgroundTexture,
                 {offset.x + itemExtent.left, offset.y + itemExtent.top},
                 {itemExtent.width, itemExtent.height},
+                getCellBackgroundColor(item));
+        }
+
+        if (item.iconTexture) {
+            Extent iconExtent(getItemIconExtent(itemExtent));
+            pass.drawImage(
+                *item.iconTexture,
+                {offset.x + iconExtent.left, offset.y + iconExtent.top},
+                {iconExtent.width, iconExtent.height},
                 getItemIconColor(item));
         }
+
+        renderItemBorder(item, focused, itemExtent, offset, pass);
+        renderFocusedBorder(item, focused, itemExtent, offset, pass);
     }
 }
 
@@ -141,8 +159,30 @@ void IconChain::setCellSpacing(int x, int y) {
     _cellSpacing.y = y;
 }
 
+void IconChain::setCellOrigin(int x, int y) {
+    _cellOrigin.x = x;
+    _cellOrigin.y = y;
+}
+
+void IconChain::setCellStep(int x, int y) {
+    _cellStep.x = x;
+    _cellStep.y = y;
+}
+
+void IconChain::setRowOffsets(std::vector<int> offsets) {
+    _rowOffsets = std::move(offsets);
+}
+
+void IconChain::setCellStyle(CellStyle style) {
+    _cellStyle = std::move(style);
+}
+
 bool IconChain::hasValidPosition(const Item &item) const {
     if (_cellSize <= 0 || item.row < _rowOffset || item.column < 0) {
+        return false;
+    }
+    if (!_rowOffsets.empty() &&
+        item.row - _rowOffset >= static_cast<int>(_rowOffsets.size())) {
         return false;
     }
     return _columnCount == 0 || item.column < _columnCount;
@@ -160,11 +200,19 @@ bool IconChain::isItemVisible(const Extent &extent) const {
 }
 
 int IconChain::getVisibleRowCount() const {
-    if (_cellSize <= 0) {
+    if (!_rowOffsets.empty()) {
+        return static_cast<int>(_rowOffsets.size());
+    }
+
+    int rowStep = getCellStepY();
+    if (_cellSize <= 0 || rowStep <= 0) {
         return 0;
     }
-    int availableHeight = _extent.height - 2 * _padding;
-    return std::max(1, (availableHeight + _cellSpacing.y) / (_cellSize + _cellSpacing.y));
+    int availableHeight = _extent.height - getCellOriginY();
+    if (availableHeight < _cellSize) {
+        return 0;
+    }
+    return 1 + (availableHeight - _cellSize) / rowStep;
 }
 
 int IconChain::getMaxRow() const {
@@ -205,14 +253,43 @@ void IconChain::clearFocusedItem() {
 
 Control::Extent IconChain::getItemExtent(const Item &item) const {
     Extent extent;
-    extent.left = _extent.left + _padding + item.column * (_cellSize + _cellSpacing.x);
-    extent.top = _extent.top + _padding + (item.row - _rowOffset) * (_cellSize + _cellSpacing.y);
+    extent.left = _extent.left + getCellOriginX() + item.column * getCellStepX();
+    int visibleRow = item.row - _rowOffset;
+    extent.top = _extent.top + (_rowOffsets.empty()
+                                     ? getCellOriginY() + visibleRow * getCellStepY()
+                                     : _rowOffsets[visibleRow]);
     extent.width = _cellSize;
     extent.height = _cellSize;
     return extent;
 }
 
+Control::Extent IconChain::getItemIconExtent(const Extent &itemExtent) const {
+    if (_cellStyle.iconSize <= 0 || _cellStyle.iconSize >= _cellSize) {
+        return itemExtent;
+    }
+
+    Extent extent(itemExtent);
+    extent.width = _cellStyle.iconSize;
+    extent.height = _cellStyle.iconSize;
+    extent.left += (_cellSize - extent.width) / 2;
+    extent.top += (_cellSize - extent.height) / 2;
+    return extent;
+}
+
 glm::vec3 IconChain::getItemBorderColor(const Item &item, bool focused) const {
+    if (_cellStyle.borderColors) {
+        if (item.selected) {
+            return _cellStyle.borderColors->selected;
+        }
+        switch (item.state) {
+        case State::Owned:
+            return _cellStyle.borderColors->owned;
+        case State::Selectable:
+            return _cellStyle.borderColors->selectable;
+        case State::Locked:
+            return _cellStyle.borderColors->locked;
+        }
+    }
     if (item.selected) {
         return kSelectedItemColor;
     }
@@ -220,7 +297,7 @@ glm::vec3 IconChain::getItemBorderColor(const Item &item, bool focused) const {
         return _hilight->color;
     }
     if (item.state == State::Locked) {
-        return kLockedItemColor;
+        return kDarkItemColor;
     }
     if (item.state == State::Selectable && _hilight) {
         return _hilight->color;
@@ -229,10 +306,63 @@ glm::vec3 IconChain::getItemBorderColor(const Item &item, bool focused) const {
 }
 
 glm::vec4 IconChain::getItemIconColor(const Item &item) const {
-    if (item.state == State::Locked) {
-        return glm::vec4(kLockedItemColor, 1.0f);
+    if (!isItemBright(item)) {
+        return glm::vec4(kDarkItemColor, 1.0f);
     }
     return glm::vec4(1.0f);
+}
+
+float IconChain::getFocusedBorderPulseFactor() const {
+    float wave = 0.5f - 0.5f * std::cos(glm::two_pi<float>() * _focusedBorderPulsePhase);
+    return glm::mix(kFocusedBorderPulseMinFactor, 1.0f, wave);
+}
+
+std::optional<glm::vec3> IconChain::getFocusedBorderColor(const Item &item, bool focused) const {
+    if (!focused || !_cellStyle.focusedBorderColors) {
+        return std::nullopt;
+    }
+
+    if (item.selected) {
+        return _cellStyle.focusedBorderColors->selected;
+    }
+
+    switch (item.state) {
+    case State::Owned:
+        return _cellStyle.focusedBorderColors->owned;
+    case State::Selectable:
+        return _cellStyle.focusedBorderColors->selectable;
+    case State::Locked:
+        return _cellStyle.focusedBorderColors->locked;
+    }
+
+    return std::nullopt;
+}
+
+bool IconChain::isItemBright(const Item &item) const {
+    return item.state == State::Owned || item.selected;
+}
+
+glm::vec4 IconChain::getCellBackgroundColor(const Item &item) const {
+    if (_cellStyle.dimLockedBackground && item.state == State::Locked && !isItemBright(item)) {
+        return glm::vec4(kDarkItemColor, 1.0f);
+    }
+    return glm::vec4(1.0f);
+}
+
+int IconChain::getCellStepX() const {
+    return _cellStep.x > 0 ? _cellStep.x : _cellSize + _cellSpacing.x;
+}
+
+int IconChain::getCellStepY() const {
+    return _cellStep.y > 0 ? _cellStep.y : _cellSize + _cellSpacing.y;
+}
+
+int IconChain::getCellOriginX() const {
+    return _cellOrigin.x >= 0 ? _cellOrigin.x : _padding;
+}
+
+int IconChain::getCellOriginY() const {
+    return _cellOrigin.y >= 0 ? _cellOrigin.y : _padding;
 }
 
 void IconChain::renderItemBorder(
@@ -242,7 +372,13 @@ void IconChain::renderItemBorder(
     const glm::ivec2 &offset,
     IRenderPass &pass) {
 
-    const std::shared_ptr<Border> &border = (focused && _hilight) ? _hilight : _border;
+    if (_cellStyle.onlyDrawItemBorderWhenBright && !isItemBright(item)) {
+        return;
+    }
+
+    const std::shared_ptr<Border> &border = _cellStyle.itemBorder
+                                               ? _cellStyle.itemBorder
+                                               : (focused && _hilight) ? _hilight : _border;
     if (!border) {
         return;
     }
@@ -251,7 +387,45 @@ void IconChain::renderItemBorder(
     _extent = extent;
     setBorderColorOverride(getItemBorderColor(item, focused));
     setUseBorderColorOverride(true);
-    renderBorder(*border, offset, {extent.width, extent.height}, pass);
+    if (_cellStyle.drawItemBorderFill || !border->fill) {
+        renderBorder(*border, offset, {extent.width, extent.height}, pass);
+    } else {
+        Border borderWithoutFill(*border);
+        borderWithoutFill.fill.reset();
+        renderBorder(borderWithoutFill, offset, {extent.width, extent.height}, pass);
+    }
+    setUseBorderColorOverride(false);
+    _extent = originalExtent;
+}
+
+void IconChain::renderFocusedBorder(
+    const Item &item,
+    bool focused,
+    const Extent &extent,
+    const glm::ivec2 &offset,
+    IRenderPass &pass) {
+
+    auto maybeColor = getFocusedBorderColor(item, focused);
+    if (!maybeColor) {
+        return;
+    }
+
+    const std::shared_ptr<Border> &border = _cellStyle.itemBorder ? _cellStyle.itemBorder : _border;
+    if (!border) {
+        return;
+    }
+
+    Extent originalExtent(_extent);
+    _extent = extent;
+    setBorderColorOverride(*maybeColor * getFocusedBorderPulseFactor());
+    setUseBorderColorOverride(true);
+    if (_cellStyle.drawItemBorderFill || !border->fill) {
+        renderBorder(*border, offset, {extent.width, extent.height}, pass);
+    } else {
+        Border borderWithoutFill(*border);
+        borderWithoutFill.fill.reset();
+        renderBorder(borderWithoutFill, offset, {extent.width, extent.height}, pass);
+    }
     setUseBorderColorOverride(false);
     _extent = originalExtent;
 }

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -32,12 +32,21 @@ static constexpr float kFocusedBorderPulseMinFactor = 0.55f;
 
 void IconChain::clearItems() {
     _items.clear();
+    _links.clear();
     _rowOffset = 0;
     clearFocusedItem();
 }
 
 void IconChain::addItem(Item item) {
     _items.push_back(std::move(item));
+}
+
+void IconChain::clearLinks() {
+    _links.clear();
+}
+
+void IconChain::addLink(Link link) {
+    _links.push_back(std::move(link));
 }
 
 void IconChain::setItemSelected(const std::string &tag, bool selected) {
@@ -106,6 +115,29 @@ void IconChain::render(const glm::ivec2 &screenSize,
 
     Control::render(screenSize, offset, pass);
 
+    for (auto &item : _items) {
+        if (!hasValidPosition(item)) {
+            continue;
+        }
+
+        Extent itemExtent(getItemExtent(item));
+        if (!isItemVisible(itemExtent)) {
+            continue;
+        }
+
+        if (_cellStyle.backgroundTexture) {
+            pass.drawImage(
+                *_cellStyle.backgroundTexture,
+                {offset.x + itemExtent.left, offset.y + itemExtent.top},
+                {itemExtent.width, itemExtent.height},
+                getCellBackgroundColor(item));
+        }
+    }
+
+    for (auto &link : _links) {
+        renderLink(link, offset, pass);
+    }
+
     for (size_t i = 0; i < _items.size(); ++i) {
         const Item &item = _items[i];
         if (!hasValidPosition(item)) {
@@ -118,14 +150,6 @@ void IconChain::render(const glm::ivec2 &screenSize,
         }
 
         bool focused = static_cast<int>(i) == _focusedItemIndex;
-        if (_cellStyle.backgroundTexture) {
-            pass.drawImage(
-                *_cellStyle.backgroundTexture,
-                {offset.x + itemExtent.left, offset.y + itemExtent.top},
-                {itemExtent.width, itemExtent.height},
-                getCellBackgroundColor(item));
-        }
-
         if (item.iconTexture) {
             Extent iconExtent(getItemIconExtent(itemExtent));
             pass.drawImage(
@@ -240,6 +264,13 @@ int IconChain::getItemIndex(int x, int y) const {
     return -1;
 }
 
+const IconChain::Item *IconChain::findItem(const std::string &tag) const {
+    auto maybeItem = std::find_if(
+        _items.begin(), _items.end(),
+        [&tag](auto &item) { return item.tag == tag; });
+    return maybeItem != _items.end() ? &*maybeItem : nullptr;
+}
+
 void IconChain::clearFocusedItem() {
     if (_focusedItemIndex == -1) {
         return;
@@ -315,6 +346,49 @@ glm::vec4 IconChain::getItemIconColor(const Item &item) const {
 float IconChain::getFocusedBorderPulseFactor() const {
     float wave = 0.5f - 0.5f * std::cos(glm::two_pi<float>() * _focusedBorderPulsePhase);
     return glm::mix(kFocusedBorderPulseMinFactor, 1.0f, wave);
+}
+
+void IconChain::renderLink(
+    const Link &link,
+    const glm::ivec2 &offset,
+    IRenderPass &pass) const {
+
+    if (!_cellStyle.linkTexture) {
+        return;
+    }
+
+    auto source = findItem(link.sourceTag);
+    auto target = findItem(link.targetTag);
+    if (!source || !target ||
+        source->row != target->row ||
+        target->column != source->column + 1 ||
+        !hasValidPosition(*source) ||
+        !hasValidPosition(*target)) {
+        return;
+    }
+
+    Extent sourceExtent(getItemExtent(*source));
+    Extent targetExtent(getItemExtent(*target));
+    if (!isItemVisible(sourceExtent) || !isItemVisible(targetExtent)) {
+        return;
+    }
+
+    glm::ivec2 linkSize = _cellStyle.linkSize;
+    if (linkSize.x <= 0) {
+        linkSize.x = _cellStyle.linkTexture->width();
+    }
+    if (linkSize.y <= 0) {
+        linkSize.y = _cellStyle.linkTexture->height();
+    }
+
+    int sourceRight = sourceExtent.left + sourceExtent.width;
+    int gapWidth = targetExtent.left - sourceRight;
+    int linkLeft = sourceRight + (gapWidth - linkSize.x) / 2;
+    int linkTop = sourceExtent.top + (sourceExtent.height - linkSize.y) / 2;
+    pass.drawImage(
+        *_cellStyle.linkTexture,
+        {offset.x + linkLeft, offset.y + linkTop},
+        linkSize);
 }
 
 std::optional<glm::vec3> IconChain::getFocusedBorderColor(const Item &item, bool focused) const {

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/gui/control/iconchain.h"
+
+#include "reone/scene/render/pass.h"
+
+using namespace reone::scene;
+
+namespace reone {
+
+namespace gui {
+
+static constexpr glm::vec3 kLockedItemColor {0.45f};
+static constexpr glm::vec3 kSelectedItemColor {1.0f};
+
+void IconChain::clearItems() {
+    _items.clear();
+    _rowOffset = 0;
+    _focusedItemIndex = -1;
+}
+
+void IconChain::addItem(Item item) {
+    _items.push_back(std::move(item));
+}
+
+bool IconChain::handleMouseMotion(int x, int y) {
+    int itemIdx = getItemIndex(x, y);
+    if (itemIdx == _focusedItemIndex) {
+        return false;
+    }
+
+    _focusedItemIndex = itemIdx;
+    if (_focusedItemIndex != -1 && _onItemFocus) {
+        _onItemFocus(_items[_focusedItemIndex].tag);
+    }
+    return false;
+}
+
+bool IconChain::handleMouseWheel(int x, int y) {
+    int maxRowOffset = std::max(0, getMaxRow() - getVisibleRowCount() + 1);
+    if (y < 0 && _rowOffset < maxRowOffset) {
+        ++_rowOffset;
+        _focusedItemIndex = -1;
+        return true;
+    }
+    if (y > 0 && _rowOffset > 0) {
+        --_rowOffset;
+        _focusedItemIndex = -1;
+        return true;
+    }
+    return false;
+}
+
+bool IconChain::handleClick(int x, int y, int clicks) {
+    int itemIdx = getItemIndex(x, y);
+    if (itemIdx == -1) {
+        return false;
+    }
+
+    _focusedItemIndex = itemIdx;
+    if (_onItemClick) {
+        _onItemClick(_items[itemIdx].tag);
+    }
+    return true;
+}
+
+void IconChain::render(const glm::ivec2 &screenSize,
+                       const glm::ivec2 &offset,
+                       IRenderPass &pass) {
+    if (!_visible) {
+        return;
+    }
+
+    Control::render(screenSize, offset, pass);
+
+    for (size_t i = 0; i < _items.size(); ++i) {
+        const Item &item = _items[i];
+        if (!hasValidPosition(item)) {
+            continue;
+        }
+
+        Extent itemExtent(getItemExtent(item));
+        if (!isItemVisible(itemExtent)) {
+            continue;
+        }
+
+        bool focused = static_cast<int>(i) == _focusedItemIndex;
+        renderItemBorder(item, focused, itemExtent, offset, pass);
+
+        if (item.iconTexture) {
+            pass.drawImage(
+                *item.iconTexture,
+                {offset.x + itemExtent.left, offset.y + itemExtent.top},
+                {itemExtent.width, itemExtent.height},
+                getItemIconColor(item));
+        }
+    }
+}
+
+void IconChain::setSelected(bool selected) {
+    Control::setSelected(selected);
+    if (!selected) {
+        _focusedItemIndex = -1;
+    }
+}
+
+void IconChain::setColumnCount(int count) {
+    _columnCount = count > 0 ? count : 0;
+}
+
+void IconChain::setCellSize(int size) {
+    if (size > 0) {
+        _cellSize = size;
+    }
+}
+
+void IconChain::setCellSpacing(int x, int y) {
+    _cellSpacing.x = x;
+    _cellSpacing.y = y;
+}
+
+bool IconChain::hasValidPosition(const Item &item) const {
+    if (_cellSize <= 0 || item.row < _rowOffset || item.column < 0) {
+        return false;
+    }
+    return _columnCount == 0 || item.column < _columnCount;
+}
+
+bool IconChain::isItemVisible(const Extent &extent) const {
+    int right = extent.left + extent.width;
+    int bottom = extent.top + extent.height;
+    int controlRight = _extent.left + _extent.width;
+    int controlBottom = _extent.top + _extent.height;
+    return extent.left >= _extent.left &&
+           extent.top >= _extent.top &&
+           right <= controlRight &&
+           bottom <= controlBottom;
+}
+
+int IconChain::getVisibleRowCount() const {
+    if (_cellSize <= 0) {
+        return 0;
+    }
+    int availableHeight = _extent.height - 2 * _padding;
+    return std::max(1, (availableHeight + _cellSpacing.y) / (_cellSize + _cellSpacing.y));
+}
+
+int IconChain::getMaxRow() const {
+    int maxRow = -1;
+    for (auto &item : _items) {
+        if (item.column >= 0 && (_columnCount == 0 || item.column < _columnCount)) {
+            maxRow = std::max(maxRow, item.row);
+        }
+    }
+    return maxRow;
+}
+
+int IconChain::getItemIndex(int x, int y) const {
+    for (size_t i = 0; i < _items.size(); ++i) {
+        const Item &item = _items[i];
+        if (!hasValidPosition(item)) {
+            continue;
+        }
+
+        Extent itemExtent(getItemExtent(item));
+        if (isItemVisible(itemExtent) && itemExtent.contains(x, y)) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+Control::Extent IconChain::getItemExtent(const Item &item) const {
+    Extent extent;
+    extent.left = _extent.left + _padding + item.column * (_cellSize + _cellSpacing.x);
+    extent.top = _extent.top + _padding + (item.row - _rowOffset) * (_cellSize + _cellSpacing.y);
+    extent.width = _cellSize;
+    extent.height = _cellSize;
+    return extent;
+}
+
+glm::vec3 IconChain::getItemBorderColor(const Item &item, bool focused) const {
+    if (item.selected) {
+        return kSelectedItemColor;
+    }
+    if (focused && _hilight) {
+        return _hilight->color;
+    }
+    if (item.state == State::Locked) {
+        return kLockedItemColor;
+    }
+    if (item.state == State::Selectable && _hilight) {
+        return _hilight->color;
+    }
+    return _border ? _border->color : glm::vec3(1.0f);
+}
+
+glm::vec4 IconChain::getItemIconColor(const Item &item) const {
+    if (item.state == State::Locked) {
+        return glm::vec4(kLockedItemColor, 1.0f);
+    }
+    return glm::vec4(1.0f);
+}
+
+void IconChain::renderItemBorder(
+    const Item &item,
+    bool focused,
+    const Extent &extent,
+    const glm::ivec2 &offset,
+    IRenderPass &pass) {
+
+    const std::shared_ptr<Border> &border = (focused && _hilight) ? _hilight : _border;
+    if (!border) {
+        return;
+    }
+
+    Extent originalExtent(_extent);
+    _extent = extent;
+    setBorderColorOverride(getItemBorderColor(item, focused));
+    setUseBorderColorOverride(true);
+    renderBorder(*border, offset, {extent.width, extent.height}, pass);
+    setUseBorderColorOverride(false);
+    _extent = originalExtent;
+}
+
+} // namespace gui
+
+} // namespace reone

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -38,6 +38,15 @@ void IconChain::addItem(Item item) {
     _items.push_back(std::move(item));
 }
 
+void IconChain::setItemSelected(const std::string &tag, bool selected) {
+    for (auto &item : _items) {
+        if (item.tag == tag) {
+            item.selected = selected;
+            return;
+        }
+    }
+}
+
 bool IconChain::handleMouseMotion(int x, int y) {
     int itemIdx = getItemIndex(x, y);
     if (itemIdx == _focusedItemIndex) {

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -31,7 +31,7 @@ static constexpr glm::vec3 kSelectedItemColor {1.0f};
 void IconChain::clearItems() {
     _items.clear();
     _rowOffset = 0;
-    _focusedItemIndex = -1;
+    clearFocusedItem();
 }
 
 void IconChain::addItem(Item item) {
@@ -47,16 +47,14 @@ void IconChain::setItemSelected(const std::string &tag, bool selected) {
     }
 }
 
-bool IconChain::handleMouseMotion(int x, int y) {
-    int itemIdx = getItemIndex(x, y);
-    if (itemIdx == _focusedItemIndex) {
-        return false;
+const IconChain::Item *IconChain::focusedItem() const {
+    if (_focusedItemIndex < 0 || _focusedItemIndex >= static_cast<int>(_items.size())) {
+        return nullptr;
     }
+    return &_items[_focusedItemIndex];
+}
 
-    _focusedItemIndex = itemIdx;
-    if (_focusedItemIndex != -1 && _onItemFocus) {
-        _onItemFocus(_items[_focusedItemIndex].tag);
-    }
+bool IconChain::handleMouseMotion(int x, int y) {
     return false;
 }
 
@@ -64,12 +62,12 @@ bool IconChain::handleMouseWheel(int x, int y) {
     int maxRowOffset = std::max(0, getMaxRow() - getVisibleRowCount() + 1);
     if (y < 0 && _rowOffset < maxRowOffset) {
         ++_rowOffset;
-        _focusedItemIndex = -1;
+        clearFocusedItem();
         return true;
     }
     if (y > 0 && _rowOffset > 0) {
         --_rowOffset;
-        _focusedItemIndex = -1;
+        clearFocusedItem();
         return true;
     }
     return false;
@@ -82,8 +80,11 @@ bool IconChain::handleClick(int x, int y, int clicks) {
     }
 
     _focusedItemIndex = itemIdx;
-    if (_onItemClick) {
-        _onItemClick(_items[itemIdx].tag);
+    if (_onItemFocus) {
+        _onItemFocus(_items[itemIdx].tag);
+    }
+    if (clicks > 1 && _onItemDoubleClick) {
+        _onItemDoubleClick(_items[itemIdx].tag);
     }
     return true;
 }
@@ -123,9 +124,6 @@ void IconChain::render(const glm::ivec2 &screenSize,
 
 void IconChain::setSelected(bool selected) {
     Control::setSelected(selected);
-    if (!selected) {
-        _focusedItemIndex = -1;
-    }
 }
 
 void IconChain::setColumnCount(int count) {
@@ -192,6 +190,17 @@ int IconChain::getItemIndex(int x, int y) const {
         }
     }
     return -1;
+}
+
+void IconChain::clearFocusedItem() {
+    if (_focusedItemIndex == -1) {
+        return;
+    }
+
+    _focusedItemIndex = -1;
+    if (_onItemFocusCleared) {
+        _onItemFocusCleared();
+    }
 }
 
 Control::Extent IconChain::getItemExtent(const Item &item) const {

--- a/src/libs/gui/gui.cpp
+++ b/src/libs/gui/gui.cpp
@@ -24,6 +24,7 @@
 #include "reone/graphics/texture.h"
 #include "reone/graphics/uniforms.h"
 #include "reone/gui/control/button.h"
+#include "reone/gui/control/iconchain.h"
 #include "reone/gui/control/imagebutton.h"
 #include "reone/gui/control/label.h"
 #include "reone/gui/control/listbox.h"
@@ -343,6 +344,9 @@ std::unique_ptr<Control> GUI::newControl(
         break;
     case ControlType::ListBox:
         control = std::make_unique<ListBox>(*this, _sceneGraphs, _graphicsSvc, _resourceSvc);
+        break;
+    case ControlType::IconChain:
+        control = std::make_unique<IconChain>(*this, _sceneGraphs, _graphicsSvc, _resourceSvc);
         break;
     default:
         debug("Unsupported control type: " + std::to_string(static_cast<int>(type)), LogChannel::GUI);

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -58,6 +58,7 @@ public:
     MOCK_METHOD(int, getLevelUpChoiceCount, (const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
     MOCK_METHOD(bool, isLevelUpCandidate, (FeatType type, const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
     MOCK_METHOD(std::vector<FeatType>, getLevelUpCandidates, (const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
+    MOCK_METHOD(std::vector<FeatDisplayEntry>, getLevelUpDisplayEntries, (const CreatureAttributes &attributes, const CreatureClass &clazz), (const override));
 };
 
 class MockFootstepSounds : public IFootstepSounds, boost::noncopyable {


### PR DESCRIPTION
## Summary

Implements the level-up Feats icon-chain presentation on top of the merged Feats selection flow.

This adds:
- display-entry metadata for level-up feat chains
- a reusable `IconChain` GUI control
- icon-chain rendering for the level-up Feats page
- click-to-focus / Add-or-double-click-to-choose behavior
- focused feat name display
- K1 and TSL visual state presentation
- focused border pulse states
- chain arrows for owned/chosen path + next selectable same-row links

## Notes

K1 and TSL use separate visual profiles:
- K1 uses `lbl_indent`, `border1d` / `border2d`, and `lbl_skarr`
- TSL uses no per-cell backing tile, compact border states, and scaled `uibit_abi_arrow`

Hover does not change focus. Single click focuses for name/description. Add or double-click chooses.

## Missing features / fixes

-  'Recommended' feats
-  Auto-granted feats
-  Integration with 'feats' tab to show leader's current feat list
-  Future logic addition: if a feat is selected and the player meets requirements for next feat in the chain, next feat should show choosable in realtime
-  K2 appears to show some backing colour behind the feat tile.  To be addressed with general GUI update