### PR TITLE
[gui] Wire action cycling arrows

### DIFF
--- a/include/reone/game/gui/actionbar.h
+++ b/include/reone/game/gui/actionbar.h
@@ -26,6 +26,10 @@ class Button;
 class Label;
 } // namespace gui
 
+namespace graphics {
+class Texture;
+} // namespace graphics
+
 namespace game {
 
 struct ServicesView;
@@ -40,6 +44,7 @@ public:
                         std::shared_ptr<gui::Label> background);
 
     void addSlot(std::shared_ptr<gui::Button> button,
+                 std::shared_ptr<gui::Button> action,
                  std::shared_ptr<gui::Button> up,
                  std::shared_ptr<gui::Button> down);
 
@@ -60,8 +65,13 @@ private:
     struct Slot {
         ActionSlot slot;
         std::shared_ptr<gui::Button> button;
+        std::shared_ptr<gui::Button> action;
         std::shared_ptr<gui::Button> up;
         std::shared_ptr<gui::Button> down;
+        std::shared_ptr<graphics::Texture> upBorderFill;
+        std::shared_ptr<graphics::Texture> upHilightFill;
+        std::shared_ptr<graphics::Texture> downBorderFill;
+        std::shared_ptr<graphics::Texture> downHilightFill;
     };
     std::vector<Slot> _slots;
 };

--- a/include/reone/game/gui/selectoverlay.h
+++ b/include/reone/game/gui/selectoverlay.h
@@ -46,6 +46,13 @@ public:
     void render();
 
 private:
+    enum class ActionBand {
+        None,
+        Previous,
+        Icon,
+        Next
+    };
+
     Game &_game;
     ServicesView &_services;
 
@@ -57,6 +64,8 @@ private:
     std::shared_ptr<graphics::Texture> _friendlyScroll;
     std::shared_ptr<graphics::Texture> _hostileScroll;
     std::shared_ptr<graphics::Texture> _hilightedScroll;
+    std::shared_ptr<graphics::Texture> _actionArrow;
+    std::shared_ptr<graphics::Texture> _hilightedActionArrow;
     std::shared_ptr<Object> _hilightedObject;
     std::shared_ptr<Object> _selectedObject;
     std::vector<ActionSlot> _actionSlots;
@@ -64,6 +73,7 @@ private:
     glm::vec3 _selectedScreenCoords {0.0f};
     int _reticleHeight {0};
     int _selectedActionSlot {-1};
+    ActionBand _hilightedActionBand {ActionBand::None};
     bool _hilightedHostile {false};
     bool _selectedHostile {false};
     bool _hasActions {false};
@@ -78,6 +88,8 @@ private:
     void renderActionBar();
 
     void renderActionFrame(int index);
+    void renderActionArrows(int index);
+    void renderActionArrow(int index, bool previous);
     void renderActionIcon(int index);
 
     bool getActionScreenCoords(int index, float &x, float &y) const;

