### PR TITLE
[game][gui] Stabilize Party Selection

### DIFF
--- a/include/reone/game/gui/partyselect.h
+++ b/include/reone/game/gui/partyselect.h
@@ -105,6 +105,7 @@ private:
 
     void onGUILoaded() override;
 
+    void bindEventHandlers();
     void bindControls() {
         _controls.BTN_ACCEPT = findControl<gui::Button>("BTN_ACCEPT");
         _controls.BTN_BACK = findControl<gui::Button>("BTN_BACK");

--- a/include/reone/game/gui/partyselect.h
+++ b/include/reone/game/gui/partyselect.h
@@ -27,7 +27,9 @@ namespace reone {
 
 namespace game {
 
-constexpr int kNpcCount = 9;
+constexpr int kKotorNpcCount = 9;
+constexpr int kTSLNpcCount = 12;
+constexpr int kMaxNpcCount = kTSLNpcCount;
 
 class PartySelection : public GameGUI {
 public:
@@ -97,8 +99,8 @@ private:
 
     PartySelectionContext _context;
     int _selectedNpc {-1};
-    bool _added[kNpcCount] {false};
-    bool _baselineAdded[kNpcCount] {false};
+    bool _added[kMaxNpcCount] {false};
+    bool _baselineAdded[kMaxNpcCount] {false};
     int _availableCount {0};
 
     void onGUILoaded() override;
@@ -168,6 +170,8 @@ private:
     void removeNpc(int npc);
 
     gui::ToggleButton &getNpcButton(int npc);
+    bool isSupportedNpc(int npc) const;
+    int npcCount() const;
 
     void onAcceptButtonClick();
     void onNpcButtonClick(int npc);

--- a/include/reone/game/gui/partyselect.h
+++ b/include/reone/game/gui/partyselect.h
@@ -98,6 +98,7 @@ private:
     PartySelectionContext _context;
     int _selectedNpc {-1};
     bool _added[kNpcCount] {false};
+    bool _baselineAdded[kNpcCount] {false};
     int _availableCount {0};
 
     void onGUILoaded() override;

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -50,6 +50,15 @@ static int g_strRefRemove = 38456;
 static glm::vec3 g_kotorColorOn = {0.984314f, 1.0f, 0};
 static glm::vec3 g_kotorColorAdded = {0, 0.831373f, 0.090196f};
 
+static bool matchesPendingSelection(const bool (&added)[kNpcCount], const bool (&baselineAdded)[kNpcCount]) {
+    for (int i = 0; i < kNpcCount; ++i) {
+        if (added[i] != baselineAdded[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 PartySelection::PartySelection(Game &game, ServicesView &services) :
     GameGUI(game, services) {
 
@@ -78,7 +87,9 @@ void PartySelection::onGUILoaded() {
         onAcceptButtonClick();
     });
     _controls.BTN_DONE->setOnClick([this]() {
-        changeParty();
+        if (!matchesPendingSelection(_added, _baselineAdded)) {
+            changeParty();
+        }
         _game.openInGame();
         if (!_context.exitScript.empty()) {
             _game.scriptRunner().run(_context.exitScript);
@@ -134,10 +145,23 @@ void PartySelection::onGUILoaded() {
 void PartySelection::prepare(const PartySelectionContext &ctx) {
     _context = ctx;
     _availableCount = kMaxFollowerCount;
+    _selectedNpc = -1;
 
     for (int i = 0; i < kNpcCount; ++i) {
         _added[i] = false;
+        _baselineAdded[i] = false;
         getNpcButton(i).setUseBorderColorOverride(false);
+    }
+    refreshNpcButtons();
+
+    Party &party = _game.party();
+    for (auto &member : party.members()) {
+        if (member.npc != kNpcPlayer) {
+            addNpc(member.npc);
+        }
+    }
+    for (int i = 0; i < kNpcCount; ++i) {
+        _baselineAdded[i] = _added[i];
     }
     if (ctx.forceNpc1 >= 0) {
         addNpc(ctx.forceNpc1);
@@ -145,7 +169,6 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
     if (ctx.forceNpc2 >= 0) {
         addNpc(ctx.forceNpc2);
     }
-    Party &party = _game.party();
     std::vector<Label *> charLabels {
         _controls.LBL_CHAR0.get(),
         _controls.LBL_CHAR1.get(),
@@ -196,6 +219,10 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
 }
 
 void PartySelection::addNpc(int npc) {
+    if (_added[npc]) {
+        return;
+    }
+
     --_availableCount;
     _added[npc] = true;
     getNpcButton(npc).setUseBorderColorOverride(true);

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -51,12 +51,12 @@ static int g_strRefRemove = 38456;
 static glm::vec3 g_kotorColorOn = {0.984314f, 1.0f, 0};
 static glm::vec3 g_kotorColorAdded = {0, 0.831373f, 0.090196f};
 
-static bool isSupportedNpc(int npc) {
-    return npc >= 0 && npc < kNpcCount;
-}
+static bool matchesPendingSelection(
+    const bool (&added)[kMaxNpcCount],
+    const bool (&baselineAdded)[kMaxNpcCount],
+    int npcCount) {
 
-static bool matchesPendingSelection(const bool (&added)[kNpcCount], const bool (&baselineAdded)[kNpcCount]) {
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount; ++i) {
         if (added[i] != baselineAdded[i]) {
             return false;
         }
@@ -81,7 +81,7 @@ void PartySelection::onGUILoaded() {
 
     bindControls();
 
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         ToggleButton &button = getNpcButton(i);
         button.setOnColor(g_kotorColorOn);
         button.setBorderColorOverride(g_kotorColorAdded);
@@ -92,7 +92,7 @@ void PartySelection::onGUILoaded() {
         onAcceptButtonClick();
     });
     _controls.BTN_DONE->setOnClick([this]() {
-        if (!matchesPendingSelection(_added, _baselineAdded)) {
+        if (!matchesPendingSelection(_added, _baselineAdded, npcCount())) {
             changeParty();
         }
         _game.openInGame();
@@ -152,9 +152,11 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
     _availableCount = kMaxFollowerCount;
     _selectedNpc = -1;
 
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < kMaxNpcCount; ++i) {
         _added[i] = false;
         _baselineAdded[i] = false;
+    }
+    for (int i = 0; i < npcCount(); ++i) {
         getNpcButton(i).setUseBorderColorOverride(false);
     }
     refreshNpcButtons();
@@ -165,7 +167,7 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
             addNpc(member.npc);
         }
     }
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         _baselineAdded[i] = _added[i];
     }
     if (ctx.forceNpc1 >= 0) {
@@ -204,7 +206,7 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
         naLabels.push_back(_controls.LBL_NA11.get());
     }
 
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         ToggleButton &BTN_NPC = getNpcButton(i);
         Label &LBL_CHAR = *charLabels[i];
         Label &LBL_NA = *naLabels[i];
@@ -245,12 +247,18 @@ ToggleButton &PartySelection::getNpcButton(int npc) {
         _controls.BTN_NPC6.get(),
         _controls.BTN_NPC7.get(),
         _controls.BTN_NPC8.get(),
-        _controls.BTN_NPC9.get()};
-    if (_game.isTSL()) {
-        npcButtons.push_back(_controls.BTN_NPC10.get());
-        npcButtons.push_back(_controls.BTN_NPC11.get());
-    }
+        _controls.BTN_NPC9.get(),
+        _controls.BTN_NPC10.get(),
+        _controls.BTN_NPC11.get()};
     return *npcButtons[npc];
+}
+
+bool PartySelection::isSupportedNpc(int npc) const {
+    return npc >= 0 && npc < npcCount();
+}
+
+int PartySelection::npcCount() const {
+    return _game.isTSL() ? kTSLNpcCount : kKotorNpcCount;
 }
 
 void PartySelection::onAcceptButtonClick() {
@@ -295,7 +303,7 @@ void PartySelection::onNpcButtonClick(int npc) {
 }
 
 void PartySelection::refreshNpcButtons() {
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         ToggleButton &button = getNpcButton(i);
 
         if ((i == _selectedNpc && !button.isOn()) ||
@@ -308,7 +316,7 @@ void PartySelection::refreshNpcButtons() {
 
 void PartySelection::changeParty() {
     Party &party = _game.party();
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         if (_added[i] && !party.isMemberAvailable(i)) {
             warn("Party selection: NPC is not available: " + std::to_string(i));
             return;
@@ -323,7 +331,7 @@ void PartySelection::changeParty() {
 
     std::shared_ptr<Creature> player(_game.party().player());
 
-    for (int i = 0; i < kNpcCount; ++i) {
+    for (int i = 0; i < npcCount(); ++i) {
         if (!_added[i])
             continue;
         party.addMember(i, party.getAvailableMember(i));

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -171,11 +171,6 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
     Party &party = _game.party();
     for (auto &member : party.members()) {
         if (member.npc != kNpcPlayer) {
-            if (isSupportedNpc(member.npc) &&
-                !party.isMemberAvailable(member.npc)) {
-
-                party.addAvailableMember(member.npc, member.creature);
-            }
             addNpc(member.npc);
         }
     }

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -171,12 +171,10 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
     Party &party = _game.party();
     for (auto &member : party.members()) {
         if (member.npc != kNpcPlayer) {
-            const std::string &blueprintResRef = member.creature->blueprintResRef();
             if (isSupportedNpc(member.npc) &&
-                !blueprintResRef.empty() &&
                 !party.isMemberAvailable(member.npc)) {
 
-                party.addAvailableMember(member.npc, blueprintResRef);
+                party.addAvailableMember(member.npc, member.creature);
             }
             addNpc(member.npc);
         }

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -29,6 +29,7 @@
 #include "reone/resource/resources.h"
 #include "reone/resource/strings.h"
 #include "reone/script/types.h"
+#include "reone/system/logutil.h"
 
 
 using namespace reone::audio;
@@ -49,6 +50,10 @@ static int g_strRefRemove = 38456;
 
 static glm::vec3 g_kotorColorOn = {0.984314f, 1.0f, 0};
 static glm::vec3 g_kotorColorAdded = {0, 0.831373f, 0.090196f};
+
+static bool isSupportedNpc(int npc) {
+    return npc >= 0 && npc < kNpcCount;
+}
 
 static bool matchesPendingSelection(const bool (&added)[kNpcCount], const bool (&baselineAdded)[kNpcCount]) {
     for (int i = 0; i < kNpcCount; ++i) {
@@ -219,7 +224,7 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
 }
 
 void PartySelection::addNpc(int npc) {
-    if (_added[npc]) {
+    if (!isSupportedNpc(npc) || _added[npc]) {
         return;
     }
 
@@ -280,6 +285,10 @@ void PartySelection::removeNpc(int npc) {
 }
 
 void PartySelection::onNpcButtonClick(int npc) {
+    if (!isSupportedNpc(npc)) {
+        return;
+    }
+
     _selectedNpc = npc;
     refreshNpcButtons();
     refreshAcceptButton();
@@ -298,10 +307,17 @@ void PartySelection::refreshNpcButtons() {
 }
 
 void PartySelection::changeParty() {
+    Party &party = _game.party();
+    for (int i = 0; i < kNpcCount; ++i) {
+        if (_added[i] && !party.isMemberAvailable(i)) {
+            warn("Party selection: NPC is not available: " + std::to_string(i));
+            return;
+        }
+    }
+
     std::shared_ptr<Area> area(_game.module()->area());
     area->unloadParty();
 
-    Party &party = _game.party();
     party.clear();
     party.addMember(kNpcPlayer, party.player());
 

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -88,6 +88,10 @@ void PartySelection::onGUILoaded() {
         button.setUseBorderColorOverride(false);
     }
 
+    bindEventHandlers();
+}
+
+void PartySelection::bindEventHandlers() {
     _controls.BTN_ACCEPT->setOnClick([this]() {
         onAcceptButtonClick();
     });
@@ -148,6 +152,9 @@ void PartySelection::onGUILoaded() {
 }
 
 void PartySelection::prepare(const PartySelectionContext &ctx) {
+    _gui->setEventListener(*this);
+    bindEventHandlers();
+
     _context = ctx;
     _availableCount = kMaxFollowerCount;
     _selectedNpc = -1;
@@ -164,6 +171,13 @@ void PartySelection::prepare(const PartySelectionContext &ctx) {
     Party &party = _game.party();
     for (auto &member : party.members()) {
         if (member.npc != kNpcPlayer) {
+            const std::string &blueprintResRef = member.creature->blueprintResRef();
+            if (isSupportedNpc(member.npc) &&
+                !blueprintResRef.empty() &&
+                !party.isMemberAvailable(member.npc)) {
+
+                party.addAvailableMember(member.npc, blueprintResRef);
+            }
             addNpc(member.npc);
         }
     }


### PR DESCRIPTION
## Summary

* Preserve Party Selection no-op OK/Done without unloading/rebuilding the active party.
* Preflight changed Party Selection applies before clearing the live party.
* Support TSL's authored 12 Party Selection roster slots while keeping K1 at 9.
* Rebind Party Selection handlers on prepare for reused/hosted GUI instances.
* Register active party members missing from the available roster using their existing Creature instance.

## Notes

* Builds on upstream #158 and #160.
* Keeps core party/script/dev paths permissive; no global max-2 enforcement (game is only GUI limited to 2 party members)
* Does not change `spawncompanion`, object registry cleanup, save/load, routing, or visual tinting.
* GUI not yet fully implemented