### PR TITLE
[gui] Fix in-game menu tab and HUD arrows

### DIFF
--- a/include/reone/gui/control.h
+++ b/include/reone/gui/control.h
@@ -86,11 +86,17 @@ public:
     };
 
     struct Border {
+        enum class FillTransform {
+            None,
+            Rotate180
+        };
+
         std::shared_ptr<graphics::Texture> corner;
         std::shared_ptr<graphics::Texture> edge;
         std::shared_ptr<graphics::Texture> fill;
         glm::vec3 color {1.0f};
         int dimension {0};
+        FillTransform fillTransform {FillTransform::None};
     };
 
     struct Text {
@@ -140,6 +146,7 @@ public:
     void setBorder(Border border);
     void setBorderFill(std::string resRef);
     void setBorderFill(std::shared_ptr<graphics::Texture> texture);
+    void setBorderFillTransform(Border::FillTransform transform);
     void setBorderColor(glm::vec3 color);
     void setBorderColorOverride(glm::vec3 color);
     void setDisabled(bool disabled);
@@ -153,6 +160,7 @@ public:
     void setHilightColor(glm::vec3 color);
     void setHilightFill(std::string resRef);
     void setHilightFill(std::shared_ptr<graphics::Texture> texture);
+    void setHilightFillTransform(Border::FillTransform transform);
     void setPadding(int padding);
     void setSceneName(std::string name);
     void setText(Text text);

--- a/src/libs/game/gui/actionbar.cpp
+++ b/src/libs/game/gui/actionbar.cpp
@@ -28,6 +28,14 @@ namespace game {
 
 static constexpr int kActionWidth = 26;
 
+static void rotateActionBarArrow(std::shared_ptr<gui::Button> button) {
+    if (!button) {
+        return;
+    }
+    button->setBorderFillTransform(gui::Control::Border::FillTransform::Rotate180);
+    button->setHilightFillTransform(gui::Control::Border::FillTransform::Rotate180);
+}
+
 void ActionBar::addDescription(std::shared_ptr<gui::Label> desc,
                                std::shared_ptr<gui::Label> background) {
     _desc = desc;
@@ -40,6 +48,7 @@ void ActionBar::addDescription(std::shared_ptr<gui::Label> desc,
 void ActionBar::addSlot(std::shared_ptr<gui::Button> button,
                         std::shared_ptr<gui::Button> up,
                         std::shared_ptr<gui::Button> down) {
+    rotateActionBarArrow(down);
 
     size_t slotIndex = _slots.size();
     _slots.push_back({ActionSlot(), button, up, down});

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -84,6 +84,12 @@ void HUD::onGUILoaded() {
             _actionBar.addSlot(action, up, down);
         }
     }
+    if (_game.isTSL()) {
+        if (auto down = findControl<gui::Button>("BTN_ACTIONDOWN5")) {
+            down->setBorderFillTransform(gui::Control::Border::FillTransform::Rotate180);
+            down->setHilightFillTransform(gui::Control::Border::FillTransform::Rotate180);
+        }
+    }
 
     _controls.BTN_CLEARALL->setVisible(false);
     _controls.BTN_TARGET0->setVisible(false);

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -37,6 +37,13 @@ static void tintK2TopNavigationIcon(const std::shared_ptr<ImageButton> &button, 
     button->setTintBorderFill(true);
 }
 
+static void configureTopNavigationIcon(const std::shared_ptr<ImageButton> &button) {
+    if (!button) {
+        return;
+    }
+    button->setSelectable(false);
+}
+
 void InGameMenu::preload(IGUI &gui) {
     if (_game.isTSL()) {
         gui.setResolution(800, 600);
@@ -45,6 +52,15 @@ void InGameMenu::preload(IGUI &gui) {
 
 void InGameMenu::onGUILoaded() {
     bindControls();
+
+    configureTopNavigationIcon(_controls.LBLH_EQU);
+    configureTopNavigationIcon(_controls.LBLH_INV);
+    configureTopNavigationIcon(_controls.LBLH_CHA);
+    configureTopNavigationIcon(_controls.LBLH_ABI);
+    configureTopNavigationIcon(_controls.LBLH_MSG);
+    configureTopNavigationIcon(_controls.LBLH_JOU);
+    configureTopNavigationIcon(_controls.LBLH_MAP);
+    configureTopNavigationIcon(_controls.LBLH_OPT);
 
     if (_game.isTSL()) {
         tintK2TopNavigationIcon(_controls.LBLH_EQU, _baseColor);
@@ -207,14 +223,14 @@ void InGameMenu::changeTab(InGameMenuTab tab) {
 }
 
 void InGameMenu::updateTabButtons() {
-    _controls.BTN_EQU->setSelected(_tab == InGameMenuTab::Equipment);
-    _controls.BTN_INV->setSelected(_tab == InGameMenuTab::Inventory);
-    _controls.BTN_CHAR->setSelected(_tab == InGameMenuTab::Character);
-    _controls.BTN_ABI->setSelected(_tab == InGameMenuTab::Abilities);
-    _controls.BTN_MSG->setSelected(_tab == InGameMenuTab::Messages);
-    _controls.BTN_JOU->setSelected(_tab == InGameMenuTab::Journal);
-    _controls.BTN_MAP->setSelected(_tab == InGameMenuTab::Map);
-    _controls.BTN_OPT->setSelected(_tab == InGameMenuTab::Options);
+    _controls.LBLH_EQU->setSelected(_tab == InGameMenuTab::Equipment);
+    _controls.LBLH_INV->setSelected(_tab == InGameMenuTab::Inventory);
+    _controls.LBLH_CHA->setSelected(_tab == InGameMenuTab::Character);
+    _controls.LBLH_ABI->setSelected(_tab == InGameMenuTab::Abilities);
+    _controls.LBLH_MSG->setSelected(_tab == InGameMenuTab::Messages);
+    _controls.LBLH_JOU->setSelected(_tab == InGameMenuTab::Journal);
+    _controls.LBLH_MAP->setSelected(_tab == InGameMenuTab::Map);
+    _controls.LBLH_OPT->setSelected(_tab == InGameMenuTab::Options);
 }
 
 void InGameMenu::openInventory() {

--- a/src/libs/gui/control.cpp
+++ b/src/libs/gui/control.cpp
@@ -249,6 +249,12 @@ void Control::renderBorder(const Border &border,
     glm::mat3x4 uv(1.0f);
 
     if (border.fill) {
+        if (border.fillTransform == Border::FillTransform::Rotate180) {
+            uv = glm::mat3x4(
+                glm::vec4(-1.0f, 0.0f, 0.0f, 0.0f),
+                glm::vec4(0.0f, -1.0f, 0.0f, 0.0f),
+                glm::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+        }
         auto blending = border.fill->features().blending == Texture::Blending::Additive
                             ? BlendMode::Additive
                             : BlendMode::Normal;
@@ -541,6 +547,12 @@ void Control::setBorderFill(std::shared_ptr<Texture> texture) {
     }
 }
 
+void Control::setBorderFillTransform(Border::FillTransform transform) {
+    if (_border) {
+        _border->fillTransform = transform;
+    }
+}
+
 void Control::setBorderColor(glm::vec3 color) {
     _border->color = std::move(color);
 }
@@ -582,6 +594,12 @@ void Control::setHilightFill(std::shared_ptr<Texture> texture) {
             _hilight = std::make_shared<Border>();
         }
         _hilight->fill = std::move(texture);
+    }
+}
+
+void Control::setHilightFillTransform(Border::FillTransform transform) {
+    if (_hilight) {
+        _hilight->fillTransform = transform;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two small GUI issues:
- top in-game menu tab icons used to momentarily illuminate, but would not indicate which tab was active
- the active top menu tab now remains illuminated to indicate the active tab
- HUD/actionbar arrows now face the correct direction where the vanilla assets are reused for both sides

Hover/select sounds are unchanged.

## Notes / Scope
-  HUD arrow highlights / select state .etc are not implemented, these are visual bug fixes only
-  Logic for when the arrows should be displayed was not added (for instance the player has only has a stack of 1 item type or no items, scrolling is not applicable and arrows do not display)