### PR TITLE
[game] Fix selection of a dialog owner in StartConversationAction

### DIFF
--- a/src/libs/game/action/startconversation.cpp
+++ b/src/libs/game/action/startconversation.cpp
@@ -31,21 +31,32 @@ void StartConversationAction::execute(std::shared_ptr<Action> self, Object &acto
     auto actorPtr = _game.getObjectById(actor.id());
 
     // Creatures should move to the target before starting the dialog.
+    // Triggers and other objects can start the dialog immediately
     if (auto creatureActor = dyn_cast<Creature>(actorPtr)) {
         bool reached =
             _ignoreStartRange ||
             creatureActor->navigateTo(_objectToConverse->position(), true, kMaxConversationDistance, dt);
 
-        if (reached) {
-            bool isActorLeader = _game.party().getLeader() == actorPtr;
-            _game.module()->area()->startDialog(isActorLeader ? _objectToConverse : actorPtr, _dialogResRef);
-            complete();
+        if (!reached) {
+            return;
         }
-        return;
     }
 
-    // Triggers and other objects can start the dialog immediately
-    _game.module()->area()->startDialog(_objectToConverse, _dialogResRef);
+    // When scripts do not specify DialogResRef, it takes a default
+    // value of caller->conversation() before StartConversationAction
+    // object is constructed.
+    //
+    // When the player initiates a conversation, DialogResRef should
+    // be empty.
+    //
+    // Therefore, if DialogResRef is empty, we must always select
+    // _objectToConverse and use its conversation() as the dialog.
+    //
+    // Otherwise, if DialogResRef is set, select Actor as the dialog
+    // owner.
+
+    std::shared_ptr<Object> dialogOwner = _dialogResRef.empty() ? _objectToConverse : actorPtr;
+    _game.module()->area()->startDialog(dialogOwner, _dialogResRef);
     complete();
 }
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1922,7 +1922,7 @@ void Game::consoleStartConversation(const ConsoleArgs &args) {
     auto leader = getConsoleLeader();
     auto target = getConsoleTargetObject();
 
-    auto action = newAction<StartConversationAction>(target, target->conversation());
+    auto action = newAction<StartConversationAction>(target, "");
     leader->addAction(std::move(action));
 }
 

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -271,7 +271,7 @@ void Module::onCreatureClick(const std::shared_ptr<Creature> &creature) {
             partyLeader->addAction(std::move(action));
         } else if (!creature->conversation().empty()) {
             partyLeader->clearAllActions();
-            partyLeader->addAction(_game.newAction<StartConversationAction>(creature, creature->conversation()));
+            partyLeader->addAction(_game.newAction<StartConversationAction>(creature, ""));
         }
     }
 }
@@ -298,7 +298,7 @@ void Module::onPlaceableClick(const std::shared_ptr<Placeable> &placeable) {
         }
     } else if (!placeable->conversation().empty()) {
         partyLeader->clearAllActions();
-        partyLeader->addAction(_game.newAction<StartConversationAction>(placeable, placeable->conversation()));
+        partyLeader->addAction(_game.newAction<StartConversationAction>(placeable, ""));
     } else {
         placeable->runOnUsed(std::move(partyLeader));
     }


### PR DESCRIPTION
Problem
-------

There are 3 cases that we need to handle:

1. Scripts use ActionStartConversation with DialogResRef.

2. Scripts use ActionStartConversation *without* DialogResRef (empty string).

  2.1. Caller has a non-empty conversation field.
  2.2. Caller has an empty conversation field.

3. Player initiates a dialog with a `Creature` or `Placeable`.

In case (1) the dialog should start for the caller, and use the provided DialogResRef.

Most scripts follow (2.1) and we should select the caller as the dialog owner.
However, Taris m02aa entry trigger (Duros and Sith) seems to rely on (2.2):

  - Trigger `sithtalk` calls StartConversationAction, but the object does not have Conversation field, and the script doesn't specify DialogResRef.

  - ObjectToConverse is a Placeable `trooper1_invis` with Conversation `tar02_preraid`.

Here we need to select `trooper1_invis` as the dialog owner and start `tar02_preraid` dialog.

Player actions (3) should always use ObjectToConverse Conversation and set this object as the dialog owner - not the player.

Implementation
--------------

ActionStartConversation sets a default value of DialogResRef to` caller->conversation()` before constructing StartConversationAction object. Once we get to `StartConversationAction::execute`, DialogResRef is not empty, even if the script did not specify it.

This way (1) and (2.1) are equivalent in
`StartConversationAction::execute`: both have DialogResRef set, and both need to select the actor as the dialog owner.

Before the patch, the engine used to set DialogResRef to ObjectToConverse Conversation for player actions, but that would make case (3) indistinguishable from (1) and (2.1), while require the opposite behavior.

The patch changes player actions to never pass DialogResRef parameter. Therefore cases (2.2) and (3) are equivalent now. In both cases, we need to select the ObjectToConverse as the owner, and use its Conversation parameter.

This patch fixes a regression from #121: StartConversationAction on Endar Spire incorrectly selected the player as the owner for the `end_room5` dialog, so actions were queued to the player instead of a special object, and any player interaction could cancel these actions.