### PR TITLE
[game] Fix incorrect static_pointer_cast in DialogGUI::getTalkPosition

### DIFF
--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -238,10 +238,12 @@ void DialogGUI::updateCamera() {
 }
 
 glm::vec3 DialogGUI::getTalkPosition(const Object &object) const {
-    auto model = std::static_pointer_cast<ModelSceneNode>(object.sceneNode());
-    if (!model)
+    auto node = object.sceneNode();
+    if (node->type() != SceneNodeType::Model) {
         return object.position();
+    }
 
+    auto model = std::static_pointer_cast<ModelSceneNode>(node);
     std::shared_ptr<ModelNode> talkDummy(model->model().getNodeByNameRecursive("talkdummy"));
     if (!talkDummy)
         return model->getWorldCenterOfAABB();


### PR DESCRIPTION
When the object is a Trigger, it the corresponding scene graph not is
a TriggerSceneNode, not a ModelSceneNode.

The static_pointer_cast used to cast the node to a different type, and
cause memory issues (use-after-free or use of uninitialized memory).

Fixes #108 "Use-after-free in Model::getNodeByNameRecursive".