### PR TITLE
[game] Support basic attacks with stun batons and unarmed

### DIFF
--- a/include/reone/game/attack.h
+++ b/include/reone/game/attack.h
@@ -64,17 +64,6 @@ struct Damage {
 };
 
 /**
- * Calculate damage for an attack with a weapon.
- *
- * It adds a descriptor to \p damage based on \p weapon damage amount and
- * type. When \result is a critical hit, the amount is multiplied by the \p
- * weapon critical multiplier.
- */
-void computeWeaponDamage(
-    const Creature &attacker, const Object &target, const Item &weapon,
-    AttackResultType result, int damageBonus, ISmallVector<Damage> &damage);
-
-/**
  * Predicate for melee weapon.
  *
  * Stun Baton and Hand-to-Hand is NOT a melee weapon. These require special
@@ -106,6 +95,15 @@ public:
                          int attackRollBonus = 0,
                          int attackThreatBonus = 0,
                          int damageBonus = 0);
+
+    /**
+     * Calculate attack roll and damage effects for an unarmed attack. Damage is
+     * added to AttackBuffer, and can be applied later with applyEffects().
+     */
+    void addUnarmedAttack(const Creature &attacker, const Object &target,
+                          int attackRollBonus = 0,
+                          int attackThreatBonus = 0,
+                          int damageBonus = 0);
 
     /**
      * Apply all previously collected damage effects from \p attacker to \p

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -69,7 +69,7 @@ public:
         Game &game,
         ServicesView &services);
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Area;
     }
 

--- a/include/reone/game/object/camera.h
+++ b/include/reone/game/object/camera.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Camera;
     }
 

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -96,7 +96,7 @@ public:
         Game &game,
         ServicesView &services);
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Creature;
     }
 

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Door;
     }
 

--- a/include/reone/game/object/encounter.h
+++ b/include/reone/game/object/encounter.h
@@ -42,7 +42,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Encounter;
     }
 

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -68,7 +68,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Item;
     }
 

--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -62,7 +62,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Module;
     }
 

--- a/include/reone/game/object/placeable.h
+++ b/include/reone/game/object/placeable.h
@@ -41,7 +41,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Placeable;
     }
 

--- a/include/reone/game/object/sound.h
+++ b/include/reone/game/object/sound.h
@@ -46,7 +46,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Sound;
     }
 

--- a/include/reone/game/object/store.h
+++ b/include/reone/game/object/store.h
@@ -39,7 +39,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Store;
     }
 };

--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -49,7 +49,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Trigger;
     }
 

--- a/include/reone/game/object/waypoint.h
+++ b/include/reone/game/object/waypoint.h
@@ -42,7 +42,7 @@ public:
             services) {
     }
 
-    static bool classof(Object *from) {
+    static bool classof(const Object *from) {
         return from->type() == ObjectType::Waypoint;
     }
 

--- a/include/reone/game/types.h
+++ b/include/reone/game/types.h
@@ -81,7 +81,8 @@ enum class CreatureWieldType {
     DualPistols = 6,
     BlasterRifle = 7,
     HandToHand = 8,
-    HeavyWeapon = 9
+    HeavyWeapon = 9,
+    HandToHandComplex = 10,
 };
 
 enum class DamageType {
@@ -629,6 +630,7 @@ enum class FeatType {
     Spirit = 204,
     ForceChain = 205,
     WarVeteran = 206,
+    ComplexUnarmedAnims = 207,
     FightingSpirit = 236,
     HeroicResolve = 237,
     PreciseShot = 240,

--- a/src/libs/game/action/attackobject.cpp
+++ b/src/libs/game/action/attackobject.cpp
@@ -49,6 +49,23 @@ static std::string getMeleeAttackAnim(CreatureWieldType attackerWield,
     return str(boost::format("g%da%d") % static_cast<int>(attackerWield) % variant);
 }
 
+static std::string getUnarmedAttackAnim(CreatureWieldType attackerWield, CreatureWieldType targetWield, int variant, bool duel) {
+    if (attackerWield == CreatureWieldType::HandToHandComplex) {
+        if (duel && targetWield == attackerWield) {
+            return str(boost::format("c%da%d") % static_cast<int>(attackerWield) % variant);
+        }
+    }
+
+    // Fallback to a basic unarmed animation.
+    variant = variant % 3;
+    return str(boost::format("g8a%d") % variant);
+}
+
+static std::string getStunBatonAttackAnim(int variant) {
+    variant = variant % 3;
+    return str(boost::format("g1a%d") % variant);
+}
+
 static void attack(const CombatRound &round, Creature &attacker, Object &target,
                    const IAnimations &anims, AttackBuffer &attacks) {
 
@@ -59,7 +76,7 @@ static void attack(const CombatRound &round, Creature &attacker, Object &target,
             attacks.addWeaponAttack(attacker, target, *offhand);
         }
     } else {
-        // TODO: handle Unarmed
+        attacks.addUnarmedAttack(attacker, target);
     }
 
     scene::AnimationProperties animProp =
@@ -74,12 +91,34 @@ static void attack(const CombatRound &round, Creature &attacker, Object &target,
 
     CreatureWieldType attackerWield = attacker.getWieldType();
 
-    // TODO: support stun batons and unarmed.
-    bool isMelee = isMeleeWieldType(attacker.getWieldType());
-
-    std::string attackAnim = isMelee
-                                 ? getMeleeAttackAnim(attackerWield, targetWield, variant, round.duel)
-                                 : getRangedAttackAnim(attacker, /*kind=*/1);
+    std::string attackAnim;
+    switch (attackerWield) {
+    case CreatureWieldType::None: {
+        assert(0 && "Monster attacks are not supported");
+        break;
+    }
+    case CreatureWieldType::SingleSword:
+    case CreatureWieldType::DoubleBladedSword:
+    case CreatureWieldType::DualSwords: {
+        attackAnim = getMeleeAttackAnim(attackerWield, targetWield, variant, round.duel);
+        break;
+    }
+    case CreatureWieldType::BlasterPistol:
+    case CreatureWieldType::DualPistols:
+    case CreatureWieldType::BlasterRifle:
+    case CreatureWieldType::HeavyWeapon: {
+        attackAnim = getRangedAttackAnim(attacker, /*kind=*/1);
+        break;
+    }
+    case CreatureWieldType::HandToHand:
+    case CreatureWieldType::HandToHandComplex: {
+        attackAnim = getUnarmedAttackAnim(attackerWield, targetWield, variant, round.duel);
+        break;
+    }
+    case CreatureWieldType::StunBaton:
+        attackAnim = getStunBatonAttackAnim(variant);
+        break;
+    }
 
     attacker.playAnimation(attackAnim, animProp);
 
