### PR TITLE
[game] Reset game state before loading a new game

### DIFF
--- a/include/reone/game/combat.h
+++ b/include/reone/game/combat.h
@@ -94,6 +94,7 @@ public:
     const CombatRound &addAction(const std::shared_ptr<Action> &action, Object &actor);
 
     void update(float dt);
+    void reset() { _rounds.clear(); }
 
 public:
     using RoundQueue = std::deque<std::unique_ptr<CombatRound>>;

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -215,6 +215,9 @@ public:
     // ResourceDirector::saveNames().
     void loadGame(std::string_view name);
 
+    // Clear state of the current game before loading a new game.
+    void resetGame();
+
     // END Module loading
 
     // Objects

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -40,6 +40,10 @@ public:
 
     bool handle(const input::Event &event);
 
+    // Clear the player, party members, available NPCs and set all other fields
+    // to their default values.
+    void reset();
+
     void clear();
     void switchLeader();
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -614,8 +614,45 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
     });
 }
 
+void Game::resetGame() {
+    if (_swoopRace.isActive()) {
+        _swoopRace.stop();
+    }
+    _screen = Screen::None;
+    _services.audio.mixer.stopAll();
+    _music.reset();
+    _movie.reset();
+    _musicResRef.clear();
+    while (!_moduleTransitionMovies.empty()) {
+        _moduleTransitionMovies.pop();
+    }
+    setCursorType(CursorType::Default);
+    _cameraType = CameraType::ThirdPerson;
+    _savedCameraType = CameraType::ThirdPerson;
+    _paused = false;
+    _quitRequested = false;
+    _relativeMouseMode = false;
+    if (_conversation) {
+        _conversation->cleanupForModuleTransition();
+        _conversation = nullptr;
+    }
+    _globalStrings.clear();
+    _globalBooleans.clear();
+    _globalNumbers.clear();
+    _globalLocations.clear();
+    _customTokens.clear();
+
+    _party.reset();
+    _combat.reset();
+    _module.reset();
+    _loadedModules.clear();
+}
+
 void Game::loadGame(std::string_view name) {
     info(str(boost::format("Loading savegame '%s'") % name));
+
+    // Reset game state before loading a new game.
+    resetGame();
 
     // Add savegame files to resource resolution.
     _services.resource.director.onGameLoad(name);

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -95,6 +95,14 @@ bool Party::addMember(int npc, std::shared_ptr<Creature> creature) {
     return true;
 }
 
+void Party::reset() {
+    _player.reset();
+    _availableMembers.clear();
+    _members.clear();
+    _solo = false;
+    _gold = 0;
+}
+
 void Party::clear() {
     _members.clear();
 }


### PR DESCRIPTION
The patch resets Game components that should not be carried over to a
new game, and keeps "global" state like GUIs, script runner, console
commands intact.

It is not always clear what state we should reset, so it is better to
move global components out of the Game class and reconstruct the Game
completely. This patch is a compromise until we redesign Game class.