### PR TITLE
[game] Deserialize party from a savegame

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -346,6 +346,9 @@ public:
     // END Global variables
 
     void deserializeGlobalVariables(resource::Gff &gvtGff);
+    void deserializeParty(resource::Gff &ifoGff);
+    void deserializePartyTable(resource::Gff &ptGff);
+    void deserializePartyMembers(resource::Gff &ptGff);
     void deserializeInventory(resource::Gff &inventoryGff);
 
 private:

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -298,6 +298,7 @@ private:
     int16_t _fortBonus {0};
     uint8_t _goodEvil {0};
     float _challengeRating {0};
+    uint32_t _xp {0};
 
     std::string _onNotice;
     std::string _onSpellAt;
@@ -336,7 +337,6 @@ private:
     bool _movementRestricted {false};
     CombatState _combatState;
     bool _immortal {false};
-    int _xp {0};
     std::shared_ptr<resource::SoundSet> _soundSet;
     BodyBag _bodyBag;
     Perception _perception;

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -587,9 +587,7 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
             }
 
             if (_party.isEmpty()) {
-                if (!loadParty()) {
-                    loadDefaultParty();
-                }
+                loadDefaultParty();
             }
 
             if (!fromSave) {
@@ -619,26 +617,41 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
 void Game::loadGame(std::string_view name) {
     info(str(boost::format("Loading savegame '%s'") % name));
 
+    // Add savegame files to resource resolution.
     _services.resource.director.onGameLoad(name);
+
+    std::shared_ptr<Gff> saveInfo(_services.resource.gffs.get("savenfo", ResType::Res));
+    if (!saveInfo) {
+        throw ResourceNotFoundException("saveinfo.res not found");
+    }
+    NFO nfo = resource::parseNFO(*saveInfo);
+
+    // Add module files to resource resolution. Since all savegame files are
+    // already in scope, this is going to resolve to the last module from the
+    // save game.
+    _services.resource.director.onModuleLoad(nfo.lastModule);
+
+    // Deserialize global variables
     std::shared_ptr<Gff> globalVars(_services.resource.gffs.get("globalvars", ResType::Res));
     if (!globalVars) {
         throw ResourceNotFoundException("globalvars.res not found");
     }
     deserializeGlobalVariables(*globalVars);
 
-    std::shared_ptr<Gff> saveInfo(_services.resource.gffs.get("savenfo", ResType::Res));
-    if (!saveInfo) {
-        throw ResourceNotFoundException("saveinfo.res not found");
+    // Deserialize party.
+    std::shared_ptr<Gff> ifo(_services.resource.gffs.get("module", ResType::Ifo));
+    if (!ifo) {
+        throw ResourceNotFoundException("Module IFO not found");
     }
+    deserializeParty(*ifo);
 
-    NFO nfo = resource::parseNFO(*saveInfo);
-    loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
-
-    // Inventory is serialized into a separate file. Once the player is loaded,
-    // deserialize it into the player's inventory.
+    // Once the player is loaded, deserialize player's inventory.
     if (auto inventoryGff = _services.resource.gffs.get("inventory", ResType::Res)) {
         deserializeInventory(*inventoryGff);
     }
+
+    // Warp to the last module.
+    loadModule(nfo.lastModule, /*entry=*/"", /*fromSave=*/true);
 }
 
 void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
@@ -668,6 +681,97 @@ void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
     }
 }
 
