### PR TITLE
[toolkit] Ignore files without an extension

### DIFF
--- a/src/apps/toolkit/viewmodel/resource/explorer.cpp
+++ b/src/apps/toolkit/viewmodel/resource/explorer.cpp
@@ -383,7 +383,7 @@ void ResourceExplorerViewModel::loadResources() {
         if (file.is_directory() ||
             (file.is_regular_file() && kFilesArchiveExtensions.count(extension) > 0)) {
             container = true;
-        } else if (file.is_regular_file() && getResTypeByExt(extension.substr(1), false) != ResType::Invalid) {
+        } else if (file.is_regular_file() && !extension.empty() && getResTypeByExt(extension.substr(1), false) != ResType::Invalid) {
             container = false;
         } else {
             continue;


### PR DESCRIPTION
The toolkit used to crash on K2 directory on linux, because the game distribution contains files without any extension.

The toolkit tripped on `extension.substr()` when `extension` is an empty string. With the patch we ignore such files, because they do not contain any data that the engine needs.