@@ -94,9 +133,6 @@ static void attack(const CombatRound &round, Creature &attacker, Object &target,
 
 /**
  * Add projectiles matching the corresponding attack animation.
- *
- * TODO: refactor this to be tied to the animation, not wield type. We need to
- * use it for CutsceneAttack as well.
  */
 void AttackObjectAction::addProjectiles(const Creature &creature) {
     ProjectileSpec *spec = _services.game.projectiles.get(

--- a/src/libs/game/action/usefeat.cpp
+++ b/src/libs/game/action/usefeat.cpp
@@ -90,6 +90,16 @@ static std::optional<ProjectileAttackType> getProjectileType(FeatType feat) {
     }
 }
 
+static std::string getStunBatonAttackAnim(int variant) {
+    variant = variant % 2;
+    return str(boost::format("g1a%d") % variant);
+}
+
+static std::string getUnarmedAttackAnim(int variant) {
+    variant = variant % 2;
+    return str(boost::format("g8a%d") % variant);
+}
+
 static std::string getAttackAnim(FeatType feat, CreatureWieldType attackerWield) {
     const char *format = getAnimFormat(feat);
     if (!format) {

--- a/src/libs/game/animations.cpp
+++ b/src/libs/game/animations.cpp
@@ -191,7 +191,7 @@ std::string Animations::getAttackResult(std::string attackAnim,
         if (isRangedWieldType(targetWield)) {
             return getNameById(it->second.dodge);
         }
-        return getNameById(it->second.damage);
+        return getNameById(it->second.parry);
     }
 
     return std::string();

--- a/src/libs/game/attack.cpp
+++ b/src/libs/game/attack.cpp
@@ -116,14 +116,11 @@ static int getWeaponAttackBonus(const Creature &attacker, const Item &weapon) {
     return modifier + effects - penalty;
 }
 
-AttackResultType computeWeaponAttack(
-    const Creature &attacker, const Object &target, const Item &weapon,
-    int rollBonus, int threatBonus) {
-
+static AttackResultType computeAttack(const Creature &attacker, const Object &target, int rollBonus, int threatBonus) {
     // Determine defense of a target
     int defense;
-    if (target.type() == ObjectType::Creature) {
-        defense = static_cast<const Creature &>(target).getDefense();
+    if (const auto *creature = dyn_cast<Creature>(&target)) {
+        defense = creature->getDefense();
     } else {
         defense = 10;
     }
@@ -132,42 +129,46 @@ AttackResultType computeWeaponAttack(
     int roll = randomInt(1, 20);
 
     if (roll == 1) {
-        debug(str(boost::format("computeWeaponAttack: miss: roll(1)")), LogChannel::Combat);
+        debug(str(boost::format("computeAttack: miss: roll(1)")), LogChannel::Combat);
         return AttackResultType::Miss;
     }
-
-    int bonus = getWeaponAttackBonus(attacker, weapon) + rollBonus;
 
     AttackResultType result;
     if (roll == 20) {
         result = AttackResultType::AutomaticHit;
-    } else if ((roll + bonus) >= defense) {
+    } else if ((roll + rollBonus) >= defense) {
         result = AttackResultType::HitSuccessful;
     } else {
-        debug(str(boost::format("computeWeaponAttack: miss: roll(%d), bonus(%d), defense(%d)") % roll % bonus % defense), LogChannel::Combat);
+        debug(str(boost::format("computeAttack: miss: roll(%d), bonus(%d), defense(%d)") % roll % rollBonus % defense), LogChannel::Combat);
         return AttackResultType::Miss;
     }
 
     // Critical threat
-    int criticalThreat = weapon.criticalThreat() + threatBonus;
-    if (roll > (20 - criticalThreat)) {
+    if (roll > (20 - threatBonus)) {
         // Critical hit roll
         int criticalRoll = randomInt(1, 20);
-        if ((criticalRoll + bonus) >= defense) {
-            debug(str(boost::format("computeWeaponAttack: critical hit: roll(%d), critical roll(%d),"
-                                    " bonus(%d), defense(%d), critical threat(%d)") %
-                      roll % criticalRoll % bonus % defense % criticalThreat),
+        if ((criticalRoll + rollBonus) >= defense) {
+            debug(str(boost::format("computeAttack: critical hit: roll(%d), critical roll(%d),"
+                                    " bonus(%d), defense(%d), critical threat(20 - %d)") %
+                      roll % criticalRoll % rollBonus % defense % threatBonus),
                   LogChannel::Combat);
             return AttackResultType::CriticalHit;
         }
     }
 
-    debug(str(boost::format("computeWeaponAttack: %s: roll(%d), bonus(%d), defense(%d), critical threat(%d)") % attackResultDesc(result) % roll % bonus % defense % criticalThreat));
+    debug(str(boost::format("computeAttack: %s: roll(%d), bonus(%d), defense(%d), critical threat(20 - %d)") % attackResultDesc(result) % roll % rollBonus % defense % threatBonus));
 
     return result;
 }
 
-void computeWeaponDamage(
+/**
+ * Calculate damage for an attack with a weapon.
+ *
+ * It adds a descriptor to \p damage based on \p weapon damage amount and
+ * type. When \result is a critical hit, the amount is multiplied by the \p
+ * weapon critical multiplier.
+ */
+static void computeWeaponDamage(
     const Creature &attacker, const Object &target, const Item &weapon,
     AttackResultType result, int damageBonus, ISmallVector<Damage> &damage) {
 
@@ -191,12 +192,29 @@ void computeWeaponDamage(
           LogChannel::Combat);
 }
 
+static void computeUnarmedDamage(
+    const Creature &attacker, const Object &target,
+    AttackResultType result, int damageBonus, ISmallVector<Damage> &damage) {
+
+    int multiplier = (result == AttackResultType::CriticalHit) ? 2 : 1;
+
+    int amount = damageBonus + 1; // FIXME: fixed damage in K1?
+
+    damage.push_back({multiplier * amount, DamageType::Bludgeoning, DamagePower::Normal});
+
+    debug(str(boost::format("computeUnarmedDamage: %s -> %s (%d)") % attacker.tag() % target.tag() % amount),
+          LogChannel::Combat);
+}
+
 void AttackBuffer::addWeaponAttack(
     const Creature &attacker, const Object &target, const Item &weapon,
     int attackRollBonus, int attackThreatBonus, int damageBonus) {
 
-    AttackResultType result = computeWeaponAttack(
-        attacker, target, weapon, attackRollBonus, attackThreatBonus);
+    attackRollBonus += getWeaponAttackBonus(attacker, weapon);
+    attackThreatBonus += weapon.criticalThreat();
+
+    AttackResultType result = computeAttack(
+        attacker, target, attackRollBonus, attackThreatBonus);
 
     _attacks.emplace_back(result);
 
@@ -206,6 +224,20 @@ void AttackBuffer::addWeaponAttack(
 
     computeWeaponDamage(attacker, target, weapon, result,
                         damageBonus, _attacks.back().damage);
+}
+
+void AttackBuffer::addUnarmedAttack(const Creature &attacker, const Object &target,
+                                    int attackRollBonus, int attackThreatBonus, int damageBonus) {
+    AttackResultType result = computeAttack(
+        attacker, target, attackRollBonus, attackThreatBonus);
+
+    _attacks.emplace_back(result);
+
+    if (!isAttackSuccessful(result)) {
+        return;
+    }
+
+    computeUnarmedDamage(attacker, target, result, damageBonus, _attacks.back().damage);
 }
 
 void AttackBuffer::applyEffects(Creature &attacker, Object &target, Game &game) {

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -596,6 +596,10 @@ CreatureWieldType Creature::getWieldType() const {
         }
     }
 
+    if (attributes().hasFeat(FeatType::ComplexUnarmedAnims)) {
+        return CreatureWieldType::HandToHandComplex;
+    }
+
     return CreatureWieldType::HandToHand;
 }
 


### PR DESCRIPTION
The patch adds attack animations for Stun Batons, as well as animations and attack/damage calculation routines for Unarmed attacks.

Stun Batons have 2 basic animations and no cinematic attacks.

Unarmed attacks in K1 also have 2 basic animations, but in K2 there is a set of "complex" unarmed animations that are only active for characters with martial arts training. Other characters should only use basic animations.

Complex animations are enabled by `FeatType::ComplexUnarmedAnims` (ID 207). Creatures with that special trait now use `HandToHandComplex` (ID 10) wield type when unarmed. Attacks with this new wield type resolved to `c10aN` and `g10aN` attack animations.

Unfortunately K2 `combatanimations.2da` does not seem to be structured the same as in K1. Most animations work fine, but there is a mismatch between these new `c10aN` attacks and the corresponding parry/dodge/damage animations.