+void Game::deserializeParty(resource::Gff &ifoGff) {
+    const auto &players = ifoGff.getList("Mod_PlayerList");
+    if (players.empty()) {
+        return;
+    }
+
+    std::shared_ptr<Creature> player = newCreature();
+    _objectById.insert(std::make_pair(player->id(), player));
+    player->deserialize(*players.front());
+    player->setTag(kObjectTagPlayer);
+    _party.addMember(kNpcPlayer, player);
+    _party.setPlayer(player);
+
+    std::shared_ptr<Gff> ptGff(_services.resource.gffs.get("partytable", ResType::Res));
+    if (!ptGff) {
+        return;
+    }
+
+    uint32_t gold = 0;
+    if (ptGff->readDword(gold, "PT_GOLD")) {
+        _party.takeGold(_party.gold());
+        _party.giveGold(gold);
+    }
+
+    uint32_t xp = 0;
+    if (ptGff->readDword(xp, "PT_XP_POOL")) {
+        player->setXP(xp);
+    }
+
+    deserializePartyTable(*ptGff);
+    deserializePartyMembers(*ptGff);
+}
+
+void Game::deserializePartyTable(resource::Gff &ptGff) {
+    int nextNpc = 0;
+    for (const auto &npcState : ptGff.getList("PT_AVAIL_NPCS")) {
+        int npc = nextNpc++;
+        if (!npcState->getBool("PT_NPC_AVAIL")) {
+            continue;
+        }
+        // TODO: handle selectability of NPCs.
+        bool select = npcState->getBool("PT_NPC_SELECT");
+
+        std::string utc = str(boost::format("availnpc%d") % npc);
+
+        std::shared_ptr<Gff> utcGff(_services.resource.gffs.get(utc, ResType::Utc));
+        if (!utcGff) {
+            return;
+        }
+
+        std::shared_ptr<Creature> creature = newCreature();
+        _objectById.insert(std::make_pair(creature->id(), creature));
+        creature->deserialize(*utcGff);
+
+        _party.addAvailableMember(npc, creature);
+    }
+}
+
+void Game::deserializePartyMembers(resource::Gff &ptGff) {
+    auto members = ptGff.getList("PT_MEMBERS");
+    auto leader = std::find_if(members.begin(), members.end(), [](auto &member) {
+        return member->getBool("PT_IS_LEADER");
+    });
+
+    auto addMember = [&](resource::Gff &memberGff) {
+        int32_t npc = -1;
+        if (!memberGff.readInt(npc, "PT_MEMBER_ID")) {
+            warn("Game: missing PT_MEMBER_ID");
+            return;
+        }
+
+        auto member = _party.getAvailableMember(npc);
+        if (!member) {
+            warn("Game: NPC is not available: " + std::to_string(npc));
+        }
+
+        _party.addMember(npc, member);
+    };
+
+    // Party leader is the first party member. Populate the party starting from
+    // the leader.
+    for (auto it = leader, end = members.end(); it != end; ++it) {
+        addMember(**it);
+    }
+
+    // Then add other members.
+    for (auto it = members.begin(), end = leader; it != end; ++it) {
+        addMember(**it);
+    }
+}
+
 void Game::deserializeInventory(resource::Gff &inventoryGff) {
     std::shared_ptr<Creature> player = _party.player();
     if (!player) {
@@ -686,18 +790,6 @@ bool Game::loadParty() {
     if (!ifo) {
         throw ResourceNotFoundException("module.ifo not found");
     }
-
-    const auto &players = ifo->getList("Mod_PlayerList");
-    if (players.empty()) {
-        return false;
-    }
-
-    std::shared_ptr<Creature> player = newCreature();
-    _objectById.insert(std::make_pair(player->id(), player));
-    player->deserialize(*players.front());
-    player->setTag(kObjectTagPlayer);
-    _party.addMember(kNpcPlayer, player);
-    _party.setPlayer(player);
 
     return true;
 }

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -1403,6 +1403,7 @@ void Creature::deserializeAll(const resource::Gff &gff) {
     gff.readShort(_fortBonus, "fortbonus");
     gff.readByte(_goodEvil, "GoodEvil");
     gff.readFloat(_challengeRating, "ChallengeRating");
+    gff.readDword(_xp, "Experience");
 
     gff.readResRef(_onNotice, "ScriptOnNotice");
     gff.readResRef(_onSpellAt, "ScriptSpellAt");


### PR DESCRIPTION
Party and the player information is split into multiple files, so `loadGame` reads and applies them in order.

The player character is deserialized from `Mod_PlayerList` of the last module's IFO. Multiple characters are technically possible there, but we only use the first one in the list.

Party table contains a list of NPCs (party members) that are available (present on the party selection screen), selectable (can be added to the party), and what NPCs are in the party.

Actual NPC GFFs are separate `availnpcN.utc` files in a savegame ERF archive.

Credits (gold) and XP are also separate fields of the party table, but we assign them to the player character. Similar to inventory, party members are supposed to use player character's XP and credits value instead of their own, but this is not implemented yet.