### PR TITLE
[game] Deserialize inventory from a save game

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -328,6 +328,8 @@ public:
 
     // END Global variables
 
+    void deserializeGlobalVariables(resource::Gff &gvtGff);
+
 private:
     resource::GameID _gameId;
     std::filesystem::path _path;

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -329,6 +329,7 @@ public:
     // END Global variables
 
     void deserializeGlobalVariables(resource::Gff &gvtGff);
+    void deserializeInventory(resource::Gff &inventoryGff);
 
 private:
     resource::GameID _gameId;

--- a/include/reone/resource/strings.h
+++ b/include/reone/resource/strings.h
@@ -57,12 +57,9 @@ class LocString {
 public:
     LocString() :
         _id(-1) {}
+
     LocString(int32_t id, std::string ref, IStrings &strings) :
-        _id(id), _ref(ref) {
-        if (_id >= 0) {
-            _loc = strings.getText(id);
-        }
-    }
+        _id(id), _ref(ref), _loc((_id >= 0) ? strings.getText(id) : ref) {}
 
     operator std::string_view() const {
         return str();

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -579,6 +579,12 @@ void Game::loadGame(std::string_view name) {
 
     NFO nfo = resource::parseNFO(*saveInfo);
     loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
+
+    // Inventory is serialized into a separate file. Once the player is loaded,
+    // deserialize it into the player's inventory.
+    if (auto inventoryGff = _services.resource.gffs.get("inventory", ResType::Res)) {
+        deserializeInventory(*inventoryGff);
+    }
 }
 
 void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
@@ -604,6 +610,19 @@ void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
         auto &[pos, rot] = value;
         float facing = glm::half_pi<float>() - glm::atan(rot.x, rot.y);
         setGlobalLocation(name, std::make_shared<Location>(pos, facing));
+    }
+}
+
+void Game::deserializeInventory(resource::Gff &inventoryGff) {
+    std::shared_ptr<Creature> player = _party.player();
+    if (!player) {
+        return;
+    }
+
+    for (const auto &itemGff : inventoryGff.getList("ItemList")) {
+        std::shared_ptr<Item> item = newItem();
+        item->deserialize(*itemGff);
+        player->addItem(item);
     }
 }
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -570,8 +570,19 @@ void Game::loadGame(std::string_view name) {
     if (!globalVars) {
         throw ResourceNotFoundException("globalvars.res not found");
     }
+    deserializeGlobalVariables(*globalVars);
 
-    GVT gvt = resource::parseGVT(*globalVars);
+    std::shared_ptr<Gff> saveInfo(_services.resource.gffs.get("savenfo", ResType::Res));
+    if (!saveInfo) {
+        throw ResourceNotFoundException("saveinfo.res not found");
+    }
+
+    NFO nfo = resource::parseNFO(*saveInfo);
+    loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
+}
+
+void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
+    GVT gvt = resource::parseGVT(gvtGff);
     _globalStrings.clear();
     _globalBooleans.clear();
     _globalNumbers.clear();
@@ -594,14 +605,6 @@ void Game::loadGame(std::string_view name) {
         float facing = glm::half_pi<float>() - glm::atan(rot.x, rot.y);
         setGlobalLocation(name, std::make_shared<Location>(pos, facing));
     }
-
-    std::shared_ptr<Gff> saveInfo(_services.resource.gffs.get("savenfo", ResType::Res));
-    if (!saveInfo) {
-        throw ResourceNotFoundException("saveinfo.res not found");
-    }
-
-    NFO nfo = resource::parseNFO(*saveInfo);
-    loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
 }
 
 bool Game::loadParty() {


### PR DESCRIPTION
This patchset enables deserialization of `inventory.res` from a save game, and addresses issues with items and locstrings found during testing.

`inventory.res` is a top-level GFF in a save game container. It lists all items that the player (party) has. The player character (Creature) has no items in the corresponding Creature GFF.

Reone treats the player character as "the party" for inventory logic. Items are always transferred to the player character, inventory screens list items from the player character, etc. The patch follows this logic and deserializes `inventory.res` into the player character's inventory.

There are also minor 2 bugfixes. See the corresponding commit messages for more details.
