### PR TITLE
[resource] Ignore missing saves directory

### DIFF
--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -108,7 +108,7 @@ std::set<std::string> ResourceDirector::saveNames() {
     auto names = std::set<std::string>();
     auto savesPath = findFileIgnoreCase(_gamePath, kSavesDirectoryName);
     if (!savesPath) {
-        throw ResourceNotFoundException("Saves directory not found");
+        return names;
     }
     for (auto &entry : std::filesystem::directory_iterator(*savesPath)) {
         names.insert(boost::to_lower_copy(entry.path().filename().string()));


### PR DESCRIPTION
Saves directory is optional, so the engine should not throw an exception. 
We now return an empty list of save names instead.

Fixes a bug introduced in #117.