### PR TITLE
[game] Apply level-up skill points

### DIFF
--- a/include/reone/game/gui/chargen/skills.h
+++ b/include/reone/game/gui/chargen/skills.h
@@ -106,6 +106,7 @@ private:
     CharacterGeneration &_charGen;
     CreatureAttributes _attributes;
     int _points {0};
+    int _allocationLevel {1};
 
     void onGUILoaded() override;
 

--- a/src/libs/game/gui/chargen/skills.cpp
+++ b/src/libs/game/gui/chargen/skills.cpp
@@ -78,9 +78,7 @@ void CharGenSkills::onGUILoaded() {
     _controls.COST_POINTS_LBL->setTextMessage("");
 
     _controls.BTN_ACCEPT->setOnClick([this]() {
-        if (_points > 0) {
-            updateCharacter();
-        }
+        updateCharacter();
         _charGen.goToNextStep();
         _charGen.openSteps();
     });
@@ -169,6 +167,7 @@ void CharGenSkills::reset(bool newGame) {
     std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
 
     _points = glm::max(1, (clazz->skillPointBase() + attributes.getAbilityModifier(Ability::Intelligence)) / 2);
+    _allocationLevel = attributes.getAggregateLevel() + (newGame ? 0 : 1);
 
     if (newGame) {
         _points *= 4;
@@ -223,7 +222,8 @@ bool CharGenSkills::canIncreaseSkill(SkillType skill) const {
     ClassType clazz = _charGen.character().attributes.getEffectiveClass();
 
     std::shared_ptr<CreatureClass> creatureClass(_services.game.classes.get(clazz));
-    int maxSkillRank = creatureClass->isClassSkill(skill) ? 4 : 2;
+    int maxClassSkillRank = _allocationLevel + 3;
+    int maxSkillRank = creatureClass->isClassSkill(skill) ? maxClassSkillRank : maxClassSkillRank / 2;
     int pointCost = creatureClass->isClassSkill(skill) ? 1 : 2;
 
     return _points >= pointCost && _attributes.getSkillRank(skill) < maxSkillRank;


### PR DESCRIPTION
## Summary

Fixes level-up skill allocations not being applied when all available skill points were spent.

`CharGenSkills` now always copies accepted skill ranks into the temporary character before advancing. Previously, the full-spend case skipped `updateCharacter()`, so selected ranks remained screen-local and were not applied on Finish.

This also fixes level-up skill rank caps so they derive from the target/post-level-up character level instead of remaining fixed at chargen caps.

## Details

- chargen still uses level 1 caps:
  - class skill max 4
  - cross-class max 2
- level-up uses target total level:
  - class skill max `level + 3`
  - cross-class max `(level + 3) / 2`
- skill costs are unchanged:
  - class skill: 1
  - cross-class skill: 2