### PR TITLE
[game] Handle missing idle animations

### DIFF
--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -241,11 +241,17 @@ void Creature::updateModelAnimation() {
         break;
     }
 
-    if (talkAnim) {
+    if (talkAnim && anim) {
         model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
         model->playAnimation(*talkAnim, _lipAnimation.get(), AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
     } else {
-        model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
+        if (anim) {
+            model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
+        }
+
+        if (talkAnim) {
+            model->playAnimation(*talkAnim, _lipAnimation.get(), AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
+        }
     }
 
     _animDirty = false;


### PR DESCRIPTION
The game used to crash on Vulkar's Base, when the player starts combats with the turrets:
```
warp tar_m10aa
setposition 159 133 2.25
```

Turrets do not have `cpause1` animation, so getAnimation returns `nullptr`. Now we check that animations are valid before dereferencing them.