### PR TITLE
[gui] Implement level-up Force Powers selection

### DIFF
--- a/include/reone/game/d20/class.h
+++ b/include/reone/game/d20/class.h
@@ -28,8 +28,8 @@ namespace reone {
 
 namespace resource {
 
-class Strings;
-class TwoDAs;
+class IStrings;
+class ITwoDAs;
 
 } // namespace resource
 
@@ -42,8 +42,8 @@ public:
     CreatureClass(
         ClassType type,
         Classes &classes,
-        resource::Strings &strings,
-        resource::TwoDAs &twoDas) :
+        resource::IStrings &strings,
+        resource::ITwoDAs &twoDas) :
         _type(type),
         _classes(classes),
         _strings(strings),
@@ -71,6 +71,7 @@ public:
     const CreatureAttributes &defaultAttributes() const { return _defaultAttributes; }
     int skillPointBase() const { return _skillPointBase; }
     int getFeatGain(int level) const;
+    int getPowerGain(int level) const;
     int getFeatListValue(FeatType feat) const;
     bool isFeatSelectable(FeatType feat) const {
         int listValue = getFeatListValue(feat);
@@ -88,14 +89,15 @@ private:
     std::unordered_map<FeatType, int> _featListValues;
     std::unordered_map<int, SavingThrows> _savingThrowsByLevel;
     std::unordered_map<int, int> _featGainsByLevel;
+    std::unordered_map<int, int> _powerGainsByLevel;
     std::vector<int> _attackBonuses;
 
     // Services
 
     Classes &_classes;
 
-    resource::Strings &_strings;
-    resource::TwoDAs &_twoDas;
+    resource::IStrings &_strings;
+    resource::ITwoDAs &_twoDas;
 
     // END Services
 
@@ -104,6 +106,7 @@ private:
     void loadAttackBonuses(const std::string &attackBonusTable);
     void loadFeatListValues(const std::string &featsPrefix);
     void loadFeatGains(const std::string &featGainPrefix);
+    void loadPowerGains(const std::string &powerGainPrefix);
 };
 
 } // namespace game

