### PR TITLE
[nfc] Allow isa, cast and dyn_cast for const pointers

### DIFF
--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -69,7 +69,7 @@ public:
         Game &game,
         ServicesView &services);
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Area;
     }
 

--- a/include/reone/game/object/camera.h
+++ b/include/reone/game/object/camera.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Camera;
     }
 

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -96,7 +96,7 @@ public:
         Game &game,
         ServicesView &services);
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Creature;
     }
 

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Door;
     }
 

--- a/include/reone/game/object/encounter.h
+++ b/include/reone/game/object/encounter.h
@@ -42,7 +42,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Encounter;
     }
 

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -68,7 +68,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Item;
     }
 

--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -62,7 +62,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Module;
     }
 

--- a/include/reone/game/object/placeable.h
+++ b/include/reone/game/object/placeable.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Placeable;
     }
 

--- a/include/reone/game/object/sound.h
+++ b/include/reone/game/object/sound.h
@@ -46,7 +46,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Sound;
     }
 

--- a/include/reone/game/object/store.h
+++ b/include/reone/game/object/store.h
@@ -39,7 +39,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Store;
     }
 };

--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -49,7 +49,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Trigger;
     }
 

--- a/include/reone/game/object/waypoint.h
+++ b/include/reone/game/object/waypoint.h
@@ -42,7 +42,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Waypoint;
     }
 


### PR DESCRIPTION
This patch fixes an oversight of #46. 
Now these cast functions work for both const and non-const pointers, and return a pointer with the corresponding qualifier.