### PR TITLE
[game][gui] Route K2 in-game menu Party and Messages

### DIFF
--- a/include/reone/game/gui/ingame.h
+++ b/include/reone/game/gui/ingame.h
@@ -23,6 +23,7 @@
 #include "reone/gui/control/togglebutton.h"
 
 #include "../gui.h"
+#include "partyselect.h"
 
 #include "ingame/abilities.h"
 #include "ingame/character.h"
@@ -52,6 +53,7 @@ public:
     void openInventory();
     void openCharacter();
     void openAbilities();
+    void openPartySelection();
     void openMessages();
     void openJournal();
     void openMap();
@@ -121,6 +123,7 @@ private:
     std::unique_ptr<Equipment> _equip;
     std::unique_ptr<InventoryMenu> _inventory;
     std::unique_ptr<AbilitiesMenu> _abilities;
+    std::unique_ptr<PartySelection> _partySelect;
     std::unique_ptr<MessagesMenu> _messages;
     std::unique_ptr<JournalMenu> _journal;
     std::unique_ptr<MapMenu> _map;
@@ -189,6 +192,7 @@ private:
     void loadEquipment();
     void loadInventory();
     void loadAbilities();
+    void loadPartySelection();
     void loadMessages();
     void loadJournal();
     void loadMap();

--- a/include/reone/game/types.h
+++ b/include/reone/game/types.h
@@ -992,6 +992,7 @@ enum class InGameMenuTab {
     Inventory,
     Character,
     Abilities,
+    Party,
     Messages,
     Journal,
     Map,

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1283,6 +1283,9 @@ void Game::openInGameMenu(InGameMenuTab tab) {
     case InGameMenuTab::Abilities:
         _inGame->openAbilities();
         break;
+    case InGameMenuTab::Party:
+        _inGame->openPartySelection();
+        break;
     case InGameMenuTab::Messages:
         _inGame->openMessages();
         break;

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -171,7 +171,11 @@ void HUD::onGUILoaded() {
         _game.openInGameMenu(InGameMenuTab::Abilities);
     });
     _controls.BTN_MSG->setOnClick([this]() {
-        _game.openInGameMenu(InGameMenuTab::Messages);
+        if (_game.isTSL()) {
+            _game.openInGameMenu(InGameMenuTab::Party);
+        } else {
+            _game.openInGameMenu(InGameMenuTab::Messages);
+        }
     });
     _controls.BTN_JOU->setOnClick([this]() {
         _game.openInGameMenu(InGameMenuTab::Journal);

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -104,7 +104,11 @@ void InGameMenu::onGUILoaded() {
         openAbilities();
     });
     _controls.BTN_MSG->setOnClick([this]() {
-        openMessages();
+        if (_game.isTSL()) {
+            openPartySelection();
+        } else {
+            openMessages();
+        }
     });
     _controls.BTN_JOU->setOnClick([this]() {
         openJournal();
@@ -120,6 +124,7 @@ void InGameMenu::onGUILoaded() {
     loadInventory();
     loadCharacter();
     loadAbilities();
+    loadPartySelection();
     loadMessages();
     loadJournal();
     loadMap();
@@ -144,6 +149,14 @@ void InGameMenu::loadCharacter() {
 void InGameMenu::loadAbilities() {
     _abilities = std::make_unique<AbilitiesMenu>(_game, _services);
     _abilities->init();
+}
+
+void InGameMenu::loadPartySelection() {
+    if (!_game.isTSL()) {
+        return;
+    }
+    _partySelect = std::make_unique<PartySelection>(_game, _services);
+    _partySelect->init();
 }
 
 void InGameMenu::loadMessages() {
@@ -187,6 +200,8 @@ GameGUI *InGameMenu::getActiveTabGUI() const {
         return _character.get();
     case InGameMenuTab::Abilities:
         return _abilities.get();
+    case InGameMenuTab::Party:
+        return _partySelect.get();
     case InGameMenuTab::Messages:
         return _messages.get();
     case InGameMenuTab::Journal:
@@ -336,8 +351,8 @@ void InGameMenu::updateTabButtons() {
     _controls.LBLH_INV->setSelected(_tab == InGameMenuTab::Inventory);
     _controls.LBLH_CHA->setSelected(_tab == InGameMenuTab::Character);
     _controls.LBLH_ABI->setSelected(_tab == InGameMenuTab::Abilities);
-    _controls.LBLH_MSG->setSelected(_tab == InGameMenuTab::Messages);
-    _controls.LBLH_JOU->setSelected(_tab == InGameMenuTab::Journal);
+    _controls.LBLH_MSG->setSelected(_tab == (_game.isTSL() ? InGameMenuTab::Party : InGameMenuTab::Messages));
+    _controls.LBLH_JOU->setSelected(_tab == InGameMenuTab::Journal || (_game.isTSL() && _tab == InGameMenuTab::Messages));
     _controls.LBLH_MAP->setSelected(_tab == InGameMenuTab::Map);
     _controls.LBLH_OPT->setSelected(_tab == InGameMenuTab::Options);
 }
@@ -356,6 +371,11 @@ void InGameMenu::openCharacter() {
 void InGameMenu::openAbilities() {
     _abilities->refreshControls();
     changeTab(InGameMenuTab::Abilities);
+}
+
+void InGameMenu::openPartySelection() {
+    _partySelect->prepare(PartySelectionContext());
+    changeTab(InGameMenuTab::Party);
 }
 
 void InGameMenu::openMessages() {

--- a/src/libs/game/gui/ingame/journal.cpp
+++ b/src/libs/game/gui/ingame/journal.cpp
@@ -18,7 +18,6 @@
 #include "reone/game/gui/ingame/journal.h"
 
 #include "reone/game/game.h"
-#include "reone/gui/control/button.h"
 
 using namespace reone::audio;
 
@@ -34,6 +33,13 @@ void JournalMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
 
+    if (_game.isTSL()) {
+        _controls.LB_ITEMS->setTintBorderFill(true);
+        _controls.LBL_ITEM_DESCRIPTION->setTintBorderFill(true);
+        _controls.BTN_MESSAGES->setOnClick([this]() {
+            _game.openInGameMenu(InGameMenuTab::Messages);
+        });
+    }
     _controls.BTN_EXIT->setOnClick([this]() {
         _game.openInGame();
     });

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -35,7 +35,11 @@ void MessagesMenu::onGUILoaded() {
     bindControls();
 
     _controls.BTN_EXIT->setOnClick([this]() {
-        _game.openInGame();
+        if (_game.isTSL()) {
+            _game.openInGameMenu(InGameMenuTab::Journal);
+        } else {
+            _game.openInGame();
+        }
     });
 
     if (!_game.isTSL()) {


### PR DESCRIPTION
## Summary
Kotor 2 used to display the 'message' page instead of the party page.  The following addresses that core issue and several other adjacent ones:
- routes K2’s Party top-bar/HUD icon to hosted Party Selection
- keeps the K2 in-game menu top tabs visible while Party Selection is active
- wires K2 Journal’s “Messages Log” button to open Messages
- makes K2 Messages Close return to Journal
- preserves K1 `BTN_MSG` Messages behavior and standalone Party Selection paths