--- a/src/libs/game/gui/actionbar.cpp
+++ b/src/libs/game/gui/actionbar.cpp
@@ -46,21 +46,55 @@ void ActionBar::addDescription(std::shared_ptr<gui::Label> desc,
 }
 
 void ActionBar::addSlot(std::shared_ptr<gui::Button> button,
+                        std::shared_ptr<gui::Button> action,
                         std::shared_ptr<gui::Button> up,
                         std::shared_ptr<gui::Button> down) {
     rotateActionBarArrow(down);
+    button->setSelectable(false);
 
     size_t slotIndex = _slots.size();
-    _slots.push_back({ActionSlot(), button, up, down});
+    _slots.push_back({
+        ActionSlot(),
+        button,
+        action,
+        up,
+        down,
+        up->border().fill,
+        up->hilight().fill,
+        down->border().fill,
+        down->hilight().fill});
+    up->setBorderFill(std::shared_ptr<graphics::Texture>());
+    up->setHilightFill(std::shared_ptr<graphics::Texture>());
+    down->setBorderFill(std::shared_ptr<graphics::Texture>());
+    down->setHilightFill(std::shared_ptr<graphics::Texture>());
 
-    button->setOnMouseWheel([slotIndex, this](int x, int y) {
+    auto cycleOnMouseWheel = [slotIndex, this](int x, int y) {
         ActionSlot &slot = _slots[slotIndex].slot;
         handleMouseWheel(slot, x, y);
-    });
-    button->setOnClick([slotIndex, this]() {
+    };
+    action->setOnMouseWheel(cycleOnMouseWheel);
+    up->setOnMouseWheel(cycleOnMouseWheel);
+    down->setOnMouseWheel(cycleOnMouseWheel);
+
+    action->setOnClick([slotIndex, this]() {
         ActionSlot &slot = _slots[slotIndex].slot;
         handleMouseButtonDown(slot);
     });
+    up->setOnClick([slotIndex, this]() {
+        ActionSlot &slot = _slots[slotIndex].slot;
+        handleMouseWheel(slot, 0, 1);
+    });
+    down->setOnClick([slotIndex, this]() {
+        ActionSlot &slot = _slots[slotIndex].slot;
+        handleMouseWheel(slot, 0, -1);
+    });
+
+    auto handleSelectionChanged = [slotIndex, this](bool selected) {
+        _slots[slotIndex].button->setSelected(selected);
+    };
+    action->setOnSelectionChanged(handleSelectionChanged);
+    up->setOnSelectionChanged(handleSelectionChanged);
+    down->setOnSelectionChanged(handleSelectionChanged);
 }
 
 void ActionBar::handleMouseWheel(ActionSlot &slot, int x, int y) {
@@ -69,12 +103,11 @@ void ActionBar::handleMouseWheel(ActionSlot &slot, int x, int y) {
     }
 
     if (y > 0) {
-        if (slot.indexSelected == 0) {
-            return;
-        }
-        --slot.indexSelected;
+        slot.indexSelected = slot.indexSelected == 0
+                                 ? slot.actions.size() - 1
+                                 : slot.indexSelected - 1;
     } else {
-        slot.indexSelected = std::min(slot.actions.size() - 1, slot.indexSelected + 1);
+        slot.indexSelected = (slot.indexSelected + 1) % slot.actions.size();
     }
 }
 
@@ -158,6 +191,11 @@ void ActionBar::update() {
         } else {
             slot.indexSelected = 0;
         }
+        bool showArrows = slot.actions.size() > 1;
+        guiSlot.up->setBorderFill(showArrows ? guiSlot.upBorderFill : nullptr);
+        guiSlot.up->setHilightFill(showArrows ? guiSlot.upHilightFill : nullptr);
+        guiSlot.down->setBorderFill(showArrows ? guiSlot.downBorderFill : nullptr);
+        guiSlot.down->setHilightFill(showArrows ? guiSlot.downHilightFill : nullptr);
     }
 
     bool showDesc = false;

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -77,17 +77,22 @@ void HUD::onGUILoaded() {
 
     for (int i = 0; i < 5; ++i) {
         auto action = findControl<gui::Button>(str(boost::format("BTN_ACTION%d") % i));
+        auto icon = findControl<gui::Button>(str(boost::format("LBL_ACTION%d") % i));
         auto up = findControl<gui::Button>(str(boost::format("BTN_ACTIONUP%d") % i));
         auto down = findControl<gui::Button>(str(boost::format("BTN_ACTIONDOWN%d") % i));
 
-        if (action && up && down) {
-            _actionBar.addSlot(action, up, down);
+        if (action && icon && up && down) {
+            _actionBar.addSlot(action, icon, up, down);
         }
     }
     if (_game.isTSL()) {
+        if (auto up = findControl<gui::Button>("BTN_ACTIONUP5")) {
+            up->setVisible(false);
+        }
         if (auto down = findControl<gui::Button>("BTN_ACTIONDOWN5")) {
             down->setBorderFillTransform(gui::Control::Border::FillTransform::Rotate180);
             down->setHilightFillTransform(gui::Control::Border::FillTransform::Rotate180);
+            down->setVisible(false);
         }
     }
 

--- a/src/libs/game/gui/selectoverlay.cpp
+++ b/src/libs/game/gui/selectoverlay.cpp
@@ -54,6 +54,22 @@ static constexpr int kActionBarMargin = 3;
 static constexpr int kActionBarPadding = 3;
 static constexpr int kActionWidth = 35;
 static constexpr int kActionHeight = 59;
+static constexpr int kActionArrowHeight = (kActionHeight - kActionWidth) / 2;
+
+static void cycleActionSlot(ActionSlot &slot, bool previous) {
+    if (slot.actions.empty())
+        return;
+
+    if (previous) {
+        if (slot.indexSelected == 0) {
+            slot.indexSelected = static_cast<uint32_t>(slot.actions.size() - 1);
+        } else {
+            --slot.indexSelected;
+        }
+    } else if (++slot.indexSelected == slot.actions.size()) {
+        slot.indexSelected = 0;
+    }
+}
 
 SelectionOverlay::SelectionOverlay(
     Game &game,
@@ -112,6 +128,25 @@ bool SelectionOverlay::handleMouseButtonDown(const input::MouseButtonEvent &even
     if (_selectedActionSlot == -1 || _selectedActionSlot >= _actionSlots.size())
         return false;
 
+    ActionSlot &slot = _actionSlots[_selectedActionSlot];
+
+    float frameX, frameY;
+    getActionScreenCoords(_selectedActionSlot, frameX, frameY);
+
+    if (event.x < frameX || event.y < frameY ||
+        event.x >= frameX + kActionWidth || event.y >= frameY + kActionHeight)
+        return false;
+
+    float actionY = event.y - frameY;
+    if (actionY < kActionArrowHeight) {
+        cycleActionSlot(slot, true);
+        return true;
+    }
+    if (actionY >= kActionArrowHeight + kActionWidth) {
+        cycleActionSlot(slot, false);
+        return true;
+    }
+
     std::shared_ptr<Creature> leader(_game.party().getLeader());
     if (!leader)
         return false;
@@ -121,7 +156,6 @@ bool SelectionOverlay::handleMouseButtonDown(const input::MouseButtonEvent &even
     if (!selectedObject)
         return false;
 
-    const ActionSlot &slot = _actionSlots[_selectedActionSlot];
     if (slot.indexSelected >= slot.actions.size())
         return false;
 
@@ -161,18 +195,10 @@ bool SelectionOverlay::handleMouseWheel(const input::MouseWheelEvent &event) {
         return false;
 
     ActionSlot &slot = _actionSlots[_selectedActionSlot];
-    size_t numSlotActions = slot.actions.size();
+    if (slot.actions.empty())
+        return false;
 
-    if (event.y > 0) {
-        if (slot.indexSelected-- == 0) {
-            slot.indexSelected = static_cast<uint32_t>(numSlotActions - 1);
-        }
-    } else {
-        if (++slot.indexSelected == numSlotActions) {
-            slot.indexSelected = 0;
-        }
-    }
-
+    cycleActionSlot(slot, event.y > 0);
     return true;
 }
 

--- a/src/libs/game/gui/selectoverlay.cpp
+++ b/src/libs/game/gui/selectoverlay.cpp
@@ -88,6 +88,8 @@ void SelectionOverlay::init() {
     _friendlyScroll = _services.resource.textures.get("lbl_miscroll_f", TextureUsage::GUI);
     _hostileScroll = _services.resource.textures.get("lbl_miscroll_h", TextureUsage::GUI);
     _hilightedScroll = _services.resource.textures.get("lbl_miscroll_hi", TextureUsage::GUI);
+    _actionArrow = _services.resource.textures.get("lbl_miarr_1", TextureUsage::GUI);
+    _hilightedActionArrow = _services.resource.textures.get("lbl_miarr_2", TextureUsage::GUI);
     _reticleHeight = _friendlyReticle2->height();
 }
 
@@ -106,6 +108,7 @@ bool SelectionOverlay::handle(const input::Event &event) {
 
 bool SelectionOverlay::handleMouseMotion(const input::MouseMotionEvent &event) {
     _selectedActionSlot = -1;
+    _hilightedActionBand = ActionBand::None;
 
     if (!_selectedObject)
         return false;
@@ -115,6 +118,14 @@ bool SelectionOverlay::handleMouseMotion(const input::MouseMotionEvent &event) {
         getActionScreenCoords(i, x, y);
         if (event.x >= x && event.y >= y && event.x < x + kActionWidth && event.y < y + kActionHeight) {
             _selectedActionSlot = i;
+            float actionY = event.y - y;
+            if (actionY < kActionArrowHeight) {
+                _hilightedActionBand = ActionBand::Previous;
+            } else if (actionY >= kActionArrowHeight + kActionWidth) {
+                _hilightedActionBand = ActionBand::Next;
+            } else {
+                _hilightedActionBand = ActionBand::Icon;
+            }
             return true;
         }
     }
@@ -378,6 +389,7 @@ void SelectionOverlay::renderActionBar() {
 
     for (int i = 0; i < kNumActionSlots; ++i) {
         renderActionFrame(i);
+        renderActionArrows(i);
         renderActionIcon(i);
     }
 }
@@ -403,6 +415,43 @@ void SelectionOverlay::renderActionFrame(int index) {
     _services.graphics.uniforms.setLocals([this, transform](auto &locals) {
         locals.reset();
         locals.model = std::move(transform);
+    });
+    _services.graphics.context.useProgram(_services.graphics.shaderRegistry.get(ShaderProgramId::mvpTexture));
+    _services.graphics.meshRegistry.get(MeshName::quad).draw(_services.graphics.statistic);
+}
+
+void SelectionOverlay::renderActionArrows(int index) {
+    if (_actionSlots[index].actions.size() < 2)
+        return;
+
+    renderActionArrow(index, true);
+    renderActionArrow(index, false);
+}
+
+void SelectionOverlay::renderActionArrow(int index, bool previous) {
+    bool hilighted = index == _selectedActionSlot &&
+                     _hilightedActionBand == (previous ? ActionBand::Previous : ActionBand::Next);
+    auto texture = hilighted ? _hilightedActionArrow : _actionArrow;
+    _services.graphics.context.bindTexture(*texture);
+
+    float frameX, frameY;
+    getActionScreenCoords(index, frameX, frameY);
+
+    glm::mat4 transform(1.0f);
+    transform = glm::translate(
+        transform,
+        glm::vec3(frameX, previous ? frameY : frameY + kActionArrowHeight + kActionWidth, 0.0f));
+    transform = glm::scale(transform, glm::vec3(kActionWidth, kActionArrowHeight, 1.0f));
+
+    _services.graphics.uniforms.setLocals([transform, previous](auto &locals) {
+        locals.reset();
+        locals.model = transform;
+        if (!previous) {
+            locals.uv = glm::mat3x4(
+                glm::vec4(-1.0f, 0.0f, 0.0f, 0.0f),
+                glm::vec4(0.0f, -1.0f, 0.0f, 0.0f),
+                glm::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+        }
     });
     _services.graphics.context.useProgram(_services.graphics.shaderRegistry.get(ShaderProgramId::mvpTexture));
     _services.graphics.meshRegistry.get(MeshName::quad).draw(_services.graphics.statistic);


### PR DESCRIPTION
## Summary

* wires red target-action frame arrow bands to cycle target actions
* renders target-action arrows only when a slot has multiple actions
* wires bottom-right action bar arrows to cycle instead of using the item/action
* shows bottom-right action bar arrows only for multi-action categories
* preserves center-click queueing/use of the displayed action
* wraps cycling at the ends of action lists