### PR TITLE
[game] Route looted items through inventory insertion

### DIFF
--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -2027,7 +2027,7 @@ void Game::consoleCastSpellAtObject(const ConsoleArgs &args) {
     std::optional<std::shared_ptr<Item>> item;
     if (spellItem) {
         for (const std::shared_ptr<Item> &inventoryItem : leader->items()) {
-            if (inventoryItem->blueprintResRef() == spellItem.value()) {
+            if (inventoryItem->tag() == spellItem.value()) {
                 item = inventoryItem;
                 break;
             }

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -221,7 +221,7 @@ std::shared_ptr<Item> Object::addItem(const std::string &resRef, int stackSize, 
     std::shared_ptr<Item> result;
 
     auto maybeItem = std::find_if(_items.begin(), _items.end(), [&resRef](auto &item) {
-        return item->blueprintResRef() == resRef;
+        return item->tag() == resRef;
     });
     if (maybeItem != _items.end()) {
         result = *maybeItem;
@@ -245,11 +245,16 @@ std::shared_ptr<Item> Object::addItem(const std::string &resRef, int stackSize, 
 }
 
 void Object::addItem(const std::shared_ptr<Item> &item) {
-    auto maybeItem = std::find_if(_items.begin(), _items.end(), [&item](auto &entry) { return entry->blueprintResRef() == item->blueprintResRef(); });
+    auto maybeItem = std::find_if(_items.begin(), _items.end(), [&item](auto &entry) { return entry->tag() == item->tag(); });
     if (maybeItem != _items.end()) {
-        (*maybeItem)->setStackSize((*maybeItem)->stackSize() + 1);
+        // Re-adding an owned stack restores one consumed item; transferred stacks merge fully.
+        int stackSize = *maybeItem == item ? 1 : item->stackSize();
+        (*maybeItem)->setStackSize((*maybeItem)->stackSize() + stackSize);
     } else {
         _items.push_back(item);
+        if (Creature *creature = dyn_cast<Creature>(this)) {
+            creature->itemAttributes().addItem(item, _services.game);
+        }
     }
 }
 
@@ -334,8 +339,12 @@ void Object::faceAwayFrom(const Object &other) {
 void Object::moveDropableItemsTo(Object &other) {
     for (auto it = _items.begin(); it != _items.end();) {
         if ((*it)->isDropable()) {
-            other._items.push_back(*it);
+            std::shared_ptr<Item> item(*it);
             it = _items.erase(it);
+            if (Creature *creature = dyn_cast<Creature>(this)) {
+                creature->itemAttributes().removeItem(item);
+            }
+            other.addItem(item);
         } else {
             ++it;
         }


### PR DESCRIPTION
## Summary

* routes droppable loot transfers through the normal inventory insertion path
* stacks inventory items by tag instead of blueprint resref
* merges full incoming stack counts when transferring stacked items
* registers usable item metadata when newly inserting items into creature inventory
* removes stale source item attributes when moving droppable creature inventory

## Notes

Looted items previously bypassed the normal `addItem` path and were pushed directly into the destination inventory list. That meant they could appear in inventory without going through the same stacking and usable-item metadata registration as items granted through `additem`.

Droppable semantics are not loosened; creature inventory still preserves authored `Dropable` values, and non-droppable creature inventory remains excluded from corpse loot. 