--- a/include/reone/game/d20/classes.h
+++ b/include/reone/game/d20/classes.h
@@ -25,8 +25,8 @@ namespace reone {
 
 namespace resource {
 
-class Strings;
-class TwoDAs;
+class IStrings;
+class ITwoDAs;
 
 } // namespace resource
 
@@ -43,7 +43,7 @@ public:
 
 class Classes : public IClasses {
 public:
-    Classes(resource::Strings &strings, resource::TwoDAs &twoDas) :
+    Classes(resource::IStrings &strings, resource::ITwoDAs &twoDas) :
         _strings(strings),
         _twoDas(twoDas) {
     }
@@ -66,8 +66,8 @@ private:
 
     // Services
 
-    resource::Strings &_strings;
-    resource::TwoDAs &_twoDas;
+    resource::IStrings &_strings;
+    resource::ITwoDAs &_twoDas;
 
     // END Services
 

--- a/include/reone/game/d20/spell.h
+++ b/include/reone/game/d20/spell.h
@@ -38,7 +38,11 @@ struct Spell {
     std::string name;
     std::string description;
     std::shared_ptr<graphics::Texture> icon;
-    uint32_t pips {1}; // 1-3, position in a feat chain
+    uint32_t pips {1};
+    std::vector<SpellType> prerequisites;
+    std::optional<SpellType> masterSpell;
+    int userType {-1};
+    std::unordered_map<ClassType, int> classLevelRequirements;
     uint32_t category {0};
     std::string impactScript;
     std::string castAnim;
@@ -48,6 +52,13 @@ struct Spell {
     uint32_t itemTargeting {0};
     bool hostile {false};
     std::shared_ptr<graphics::Model> projModel;
+
+    std::optional<int> getClassLevelRequirement(ClassType clazz) const {
+        auto maybeRequirement = classLevelRequirements.find(clazz);
+        return maybeRequirement != classLevelRequirements.end()
+                   ? std::optional<int>(maybeRequirement->second)
+                   : std::nullopt;
+    }
 };
 
 } // namespace game

--- a/include/reone/game/d20/spells.h
+++ b/include/reone/game/d20/spells.h
@@ -35,11 +35,53 @@ class IModels;
 
 namespace game {
 
+class CreatureAttributes;
+class CreatureClass;
+
+enum class SpellAvailability {
+    Hidden,
+    Known,
+    Chosen,
+    Selectable,
+    LockedClassLevel,
+    LockedMissingPrerequisite
+};
+
+struct SpellDisplayEntry {
+    SpellType type;
+    std::string name;
+    std::string description;
+    std::shared_ptr<graphics::Texture> icon;
+    std::vector<SpellType> prerequisites;
+    SpellAvailability availability {SpellAvailability::Hidden};
+    bool visible {false};
+    bool known {false};
+    bool chosen {false};
+    bool selectable {false};
+    std::optional<SpellType> displayParent;
+    SpellType chainRoot {SpellType::All};
+    int visualDepth {0};
+    int sourceOrder {0};
+};
+
 class ISpells {
 public:
     virtual ~ISpells() = default;
 
     virtual std::shared_ptr<Spell> get(SpellType type) const = 0;
+    virtual bool isLevelUpCandidate(
+        SpellType type,
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const = 0;
+    virtual std::vector<SpellType> getLevelUpCandidates(
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const = 0;
+    virtual std::vector<SpellDisplayEntry> getLevelUpDisplayEntries(
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const = 0;
 };
 
 class Spells : public ISpells, boost::noncopyable {
@@ -60,6 +102,19 @@ public:
     void init();
 
     std::shared_ptr<Spell> get(SpellType type) const override;
+    bool isLevelUpCandidate(
+        SpellType type,
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const override;
+    std::vector<SpellType> getLevelUpCandidates(
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const override;
+    std::vector<SpellDisplayEntry> getLevelUpDisplayEntries(
+        const CreatureAttributes &attributes,
+        const CreatureClass &clazz,
+        const std::set<SpellType> &chosen) const override;
 
 private:
     std::unordered_map<SpellType, std::shared_ptr<Spell>> _spells;

--- a/include/reone/game/d20/spells.h
+++ b/include/reone/game/d20/spells.h
@@ -25,11 +25,11 @@ namespace reone {
 
 namespace resource {
 
-class Strings;
-class TwoDAs;
-class Textures;
-class AudioClips;
-class Models;
+class IStrings;
+class ITwoDAs;
+class ITextures;
+class IAudioClips;
+class IModels;
 
 } // namespace resource
 
@@ -45,11 +45,11 @@ public:
 class Spells : public ISpells, boost::noncopyable {
 public:
     Spells(
-        resource::Textures &textures,
-        resource::AudioClips &audioClips,
-        resource::Models &models,
-        resource::Strings &strings,
-        resource::TwoDAs &twoDas) :
+        resource::ITextures &textures,
+        resource::IAudioClips &audioClips,
+        resource::IModels &models,
+        resource::IStrings &strings,
+        resource::ITwoDAs &twoDas) :
         _textures(textures),
         _audioClips(audioClips),
         _models(models),
@@ -66,11 +66,11 @@ private:
 
     // Services
 
-    resource::Textures &_textures;
-    resource::AudioClips &_audioClips;
-    resource::Models &_models;
-    resource::Strings &_strings;
-    resource::TwoDAs &_twoDas;
+    resource::ITextures &_textures;
+    resource::IAudioClips &_audioClips;
+    resource::IModels &_models;
+    resource::IStrings &_strings;
+    resource::ITwoDAs &_twoDas;
 
     // END Services
 };

--- a/include/reone/game/gui/chargen.h
+++ b/include/reone/game/gui/chargen.h
@@ -31,6 +31,7 @@
 #include "chargen/levelup.h"
 #include "chargen/nameentry.h"
 #include "chargen/portraitselect.h"
+#include "chargen/powers.h"
 #include "chargen/quick.h"
 #include "chargen/quickorcustom.h"
 #include "chargen/skills.h"
@@ -55,6 +56,7 @@ enum class CharGenScreen {
     Abilities,
     Skills,
     Feats,
+    Powers,
     LevelUp
 };
 
@@ -84,6 +86,7 @@ public:
     void openAbilities();
     void openSkills();
     void openFeats();
+    void openPowers();
     void openPortraitSelection();
     void openQuick();
     void openQuickOrCustom();
@@ -178,6 +181,7 @@ private:
     std::unique_ptr<CharGenAbilities> _abilities;
     std::unique_ptr<CharGenSkills> _charGenSkills;
     std::unique_ptr<CharGenFeats> _charGenFeats;
+    std::unique_ptr<CharGenPowers> _charGenPowers;
     std::unique_ptr<NameEntry> _nameEntry;
     std::unique_ptr<LevelUpMenu> _levelUp;
 
@@ -258,6 +262,7 @@ private:
     void loadAbilities();
     void loadSkills();
     void loadFeats();
+    void loadPowers();
     void loadLevelUp();
 
     // END Loading

--- a/include/reone/game/gui/chargen/levelup.h
+++ b/include/reone/game/gui/chargen/levelup.h
@@ -80,6 +80,7 @@ private:
     int _step {0};
     bool _hasAttributes {false};
     bool _hasFeats {false};
+    bool _hasPowers {false};
 
     void onGUILoaded() override;
 
@@ -105,6 +106,7 @@ private:
 
     void doSetStep(int step);
     bool hasFeatChoices() const;
+    bool hasPowerChoices() const;
 };
 
 } // namespace game

--- a/include/reone/game/gui/chargen/powers.h
+++ b/include/reone/game/gui/chargen/powers.h
@@ -73,6 +73,7 @@ private:
 
     CharacterGeneration &_charGen;
     std::vector<SpellDisplayEntry> _displayEntries;
+    std::set<SpellType> _selectedPowers;
     std::string _defaultPowerNameText;
     int _powerGain {0};
 
@@ -97,11 +98,18 @@ private:
 
     void loadDisplayEntries();
     void refreshControls();
+    void refreshSelectionControls();
     void refreshIconChain();
+    void refreshIconChainSelection();
     void refreshIconChainLinks(const std::map<SpellType, glm::ivec2> &positions);
+    void updateCharacter();
+    void toggleSelectedPower(SpellType power);
+    void removeInvalidSelectedPowers();
     void showPowerDescription(SpellType type);
     void resetFocusedPowerName();
     void onPowerFocused(const std::string &power);
+    void onPowerActivated(const std::string &power);
+    void activateFocusedPower();
 };
 
 } // namespace game

--- a/include/reone/game/gui/chargen/powers.h
+++ b/include/reone/game/gui/chargen/powers.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/label.h"
+#include "reone/gui/control/listbox.h"
+
+#include "../../d20/spells.h"
+#include "../../gui.h"
+
+namespace reone {
+
+namespace gui {
+
+class Button;
+class IconChain;
+
+} // namespace gui
+
+namespace game {
+
+class CharacterGeneration;
+
+class CharGenPowers : public GameGUI {
+public:
+    CharGenPowers(
+        CharacterGeneration &charGen,
+        Game &game,
+        ServicesView &services) :
+        GameGUI(game, services),
+        _charGen(charGen) {
+        _resRef = guiResRef("pwrlvlup");
+    }
+
+    void reset();
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Button> ACCEPT_BTN;
+        std::shared_ptr<gui::Button> BACK_BTN;
+        std::shared_ptr<gui::Label> DESC_LBL;
+        std::shared_ptr<gui::Label> LBL_BAR1;
+        std::shared_ptr<gui::Label> LBL_BAR2;
+        std::shared_ptr<gui::Label> LBL_POWER;
+        std::shared_ptr<gui::IconChain> ICONCHAIN_POWERS;
+        std::shared_ptr<gui::ListBox> LB_DESC;
+        std::shared_ptr<gui::ListBox> LB_POWERS;
+        std::shared_ptr<gui::Label> MAIN_TITLE_LBL;
+        std::shared_ptr<gui::Button> RECOMMENDED_BTN;
+        std::shared_ptr<gui::Label> REMAINING_SELECTIONS_LBL;
+        std::shared_ptr<gui::Label> SELECTIONS_REMAINING_LBL;
+        std::shared_ptr<gui::Button> SELECT_BTN;
+        std::shared_ptr<gui::Label> SUB_TITLE_LBL;
+    };
+
+    Controls _controls;
+
+    CharacterGeneration &_charGen;
+    std::vector<SpellDisplayEntry> _displayEntries;
+    std::string _defaultPowerNameText;
+    int _powerGain {0};
+
+    void onGUILoaded() override;
+
+    void bindControls() {
+        _controls.ACCEPT_BTN = findControl<gui::Button>("ACCEPT_BTN");
+        _controls.BACK_BTN = findControl<gui::Button>("BACK_BTN");
+        _controls.DESC_LBL = findControl<gui::Label>("DESC_LBL");
+        _controls.LBL_BAR1 = findControl<gui::Label>("LBL_BAR1");
+        _controls.LBL_BAR2 = findControl<gui::Label>("LBL_BAR2");
+        _controls.LBL_POWER = findControl<gui::Label>("LBL_POWER");
+        _controls.LB_DESC = findControl<gui::ListBox>("LB_DESC");
+        _controls.LB_POWERS = findControl<gui::ListBox>("LB_POWERS");
+        _controls.MAIN_TITLE_LBL = findControl<gui::Label>("MAIN_TITLE_LBL");
+        _controls.RECOMMENDED_BTN = findControl<gui::Button>("RECOMMENDED_BTN");
+        _controls.REMAINING_SELECTIONS_LBL = findControl<gui::Label>("REMAINING_SELECTIONS_LBL");
+        _controls.SELECTIONS_REMAINING_LBL = findControl<gui::Label>("SELECTIONS_REMAINING_LBL");
+        _controls.SELECT_BTN = findControl<gui::Button>("SELECT_BTN");
+        _controls.SUB_TITLE_LBL = findControl<gui::Label>("SUB_TITLE_LBL");
+    }
+
+    void loadDisplayEntries();
+    void refreshControls();
+    void refreshIconChain();
+    void refreshIconChainLinks(const std::map<SpellType, glm::ivec2> &positions);
+    void showPowerDescription(SpellType type);
+    void resetFocusedPowerName();
+    void onPowerFocused(const std::string &power);
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -92,6 +92,7 @@ public:
     void clearLinks();
     void addLink(Link link);
     void setItemSelected(const std::string &tag, bool selected);
+    void setItemState(const std::string &tag, State state);
     void focusItem(const std::string &tag);
     const Item *focusedItem() const;
 

--- a/include/reone/gui/control/iconchain.h
+++ b/include/reone/gui/control/iconchain.h
@@ -92,6 +92,7 @@ public:
     void clearLinks();
     void addLink(Link link);
     void setItemSelected(const std::string &tag, bool selected);
+    void focusItem(const std::string &tag);
     const Item *focusedItem() const;
 
     bool handleMouseMotion(int x, int y) override;

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -197,6 +197,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/chargen/levelup.h
     ${GAME_INCLUDE_DIR}/gui/chargen/nameentry.h
     ${GAME_INCLUDE_DIR}/gui/chargen/portraitselect.h
+    ${GAME_INCLUDE_DIR}/gui/chargen/powers.h
     ${GAME_INCLUDE_DIR}/gui/chargen/quick.h
     ${GAME_INCLUDE_DIR}/gui/chargen/quickorcustom.h
     ${GAME_INCLUDE_DIR}/gui/chargen/skills.h
@@ -465,6 +466,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/chargen/levelup.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/nameentry.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/portraitselect.cpp
+    ${GAME_SOURCE_DIR}/gui/chargen/powers.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/quick.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/quickorcustom.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/skills.cpp

--- a/src/libs/game/d20/class.cpp
+++ b/src/libs/game/d20/class.cpp
@@ -32,6 +32,7 @@ namespace game {
 static const char kSkillsTwoDAResRef[] = "skills";
 static const char kFeatTwoDAResRef[] = "feat";
 static const char kFeatGainTwoDAResRef[] = "featgain";
+static const char kPowerGainTwoDAResRef[] = "classpowergain";
 
 static bool hasColumn(const TwoDA &twoDa, const std::string &column) {
     return std::find(twoDa.columns().begin(), twoDa.columns().end(), column) != twoDa.columns().end();
@@ -72,6 +73,9 @@ void CreatureClass::load(const TwoDA &twoDa, int row) {
 
     std::string featGainPrefix(boost::to_lower_copy(twoDa.getString(row, "featgain")));
     loadFeatGains(featGainPrefix);
+
+    std::string powerGainPrefix(boost::to_lower_copy(twoDa.getString(row, "spellgaintable")));
+    loadPowerGains(powerGainPrefix);
 }
 
 void CreatureClass::loadClassSkills(const std::string &skillsTable) {
@@ -140,6 +144,24 @@ void CreatureClass::loadFeatGains(const std::string &featGainPrefix) {
     }
 }
 
+void CreatureClass::loadPowerGains(const std::string &powerGainPrefix) {
+    if (powerGainPrefix.empty()) {
+        return;
+    }
+
+    std::shared_ptr<TwoDA> powerGain(_twoDas.get(kPowerGainTwoDAResRef));
+    if (!powerGain || !hasColumn(*powerGain, powerGainPrefix)) {
+        return;
+    }
+
+    for (int row = 0; row < powerGain->getRowCount(); ++row) {
+        auto level = getLevel(*powerGain, row);
+        if (level) {
+            _powerGainsByLevel.insert(std::make_pair(*level, powerGain->getInt(row, powerGainPrefix, 0)));
+        }
+    }
+}
+
 bool CreatureClass::isClassSkill(SkillType skill) const {
     return _classSkills.count(skill) > 0;
 }
@@ -162,6 +184,11 @@ int CreatureClass::getAttackBonus(int level) const {
 int CreatureClass::getFeatGain(int level) const {
     auto maybeFeatGain = _featGainsByLevel.find(level);
     return maybeFeatGain != _featGainsByLevel.end() ? maybeFeatGain->second : 0;
+}
+
+int CreatureClass::getPowerGain(int level) const {
+    auto maybePowerGain = _powerGainsByLevel.find(level);
+    return maybePowerGain != _powerGainsByLevel.end() ? maybePowerGain->second : 0;
 }
 
 int CreatureClass::getFeatListValue(FeatType feat) const {

--- a/src/libs/game/d20/spells.cpp
+++ b/src/libs/game/d20/spells.cpp
@@ -24,6 +24,9 @@
 #include "reone/resource/provider/textures.h"
 #include "reone/resource/strings.h"
 
+#include "reone/game/d20/attributes.h"
+#include "reone/game/d20/class.h"
+
 using namespace reone::graphics;
 using namespace reone::audio;
 using namespace reone::resource;
@@ -69,6 +72,78 @@ static std::vector<SpellType> parsePrerequisites(const std::string &value) {
         if (maybeSpell) {
             result.push_back(*maybeSpell);
         }
+    }
+    return result;
+}
+
+static bool isPickerVisible(const Spell &spell, const CreatureClass &clazz) {
+    auto maybeRequirement = spell.getClassLevelRequirement(clazz.type());
+    return spell.userType == 1 && maybeRequirement && *maybeRequirement >= 0;
+}
+
+static bool prerequisitesSatisfied(
+    const Spell &spell,
+    const CreatureAttributes &attributes,
+    const std::set<SpellType> &chosen) {
+    return std::all_of(spell.prerequisites.begin(), spell.prerequisites.end(), [&](SpellType prerequisite) {
+        return attributes.hasSpell(prerequisite) || chosen.count(prerequisite) > 0;
+    });
+}
+
+static int getVisualDepth(
+    SpellType type,
+    const std::unordered_map<SpellType, std::shared_ptr<Spell>> &spells,
+    const std::set<SpellType> &visible,
+    std::unordered_map<SpellType, int> &depths,
+    std::set<SpellType> &visited) {
+    auto maybeDepth = depths.find(type);
+    if (maybeDepth != depths.end()) {
+        return maybeDepth->second;
+    }
+    if (!visited.insert(type).second) {
+        return 0;
+    }
+
+    int result = 0;
+    auto spell = spells.at(type);
+    for (auto prerequisite : spell->prerequisites) {
+        if (visible.count(prerequisite) > 0) {
+            result = std::max(result, getVisualDepth(prerequisite, spells, visible, depths, visited) + 1);
+        }
+    }
+
+    visited.erase(type);
+    depths.emplace(type, result);
+    return result;
+}
+
+static std::optional<SpellType> getDisplayParent(
+    const Spell &spell,
+    const std::set<SpellType> &visible,
+    const std::unordered_map<SpellType, int> &depths) {
+    std::optional<SpellType> result;
+    int deepest = -1;
+    for (auto prerequisite : spell.prerequisites) {
+        auto maybeDepth = depths.find(prerequisite);
+        if (visible.count(prerequisite) > 0 && maybeDepth != depths.end() && maybeDepth->second > deepest) {
+            result = prerequisite;
+            deepest = maybeDepth->second;
+        }
+    }
+    return result;
+}
+
+static SpellType getChainRoot(
+    SpellType type,
+    const std::unordered_map<SpellType, std::optional<SpellType>> &parents) {
+    std::set<SpellType> visited;
+    SpellType result = type;
+    while (visited.insert(result).second) {
+        auto maybeParent = parents.find(result);
+        if (maybeParent == parents.end() || !maybeParent->second) {
+            break;
+        }
+        result = *maybeParent->second;
     }
     return result;
 }
@@ -128,6 +203,118 @@ void Spells::init() {
 std::shared_ptr<Spell> Spells::get(SpellType type) const {
     auto it = _spells.find(type);
     return it != _spells.end() ? it->second : nullptr;
+}
+
+bool Spells::isLevelUpCandidate(
+    SpellType type,
+    const CreatureAttributes &attributes,
+    const CreatureClass &clazz,
+    const std::set<SpellType> &chosen) const {
+    auto maybeSpell = _spells.find(type);
+    if (maybeSpell == _spells.end() ||
+        !isPickerVisible(*maybeSpell->second, clazz) ||
+        attributes.hasSpell(type) ||
+        chosen.count(type) > 0) {
+        return false;
+    }
+
+    int targetClassLevel = attributes.getClassLevel(clazz.type()) + 1;
+    auto maybeRequirement = maybeSpell->second->getClassLevelRequirement(clazz.type());
+    return maybeRequirement && targetClassLevel >= *maybeRequirement &&
+           prerequisitesSatisfied(*maybeSpell->second, attributes, chosen);
+}
+
+std::vector<SpellType> Spells::getLevelUpCandidates(
+    const CreatureAttributes &attributes,
+    const CreatureClass &clazz,
+    const std::set<SpellType> &chosen) const {
+    std::vector<SpellType> result;
+    for (const auto &[type, spell] : _spells) {
+        if (isLevelUpCandidate(type, attributes, clazz, chosen)) {
+            result.push_back(type);
+        }
+    }
+    std::sort(result.begin(), result.end(), [](SpellType left, SpellType right) {
+        return static_cast<int>(left) < static_cast<int>(right);
+    });
+    return result;
+}
+
+std::vector<SpellDisplayEntry> Spells::getLevelUpDisplayEntries(
+    const CreatureAttributes &attributes,
+    const CreatureClass &clazz,
+    const std::set<SpellType> &chosen) const {
+    std::set<SpellType> visible;
+    for (const auto &[type, spell] : _spells) {
+        if (isPickerVisible(*spell, clazz)) {
+            visible.insert(type);
+        }
+    }
+
+    std::unordered_map<SpellType, int> depths;
+    for (auto type : visible) {
+        std::set<SpellType> visited;
+        getVisualDepth(type, _spells, visible, depths, visited);
+    }
+
+    std::unordered_map<SpellType, std::optional<SpellType>> parents;
+    for (auto type : visible) {
+        parents.emplace(type, getDisplayParent(*_spells.at(type), visible, depths));
+    }
+
+    int targetClassLevel = attributes.getClassLevel(clazz.type()) + 1;
+    std::vector<SpellDisplayEntry> result;
+    for (const auto &[type, spell] : _spells) {
+        SpellDisplayEntry entry;
+        entry.type = type;
+        entry.name = spell->name;
+        entry.description = spell->description;
+        entry.icon = spell->icon;
+        entry.prerequisites = spell->prerequisites;
+        entry.sourceOrder = static_cast<int>(type);
+        entry.known = attributes.hasSpell(type);
+        entry.chosen = chosen.count(type) > 0;
+        entry.visible = visible.count(type) > 0;
+        if (!entry.visible) {
+            result.push_back(std::move(entry));
+            continue;
+        }
+
+        entry.displayParent = parents.at(type);
+        entry.chainRoot = getChainRoot(type, parents);
+        entry.visualDepth = depths.at(type);
+        auto maybeRequirement = spell->getClassLevelRequirement(clazz.type());
+        if (entry.known) {
+            entry.availability = SpellAvailability::Known;
+        } else if (entry.chosen) {
+            entry.availability = SpellAvailability::Chosen;
+        } else if (maybeRequirement && targetClassLevel < *maybeRequirement) {
+            entry.availability = SpellAvailability::LockedClassLevel;
+        } else if (!prerequisitesSatisfied(*spell, attributes, chosen)) {
+            entry.availability = SpellAvailability::LockedMissingPrerequisite;
+        } else {
+            entry.availability = SpellAvailability::Selectable;
+            entry.selectable = true;
+        }
+        result.push_back(std::move(entry));
+    }
+
+    std::sort(result.begin(), result.end(), [](const SpellDisplayEntry &left, const SpellDisplayEntry &right) {
+        if (left.visible != right.visible) {
+            return left.visible;
+        }
+        if (!left.visible) {
+            return left.sourceOrder < right.sourceOrder;
+        }
+        if (left.chainRoot != right.chainRoot) {
+            return static_cast<int>(left.chainRoot) < static_cast<int>(right.chainRoot);
+        }
+        if (left.visualDepth != right.visualDepth) {
+            return left.visualDepth < right.visualDepth;
+        }
+        return left.sourceOrder < right.sourceOrder;
+    });
+    return result;
 }
 
 } // namespace game

--- a/src/libs/game/d20/spells.cpp
+++ b/src/libs/game/d20/spells.cpp
@@ -32,6 +32,47 @@ namespace reone {
 
 namespace game {
 
+static const std::vector<std::pair<ClassType, std::string>> kClassLevelColumns = {
+    {ClassType::JediGuardian, "guardian"},
+    {ClassType::JediConsular, "consular"},
+    {ClassType::JediSentinel, "sentinel"},
+    {ClassType::JediWeaponMaster, "weapmstr"},
+    {ClassType::JediMaster, "jedimaster"},
+    {ClassType::JediWatchman, "watchman"},
+    {ClassType::SithMarauder, "marauder"},
+    {ClassType::SithLord, "sithlord"},
+    {ClassType::SithAssassin, "assassin"}};
+
+static std::optional<SpellType> parseSpellType(const std::string &value) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+
+    try {
+        size_t parsedLength = 0;
+        int parsed = std::stoi(value, &parsedLength);
+        if (parsedLength == value.size() && parsed >= 0) {
+            return static_cast<SpellType>(parsed);
+        }
+    } catch (const std::exception &) {
+    }
+
+    return std::nullopt;
+}
+
+static std::vector<SpellType> parsePrerequisites(const std::string &value) {
+    std::vector<SpellType> result;
+    std::vector<std::string> tokens;
+    boost::split(tokens, value, boost::is_any_of("_"));
+    for (const auto &token : tokens) {
+        auto maybeSpell = parseSpellType(token);
+        if (maybeSpell) {
+            result.push_back(*maybeSpell);
+        }
+    }
+    return result;
+}
+
 void Spells::init() {
     std::shared_ptr<TwoDA> spells(_twoDas.get("spells"));
     if (!spells)
@@ -43,6 +84,9 @@ void Spells::init() {
         std::string description(_strings.getText(spells->getInt(row, "spelldesc", -1)));
         std::shared_ptr<Texture> icon(_textures.get(spells->getString(row, "iconresref"), TextureUsage::GUI));
         uint32_t pips = spells->getHexInt(row, "pips");
+        std::vector<SpellType> prerequisites(parsePrerequisites(spells->getString(row, "prerequisites")));
+        std::optional<SpellType> masterSpell(parseSpellType(spells->getString(row, "masterspell")));
+        int userType = spells->getInt(row, "usertype", -1);
         uint32_t category = spells->getHexInt(row, "category");
         std::string impactScript = spells->getString(row, "impactscript");
         std::string castAnim = spells->getString(row, "castanim");
@@ -59,6 +103,15 @@ void Spells::init() {
         spell->description = std::move(description);
         spell->icon = std::move(icon);
         spell->pips = pips;
+        spell->prerequisites = std::move(prerequisites);
+        spell->masterSpell = masterSpell;
+        spell->userType = userType;
+        for (const auto &[clazz, column] : kClassLevelColumns) {
+            auto maybeRequirement = spells->getIntOpt(row, column);
+            if (maybeRequirement) {
+                spell->classLevelRequirements.emplace(clazz, *maybeRequirement);
+            }
+        }
         spell->category = category;
         spell->impactScript = impactScript;
         spell->castAnim = castAnim;

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -85,6 +85,7 @@ void CharacterGeneration::onGUILoaded() {
     loadAbilities();
     loadSkills();
     loadFeats();
+    loadPowers();
     loadLevelUp();
 }
 
@@ -128,6 +129,11 @@ void CharacterGeneration::loadFeats() {
     _charGenFeats->init();
 }
 
+void CharacterGeneration::loadPowers() {
+    _charGenPowers = std::make_unique<CharGenPowers>(*this, _game, _services);
+    _charGenPowers->init();
+}
+
 void CharacterGeneration::loadNameEntry() {
     _nameEntry = std::make_unique<NameEntry>(*this, _game, _services);
     _nameEntry->init();
@@ -163,6 +169,8 @@ GameGUI *CharacterGeneration::getSubGUI() const {
         return _charGenSkills.get();
     case CharGenScreen::Feats:
         return _charGenFeats.get();
+    case CharGenScreen::Powers:
+        return _charGenPowers.get();
     case CharGenScreen::Name:
         return _nameEntry.get();
     case CharGenScreen::LevelUp:
@@ -302,6 +310,12 @@ void CharacterGeneration::openFeats() {
     _charGenFeats->reset(_type == Type::LevelUp);
     _controls.MODEL_LBL->setVisible(false);
     changeScreen(CharGenScreen::Feats);
+}
+
+void CharacterGeneration::openPowers() {
+    _charGenPowers->reset();
+    _controls.MODEL_LBL->setVisible(false);
+    changeScreen(CharGenScreen::Powers);
 }
 
 void CharacterGeneration::openNameEntry() {

--- a/src/libs/game/gui/chargen/levelup.cpp
+++ b/src/libs/game/gui/chargen/levelup.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/game/d20/classes.h"
 #include "reone/game/d20/feats.h"
+#include "reone/game/d20/spells.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/chargen.h"
 #include "reone/gui/control/button.h"
@@ -51,6 +52,9 @@ void LevelUpMenu::onGUILoaded() {
     _controls.BTN_STEPNAME3->setOnClick([this]() {
         _charGen.openFeats();
     });
+    _controls.BTN_STEPNAME4->setOnClick([this]() {
+        _charGen.openPowers();
+    });
     _controls.BTN_STEPNAME5->setOnClick([this]() {
         _charGen.finish();
     });
@@ -60,18 +64,17 @@ void LevelUpMenu::reset() {
     int nextLevel = _charGen.character().attributes.getAggregateLevel() + 1;
     _hasAttributes = nextLevel % 4 == 0;
     _hasFeats = hasFeatChoices();
-
-    // TODO: Force Powers are not yet implemented
+    _hasPowers = hasPowerChoices();
 
     _controls.LBL_1->setVisible(_hasAttributes);
     _controls.LBL_3->setVisible(_hasFeats);
-    _controls.LBL_4->setVisible(false);
+    _controls.LBL_4->setVisible(_hasPowers);
     _controls.LBL_NUM1->setVisible(_hasAttributes);
     _controls.LBL_NUM3->setVisible(_hasFeats);
-    _controls.LBL_NUM4->setVisible(false);
+    _controls.LBL_NUM4->setVisible(_hasPowers);
     _controls.BTN_STEPNAME1->setVisible(_hasAttributes);
     _controls.BTN_STEPNAME3->setVisible(_hasFeats);
-    _controls.BTN_STEPNAME4->setVisible(false);
+    _controls.BTN_STEPNAME4->setVisible(_hasPowers);
 }
 
 void LevelUpMenu::goToNextStep() {
@@ -80,9 +83,12 @@ void LevelUpMenu::goToNextStep() {
         doSetStep(1);
         break;
     case 1:
-        doSetStep(_hasFeats ? 2 : 4);
+        doSetStep(_hasFeats ? 2 : (_hasPowers ? 3 : 4));
         break;
     case 2:
+        doSetStep(_hasPowers ? 3 : 4);
+        break;
+    case 3:
         doSetStep(4);
         break;
     default:
@@ -131,6 +137,24 @@ bool LevelUpMenu::hasFeatChoices() const {
     const CreatureAttributes &attributes = _charGen.character().attributes;
     std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
     return _services.game.feats.getLevelUpChoiceCount(attributes, *clazz) > 0;
+}
+
+bool LevelUpMenu::hasPowerChoices() const {
+    const CreatureAttributes &attributes = _charGen.character().attributes;
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
+    if (!clazz) {
+        return false;
+    }
+
+    int targetClassLevel = attributes.getClassLevel(clazz->type()) + 1;
+    if (clazz->getPowerGain(targetClassLevel) <= 0) {
+        return false;
+    }
+
+    auto entries = _services.game.spells.getLevelUpDisplayEntries(attributes, *clazz, {});
+    return std::any_of(entries.begin(), entries.end(), [](const SpellDisplayEntry &entry) {
+        return entry.visible;
+    });
 }
 
 } // namespace game

--- a/src/libs/game/gui/chargen/powers.cpp
+++ b/src/libs/game/gui/chargen/powers.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/gui/chargen/powers.h"
+
+#include "reone/game/d20/classes.h"
+#include "reone/game/game.h"
+#include "reone/game/gui/chargen.h"
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/iconchain.h"
+#include "reone/gui/control/listbox.h"
+#include "reone/resource/provider/textures.h"
+
+using namespace reone::gui;
+using namespace reone::graphics;
+using namespace reone::resource;
+
+namespace reone {
+
+namespace game {
+
+static constexpr int kPowerIconCellSize = 40;
+static constexpr int kPowerIconColumnCount = 3;
+static constexpr int kPowerIconSize = 32;
+static constexpr int kK1PowerArrowSize = 32;
+static constexpr int kTSLPowerArrowSize = 32;
+static constexpr int kK1VisiblePowerRows = 5;
+static constexpr int kTSLVisiblePowerRows = 7;
+static constexpr char kK1PowerCellFill[] = "lbl_indent";
+static constexpr char kK1PowerArrow[] = "lbl_skarr";
+static constexpr char kK1PowerCellBorderCorner[] = "border2d";
+static constexpr char kK1PowerCellBorderEdge[] = "border1d";
+static constexpr int kK1PowerCellBorderDimension = 8;
+static constexpr glm::vec3 kK1PowerBorderGreen {0.278431f, 0.921569f, 0.105882f};
+static constexpr glm::vec3 kK1PowerBorderGreenDim = 0.7f * kK1PowerBorderGreen;
+static constexpr glm::vec3 kK1PowerBorderGold {0.980392f, 1.0f, 0.0f};
+static constexpr glm::vec3 kK1PowerBorderRed {0.698039f, 0.0f, 0.0f};
+static constexpr glm::vec3 kTSLLockedPowerBorderColor {0.698039f, 0.0f, 0.0f};
+static constexpr glm::vec3 kTSLSelectablePowerBorderColor {0.05098f, 0.34902f, 0.270588f};
+static constexpr glm::vec3 kTSLOwnedPowerBorderColor {0.101961f, 0.698039f, 0.54902f};
+static constexpr glm::vec3 kTSLChosenPowerBorderColor {1.0f};
+static constexpr char kTSLPowerArrow[] = "uibit_abi_arrow";
+
+static std::map<SpellType, glm::ivec2> getPowerIconPositions(
+    const std::vector<SpellDisplayEntry> &entries) {
+
+    std::map<SpellType, int> nextIndexByRoot;
+    std::vector<SpellType> chainRoots;
+    std::map<SpellType, glm::ivec2> result;
+    for (const auto &entry : entries) {
+        if (!entry.visible) {
+            continue;
+        }
+
+        SpellType root = entry.chainRoot != SpellType::All ? entry.chainRoot : entry.type;
+        auto maybeIndex = nextIndexByRoot.insert({root, 0});
+        if (maybeIndex.second) {
+            chainRoots.push_back(root);
+        }
+        int index = maybeIndex.first->second++;
+        result.emplace(entry.type, glm::ivec2(index % kPowerIconColumnCount, index / kPowerIconColumnCount));
+    }
+
+    std::map<SpellType, int> rowBases;
+    int nextRow = 0;
+    for (auto root : chainRoots) {
+        int count = nextIndexByRoot.at(root);
+        rowBases.emplace(root, nextRow);
+        nextRow += (count + kPowerIconColumnCount - 1) / kPowerIconColumnCount;
+    }
+
+    for (const auto &entry : entries) {
+        if (!entry.visible) {
+            continue;
+        }
+        SpellType root = entry.chainRoot != SpellType::All ? entry.chainRoot : entry.type;
+        result.at(entry.type).y += rowBases.at(root);
+    }
+    return result;
+}
+
+void CharGenPowers::onGUILoaded() {
+    bindControls();
+    _defaultPowerNameText = _controls.LBL_POWER->text().text;
+
+    auto iconChainControl = std::shared_ptr<Control>(_gui->newControl(ControlType::IconChain, "ICONCHAIN_POWERS"));
+    _controls.ICONCHAIN_POWERS = std::static_pointer_cast<IconChain>(iconChainControl);
+    _controls.ICONCHAIN_POWERS->setExtent(_controls.LB_POWERS->extent());
+    _controls.ICONCHAIN_POWERS->setPadding(_controls.LB_POWERS->padding());
+    _controls.ICONCHAIN_POWERS->setBorder(_controls.LB_POWERS->border());
+    if (!_game.isTSL()) {
+        _controls.ICONCHAIN_POWERS->setHilight(_controls.LB_POWERS->border());
+        _controls.ICONCHAIN_POWERS->setHilightColor(_hilightColor);
+    }
+    _controls.ICONCHAIN_POWERS->setTintBorderFill(_game.isTSL());
+    _controls.ICONCHAIN_POWERS->setCellSize(kPowerIconCellSize);
+    auto &listExtent = _controls.LB_POWERS->extent();
+    auto &protoExtent = _controls.LB_POWERS->protoItem().extent();
+    int contentInsetY = protoExtent.top - listExtent.top;
+    int originY = contentInsetY;
+    int rowStep = protoExtent.height;
+    if (!_game.isTSL()) {
+        int contentHeight = listExtent.height - 2 * contentInsetY;
+        int remainingHeight = contentHeight - kK1VisiblePowerRows * kPowerIconCellSize;
+        int gapCount = kK1VisiblePowerRows + 1;
+        int rowGap = (remainingHeight + gapCount / 2) / gapCount;
+        originY += rowGap;
+        rowStep = kPowerIconCellSize + rowGap;
+    } else {
+        int fillInsetY = _controls.LB_POWERS->border().dimension;
+        int fillHeight = listExtent.height - 2 * fillInsetY;
+        int rowRange = fillHeight - kPowerIconCellSize;
+        int gapCount = kTSLVisiblePowerRows - 1;
+        std::vector<int> rowOffsets;
+        rowOffsets.reserve(kTSLVisiblePowerRows);
+        for (int row = 0; row < kTSLVisiblePowerRows; ++row) {
+            rowOffsets.push_back(
+                fillInsetY + (row * rowRange + gapCount / 2) / gapCount);
+        }
+        _controls.ICONCHAIN_POWERS->setRowOffsets(std::move(rowOffsets));
+    }
+    _controls.ICONCHAIN_POWERS->setCellOrigin(protoExtent.left - listExtent.left, originY);
+    _controls.ICONCHAIN_POWERS->setCellStep(
+        (protoExtent.width - kPowerIconCellSize) / (kPowerIconColumnCount - 1),
+        rowStep);
+
+    IconChain::CellStyle cellStyle;
+    if (!_game.isTSL()) {
+        cellStyle.backgroundTexture = _services.resource.textures.get(kK1PowerCellFill, TextureUsage::GUI);
+        cellStyle.linkTexture = _services.resource.textures.get(kK1PowerArrow, TextureUsage::GUI);
+        cellStyle.linkSize = {kK1PowerArrowSize, kK1PowerArrowSize};
+        cellStyle.itemBorder = std::make_shared<Control::Border>();
+        cellStyle.itemBorder->corner = _services.resource.textures.get(kK1PowerCellBorderCorner, TextureUsage::GUI);
+        cellStyle.itemBorder->edge = _services.resource.textures.get(kK1PowerCellBorderEdge, TextureUsage::GUI);
+        cellStyle.itemBorder->dimension = kK1PowerCellBorderDimension;
+        cellStyle.borderColors = std::make_shared<IconChain::CellStyle::BorderColors>();
+        cellStyle.borderColors->owned = kK1PowerBorderGreenDim;
+        cellStyle.borderColors->selected = kK1PowerBorderGreen;
+        cellStyle.focusedBorderColors = std::make_shared<IconChain::CellStyle::FocusedBorderColors>();
+        cellStyle.focusedBorderColors->locked = kK1PowerBorderRed;
+        cellStyle.focusedBorderColors->selectable = kK1PowerBorderGold;
+        cellStyle.focusedBorderColors->owned = kK1PowerBorderGreen;
+        cellStyle.focusedBorderColors->selected = kK1PowerBorderGreen;
+        cellStyle.onlyDrawItemBorderWhenBright = true;
+    } else {
+        cellStyle.linkTexture = _services.resource.textures.get(kTSLPowerArrow, TextureUsage::GUI);
+        cellStyle.linkSize = {kTSLPowerArrowSize, kTSLPowerArrowSize};
+        cellStyle.borderColors = std::make_shared<IconChain::CellStyle::BorderColors>();
+        cellStyle.borderColors->locked = kTSLLockedPowerBorderColor;
+        cellStyle.borderColors->selectable = kTSLSelectablePowerBorderColor;
+        cellStyle.borderColors->owned = kTSLOwnedPowerBorderColor;
+        cellStyle.borderColors->selected = kTSLChosenPowerBorderColor;
+        cellStyle.focusedBorderColors = std::make_shared<IconChain::CellStyle::FocusedBorderColors>();
+        cellStyle.focusedBorderColors->locked = kTSLLockedPowerBorderColor;
+        cellStyle.focusedBorderColors->selectable = kTSLSelectablePowerBorderColor;
+        cellStyle.focusedBorderColors->owned = kTSLOwnedPowerBorderColor;
+        cellStyle.focusedBorderColors->selected = kTSLChosenPowerBorderColor;
+    }
+    cellStyle.iconSize = kPowerIconSize;
+    cellStyle.dimLockedBackground = !_game.isTSL();
+    cellStyle.drawItemBorderFill = !_game.isTSL();
+    _controls.ICONCHAIN_POWERS->setCellStyle(std::move(cellStyle));
+    _controls.ICONCHAIN_POWERS->setOnItemFocus([this](const std::string &item) {
+        onPowerFocused(item);
+    });
+    _controls.ICONCHAIN_POWERS->setOnItemFocusCleared([this]() {
+        resetFocusedPowerName();
+    });
+    _gui->addControlToBack(_controls.ICONCHAIN_POWERS);
+
+    _controls.LB_DESC->setProtoMatchContent(true);
+    _controls.LB_POWERS->setVisible(false);
+    _controls.SELECT_BTN->setDisabled(true);
+    _controls.SELECT_BTN->setVisible(false);
+    _controls.RECOMMENDED_BTN->setDisabled(true);
+    _controls.RECOMMENDED_BTN->setVisible(false);
+    _controls.ACCEPT_BTN->setOnClick([this]() {
+        _charGen.goToNextStep();
+        _charGen.openSteps();
+    });
+    _controls.BACK_BTN->setOnClick([this]() {
+        _charGen.openSteps();
+    });
+}
+
+void CharGenPowers::reset() {
+    _displayEntries.clear();
+    _controls.LB_DESC->clearItems();
+    resetFocusedPowerName();
+    loadDisplayEntries();
+    refreshControls();
+}
+
+void CharGenPowers::loadDisplayEntries() {
+    const CreatureAttributes &attributes = _charGen.character().attributes;
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
+    if (!clazz) {
+        _powerGain = 0;
+        return;
+    }
+
+    int targetClassLevel = attributes.getClassLevel(clazz->type()) + 1;
+    _powerGain = clazz->getPowerGain(targetClassLevel);
+    _displayEntries = _services.game.spells.getLevelUpDisplayEntries(attributes, *clazz, {});
+}
+
+void CharGenPowers::refreshControls() {
+    _controls.SELECTIONS_REMAINING_LBL->setTextMessage(std::to_string(_powerGain));
+    refreshIconChain();
+}
+
+void CharGenPowers::refreshIconChain() {
+    _controls.ICONCHAIN_POWERS->clearItems();
+    _controls.ICONCHAIN_POWERS->setColumnCount(kPowerIconColumnCount);
+
+    auto positions = getPowerIconPositions(_displayEntries);
+    std::string firstVisible;
+    for (const auto &entry : _displayEntries) {
+        if (!entry.visible) {
+            continue;
+        }
+
+        IconChain::Item item;
+        item.tag = std::to_string(static_cast<int>(entry.type));
+        item.column = positions.at(entry.type).x;
+        item.row = positions.at(entry.type).y;
+        item.iconTexture = entry.icon;
+        item.selected = entry.chosen;
+        switch (entry.availability) {
+        case SpellAvailability::Known:
+            item.state = IconChain::State::Owned;
+            break;
+        case SpellAvailability::Chosen:
+        case SpellAvailability::Selectable:
+            item.state = IconChain::State::Selectable;
+            break;
+        case SpellAvailability::Hidden:
+        case SpellAvailability::LockedClassLevel:
+        case SpellAvailability::LockedMissingPrerequisite:
+            item.state = IconChain::State::Locked;
+            break;
+        }
+        if (firstVisible.empty()) {
+            firstVisible = item.tag;
+        }
+        _controls.ICONCHAIN_POWERS->addItem(std::move(item));
+    }
+
+    refreshIconChainLinks(positions);
+    _controls.ICONCHAIN_POWERS->setVisible(true);
+    if (!firstVisible.empty()) {
+        _controls.ICONCHAIN_POWERS->focusItem(firstVisible);
+    }
+}
+
+void CharGenPowers::refreshIconChainLinks(const std::map<SpellType, glm::ivec2> &positions) {
+    _controls.ICONCHAIN_POWERS->clearLinks();
+    for (const auto &entry : _displayEntries) {
+        if (!entry.visible || !entry.displayParent) {
+            continue;
+        }
+
+        auto source = positions.find(*entry.displayParent);
+        auto target = positions.find(entry.type);
+        if (source == positions.end() ||
+            target == positions.end() ||
+            source->second.y != target->second.y ||
+            target->second.x != source->second.x + 1) {
+            continue;
+        }
+
+        IconChain::Link link;
+        link.sourceTag = std::to_string(static_cast<int>(*entry.displayParent));
+        link.targetTag = std::to_string(static_cast<int>(entry.type));
+        _controls.ICONCHAIN_POWERS->addLink(std::move(link));
+    }
+}
+
+void CharGenPowers::showPowerDescription(SpellType type) {
+    auto maybeEntry = std::find_if(
+        _displayEntries.begin(), _displayEntries.end(),
+        [&type](const SpellDisplayEntry &entry) { return entry.type == type; });
+    if (maybeEntry == _displayEntries.end()) {
+        return;
+    }
+
+    _controls.LBL_POWER->setTextMessage(maybeEntry->name);
+    _controls.LB_DESC->clearItems();
+    _controls.LB_DESC->addTextLinesAsItems(maybeEntry->description);
+}
+
+void CharGenPowers::resetFocusedPowerName() {
+    _controls.LBL_POWER->setTextMessage(_defaultPowerNameText);
+}
+
+void CharGenPowers::onPowerFocused(const std::string &power) {
+    showPowerDescription(static_cast<SpellType>(std::stoi(power)));
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/gui/chargen/powers.cpp
+++ b/src/libs/game/gui/chargen/powers.cpp
@@ -55,6 +55,21 @@ static constexpr glm::vec3 kTSLOwnedPowerBorderColor {0.101961f, 0.698039f, 0.54
 static constexpr glm::vec3 kTSLChosenPowerBorderColor {1.0f};
 static constexpr char kTSLPowerArrow[] = "uibit_abi_arrow";
 
+static IconChain::State getPowerIconState(SpellAvailability availability) {
+    switch (availability) {
+    case SpellAvailability::Known:
+        return IconChain::State::Owned;
+    case SpellAvailability::Chosen:
+    case SpellAvailability::Selectable:
+        return IconChain::State::Selectable;
+    case SpellAvailability::Hidden:
+    case SpellAvailability::LockedClassLevel:
+    case SpellAvailability::LockedMissingPrerequisite:
+        return IconChain::State::Locked;
+    }
+    return IconChain::State::Locked;
+}
+
 static std::map<SpellType, glm::ivec2> getPowerIconPositions(
     const std::vector<SpellDisplayEntry> &entries) {
 
@@ -180,15 +195,24 @@ void CharGenPowers::onGUILoaded() {
     _controls.ICONCHAIN_POWERS->setOnItemFocusCleared([this]() {
         resetFocusedPowerName();
     });
+    _controls.ICONCHAIN_POWERS->setOnItemDoubleClick([this](const std::string &item) {
+        onPowerActivated(item);
+    });
     _gui->addControlToBack(_controls.ICONCHAIN_POWERS);
 
     _controls.LB_DESC->setProtoMatchContent(true);
     _controls.LB_POWERS->setVisible(false);
-    _controls.SELECT_BTN->setDisabled(true);
-    _controls.SELECT_BTN->setVisible(false);
+    _controls.SELECT_BTN->setOnClick([this]() {
+        activateFocusedPower();
+    });
+    _controls.SELECT_BTN->setVisible(true);
     _controls.RECOMMENDED_BTN->setDisabled(true);
     _controls.RECOMMENDED_BTN->setVisible(false);
     _controls.ACCEPT_BTN->setOnClick([this]() {
+        if (_selectedPowers.size() != static_cast<size_t>(_powerGain)) {
+            return;
+        }
+        updateCharacter();
         _charGen.goToNextStep();
         _charGen.openSteps();
     });
@@ -198,8 +222,11 @@ void CharGenPowers::onGUILoaded() {
 }
 
 void CharGenPowers::reset() {
+    _powerGain = 0;
     _displayEntries.clear();
+    _selectedPowers.clear();
     _controls.LB_DESC->clearItems();
+    _controls.SELECT_BTN->setDisabled(true);
     resetFocusedPowerName();
     loadDisplayEntries();
     refreshControls();
@@ -215,12 +242,18 @@ void CharGenPowers::loadDisplayEntries() {
 
     int targetClassLevel = attributes.getClassLevel(clazz->type()) + 1;
     _powerGain = clazz->getPowerGain(targetClassLevel);
-    _displayEntries = _services.game.spells.getLevelUpDisplayEntries(attributes, *clazz, {});
+    _displayEntries = _services.game.spells.getLevelUpDisplayEntries(attributes, *clazz, _selectedPowers);
 }
 
 void CharGenPowers::refreshControls() {
-    _controls.SELECTIONS_REMAINING_LBL->setTextMessage(std::to_string(_powerGain));
+    refreshSelectionControls();
     refreshIconChain();
+}
+
+void CharGenPowers::refreshSelectionControls() {
+    int remaining = _powerGain - static_cast<int>(_selectedPowers.size());
+    _controls.SELECTIONS_REMAINING_LBL->setTextMessage(std::to_string(remaining));
+    _controls.ACCEPT_BTN->setDisabled(remaining != 0);
 }
 
 void CharGenPowers::refreshIconChain() {
@@ -240,20 +273,7 @@ void CharGenPowers::refreshIconChain() {
         item.row = positions.at(entry.type).y;
         item.iconTexture = entry.icon;
         item.selected = entry.chosen;
-        switch (entry.availability) {
-        case SpellAvailability::Known:
-            item.state = IconChain::State::Owned;
-            break;
-        case SpellAvailability::Chosen:
-        case SpellAvailability::Selectable:
-            item.state = IconChain::State::Selectable;
-            break;
-        case SpellAvailability::Hidden:
-        case SpellAvailability::LockedClassLevel:
-        case SpellAvailability::LockedMissingPrerequisite:
-            item.state = IconChain::State::Locked;
-            break;
-        }
+        item.state = getPowerIconState(entry.availability);
         if (firstVisible.empty()) {
             firstVisible = item.tag;
         }
@@ -267,10 +287,37 @@ void CharGenPowers::refreshIconChain() {
     }
 }
 
+void CharGenPowers::refreshIconChainSelection() {
+    for (const auto &entry : _displayEntries) {
+        if (!entry.visible) {
+            continue;
+        }
+
+        std::string tag = std::to_string(static_cast<int>(entry.type));
+        _controls.ICONCHAIN_POWERS->setItemSelected(tag, entry.chosen);
+        _controls.ICONCHAIN_POWERS->setItemState(tag, getPowerIconState(entry.availability));
+    }
+
+    refreshIconChainLinks(getPowerIconPositions(_displayEntries));
+}
+
 void CharGenPowers::refreshIconChainLinks(const std::map<SpellType, glm::ivec2> &positions) {
     _controls.ICONCHAIN_POWERS->clearLinks();
     for (const auto &entry : _displayEntries) {
         if (!entry.visible || !entry.displayParent) {
+            continue;
+        }
+
+        auto sourceEntry = std::find_if(
+            _displayEntries.begin(), _displayEntries.end(),
+            [&entry](const SpellDisplayEntry &candidate) { return candidate.type == *entry.displayParent; });
+        bool sourceEffectivelyKnown = sourceEntry != _displayEntries.end() &&
+                                      (sourceEntry->availability == SpellAvailability::Known ||
+                                       sourceEntry->availability == SpellAvailability::Chosen);
+        bool targetReachable = entry.availability == SpellAvailability::Known ||
+                               entry.availability == SpellAvailability::Chosen ||
+                               entry.availability == SpellAvailability::Selectable;
+        if (!sourceEffectivelyKnown || !targetReachable) {
             continue;
         }
 
@@ -288,6 +335,54 @@ void CharGenPowers::refreshIconChainLinks(const std::map<SpellType, glm::ivec2> 
         link.targetTag = std::to_string(static_cast<int>(entry.type));
         _controls.ICONCHAIN_POWERS->addLink(std::move(link));
     }
+}
+
+void CharGenPowers::updateCharacter() {
+    Character character(_charGen.character());
+    for (auto power : _selectedPowers) {
+        character.attributes.addSpell(power);
+    }
+    _charGen.setCharacter(std::move(character));
+}
+
+void CharGenPowers::toggleSelectedPower(SpellType power) {
+    auto maybeSelectedPower = _selectedPowers.find(power);
+    if (maybeSelectedPower != _selectedPowers.end()) {
+        _selectedPowers.erase(maybeSelectedPower);
+        removeInvalidSelectedPowers();
+    } else if (_selectedPowers.size() < static_cast<size_t>(_powerGain)) {
+        _selectedPowers.insert(power);
+    }
+
+    std::string focusedPower = std::to_string(static_cast<int>(power));
+    loadDisplayEntries();
+    refreshSelectionControls();
+    refreshIconChainSelection();
+    onPowerFocused(focusedPower);
+}
+
+void CharGenPowers::removeInvalidSelectedPowers() {
+    const CreatureAttributes &attributes = _charGen.character().attributes;
+    std::shared_ptr<CreatureClass> clazz(_services.game.classes.get(attributes.getEffectiveClass()));
+    if (!clazz) {
+        _selectedPowers.clear();
+        return;
+    }
+
+    bool removed;
+    do {
+        removed = false;
+        for (auto power : _selectedPowers) {
+            std::set<SpellType> prerequisiteChoices(_selectedPowers);
+            prerequisiteChoices.erase(power);
+            if (!_services.game.spells.isLevelUpCandidate(
+                    power, attributes, *clazz, prerequisiteChoices)) {
+                _selectedPowers.erase(power);
+                removed = true;
+                break;
+            }
+        }
+    } while (removed);
 }
 
 void CharGenPowers::showPowerDescription(SpellType type) {
@@ -308,7 +403,42 @@ void CharGenPowers::resetFocusedPowerName() {
 }
 
 void CharGenPowers::onPowerFocused(const std::string &power) {
-    showPowerDescription(static_cast<SpellType>(std::stoi(power)));
+    auto powerType = static_cast<SpellType>(std::stoi(power));
+    showPowerDescription(powerType);
+
+    auto maybeDisplayEntry = std::find_if(
+        _displayEntries.begin(), _displayEntries.end(),
+        [&powerType](const SpellDisplayEntry &entry) { return entry.type == powerType; });
+    bool canActivate = maybeDisplayEntry != _displayEntries.end() &&
+                       (maybeDisplayEntry->chosen ||
+                        (maybeDisplayEntry->selectable &&
+                         _selectedPowers.size() < static_cast<size_t>(_powerGain)));
+    _controls.SELECT_BTN->setDisabled(!canActivate);
+}
+
+void CharGenPowers::onPowerActivated(const std::string &power) {
+    auto powerType = static_cast<SpellType>(std::stoi(power));
+    showPowerDescription(powerType);
+
+    auto maybeDisplayEntry = std::find_if(
+        _displayEntries.begin(), _displayEntries.end(),
+        [&powerType](const SpellDisplayEntry &entry) { return entry.type == powerType; });
+    if (maybeDisplayEntry == _displayEntries.end()) {
+        return;
+    }
+    if (maybeDisplayEntry->chosen ||
+        (maybeDisplayEntry->selectable &&
+         _selectedPowers.size() < static_cast<size_t>(_powerGain))) {
+        toggleSelectedPower(powerType);
+    }
+}
+
+void CharGenPowers::activateFocusedPower() {
+    const IconChain::Item *item = _controls.ICONCHAIN_POWERS->focusedItem();
+    if (!item) {
+        return;
+    }
+    onPowerActivated(item->tag);
 }
 
 } // namespace game

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -58,6 +58,15 @@ void IconChain::setItemSelected(const std::string &tag, bool selected) {
     }
 }
 
+void IconChain::setItemState(const std::string &tag, State state) {
+    for (auto &item : _items) {
+        if (item.tag == tag) {
+            item.state = state;
+            return;
+        }
+    }
+}
+
 void IconChain::focusItem(const std::string &tag) {
     auto maybeItem = std::find_if(
         _items.begin(), _items.end(),

--- a/src/libs/gui/control/iconchain.cpp
+++ b/src/libs/gui/control/iconchain.cpp
@@ -58,6 +58,20 @@ void IconChain::setItemSelected(const std::string &tag, bool selected) {
     }
 }
 
+void IconChain::focusItem(const std::string &tag) {
+    auto maybeItem = std::find_if(
+        _items.begin(), _items.end(),
+        [&tag](const Item &item) { return item.tag == tag; });
+    if (maybeItem == _items.end()) {
+        return;
+    }
+
+    _focusedItemIndex = static_cast<int>(std::distance(_items.begin(), maybeItem));
+    if (_onItemFocus) {
+        _onItemFocus(maybeItem->tag);
+    }
+}
+
 const IconChain::Item *IconChain::focusedItem() const {
     if (_focusedItemIndex < 0 || _focusedItemIndex >= static_cast<int>(_items.size())) {
         return nullptr;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(TESTS_HEADERS
 
 set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/audio/format/wavreader.cpp
+    ${TESTS_SOURCE_DIR}/game/d20/class.cpp
+    ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -95,6 +95,9 @@ public:
 class MockSpells : public ISpells, boost::noncopyable {
 public:
     MOCK_METHOD(std::shared_ptr<Spell>, get, (SpellType type), (const override));
+    MOCK_METHOD(bool, isLevelUpCandidate, (SpellType type, const CreatureAttributes &attributes, const CreatureClass &clazz, const std::set<SpellType> &chosen), (const override));
+    MOCK_METHOD(std::vector<SpellType>, getLevelUpCandidates, (const CreatureAttributes &attributes, const CreatureClass &clazz, const std::set<SpellType> &chosen), (const override));
+    MOCK_METHOD(std::vector<SpellDisplayEntry>, getLevelUpDisplayEntries, (const CreatureAttributes &attributes, const CreatureClass &clazz, const std::set<SpellType> &chosen), (const override));
 };
 
 class MockSurfaces : public ISurfaces, boost::noncopyable {

--- a/test/game/d20/class.cpp
+++ b/test/game/d20/class.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../../fixtures/resource.h"
+
+#include "reone/game/d20/classes.h"
+#include "reone/resource/2da.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+
+std::shared_ptr<TwoDA> makeTable(
+    const std::vector<std::string> &columns,
+    const std::vector<std::vector<std::string>> &rows) {
+    TwoDA::Builder builder;
+    builder.columns(columns);
+    for (const auto &row : rows) {
+        builder.row(row);
+    }
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<TwoDA> makeClassesTable() {
+    const std::vector<std::string> columns = {
+        "name", "description", "hitdie", "skillpointbase", "str", "dex", "con", "int", "wis", "cha",
+        "skillstable", "savingthrowtable", "attackbonustable", "featstable", "featgain", "spellgaintable"};
+    std::vector<std::vector<std::string>> rows(17, std::vector<std::string>(columns.size()));
+    rows[static_cast<int>(ClassType::JediGuardian)] = {"1", "2", "10", "1", "10", "10", "10", "10", "10", "10", "jgd", "save", "attack", "", "", "JGD"};
+    rows[static_cast<int>(ClassType::JediMaster)] = {"1", "2", "6", "1", "10", "10", "10", "10", "10", "10", "jma", "save", "attack", "", "", "JMA"};
+    return makeTable(columns, rows);
+}
+
+} // namespace
+
+TEST(CreatureClass, should_load_power_gains_for_k1_base_and_tsl_prestige_classes) {
+    NiceMock<MockStrings> strings;
+    NiceMock<MockTwoDAs> twoDas;
+    auto classesTable = makeClassesTable();
+    auto skillsTable = makeTable({}, {});
+    auto savingThrowsTable = makeTable({"level", "fortsave", "refsave", "willsave"}, {{"1", "0", "0", "0"}});
+    auto attackBonusTable = makeTable({"bab"}, {{"0"}});
+    auto powerGainTable = makeTable(
+        {"label", "jgd", "jma"},
+        {{"1", "2", "2"},
+         {"2", "1", "1"},
+         {"4", "1", "2"}});
+
+    ON_CALL(twoDas, get("classes")).WillByDefault(Return(classesTable));
+    ON_CALL(twoDas, get("skills")).WillByDefault(Return(skillsTable));
+    ON_CALL(twoDas, get("save")).WillByDefault(Return(savingThrowsTable));
+    ON_CALL(twoDas, get("attack")).WillByDefault(Return(attackBonusTable));
+    ON_CALL(twoDas, get("classpowergain")).WillByDefault(Return(powerGainTable));
+
+    Classes classes(strings, twoDas);
+    auto guardian = classes.get(ClassType::JediGuardian);
+    auto jediMaster = classes.get(ClassType::JediMaster);
+
+    ASSERT_TRUE(guardian);
+    EXPECT_EQ(guardian->getPowerGain(1), 2);
+    EXPECT_EQ(guardian->getPowerGain(2), 1);
+    EXPECT_EQ(guardian->getPowerGain(99), 0);
+
+    ASSERT_TRUE(jediMaster);
+    EXPECT_EQ(jediMaster->getPowerGain(1), 2);
+    EXPECT_EQ(jediMaster->getPowerGain(4), 2);
+    EXPECT_EQ(jediMaster->getPowerGain(99), 0);
+}

--- a/test/game/d20/spells.cpp
+++ b/test/game/d20/spells.cpp
@@ -240,6 +240,7 @@ TEST_F(SpellsTest, should_expose_known_and_chosen_prerequisites_as_candidate_con
     entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
     EXPECT_EQ(getEntry(entries, SpellType::ForcePush).availability, SpellAvailability::Known);
     EXPECT_EQ(getEntry(entries, SpellType::ForceWhirlwind).availability, SpellAvailability::Selectable);
+    EXPECT_FALSE(spells->isLevelUpCandidate(SpellType::ForcePush, attributes, getGuardian(), {}));
     EXPECT_TRUE(spells->isLevelUpCandidate(SpellType::ForceWhirlwind, attributes, getGuardian(), {}));
     EXPECT_THAT(spells->getLevelUpCandidates(attributes, getGuardian(), {}), Contains(SpellType::ForceWhirlwind));
 
@@ -247,6 +248,7 @@ TEST_F(SpellsTest, should_expose_known_and_chosen_prerequisites_as_candidate_con
     entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), chosen);
     EXPECT_EQ(getEntry(entries, SpellType::ForceWhirlwind).availability, SpellAvailability::Chosen);
     EXPECT_EQ(getEntry(entries, SpellType::ForceWave).availability, SpellAvailability::Selectable);
+    EXPECT_FALSE(spells->isLevelUpCandidate(SpellType::ForceWhirlwind, attributes, getGuardian(), chosen));
     EXPECT_TRUE(spells->isLevelUpCandidate(SpellType::ForceWave, attributes, getGuardian(), chosen));
 }
 

--- a/test/game/d20/spells.cpp
+++ b/test/game/d20/spells.cpp
@@ -20,6 +20,7 @@
 
 #include "../../fixtures/resource.h"
 
+#include "reone/game/d20/classes.h"
 #include "reone/game/d20/spells.h"
 #include "reone/resource/2da.h"
 
@@ -62,11 +63,29 @@ protected:
     NiceMock<MockStrings> strings;
     NiceMock<MockTwoDAs> twoDas;
     std::unique_ptr<Spells> spells;
+    std::unique_ptr<Classes> classes;
+    std::unique_ptr<CreatureClass> guardian;
 
     void load(std::shared_ptr<TwoDA> table) {
         EXPECT_CALL(twoDas, get("spells")).WillOnce(Return(std::move(table)));
         spells = std::make_unique<Spells>(textures, audioClips, models, strings, twoDas);
         spells->init();
+    }
+
+    CreatureClass &getGuardian() {
+        if (!guardian) {
+            classes = std::make_unique<Classes>(strings, twoDas);
+            guardian = std::make_unique<CreatureClass>(ClassType::JediGuardian, *classes, strings, twoDas);
+        }
+        return *guardian;
+    }
+
+    static const SpellDisplayEntry &getEntry(const std::vector<SpellDisplayEntry> &entries, SpellType type) {
+        auto maybeEntry = std::find_if(entries.begin(), entries.end(), [&](const SpellDisplayEntry &entry) {
+            return entry.type == type;
+        });
+        EXPECT_NE(maybeEntry, entries.end());
+        return *maybeEntry;
     }
 };
 
@@ -160,4 +179,123 @@ TEST_F(SpellsTest, should_ignore_blank_and_malformed_prerequisites) {
 
     EXPECT_THAT(spells->get(static_cast<SpellType>(0))->prerequisites, ElementsAre(SpellType::ForcePush, SpellType::ForceWhirlwind));
     EXPECT_TRUE(spells->get(static_cast<SpellType>(1))->prerequisites.empty());
+}
+
+TEST_F(SpellsTest, should_build_k1_display_chains_from_prerequisites_in_source_root_order) {
+    auto table = makeSpellsTable(
+        {"prerequisites", "usertype", "guardian"},
+        51,
+        {{static_cast<int>(SpellType::ForcePush), {{"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceWhirlwind), {{"prerequisites", "23"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceWave), {{"prerequisites", "23_27"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::Shock), {{"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::Lightning), {{"prerequisites", "43"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceStorm), {{"prerequisites", "43_35"}, {"usertype", "1"}, {"guardian", "0"}}}});
+    load(std::move(table));
+
+    CreatureAttributes attributes;
+    auto entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+    std::vector<SpellType> visibleTypes;
+    for (const auto &entry : entries) {
+        if (entry.visible) {
+            visibleTypes.push_back(entry.type);
+        }
+    }
+
+    EXPECT_THAT(visibleTypes, ElementsAre(
+                                  SpellType::ForcePush,
+                                  SpellType::ForceWhirlwind,
+                                  SpellType::ForceWave,
+                                  SpellType::Shock,
+                                  SpellType::Lightning,
+                                  SpellType::ForceStorm));
+
+    const auto &wave = getEntry(entries, SpellType::ForceWave);
+    EXPECT_EQ(wave.displayParent, SpellType::ForceWhirlwind);
+    EXPECT_EQ(wave.chainRoot, SpellType::ForcePush);
+    EXPECT_EQ(wave.visualDepth, 2);
+
+    const auto &storm = getEntry(entries, SpellType::ForceStorm);
+    EXPECT_EQ(storm.displayParent, SpellType::Lightning);
+    EXPECT_EQ(storm.chainRoot, SpellType::Shock);
+    EXPECT_EQ(storm.visualDepth, 2);
+}
+
+TEST_F(SpellsTest, should_expose_known_and_chosen_prerequisites_as_candidate_context) {
+    auto table = makeSpellsTable(
+        {"prerequisites", "usertype", "guardian"},
+        28,
+        {{static_cast<int>(SpellType::ForcePush), {{"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceWhirlwind), {{"prerequisites", "23"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceWave), {{"prerequisites", "23_27"}, {"usertype", "1"}, {"guardian", "0"}}}});
+    load(std::move(table));
+
+    CreatureAttributes attributes;
+    auto entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+    EXPECT_EQ(getEntry(entries, SpellType::ForcePush).availability, SpellAvailability::Selectable);
+    EXPECT_EQ(getEntry(entries, SpellType::ForceWhirlwind).availability, SpellAvailability::LockedMissingPrerequisite);
+    EXPECT_FALSE(spells->isLevelUpCandidate(SpellType::ForceWhirlwind, attributes, getGuardian(), {}));
+
+    attributes.addSpell(SpellType::ForcePush);
+    entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+    EXPECT_EQ(getEntry(entries, SpellType::ForcePush).availability, SpellAvailability::Known);
+    EXPECT_EQ(getEntry(entries, SpellType::ForceWhirlwind).availability, SpellAvailability::Selectable);
+    EXPECT_TRUE(spells->isLevelUpCandidate(SpellType::ForceWhirlwind, attributes, getGuardian(), {}));
+    EXPECT_THAT(spells->getLevelUpCandidates(attributes, getGuardian(), {}), Contains(SpellType::ForceWhirlwind));
+
+    std::set<SpellType> chosen {SpellType::ForceWhirlwind};
+    entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), chosen);
+    EXPECT_EQ(getEntry(entries, SpellType::ForceWhirlwind).availability, SpellAvailability::Chosen);
+    EXPECT_EQ(getEntry(entries, SpellType::ForceWave).availability, SpellAvailability::Selectable);
+    EXPECT_TRUE(spells->isLevelUpCandidate(SpellType::ForceWave, attributes, getGuardian(), chosen));
+}
+
+TEST_F(SpellsTest, should_build_tsl_chains_from_prerequisites_when_pips_do_not_express_depth) {
+    auto table = makeSpellsTable(
+        {"pips", "prerequisites", "usertype", "guardian"},
+        138,
+        {{static_cast<int>(SpellType::Cure), {{"pips", "2"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::Heal), {{"pips", "3"}, {"prerequisites", "10"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::MasterHeal), {{"pips", "3"}, {"prerequisites", "10_28"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ForceBarrier), {{"pips", "3"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::ImprovedForceBarrier), {{"pips", "3"}, {"prerequisites", "135"}, {"usertype", "1"}, {"guardian", "0"}}},
+         {static_cast<int>(SpellType::MasterForceBarrier), {{"pips", "3"}, {"prerequisites", "135_136"}, {"usertype", "1"}, {"guardian", "0"}}}});
+    load(std::move(table));
+
+    CreatureAttributes attributes;
+    auto entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+
+    EXPECT_EQ(getEntry(entries, SpellType::Heal).visualDepth, 1);
+    EXPECT_EQ(getEntry(entries, SpellType::MasterHeal).visualDepth, 2);
+    EXPECT_EQ(getEntry(entries, SpellType::ImprovedForceBarrier).visualDepth, 1);
+    EXPECT_EQ(getEntry(entries, SpellType::MasterForceBarrier).visualDepth, 2);
+    EXPECT_EQ(spells->get(SpellType::ForceBarrier)->pips, 3);
+    EXPECT_EQ(spells->get(SpellType::ImprovedForceBarrier)->pips, 3);
+    EXPECT_EQ(spells->get(SpellType::MasterForceBarrier)->pips, 3);
+}
+
+TEST_F(SpellsTest, should_filter_non_picker_rows_and_preserve_class_gate_locking) {
+    auto table = makeSpellsTable(
+        {"usertype", "guardian"},
+        5,
+        {{0, {{"usertype", "1"}, {"guardian", "2"}}},
+         {1, {{"usertype", "4"}, {"guardian", "0"}}},
+         {2, {{"usertype", "6"}, {"guardian", "0"}}},
+         {3, {{"usertype", "-2"}, {"guardian", "0"}}},
+         {4, {{"usertype", "1"}, {"guardian", "-1"}}}});
+    load(std::move(table));
+
+    CreatureAttributes attributes;
+    auto entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+    EXPECT_TRUE(getEntry(entries, static_cast<SpellType>(0)).visible);
+    EXPECT_EQ(getEntry(entries, static_cast<SpellType>(0)).availability, SpellAvailability::LockedClassLevel);
+    EXPECT_FALSE(getEntry(entries, static_cast<SpellType>(1)).visible);
+    EXPECT_FALSE(getEntry(entries, static_cast<SpellType>(2)).visible);
+    EXPECT_FALSE(getEntry(entries, static_cast<SpellType>(3)).visible);
+    EXPECT_FALSE(getEntry(entries, static_cast<SpellType>(4)).visible);
+
+    attributes.addClassLevels(&getGuardian(), 1);
+    entries = spells->getLevelUpDisplayEntries(attributes, getGuardian(), {});
+    EXPECT_EQ(getEntry(entries, static_cast<SpellType>(0)).availability, SpellAvailability::Selectable);
+    EXPECT_TRUE(spells->isLevelUpCandidate(static_cast<SpellType>(0), attributes, getGuardian(), {}));
 }

--- a/test/game/d20/spells.cpp
+++ b/test/game/d20/spells.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../../fixtures/resource.h"
+
+#include "reone/game/d20/spells.h"
+#include "reone/resource/2da.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+
+using SpellRow = std::unordered_map<std::string, std::string>;
+
+std::shared_ptr<TwoDA> makeSpellsTable(
+    const std::vector<std::string> &columns,
+    int rowCount,
+    const std::unordered_map<int, SpellRow> &values) {
+    TwoDA::Builder builder;
+    builder.columns(columns);
+    for (int row = 0; row < rowCount; ++row) {
+        std::vector<std::string> cells(columns.size());
+        auto maybeRow = values.find(row);
+        if (maybeRow != values.end()) {
+            for (size_t column = 0; column < columns.size(); ++column) {
+                auto maybeValue = maybeRow->second.find(columns[column]);
+                if (maybeValue != maybeRow->second.end()) {
+                    cells[column] = maybeValue->second;
+                }
+            }
+        }
+        builder.row(std::move(cells));
+    }
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+class SpellsTest : public Test {
+protected:
+    NiceMock<MockTextures> textures;
+    NiceMock<MockAudioClips> audioClips;
+    NiceMock<MockModels> models;
+    NiceMock<MockStrings> strings;
+    NiceMock<MockTwoDAs> twoDas;
+    std::unique_ptr<Spells> spells;
+
+    void load(std::shared_ptr<TwoDA> table) {
+        EXPECT_CALL(twoDas, get("spells")).WillOnce(Return(std::move(table)));
+        spells = std::make_unique<Spells>(textures, audioClips, models, strings, twoDas);
+        spells->init();
+    }
+};
+
+} // namespace
+
+TEST_F(SpellsTest, should_load_k1_force_power_chain_metadata_and_base_class_requirements) {
+    auto table = makeSpellsTable(
+        {"pips", "prerequisites", "masterspell", "usertype", "guardian", "consular", "sentinel", "category", "hostilesetting"},
+        51,
+        {{static_cast<int>(SpellType::ForcePush), {{"pips", "1"}, {"usertype", "1"}, {"guardian", "0"}, {"consular", "0"}, {"sentinel", "0"}, {"category", "0x1301"}, {"hostilesetting", "1"}}},
+         {static_cast<int>(SpellType::ForceWhirlwind), {{"pips", "2"}, {"prerequisites", "23"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::ForceWave), {{"pips", "3"}, {"prerequisites", "23_27"}, {"masterspell", "23"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::Shock), {{"pips", "1"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::Lightning), {{"pips", "2"}, {"prerequisites", "43"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::ForceStorm), {{"pips", "3"}, {"prerequisites", "43_35"}, {"usertype", "1"}}}});
+
+    load(std::move(table));
+
+    auto push = spells->get(SpellType::ForcePush);
+    auto whirlwind = spells->get(SpellType::ForceWhirlwind);
+    auto wave = spells->get(SpellType::ForceWave);
+    auto lightning = spells->get(SpellType::Lightning);
+    auto storm = spells->get(SpellType::ForceStorm);
+
+    ASSERT_TRUE(push);
+    EXPECT_EQ(push->pips, 1);
+    EXPECT_EQ(push->category, 0x1301);
+    EXPECT_TRUE(push->hostile);
+    EXPECT_EQ(push->userType, 1);
+    EXPECT_EQ(push->getClassLevelRequirement(ClassType::JediGuardian), 0);
+    EXPECT_EQ(push->getClassLevelRequirement(ClassType::JediConsular), 0);
+    EXPECT_EQ(push->getClassLevelRequirement(ClassType::JediSentinel), 0);
+    EXPECT_EQ(push->getClassLevelRequirement(ClassType::JediMaster), std::nullopt);
+
+    ASSERT_TRUE(whirlwind);
+    ASSERT_TRUE(wave);
+    EXPECT_THAT(whirlwind->prerequisites, ElementsAre(SpellType::ForcePush));
+    EXPECT_THAT(wave->prerequisites, ElementsAre(SpellType::ForcePush, SpellType::ForceWhirlwind));
+    EXPECT_EQ(wave->masterSpell, SpellType::ForcePush);
+
+    ASSERT_TRUE(lightning);
+    ASSERT_TRUE(storm);
+    EXPECT_THAT(lightning->prerequisites, ElementsAre(SpellType::Shock));
+    EXPECT_THAT(storm->prerequisites, ElementsAre(SpellType::Shock, SpellType::Lightning));
+}
+
+TEST_F(SpellsTest, should_load_tsl_chain_metadata_and_prestige_class_requirements) {
+    auto table = makeSpellsTable(
+        {"pips", "prerequisites", "usertype", "guardian", "consular", "sentinel", "weapmstr", "jedimaster", "watchman", "marauder", "sithlord", "assassin"},
+        201,
+        {{static_cast<int>(SpellType::Cure), {{"pips", "2"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::Heal), {{"pips", "3"}, {"prerequisites", "10"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::MasterHeal), {{"pips", "3"}, {"prerequisites", "10_28"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::ForceBarrier), {{"pips", "3"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::ImprovedForceBarrier), {{"pips", "3"}, {"prerequisites", "135"}, {"usertype", "1"}}},
+         {static_cast<int>(SpellType::MasterForceBarrier), {{"pips", "3"}, {"prerequisites", "135_136"}, {"usertype", "1"}}},
+         {200, {{"pips", "3"}, {"prerequisites", "181"}, {"usertype", "1"}, {"guardian", "-1"}, {"consular", "-1"}, {"sentinel", "-1"}, {"weapmstr", "1"}, {"jedimaster", "1"}, {"watchman", "1"}, {"marauder", "1"}, {"sithlord", "1"}, {"assassin", "1"}}}});
+
+    load(std::move(table));
+
+    EXPECT_THAT(spells->get(SpellType::Heal)->prerequisites, ElementsAre(SpellType::Cure));
+    EXPECT_THAT(spells->get(SpellType::MasterHeal)->prerequisites, ElementsAre(SpellType::Cure, SpellType::Heal));
+
+    auto barrier = spells->get(SpellType::ForceBarrier);
+    auto improvedBarrier = spells->get(SpellType::ImprovedForceBarrier);
+    auto masterBarrier = spells->get(SpellType::MasterForceBarrier);
+    ASSERT_TRUE(barrier);
+    ASSERT_TRUE(improvedBarrier);
+    ASSERT_TRUE(masterBarrier);
+    EXPECT_EQ(barrier->pips, 3);
+    EXPECT_EQ(improvedBarrier->pips, 3);
+    EXPECT_EQ(masterBarrier->pips, 3);
+    EXPECT_THAT(improvedBarrier->prerequisites, ElementsAre(SpellType::ForceBarrier));
+    EXPECT_THAT(masterBarrier->prerequisites, ElementsAre(SpellType::ForceBarrier, SpellType::ImprovedForceBarrier));
+
+    auto prestigePower = spells->get(static_cast<SpellType>(200));
+    ASSERT_TRUE(prestigePower);
+    EXPECT_EQ(prestigePower->getClassLevelRequirement(ClassType::JediGuardian), -1);
+    EXPECT_EQ(prestigePower->getClassLevelRequirement(ClassType::JediWeaponMaster), 1);
+    EXPECT_EQ(prestigePower->getClassLevelRequirement(ClassType::SithAssassin), 1);
+}
+
+TEST_F(SpellsTest, should_ignore_blank_and_malformed_prerequisites) {
+    auto table = makeSpellsTable(
+        {"prerequisites"},
+        2,
+        {{0, {{"prerequisites", "23_bad__27"}}},
+         {1, {{"prerequisites", "****"}}}});
+
+    load(std::move(table));
+
+    EXPECT_THAT(spells->get(static_cast<SpellType>(0))->prerequisites, ElementsAre(SpellType::ForcePush, SpellType::ForceWhirlwind));
+    EXPECT_TRUE(spells->get(static_cast<SpellType>(1))->prerequisites.empty());
+}


### PR DESCRIPTION
## Summary

Implements level-up Force Powers selection.

This adds the full Force Powers level-up stack:

- loads selection-relevant `spells.2da` metadata
- loads class power-gain data from `classpowergain.2da`
- builds spell display entries from prerequisite chains
- renders the Force Powers picker with the shared `IconChain` control
- supports known/selectable/locked/chosen visual states
- supports focus/name/description display
- requires spending granted power selections before advancing
- applies selected powers through the temporary level-up character attributes before Finish

The implementation follows the level-up Feats architecture from #136, but keeps spell-specific data/rules separate. Force Power chains are built from `spells.2da` prerequisites, not Feats successor logic, `pips`, or `masterspell`.

## Notes

- No Feats behavior is changed.
- No actionbar Force Power behavior is changed.
- No droid-specific picker behavior is claimed.
- `IconChain` changes are additive generic APIs used for focus/state refresh.

## Known bugs

-  'Feats' doesn't illuminate the tile of the next valid feat if the preceding feat is chosen and prereqs are satisfied for the next feat
-  Both feats and powers exhibit a bug where the feat/power name reverts to 'description' if scrolling after highlighting a feat/power