### PR TITLE
[game] Change Party to keep available NPC as Creatures

### DIFF
--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -78,12 +78,12 @@ public:
     // Available members
 
     bool addAvailableMember(int npc, const std::string &blueprint);
+    bool addAvailableMember(int npc, std::shared_ptr<Creature> creature);
     bool removeAvailableMember(int npc);
 
     bool isMemberAvailable(int npc) const;
 
-    std::shared_ptr<Creature> createAvailableMember(int npc);
-    const std::string &getAvailableMember(int npc) const;
+    std::shared_ptr<Creature> getAvailableMember(int npc) const;
 
     // END Available members
 
@@ -97,7 +97,7 @@ private:
     Game &_game;
 
     std::shared_ptr<Creature> _player;
-    std::map<int, std::string> _availableMembers;
+    std::map<int, std::shared_ptr<Creature>> _availableMembers;
     std::vector<Member> _members;
     bool _solo {false};
 

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -181,17 +181,8 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
         Label &LBL_CHAR = *charLabels[i];
         Label &LBL_NA = *naLabels[i];
 
-        if (party.isMemberAvailable(i)) {
-            std::string blueprintResRef(party.getAvailableMember(i));
-            std::shared_ptr<Gff> utc(_services.resource.gffs.get(blueprintResRef, ResType::Utc));
-            std::shared_ptr<Texture> portrait;
-            int portraitId = utc->getInt("PortraitId", 0);
-            if (portraitId > 0) {
-                portrait = _services.game.portraits.getTextureByIndex(portraitId);
-            } else {
-                int appearance = utc->getInt("Appearance_Type");
-                portrait = _services.game.portraits.getTextureByAppearance(appearance);
-            }
+        if (auto member = party.getAvailableMember(i)) {
+            auto portrait = member->portrait();
             BTN_NPC.setDisabled(false);
             LBL_CHAR.setBorderFill(std::move(portrait));
             LBL_NA.setVisible(false);
@@ -292,14 +283,7 @@ void PartySelection::changeParty() {
     for (int i = 0; i < kNpcCount; ++i) {
         if (!_added[i])
             continue;
-
-        std::string blueprintResRef(party.getAvailableMember(i));
-
-        std::shared_ptr<Creature> creature = _game.newCreature();
-        creature->loadFromBlueprint(blueprintResRef);
-        creature->setFaction(Faction::Friendly1);
-        creature->setImmortal(true);
-        party.addMember(i, creature);
+        party.addMember(i, party.getAvailableMember(i));
     }
 
     area->reloadParty();

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -53,13 +53,27 @@ bool Party::handleKeyDown(const input::KeyEvent &event) {
 }
 
 bool Party::addAvailableMember(int npc, const std::string &blueprint) {
-    auto maybeMember = _availableMembers.find(npc);
-    if (maybeMember != _availableMembers.end()) {
-        warn("Party: NPC already exists");
+    if (isMemberAvailable(npc)) {
+        warn(str(boost::format("Party: NPC %d already exists") % npc));
         return false;
     }
-    _availableMembers.insert(std::make_pair(npc, blueprint));
 
+    auto creature = _game.newCreature();
+    creature->loadFromBlueprint(blueprint);
+    creature->setFaction(Faction::Friendly1);
+    creature->setImmortal(true);
+
+    _availableMembers.insert({npc, std::move(creature)});
+    return true;
+}
+
+bool Party::addAvailableMember(int npc, std::shared_ptr<Creature> creature) {
+    if (isMemberAvailable(npc)) {
+        warn(str(boost::format("Party: NPC %d already exists") % npc));
+        return false;
+    }
+
+    _availableMembers.insert({npc, std::move(creature)});
     return true;
 }
 
@@ -108,22 +122,12 @@ void Party::onLeaderChanged() {
     _game.module()->area()->onPartyLeaderMoved(true);
 }
 
-const std::string &Party::getAvailableMember(int npc) const {
-    return _availableMembers.find(npc)->second;
-}
-
-std::shared_ptr<Creature> Party::createAvailableMember(int npc) {
-    auto maybeBlueprint = _availableMembers.find(npc);
-    if (maybeBlueprint == _availableMembers.end()) {
+std::shared_ptr<Creature> Party::getAvailableMember(int npc) const {
+    auto member = _availableMembers.find(npc);
+    if (member == _availableMembers.end()) {
         return nullptr;
     }
-
-    auto creature = _game.newCreature();
-    creature->loadFromBlueprint(maybeBlueprint->second);
-    creature->setFaction(Faction::Friendly1);
-    creature->setImmortal(true);
-
-    return creature;
+    return member->second;
 }
 
 std::shared_ptr<Creature> Party::getMember(int index) const {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -218,7 +218,7 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
     if (nNPC == kNpcPlayer) {
         creature = party.player();
     } else {
-        creature = party.createAvailableMember(nNPC);
+        creature = party.getAvailableMember(nNPC);
     }
     if (!creature) {
         warn("Party: NPC not found: " + std::to_string(nNPC));


### PR DESCRIPTION
Party used to only contain blueprints (templates) for NPC, and spawn
new creatures when an NPC is requested.

That means if an NPC is removed from the party, it used to be created
from scratch next time this NPC is needed. This approach is not going
to work for savegames, because they contain fully instantiated
creatures.

The patch replaces template references with Creature objects. It is
still possible to add available members by templates, but they are
instantiated immediately.