### PR TITLE
[gui] Play level-up notification sound

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -150,6 +150,7 @@ public:
     void openInGame();
     void openInGameMenu(InGameMenuTab tab);
     void openLevelUp();
+    void notifyLevelUpPending(const Creature &creature);
     void openContainer(const std::shared_ptr<Object> &container);
     void openPartySelection(const PartySelectionContext &ctx);
     void openSaveLoad(SaveLoadMode mode);

--- a/include/reone/game/gui/sounds.h
+++ b/include/reone/game/gui/sounds.h
@@ -41,6 +41,7 @@ public:
 
     virtual std::shared_ptr<audio::AudioClip> getOnClick() const = 0;
     virtual std::shared_ptr<audio::AudioClip> getOnEnter() const = 0;
+    virtual std::shared_ptr<audio::AudioClip> getOnLevelUpNotify() const = 0;
 };
 
 class GUISounds : public IGUISounds, boost::noncopyable {
@@ -57,6 +58,7 @@ public:
 
     std::shared_ptr<audio::AudioClip> getOnClick() const override { return _onClick; }
     std::shared_ptr<audio::AudioClip> getOnEnter() const override { return _onEnter; }
+    std::shared_ptr<audio::AudioClip> getOnLevelUpNotify() const override { return _onLevelUpNotify; }
 
 private:
     resource::AudioClips &_audioClips;
@@ -64,6 +66,7 @@ private:
 
     std::shared_ptr<audio::AudioClip> _onClick;
     std::shared_ptr<audio::AudioClip> _onEnter;
+    std::shared_ptr<audio::AudioClip> _onLevelUpNotify;
 
     void loadSound(const resource::TwoDA &twoDa, const std::string &label, std::shared_ptr<audio::AudioClip> &sound);
 };

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -111,6 +111,7 @@ public:
     void damage(int amount, uint32_t damager) override;
 
     void giveXP(int amount);
+    void setXP(int xp);
 
     void playSound(resource::SoundSetEntry entry, bool positional = true);
 
@@ -149,7 +150,6 @@ public:
     void setFaction(Faction faction) { _faction = faction; }
     void setMovementRestricted(bool restricted) { _movementRestricted = restricted; }
     void setImmortal(bool immortal) { _immortal = immortal; }
-    void setXP(int xp) { _xp = xp; }
     void setAIStyle(NPCAIStyle style) { _aiStyle = style; }
     void setWalkmeshMaterial(int material) { _walkmeshMaterial = material; }
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -27,6 +27,7 @@
 #include "reone/game/d20/spells.h"
 #include "reone/game/debug.h"
 #include "reone/game/di/services.h"
+#include "reone/game/gui/sounds.h"
 #include "reone/game/location.h"
 #include "reone/game/party.h"
 #include "reone/game/reputes.h"
@@ -1336,6 +1337,13 @@ void Game::openLevelUp() {
     setCursorType(CursorType::Default);
     _charGen->startLevelUp();
     changeScreen(Screen::CharacterGeneration);
+}
+
+void Game::notifyLevelUpPending(const Creature &creature) {
+    if (!_party.isMember(creature)) {
+        return;
+    }
+    _services.audio.mixer.play(_services.game.guiSounds.getOnLevelUpNotify(), AudioType::Sound);
 }
 
 void Game::startCharacterGeneration() {

--- a/src/libs/game/gui/sounds.cpp
+++ b/src/libs/game/gui/sounds.cpp
@@ -35,6 +35,7 @@ void GUISounds::init() {
     }
     loadSound(*sounds, "Clicked_Default", _onClick);
     loadSound(*sounds, "Entered_Default", _onEnter);
+    loadSound(*sounds, "Level_Up_Notify", _onLevelUpNotify);
 }
 
 void GUISounds::loadSound(const TwoDA &twoDa, const std::string &label, std::shared_ptr<AudioClip> &sound) {
@@ -47,6 +48,7 @@ void GUISounds::loadSound(const TwoDA &twoDa, const std::string &label, std::sha
 void GUISounds::deinit() {
     _onClick.reset();
     _onEnter.reset();
+    _onLevelUpNotify.reset();
 }
 
 } // namespace game

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -517,7 +517,16 @@ void Creature::runDialogueScript(uint32_t speakerId, int32_t listenNumber) {
 }
 
 void Creature::giveXP(int amount) {
-    _xp += amount;
+    setXP(_xp + amount);
+}
+
+void Creature::setXP(int xp) {
+    bool wasLevelUpPending = isLevelUpPending();
+    _xp = xp;
+
+    if (!wasLevelUpPending && isLevelUpPending()) {
+        _game.notifyLevelUpPending(*this);
+    }
 }
 
 void Creature::playSound(SoundSetEntry entry, bool positional) {

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -71,6 +71,7 @@ class MockGUISounds : public IGUISounds, boost::noncopyable {
 public:
     MOCK_METHOD(std::shared_ptr<audio::AudioClip>, getOnClick, (), (const override));
     MOCK_METHOD(std::shared_ptr<audio::AudioClip>, getOnEnter, (), (const override));
+    MOCK_METHOD(std::shared_ptr<audio::AudioClip>, getOnLevelUpNotify, (), (const override));
 };
 
 class MockPortraits : public IPortraits, boost::noncopyable {


### PR DESCRIPTION
## Summary

Adds vanilla level-up notification sound support.

Both K1 and TSL define `Level_Up_Notify` in `guisounds.2da`, resolving to `gui_level`. Reone now loads that sound and plays it when an active party member newly becomes eligible to level up.

## Architecture

`Creature` detects the XP threshold transition near XP mutation, covering both `GiveXPToCreature` and script `SetXP`.

The player-facing decision and sound playback are delegated to `Game::notifyLevelUpPending`, which filters to active party members and plays the GUI notification sound.