### PR TITLE
[game] Add swoop race skeleton

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -62,6 +62,7 @@
 #include "options.h"
 #include "party.h"
 #include "script/runner.h"
+#include "swooprace.h"
 #include "talent.h"
 
 #include <queue>
@@ -95,7 +96,8 @@ public:
         Conversation,
         Container,
         PartySelection,
-        SaveLoad
+        SaveLoad,
+        SwoopRace
     };
 
     Game(
@@ -110,7 +112,8 @@ public:
         _services(services),
         _console(console),
         _party(*this),
-        _combat(*this, services) {
+        _combat(*this, services),
+        _swoopRace(*this) {
     }
 
     void init();
@@ -148,6 +151,17 @@ public:
 
     void openMainMenu();
     void openInGame();
+
+    // Swoop race (developer skeleton)
+
+    void openSwoopRace();
+    void closeSwoopRace();
+
+    // Exit the active race: returns to the lifecycle origin if a lifecycle race
+    // is in progress, otherwise just stops the dev race in place.
+    void exitSwoopRace();
+
+    // END Swoop race
     void openInGameMenu(InGameMenuTab tab);
     void openLevelUp();
     void notifyLevelUpPending(const Creature &creature);
@@ -351,12 +365,27 @@ private:
     DeveloperOverlay _developerOverlay;
     std::shared_ptr<graphics::Font> _developerFont;
 
+    // Non-blocking swoop lifecycle session: origin module/state -> swoop module
+    // -> auto-start race -> forced-success finish -> return to origin. Passive
+    // bookkeeping only; it does not touch party membership, inventory, or story.
+    struct SwoopLifecycle {
+        bool active {false};        // a lifecycle race is in progress (return pending)
+        bool haveOrigin {false};    // origin position/facing captured
+        std::string originModule;   // module resref to return to
+        glm::vec3 originPosition {0.0f};
+        float originFacing {0.0f};
+        bool forcedSuccess {true};  // PR1: finish is always non-blocking success
+    };
+
+    SwoopLifecycle _swoopLifecycle;
+
     std::shared_ptr<movie::IMovie> _movie;
     std::queue<std::string> _moduleTransitionMovies;
     resource::CursorType _cursorType {resource::CursorType::None};
     std::shared_ptr<graphics::Cursor> _cursor;
     float _gameSpeed {1.0f};
     CameraType _cameraType {CameraType::ThirdPerson};
+    CameraType _savedCameraType {CameraType::ThirdPerson};
     bool _paused {false};
     std::set<std::string> _moduleNames;
     std::set<std::string> _saveNames;
@@ -370,6 +399,7 @@ private:
 
     Party _party;
     Combat _combat;
+    SwoopRace _swoopRace;
 
     std::unique_ptr<script::IRoutines> _routines;
     std::unique_ptr<ScriptRunner> _scriptRunner;
@@ -428,6 +458,25 @@ private:
     void loadNextModule();
     void playMusic(const std::string &resRef);
     void toggleInGameCameraType();
+
+    // Stop the active lifecycle race and return to the stored origin module
+    // (restoring the leader's position/facing). Safe no-op if no lifecycle race.
+    void finishSwoopLifecycle(bool success);
+
+    // Show/hide the active party creatures. Used to suppress the normal party
+    // while a minigame is running: vanilla does not add the party to the scene
+    // in a minigame module (the minigame actor represents the player).
+    void setPartyVisible(bool visible);
+
+    // The vanilla race-end return waypoint tag for the given race module (the
+    // StartNewModule startpoint the race-end script uses), or "" if unknown.
+    std::string swoopReturnWaypoint(const std::string &raceModule) const;
+
+    // Apply the planet-specific forced-success race result for the given race
+    // module (K1 Taris confirmed; others no-op). Sets the player's finish-time
+    // globals and runs the vanilla post-race result script.
+    void applySwoopForcedSuccessResult(const std::string &raceModule);
+    void applyTarisForcedWinningTime();
 
     bool handleKeyDown(const input::KeyEvent &event);
     bool handleMouseMotion(const input::MouseMotionEvent &event);
@@ -524,6 +573,7 @@ private:
     void consoleKill(const ConsoleArgs &tokens);
     void consoleAddItem(const ConsoleArgs &tokens);
     void consoleGiveXP(const ConsoleArgs &tokens);
+    void consoleGiveGold(const ConsoleArgs &tokens);
     void consoleWarp(const ConsoleArgs &tokens);
     void consoleRunScript(const ConsoleArgs &tokens);
     void consoleShowAABB(const ConsoleArgs &tokens);
@@ -551,6 +601,12 @@ private:
     void consoleOpenCloseDoor(const ConsoleArgs &tokens);
     void consoleListGames(const ConsoleArgs &tokens);
     void consoleLoadGame(const ConsoleArgs &tokens);
+    void consoleMiniGameInfo(const ConsoleArgs &tokens);
+    void consoleStartSwoop(const ConsoleArgs &tokens);
+    void consoleStopSwoop(const ConsoleArgs &tokens);
+    void consoleSwoopState(const ConsoleArgs &tokens);
+    void consoleStartSwoopRace(const ConsoleArgs &tokens);
+    void consoleFinishSwoop(const ConsoleArgs &tokens);
 
     // END Console commands
 };

--- a/include/reone/game/minigame.h
+++ b/include/reone/game/minigame.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace reone {
+
+namespace game {
+
+enum class MinigameType {
+    None = 0,
+    SwoopRace = 1,
+    Turret = 2,
+    Unknown
+};
+
+inline MinigameType minigameTypeFromUint(uint32_t value) {
+    switch (value) {
+    case 0:
+        return MinigameType::None;
+    case 1:
+        return MinigameType::SwoopRace;
+    case 2:
+        return MinigameType::Turret;
+    default:
+        return MinigameType::Unknown;
+    }
+}
+
+inline const char *minigameTypeName(MinigameType t) {
+    switch (t) {
+    case MinigameType::None:
+        return "none";
+    case MinigameType::SwoopRace:
+        return "swooprace";
+    case MinigameType::Turret:
+        return "turret";
+    default:
+        return "unknown";
+    }
+}
+
+struct MinigamePlayerScriptSpec {
+    std::string onCreate;
+    std::string onDeath;
+    std::string onTrackLoop;
+    std::string onDamage;
+    std::string onAccelerate;
+    std::string onHeartbeat;
+};
+
+struct MinigamePlayerSpec {
+    std::string cameraResRef;
+    std::string trackResRef;
+    std::vector<std::string> modelResRefs;
+    float minimumSpeed {0.0f};
+    float maximumSpeed {0.0f};
+    float accelSecs {0.0f};
+    float sphereRadius {0.0f};
+    uint32_t hitPoints {0};
+    MinigamePlayerScriptSpec scripts;
+
+    // Tunnel bounds, as stored in the .are (angular limits, in degrees, that
+    // vanilla applies to bike lean/rotation per axis - not lateral position).
+    float tunnelXPos {0.0f};
+    float tunnelXNeg {0.0f};
+    float tunnelYPos {0.0f};
+    float tunnelYNeg {0.0f};
+    float tunnelZPos {0.0f};
+    float tunnelZNeg {0.0f};
+};
+
+struct MinigameEnemySpec {
+    std::string trackResRef;
+    std::vector<std::string> modelResRefs;
+    uint32_t hitPoints {0};
+    std::string onCreate;
+};
+
+struct MinigameObstacleSpec {
+    std::string name;
+    std::string onCreate;
+};
+
+// Passive data parsed from the .are MiniGame struct. Stored on Area.
+// Not instantiated as a game object — that belongs to a future slice.
+struct MinigameSpec {
+    MinigameType type {MinigameType::None};
+    float cameraViewAngle {0.0f};
+    float lateralAccel {0.0f};
+    float movementPerSec {0.0f};
+    bool useInertia {false};
+    uint32_t bumpPlane {0};
+    bool doBumping {false};
+    MinigamePlayerSpec player;
+    std::vector<MinigameEnemySpec> enemies;
+    std::vector<MinigameObstacleSpec> obstacles;
+
+    // Unique track resrefs referenced by player and enemies.
+    // Derived at parse time; not stored separately in the .are format.
+    std::vector<std::string> trackResRefs;
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "reone/game/messagebus.h"
+#include "reone/game/minigame.h"
 #include "reone/graphics/texture.h"
 #include "reone/graphics/types.h"
 #include "reone/input/event.h"
@@ -96,6 +97,9 @@ public:
     void determineObjectRoom(Object &object);
 
     bool isUnescapable() const { return _unescapable; }
+
+    bool hasMinigame() const { return _miniGameSpec.has_value(); }
+    const MinigameSpec &miniGame() const { return *_miniGameSpec; }
 
     Object *getObjectAt(int x, int y) const;
     glm::vec3 getSelectableScreenCoords(const std::shared_ptr<Object> &object, const glm::mat4 &projection, const glm::mat4 &view) const;
@@ -241,6 +245,7 @@ private:
     Timer _heartbeatTimer;
     bool _unescapable {false};
     Grass _grass;
+    std::optional<MinigameSpec> _miniGameSpec;
     glm::vec3 _ambientColor {0.0f};
     Timer _perceptionTimer;
     std::shared_ptr<Object> _hilightedObject;
@@ -323,7 +328,13 @@ private:
      */
     resource::Visibility fixVisibility(const resource::Visibility &visiblity);
 
-    void checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer);
+    void checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer, bool fireTransitions = true);
+
+    // Fire OnEnter for non-transition triggers the party leader currently
+    // occupies (so triggers fire when the leader is placed/spawned inside them,
+    // not only when moving across the boundary). Module-transition triggers are
+    // left to movement-based firing to avoid spawn bounce.
+    void updateLeaderTriggerOccupancy();
 
     // Loading ARE
 
@@ -336,6 +347,7 @@ private:
     void loadStealthXP(const resource::generated::ARE &are);
     void loadGrass(const resource::generated::ARE &are);
     void loadFog(const resource::generated::ARE &are);
+    void loadMiniGame(const resource::generated::ARE &are);
 
     // END Loading ARE
 

--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -58,6 +58,12 @@ public:
 
     void addTenant(const std::shared_ptr<Object> &object);
 
+    // Drop an object from the tenant set without firing OnExit. Used when an
+    // object is destroyed while standing inside the trigger: a destroyed object
+    // never moves, so Trigger::update would otherwise keep it as a tenant
+    // forever (leaking it and leaving the trigger stuck in the Inside state).
+    void removeTenant(const Object *object);
+
     bool isIn(const glm::vec2 &point) const;
     bool isTenant(const std::shared_ptr<Object> &object) const;
 

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -93,6 +93,18 @@ public:
 
     // END Default party
 
+    // Credits
+    //
+    // KOTOR stores credits as a single party-shared pool, not per creature.
+    // Gold script routines (GetGold/GiveGoldToCreature/TakeGoldFromCreature)
+    // that target a party member operate on this pool.
+
+    int gold() const { return _gold; }
+    void giveGold(int amount);
+    void takeGold(int amount);
+
+    // END Credits
+
 private:
     Game &_game;
 
@@ -100,6 +112,7 @@ private:
     std::map<int, std::shared_ptr<Creature>> _availableMembers;
     std::vector<Member> _members;
     bool _solo {false};
+    int _gold {0};
 
     bool handleKeyDown(const input::KeyEvent &event);
 

--- a/include/reone/game/swooprace.h
+++ b/include/reone/game/swooprace.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/input/event.h"
+
+#include "minigame.h"
+
+namespace reone {
+
+namespace scene {
+
+class ModelSceneNode;
+
+}
+
+namespace game {
+
+class Game;
+class FirstPersonCamera;
+
+/**
+ * Developer skeleton for the swoop racing minigame, consuming passive metadata
+ * parsed from the area's .are MiniGame struct (see MinigameSpec).
+ *
+ * Movement uses an explicit track-relative progress model that matches the
+ * vanilla drag-race shape (not an arcade racer):
+ *
+ *   centerline = trackStart + trackForward * progress
+ *   bikePos    = centerline + trackRight   * lateralOffset
+ *
+ * Forward progress is automatic/speed-driven down the authored track frame;
+ * left/right input is a lateral strafe only (it never turns/yaws the bike for
+ * navigation). The bike always faces down-course; any lean is small and purely
+ * cosmetic. The track frame (start/forward/right) comes from the LYT track
+ * placement combined with the track model's "modelhook"; a leader-anchored
+ * fallback is used when that is unavailable.
+ *
+ * Intentionally minimal: no obstacles, enemies, boost, lap/finish, HUD, or
+ * scripts; the track model's animation is not sampled for progress (vanilla
+ * does not either).
+ */
+class SwoopRace {
+public:
+    SwoopRace(Game &game) :
+        _game(game) {
+    }
+
+    /**
+     * Initialize and activate the race from the given metadata, anchored at the
+     * supplied world position and facing.
+     *
+     * @param camera the area first-person camera, reused as a chase camera; may be null
+     * @param bikeNodes the visible bike model scene nodes (already added to the scene); may be empty
+     * @param finishProgress forward-progress distance at which the race is considered finished
+     */
+    void start(const MinigameSpec &spec,
+               FirstPersonCamera *camera,
+               std::vector<std::shared_ptr<scene::ModelSceneNode>> bikeNodes,
+               const glm::vec3 &startPosition,
+               float startFacing,
+               float finishProgress);
+
+    void stop();
+
+    void update(float dt);
+    bool handle(const input::Event &event);
+
+    bool isActive() const { return _active; }
+
+    // The visible bike model scene nodes, so the owner can detach them on exit.
+    const std::vector<std::shared_ptr<scene::ModelSceneNode>> &bikeNodes() const { return _bikeNodes; }
+
+    // Diagnostics
+
+    MinigameType type() const { return _type; }
+    const std::string &trackResRef() const { return _trackResRef; }
+    size_t modelCount() const { return _modelCount; }
+    float movePerSec() const { return _movePerSec; }
+    float lateralAccel() const { return _lateralAccel; }
+    float cameraViewAngle() const { return _camFov; }
+    float elapsed() const { return _elapsed; }
+    float speed() const { return _speed; }
+
+    float lateralLeftBound() const { return _lateralLeftBound; }
+    float lateralRightBound() const { return _lateralRightBound; }
+    const std::string &lateralBoundSource() const { return _lateralBoundSource; }
+
+    float progress() const { return _progress; }
+    float lateralOffset() const { return _lateralOffset; }
+    glm::vec3 position() const { return bikePosition(); }
+
+    float finishProgress() const { return _finishProgress; }
+
+    // True once forward progress has reached the finish threshold.
+    bool finishReached() const { return _finishProgress > 0.0f && _progress >= _finishProgress; }
+
+    // END Diagnostics
+
+private:
+    Game &_game;
+
+    bool _active {false};
+
+    // Tuning copied from metadata at start
+
+    MinigameType _type {MinigameType::None};
+    float _movePerSec {0.0f};
+    float _lateralAccel {0.0f};
+    float _camFov {0.0f};
+    std::string _trackResRef;
+    size_t _modelCount {0};
+
+    // Track-relative frame, computed once at start. The bike advances along
+    // _trackForward and strafes along _trackRight; _facing is the down-course
+    // yaw applied to the bike model.
+    glm::vec3 _trackStart {0.0f};
+    glm::vec3 _trackForward {0.0f, 1.0f, 0.0f};
+    glm::vec3 _trackRight {1.0f, 0.0f, 0.0f};
+    float _facing {0.0f};
+
+    // Runtime state
+
+    float _speed {0.0f};
+    float _progress {0.0f};       // forward distance along the track frame
+    float _finishProgress {0.0f}; // progress at which the race auto-finishes (0 = none)
+    float _lateralOffset {0.0f};  // strafe offset along _trackRight
+    float _lateralVel {0.0f};
+    float _elapsed {0.0f};
+    int _steerDir {0}; // -1 left, +1 right, 0 none
+
+    // Lateral travel limits (world units), derived from tunnel metadata or a
+    // safe fallback. Asymmetric: negative offset clamps to -_lateralLeftBound,
+    // positive offset clamps to +_lateralRightBound.
+    float _lateralLeftBound {0.0f};
+    float _lateralRightBound {0.0f};
+    std::string _lateralBoundSource;
+
+    FirstPersonCamera *_camera {nullptr};
+    std::vector<std::shared_ptr<scene::ModelSceneNode>> _bikeNodes;
+
+    bool handleKeyDown(const input::KeyEvent &event);
+    bool handleKeyUp(const input::KeyEvent &event);
+
+    float cameraAspect() const;
+    glm::vec3 bikePosition() const;
+    void applyChaseCamera();
+    void applyBikeTransform();
+    void setCameraFieldOfView(float fovDegrees);
+    void computeLateralBounds(const MinigamePlayerSpec &player);
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/resource/format/lytreader.h
+++ b/include/reone/resource/format/lytreader.h
@@ -35,18 +35,24 @@ private:
     enum class State {
         None,
         Layout,
-        Rooms
+        Rooms,
+        Tracks,
+        Obstacles
     };
 
     std::filesystem::path _path;
     State _state {State::None};
     int _roomCount {0};
+    int _trackCount {0};
+    int _obstacleCount {0};
 
     Layout _layout;
 
     void processLine(const std::string &line);
 
     void appendRoom(const std::vector<std::string> &tokens);
+    void appendTrack(const std::vector<std::string> &tokens);
+    void appendObstacle(const std::vector<std::string> &tokens);
 };
 
 } // namespace resource

--- a/include/reone/resource/layout.h
+++ b/include/reone/resource/layout.h
@@ -27,12 +27,48 @@ struct Layout {
         glm::vec3 position {0.0f};
     };
 
+    // Minigame track placement (LYT "trackcount" section). Position only; the
+    // LYT track format carries no rotation.
+    struct Track {
+        std::string name;
+        glm::vec3 position {0.0f};
+    };
+
+    // Minigame obstacle placement (LYT "obstaclecount" section). Same
+    // "<name> <x> <y> <z>" format as tracks; position only.
+    struct Obstacle {
+        std::string name;
+        glm::vec3 position {0.0f};
+    };
+
     std::vector<Room> rooms;
+    std::vector<Track> tracks;
+    std::vector<Obstacle> obstacles;
 
     std::optional<std::reference_wrapper<const Room>> findByName(const std::string &name) const {
         for (auto &room : rooms) {
             if (room.name == name) {
                 return room;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::reference_wrapper<const Track>> findTrackByName(const std::string &name) const {
+        std::string lower(boost::to_lower_copy(name));
+        for (auto &track : tracks) {
+            if (track.name == lower) {
+                return track;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::reference_wrapper<const Obstacle>> findObstacleByName(const std::string &name) const {
+        std::string lower(boost::to_lower_copy(name));
+        for (auto &obstacle : obstacles) {
+            if (obstacle.name == lower) {
+                return obstacle;
             }
         }
         return std::nullopt;

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -289,6 +289,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/sounds.h
     ${GAME_INCLUDE_DIR}/location.h
     ${GAME_INCLUDE_DIR}/messagebus.h
+    ${GAME_INCLUDE_DIR}/minigame.h
     ${GAME_INCLUDE_DIR}/object.h
     ${GAME_INCLUDE_DIR}/object/area.h
     ${GAME_INCLUDE_DIR}/object/camera.h
@@ -324,6 +325,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/script/runner.h
     ${GAME_INCLUDE_DIR}/surface.h
     ${GAME_INCLUDE_DIR}/surfaces.h
+    ${GAME_INCLUDE_DIR}/swooprace.h
     ${GAME_INCLUDE_DIR}/talent.h
     ${GAME_INCLUDE_DIR}/types.h
     ${GAME_INCLUDE_DIR}/visualeffects.h)
@@ -526,6 +528,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/script/routines.cpp
     ${GAME_SOURCE_DIR}/script/runner.cpp
     ${GAME_SOURCE_DIR}/surfaces.cpp
+    ${GAME_SOURCE_DIR}/swooprace.cpp
     ${GAME_SOURCE_DIR}/visualeffects.cpp)
 
 add_library(game STATIC ${GAME_HEADERS} ${GAME_SOURCES} ${CLANG_FORMAT_PATH})

--- a/src/libs/game/action/startconversation.cpp
+++ b/src/libs/game/action/startconversation.cpp
@@ -30,9 +30,20 @@ static constexpr float kMaxConversationDistance = 4.0f;
 void StartConversationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     auto actorPtr = _game.getObjectById(actor.id());
 
-    // Creatures should move to the target before starting the dialog.
-    // Triggers and other objects can start the dialog immediately
+    // A creature walks up to its conversation partner before talking. If the
+    // target object is invalid - a script can pass an object that was never
+    // created (e.g. GetObjectByTag on a tag with no instance) or one that has
+    // been destroyed - there is nobody to approach, so the action is dropped
+    // rather than starting a partnerless dialog. This mirrors retail/KotOR.js,
+    // where the creature path requires a valid target (it navigates to and
+    // references the target) and the action otherwise fails. It also prevents a
+    // null dereference below and stops an NPC told to converse with a missing
+    // placeholder from starting a stray dialog.
     if (auto creatureActor = dyn_cast<Creature>(actorPtr)) {
+        if (!_objectToConverse) {
+            complete();
+            return;
+        }
         bool reached =
             _ignoreStartRange ||
             creatureActor->navigateTo(_objectToConverse->position(), true, kMaxConversationDistance, dt);
@@ -42,20 +53,53 @@ void StartConversationAction::execute(std::shared_ptr<Action> self, Object &acto
         }
     }
 
-    // When scripts do not specify DialogResRef, it takes a default
-    // value of caller->conversation() before StartConversationAction
-    // object is constructed.
+    // Dialog owner selection - i.e. which participant's Conversation/DLG plays:
     //
-    // When the player initiates a conversation, DialogResRef should
-    // be empty.
+    //  - Explicit DialogResRef: the named dialog is caller-owned (PR #150).
     //
-    // Therefore, if DialogResRef is empty, we must always select
-    // _objectToConverse and use its conversation() as the dialog.
+    //  - Blank DialogResRef: a party member is always the listener, never the
+    //    dialog owner, so the OTHER participant owns the conversation:
+    //      * the target owns it when the target is not a party member and has
+    //        its own Conversation. This covers the player clicking an NPC or a
+    //        placeable, and a script pointing the caller at an invisible dialog
+    //        anchor whose Conversation is the scene's dialogue (an NPC told to
+    //        converse with such a placeable).
+    //      * otherwise the caller owns it when the caller has a Conversation.
+    //        This is the common NPC-starts-dialogue-with-the-PC shape, where the
+    //        target is the party member.
+    //      * otherwise fall back to the target's Conversation if it has one.
     //
-    // Otherwise, if DialogResRef is set, select Actor as the dialog
-    // owner.
+    // Keyed only on party membership and Conversation presence, so it is generic
+    // (it does not depend on whether the PC/leader happens to have a
+    // Conversation field of its own).
+    std::shared_ptr<Object> dialogOwner;
+    if (!_dialogResRef.empty()) {
+        dialogOwner = actorPtr;
+    } else {
+        bool targetHasConversation =
+            _objectToConverse && !_objectToConverse->conversation().empty();
+        bool targetIsPartyMember =
+            _objectToConverse && _game.party().isMember(*_objectToConverse);
+        bool callerHasConversation = actorPtr && !actorPtr->conversation().empty();
 
-    std::shared_ptr<Object> dialogOwner = _dialogResRef.empty() ? _objectToConverse : actorPtr;
+        if (targetHasConversation && !targetIsPartyMember) {
+            dialogOwner = _objectToConverse;
+        } else if (callerHasConversation) {
+            dialogOwner = actorPtr;
+        } else if (targetHasConversation) {
+            dialogOwner = _objectToConverse;
+        }
+    }
+
+    // If no valid owner can be resolved there is no dialogue to start (e.g. an
+    // invalid target combined with an empty resref). Complete the action so it
+    // does not block the queue, but do not dereference a null owner -
+    // Area::startDialog reads owner->conversation() for an empty resref.
+    if (!dialogOwner) {
+        complete();
+        return;
+    }
+
     _game.module()->area()->startDialog(dialogOwner, _dialogResRef);
     complete();
 }

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/game.h"
 
+#include "reone/game/minigame.h"
+
 #include "reone/audio/context.h"
 #include "reone/audio/di/services.h"
 #include "reone/audio/mixer.h"
@@ -39,6 +41,8 @@
 #include "reone/graphics/font.h"
 #include "reone/graphics/format/tgawriter.h"
 #include "reone/graphics/meshregistry.h"
+#include "reone/graphics/model.h"
+#include "reone/graphics/modelnode.h"
 #include "reone/graphics/renderbuffer.h"
 #include "reone/graphics/shaderregistry.h"
 #include "reone/graphics/uniforms.h"
@@ -59,6 +63,7 @@
 #include "reone/resource/provider/dialogs.h"
 #include "reone/resource/provider/fonts.h"
 #include "reone/resource/provider/gffs.h"
+#include "reone/resource/provider/layouts.h"
 #include "reone/resource/provider/lips.h"
 #include "reone/resource/provider/models.h"
 #include "reone/resource/provider/movies.h"
@@ -239,6 +244,7 @@ void Game::initConsole() {
     registerConsoleCommand("kill", "kill selected object", &Game::consoleKill);
     registerConsoleCommand("additem", "add item to selected object", &Game::consoleAddItem);
     registerConsoleCommand("givexp", "give experience to selected creature", &Game::consoleGiveXP);
+    registerConsoleCommand("givegold", "give credits to the party", &Game::consoleGiveGold);
     registerConsoleCommand("showaabb", "toggle rendering AABB", &Game::consoleShowAABB);
     registerConsoleCommand("showwalkmesh", "toggle rendering walkmesh", &Game::consoleShowWalkmesh);
     registerConsoleCommand("showtriggers", "toggle rendering triggers", &Game::consoleShowTriggers);
@@ -267,6 +273,14 @@ void Game::initConsole() {
     registerConsoleCommand("closedoor", "close a selected door object", &Game::consoleOpenCloseDoor);
     registerConsoleCommand("listgames", "list savegames", &Game::consoleListGames);
     registerConsoleCommand("loadgame", "load a savegame", &Game::consoleLoadGame);
+    if (_options.game.developer) {
+        registerConsoleCommand("minigameinfo", "print minigame metadata for current area", &Game::consoleMiniGameInfo);
+        registerConsoleCommand("startswoop", "enter the developer swoop race mode for the current area", &Game::consoleStartSwoop);
+        registerConsoleCommand("stopswoop", "exit the developer swoop race mode", &Game::consoleStopSwoop);
+        registerConsoleCommand("swoopstate", "print the current swoop race progress/lateral state", &Game::consoleSwoopState);
+        registerConsoleCommand("startswooprace", "enter a swoop module from the current one and auto-start the race", &Game::consoleStartSwoopRace);
+        registerConsoleCommand("finishswoop", "finish the lifecycle swoop race (forced success) and return to origin", &Game::consoleFinishSwoop);
+    }
 }
 
 void Game::initLocalServices() {
@@ -336,6 +350,11 @@ bool Game::handle(const input::Event &event) {
             }
             break;
         }
+        case Screen::SwoopRace:
+            if (_swoopRace.handle(event)) {
+                return true;
+            }
+            break;
         default:
             break;
         }
@@ -356,6 +375,21 @@ void Game::update(float frameTime) {
         loadNextModule();
     }
     updateCamera(dt);
+
+    if (_swoopRace.isActive()) {
+        _swoopRace.update(dt);
+
+        // Non-blocking auto-finish: when a lifecycle race reaches the finish
+        // threshold, force success and return to the origin module. Plain dev
+        // races (no lifecycle) keep riding so the dev stays in control.
+        if (_swoopLifecycle.active && _swoopRace.finishReached()) {
+            debug(str(boost::format("swoop: auto-finish progress=%.1f finish=%.1f forcedSuccess=yes returning=%s")
+                      % _swoopRace.progress()
+                      % _swoopRace.finishProgress()
+                      % _swoopLifecycle.originModule));
+            finishSwoopLifecycle(/*success=*/true);
+        }
+    }
 
     bool updModule = !_movie && _module && (_screen == Screen::InGame || _screen == Screen::Conversation);
     if (updModule && !_paused) {
@@ -496,6 +530,19 @@ bool Game::handleMouseButtonUp(const input::MouseButtonEvent &event) {
 
 void Game::loadModule(const std::string &name, std::string entry, bool fromSave) {
     info("Loading module '" + name + "'");
+
+    // Tear down an active race before the current area (and its camera/scene)
+    // is unloaded, so no dangling references survive the transition.
+    if (_swoopRace.isActive()) {
+        _swoopRace.stop();
+        _cameraType = _savedCameraType;
+    }
+    // A direct module load (e.g. warp) while a lifecycle race is pending means
+    // the player navigated away; abandon the pending return. (Lifecycle-managed
+    // loads clear the session beforehand, so this only fires on external loads.)
+    if (_swoopLifecycle.active) {
+        _swoopLifecycle = SwoopLifecycle();
+    }
 
     if (_screen == Screen::Conversation && _conversation) {
         _conversation->cleanupForModuleTransition();
@@ -1095,10 +1142,59 @@ void Game::updateMusic() {
 }
 
 void Game::loadNextModule() {
+    std::string target(_nextModule);
+
+    // Capture the origin (current module + leader location) before the deferred
+    // transition runs, so a swoop module entered from a script can return here.
+    std::string originModule;
+    glm::vec3 originPosition(0.0f);
+    float originFacing = 0.0f;
+    bool haveOrigin = false;
+    if (_module) {
+        originModule = _module->name();
+        if (auto leader = _party.getLeader()) {
+            originPosition = leader->position();
+            originFacing = leader->getFacing();
+            haveOrigin = true;
+        }
+    }
+    bool wasLifecycleActive = _swoopLifecycle.active;
+
     loadModule(_nextModule, _nextEntry);
 
     _nextModule.clear();
     _nextEntry.clear();
+
+    // Vanilla K1 swoop entry: a dialogue node fires a script that calls
+    // StartNewModule("<*mg>"); the engine auto-enters the minigame on load (no
+    // dedicated start routine). Route that generic transition through the
+    // forced-success lifecycle harness when the loaded area is a swoop minigame.
+    if (wasLifecycleActive || _swoopLifecycle.active) {
+        return;
+    }
+    if (originModule.empty() || boost::iequals(originModule, target)) {
+        return;
+    }
+    auto mod = _module;
+    if (!mod || !mod->area() || !mod->area()->hasMinigame()) {
+        return;
+    }
+    if (mod->area()->miniGame().type != MinigameType::SwoopRace) {
+        return;
+    }
+
+    openSwoopRace();
+    if (_swoopRace.isActive()) {
+        _swoopLifecycle = SwoopLifecycle();
+        _swoopLifecycle.active = true;
+        _swoopLifecycle.haveOrigin = haveOrigin;
+        _swoopLifecycle.originModule = originModule;
+        _swoopLifecycle.originPosition = originPosition;
+        _swoopLifecycle.originFacing = originFacing;
+        _swoopLifecycle.forcedSuccess = true;
+        debug(str(boost::format("swoop: script lifecycle start origin=%s target=%s forcedSuccess=yes hook=StartNewModule")
+                  % originModule % target));
+    }
 }
 
 void Game::stopMovement() {
@@ -1290,6 +1386,469 @@ void Game::openInGame() {
     changeScreen(Screen::InGame);
 }
 
+namespace {
+
+// Result of trying to anchor the race to the authored player track.
+struct SwoopTrackFrame {
+    glm::vec3 position {0.0f};
+    float facing {0.0f};
+    std::string mode {"fallback"}; // "lyt-track", "track-model", or "fallback"
+    std::string reason;            // why fallback was used
+    std::string info;              // concise track inspection details
+};
+
+// Max 2D distance (world units) the track's start hook may be from the party
+// leader to be trusted WITHOUT an LYT placement. With an LYT track placement the
+// hook is in module/world space, so this guard does not apply; without one a
+// standalone-loaded track model may sit in a different frame and would otherwise
+// teleport the bike into the void, so the proven leader anchor is kept.
+constexpr float kTrackFrameMaxDistance = 64.0f;
+
+// PR1 non-blocking finish threshold (forward-progress units). The race finishes
+// a margin past the furthest mapped obstacle, or at a conservative fallback
+// distance when no obstacle placements exist.
+constexpr float kSwoopFinishMargin = 500.0f;
+constexpr float kSwoopFallbackFinishProgress = 4000.0f;
+
+// Derive the bike start frame from the player track model's "modelhook" node
+// (vanilla parents the player to this node). When an LYT track placement is
+// supplied, the hook is placed into module/world space and used unconditionally;
+// otherwise it is trusted only if it already resolves near the party leader,
+// falling back to the leader frame.
+SwoopTrackFrame deriveSwoopTrackFrame(const std::shared_ptr<graphics::Model> &trackModel,
+                                      const std::string &trackResRef,
+                                      const glm::vec3 *lytTrackPos,
+                                      const glm::vec3 &leaderPos,
+                                      float leaderFacing) {
+    SwoopTrackFrame frame;
+    frame.position = leaderPos;
+    frame.facing = leaderFacing;
+
+    if (trackResRef.empty()) {
+        frame.reason = "no-track-ref";
+        return frame;
+    }
+    if (!trackModel) {
+        frame.reason = "track-model-missing";
+        return frame;
+    }
+
+    size_t animCount = trackModel->getAnimationNames().size();
+    auto hook = trackModel->getNodeByNameRecursive("modelhook");
+    if (!hook) {
+        frame.reason = "no-modelhook";
+        frame.info = str(boost::format("modelhook=no placement=%s anims=%zu")
+                         % (lytTrackPos ? "yes" : "no") % animCount);
+        return frame;
+    }
+
+    const glm::mat4 &abs = hook->absoluteTransform();
+    glm::vec3 hookLocal(abs[3]);
+    // Engine facing convention: forward = (-sin f, cos f). The LYT track
+    // placement carries no rotation, so the hook's model-space orientation is
+    // also its world orientation.
+    glm::vec3 forward = glm::normalize(glm::vec3(glm::mat3(abs) * glm::vec3(0.0f, 1.0f, 0.0f)));
+    float facing = glm::atan(-forward.x, forward.y);
+
+    if (lytTrackPos) {
+        // Combine the LYT placement (translation only) with the modelhook's
+        // model-local transform to get the hook in module/world space.
+        glm::vec3 start = *lytTrackPos + hookLocal;
+        frame.position = start;
+        frame.facing = facing;
+        frame.mode = "lyt-track";
+        frame.info = str(boost::format("modelhook=yes placement=yes anims=%zu lyt=[%.1f,%.1f,%.1f] hook=[%.1f,%.1f,%.1f] start=[%.1f,%.1f,%.1f]")
+                         % animCount
+                         % lytTrackPos->x % lytTrackPos->y % lytTrackPos->z
+                         % hookLocal.x % hookLocal.y % hookLocal.z
+                         % start.x % start.y % start.z);
+        return frame;
+    }
+
+    float dist = glm::distance(glm::vec2(hookLocal), glm::vec2(leaderPos));
+    frame.info = str(boost::format("modelhook=yes placement=no anims=%zu hook=[%.1f,%.1f,%.1f] dist=%.1f")
+                     % animCount % hookLocal.x % hookLocal.y % hookLocal.z % dist);
+
+    if (dist > kTrackFrameMaxDistance) {
+        // No LYT placement and the hook is not in the party's world frame.
+        frame.reason = "no-lyt-track-placement";
+        return frame;
+    }
+
+    frame.position = hookLocal;
+    frame.facing = facing;
+    frame.mode = "track-model";
+    return frame;
+}
+
+} // namespace
+
+void Game::openSwoopRace() {
+    if (_swoopRace.isActive()) {
+        _console.printLine("swoop: already running");
+        return;
+    }
+    if (!_module || !_module->area()) {
+        _console.printLine("swoop: no module loaded");
+        return;
+    }
+    auto area = _module->area();
+    if (!area->hasMinigame() || area->miniGame().type != MinigameType::SwoopRace) {
+        _console.printLine("swoop: current area has no swoop minigame");
+        return;
+    }
+    auto leader = _party.getLeader();
+    if (!leader) {
+        _console.printLine("swoop: no party leader to anchor the race");
+        return;
+    }
+
+    const auto &mg = area->miniGame();
+    auto camera = area->getCamera<FirstPersonCamera>(CameraType::FirstPerson);
+    if (camera) {
+        camera->stopMovement();
+    }
+
+    // Load the whole player model set, not just the first entry. Vanilla loads
+    // every Player.Models entry and hides the one that is the camera mount
+    // (player.cameraResRef). We skip that mount so areas whose visible bike is
+    // in a later entry (e.g. Tatooine) still show a body.
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+    std::vector<std::shared_ptr<ModelSceneNode>> bikeNodes;
+    std::vector<std::string> modelDiag;
+    bool anyMissing = false;
+    for (const auto &resRef : mg.player.modelResRefs) {
+        if (resRef.empty()) {
+            continue;
+        }
+        if (!mg.player.cameraResRef.empty() && boost::iequals(resRef, mg.player.cameraResRef)) {
+            modelDiag.push_back(resRef + " camera-skip");
+            continue;
+        }
+        auto model = _services.resource.models.get(resRef);
+        if (!model) {
+            modelDiag.push_back(resRef + " missing");
+            anyMissing = true;
+            continue;
+        }
+        auto node = sceneGraph.newModel(*model, ModelUsage::Placeable);
+        node->setDrawDistance(_options.graphics.drawDistance);
+        sceneGraph.addRoot(node);
+        bikeNodes.push_back(std::move(node));
+        modelDiag.push_back(resRef + " loaded");
+    }
+
+    // Anchor the race to the authored player track. Prefer the LYT track
+    // placement (module/world space); otherwise fall back as before.
+    std::shared_ptr<graphics::Model> trackModel;
+    if (!mg.player.trackResRef.empty()) {
+        trackModel = _services.resource.models.get(mg.player.trackResRef);
+    }
+    auto layout = _services.resource.layouts.get(area->name());
+    glm::vec3 lytTrackPos(0.0f);
+    bool haveLytTrackPos = false;
+    if (layout && !mg.player.trackResRef.empty()) {
+        if (auto placement = layout->findTrackByName(mg.player.trackResRef)) {
+            lytTrackPos = placement->get().position;
+            haveLytTrackPos = true;
+        }
+    }
+    SwoopTrackFrame trackFrame = deriveSwoopTrackFrame(
+        trackModel, mg.player.trackResRef, haveLytTrackPos ? &lytTrackPos : nullptr,
+        leader->position(), leader->getFacing());
+
+    // Choose a non-blocking finish threshold (PR1). Vanilla loop/finish is
+    // script-driven and not yet implemented, so use the furthest mapped LYT
+    // obstacle (the obstacle field spans the playable track) plus a margin, or
+    // a conservative fallback distance when no obstacle placements are present.
+    glm::vec3 frameForward(-glm::sin(trackFrame.facing), glm::cos(trackFrame.facing), 0.0f);
+    float maxObstacleProgress = 0.0f;
+    if (layout) {
+        for (const auto &obs : layout->obstacles) {
+            float p = glm::dot(obs.position - trackFrame.position, frameForward);
+            maxObstacleProgress = glm::max(maxObstacleProgress, p);
+        }
+    }
+    float finishProgress = maxObstacleProgress > 0.0f
+                               ? maxObstacleProgress + kSwoopFinishMargin
+                               : kSwoopFallbackFinishProgress;
+
+    _savedCameraType = _cameraType;
+    size_t loadedCount = bikeNodes.size();
+    _swoopRace.start(mg, camera, std::move(bikeNodes), trackFrame.position, trackFrame.facing, finishProgress);
+
+    _cameraType = CameraType::FirstPerson;
+    setRelativeMouseMode(false);
+    changeScreen(Screen::SwoopRace);
+
+    // Hide the normal party while the minigame runs. Vanilla does not add the
+    // party to the scene in a minigame module (the swoop bike actor represents
+    // the player); otherwise the frozen-but-rendered party leader appears on the
+    // track. Restored on exit (or naturally re-spawned on the return module).
+    setPartyVisible(false);
+
+    debug(str(boost::format("swoop: started type=%s track=%s models=%zu loaded=%zu camera=chase movePerSec=%.0f lataccel=%.0f camfov=%.0f")
+              % minigameTypeName(mg.type)
+              % mg.player.trackResRef
+              % mg.player.modelResRefs.size()
+              % loadedCount
+              % mg.movementPerSec
+              % mg.lateralAccel
+              % mg.cameraViewAngle));
+
+    // Track frame: lyt-track/track-model/fallback mode and how the start frame
+    // was chosen (see deriveSwoopTrackFrame).
+    std::string trackLabel(mg.player.trackResRef.empty() ? std::string("<none>") : mg.player.trackResRef);
+    if (trackFrame.mode == "fallback") {
+        debug(str(boost::format("swoop: track=%s mode=fallback reason=%s%s")
+                  % trackLabel
+                  % trackFrame.reason
+                  % (trackFrame.info.empty() ? std::string() : (" " + trackFrame.info))));
+    } else {
+        debug(str(boost::format("swoop: track=%s mode=%s %s startFacing=%.2f")
+                  % trackLabel
+                  % trackFrame.mode
+                  % trackFrame.info
+                  % trackFrame.facing));
+    }
+
+    // Movement model: track-relative progress + lateral strafe (no turning).
+    debug(str(boost::format("swoop: movement=track-progress strafeOnly=yes progressAxis=trackForward lateralAxis=trackRight anim=deferred start=[%.1f,%.1f,%.1f] facing=%.2f finish=%.1f")
+              % trackFrame.position.x % trackFrame.position.y % trackFrame.position.z
+              % trackFrame.facing
+              % finishProgress));
+
+    // Lateral bounds chosen for the strafe (see SwoopRace::computeLateralBounds).
+    debug(str(boost::format("swoop: bounds lateral=[-%.1f,+%.1f] source=%s tunnelX=[%.1f,%.1f]")
+              % _swoopRace.lateralLeftBound()
+              % _swoopRace.lateralRightBound()
+              % _swoopRace.lateralBoundSource()
+              % mg.player.tunnelXNeg
+              % mg.player.tunnelXPos));
+
+    // Map authored LYT obstacle placements into the current track frame
+    // (progress = down-course distance, lateral = strafe offset). Diagnostic
+    // only: no damage/collision is applied in this slice. The "match" count is
+    // how many .are MiniGame obstacles have a same-name LYT placement.
+    if (layout) {
+        glm::vec3 fwd(-glm::sin(trackFrame.facing), glm::cos(trackFrame.facing), 0.0f);
+        glm::vec3 right(glm::cos(trackFrame.facing), glm::sin(trackFrame.facing), 0.0f);
+        size_t areMatched = 0;
+        for (const auto &obs : mg.obstacles) {
+            if (layout->findObstacleByName(obs.name)) {
+                ++areMatched;
+            }
+        }
+        debug(str(boost::format("swoop: lyt obstacles=%zu areObstacles=%zu matched=%zu")
+                  % layout->obstacles.size() % mg.obstacles.size() % areMatched));
+        constexpr size_t kMaxObstacleDiag = 6;
+        for (size_t i = 0; i < layout->obstacles.size() && i < kMaxObstacleDiag; ++i) {
+            const auto &obs = layout->obstacles[i];
+            glm::vec3 d = obs.position - trackFrame.position;
+            float progress = glm::dot(d, fwd);
+            float lateral = glm::dot(d, right);
+            debug(str(boost::format("  swoopobj[%zu] name=%s pos=[%.1f,%.1f,%.1f] progress=%.1f lateral=%.1f type=obstacle")
+                      % i % obs.name
+                      % obs.position.x % obs.position.y % obs.position.z
+                      % progress % lateral));
+        }
+    }
+
+    // Print the per-model breakdown when nothing loaded or a load failed; it is
+    // a one-shot dev diagnostic, so avoid spam on the common success path.
+    if (loadedCount == 0 || anyMissing) {
+        for (size_t i = 0; i < modelDiag.size(); ++i) {
+            debug(str(boost::format("  model[%zu]=%s") % i % modelDiag[i]));
+        }
+    }
+}
+
+void Game::closeSwoopRace() {
+    if (!_swoopRace.isActive()) {
+        debug("swoop: closeSwoopRace called but race not active");
+        return;
+    }
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+    for (const auto &bikeNode : _swoopRace.bikeNodes()) {
+        if (bikeNode) {
+            sceneGraph.removeRoot(*bikeNode);
+        }
+    }
+    _swoopRace.stop();
+    setPartyVisible(true);
+    _cameraType = _savedCameraType;
+    setRelativeMouseMode(_cameraType == CameraType::FirstPerson);
+    openInGame();
+    debug("swoop: stopped (race ended, party restored, camera reset)");
+}
+
+void Game::setPartyVisible(bool visible) {
+    for (auto &member : _party.members()) {
+        if (member.creature) {
+            member.creature->setVisible(visible);
+        }
+    }
+}
+
+void Game::exitSwoopRace() {
+    // Escape / stopswoop entry point. If a lifecycle race is in progress, return
+    // to the origin module; otherwise just stop the dev race in place.
+    if (_swoopLifecycle.active) {
+        finishSwoopLifecycle(/*success=*/true);
+    } else {
+        closeSwoopRace();
+    }
+}
+
+void Game::finishSwoopLifecycle(bool success) {
+    if (!_swoopLifecycle.active) {
+        return;
+    }
+    // Capture and clear the session first so the upcoming module load does not
+    // re-enter this path. The current module (before returning) is the race
+    // module, which selects the planet-specific result contract.
+    SwoopLifecycle session = _swoopLifecycle;
+    _swoopLifecycle = SwoopLifecycle();
+    std::string raceModule = _module ? _module->name() : "";
+
+    // Stop the race (removes bike models, restores camera/FOV/input, screen).
+    closeSwoopRace();
+
+    // Return to the originating module. Prefer the vanilla race-return waypoint
+    // (e.g. Taris heartbeat returns to tar_m03af at tar03_wpmechanic) so the
+    // leader lands on the authored return spot and naturally occupies the
+    // post-race trigger; fall back to the saved pre-race position otherwise.
+    loadModule(session.originModule);
+    if (auto mod = _module) {
+        if (auto area = mod->area()) {
+            if (auto leader = _party.getLeader()) {
+                glm::vec3 pos = session.originPosition;
+                float facing = session.originFacing;
+                bool havePlacement = session.haveOrigin;
+
+                std::string returnWaypoint = swoopReturnWaypoint(raceModule);
+                if (!returnWaypoint.empty()) {
+                    if (auto wp = area->getObjectByTag(returnWaypoint)) {
+                        pos = wp->position();
+                        facing = wp->getFacing();
+                        havePlacement = true;
+                        debug(str(boost::format("swoop: return waypoint=%s pos=[%.1f,%.1f,%.1f]")
+                              % returnWaypoint % pos.x % pos.y % pos.z));
+                    }
+                }
+
+                if (havePlacement) {
+                    leader->setPosition(pos);
+                    leader->setFacing(facing);
+                    area->determineObjectRoom(*leader);
+                    area->onPartyLeaderMoved(/*roomChanged=*/true);
+                }
+            }
+        }
+    }
+
+    if (success) {
+        applySwoopForcedSuccessResult(raceModule);
+    }
+
+    debug(str(boost::format("swoop: finished forcedSuccess=%s returning=%s")
+              % (success ? "yes" : "no")
+              % session.originModule));
+}
+
+std::string Game::swoopReturnWaypoint(const std::string &raceModule) const {
+    // Vanilla race-end transition target (StartNewModule waypoint), confirmed
+    // from assets. K1 Taris: heartbeat.ncs returns to tar_m03af at the
+    // tar03_wpmechanic waypoint, which sits inside the tar03_postrace trigger.
+    // Other planets are not yet wired (empty = use the saved pre-race position).
+    if (boost::iequals(raceModule, "tar_m03mg")) {
+        return "tar03_wpmechanic";
+    }
+    return "";
+}
+
+void Game::applyTarisForcedWinningTime() {
+    // Read the current heat's time-to-beat. k_ptar_racefirst sets these to
+    // MIN_BEAT=0 / SEC_BEAT=38 / MSEC_BEAT=43 for heat 1 (total=3843 in the
+    // vanilla comparison unit: MIN*10000 + SEC*100 + MSEC, confirmed by
+    // disassembly of k_ptar_postswoop.ncs subroutine at 0x0524).
+    //
+    // We must win (playerTotal < beatTotal) AND keep playerTotal > 25 so that
+    // the win-handler's beat update (k_ptar_postswoop 0x0572,
+    // new_beat = playerTime - 25cs) stays strictly positive. Setting
+    // player=0:00.00 underflows to MIN_BEAT=-1 (total=-4025), making every
+    // subsequent heat unwinnable.
+    int beatMin  = getGlobalNumber("TAR_SWOOP_MIN_BEAT");
+    int beatSec  = getGlobalNumber("TAR_SWOOP_SEC_BEAT");
+    int beatMsec = getGlobalNumber("TAR_SWOOP_MSEC_BEAT");
+    int beatTotal = beatMin * 10000 + beatSec * 100 + beatMsec;
+
+    // Choose a player time that wins with comfortable headroom. A 50cs margin
+    // keeps enough distance from the beat target while the next beat
+    // (playerTotal - 25) stays well above zero.
+    //   - Normal case (beatTotal > 150): subtract the full 50cs margin;
+    //     guarantees playerTotal > 100 and next beat stays positive.
+    //   - Low beat (26-150): win by 1cs, floor at 26 so next beat stays > 0.
+    //   - Degenerate beat (<= 25): use the asset-confirmed heat-1 reference
+    //     (3793 = 3843 - 50); this path should not occur in normal Taris flow.
+    static constexpr int kMargin = 50;
+    static constexpr int kMinSafe = 26;                     // next beat = playerTotal - 25 > 0
+    static constexpr int kMinSafePlayerTime = 100;          // floor for the comfortable-margin branch
+    static constexpr int kNormalThreshold = kMinSafePlayerTime + kMargin; // 150
+    static constexpr int kFallback = 3793;                  // k_ptar_racefirst heat-1 beat (3843) - 50
+
+    int playerTotal;
+    if (beatTotal > kNormalThreshold) {
+        playerTotal = beatTotal - kMargin;
+    } else if (beatTotal > 25) {
+        playerTotal = std::max(beatTotal - 1, kMinSafe);
+    } else {
+        playerTotal = kFallback;
+    }
+
+    int playerMin  = playerTotal / 10000;
+    int playerSec  = (playerTotal % 10000) / 100;
+    int playerMsec = playerTotal % 100;
+    setGlobalNumber("TAR_SWOOP_MIN",  playerMin);
+    setGlobalNumber("TAR_SWOOP_SEC",  playerSec);
+    setGlobalNumber("TAR_SWOOP_MSEC", playerMsec);
+
+    _console.printLine(str(boost::format(
+        "swoop: result forcedSuccess=yes planet=taris TAR_SWOOP_RUN=1"
+        " beat=%d:%d.%d time=%d:%d.%d margin=%d") %
+        beatMin % beatSec % beatMsec %
+        playerMin % playerSec % playerMsec %
+        (beatTotal - playerTotal)));
+}
+
+void Game::applySwoopForcedSuccessResult(const std::string &raceModule) {
+    // K1 Taris swoop result contract, confirmed from local assets:
+    //   tar_m03mg.are -> player OnHeartbeat = "heartbeat" is the race brain. At
+    //     race start it sets the boolean global TAR_SWOOP_RUN = TRUE
+    //     (SetGlobalBoolean) and records the run time in TAR_SWOOP_MIN / _SEC /
+    //     _MSEC; reone substitutes the race and never runs heartbeat.
+    //   The post-race scene is the "tar03_postrace" trigger, whose ScriptOnEnter
+    //     is k_ptar_postswoop. Disassembly of k_ptar_postswoop.ncs shows it
+    //     begins with: if (!GetGlobalBoolean("TAR_SWOOP_RUN")) return; then
+    //     SetGlobalBoolean("TAR_SWOOP_RUN", FALSE); compares the run time vs the
+    //     TAR_SWOOP_*_BEAT targets; SetGlobalNumber("Tar_SwoopStatus", 2) when
+    //     the player time is lower (won) else 1; increments Tar_SwoopRaceCounter;
+    //     and starts the announcer/Brejik scene (ActionStartConversation, using
+    //     the entering PC).
+    // So forced success must reproduce heartbeat's race-state outputs: set
+    // TAR_SWOOP_RUN = TRUE so postswoop passes its guard, then choose a player
+    // time strictly less than TAR_SWOOP_*_BEAT so postswoop computes a win.
+    // Win state (Tar_SwoopStatus) and the scene are produced by the vanilla
+    // trigger->postswoop chain (see Area::updateLeaderTriggerOccupancy and the
+    // return-waypoint placement). No result/winner globals are set here.
+    // Other planets are not yet wired.
+    if (!boost::iequals(raceModule, "tar_m03mg")) {
+        return;
+    }
+    setGlobalBoolean("TAR_SWOOP_RUN", true);
+    applyTarisForcedWinningTime();
+}
+
 void Game::openInGameMenu(InGameMenuTab tab) {
     setCursorType(CursorType::Default);
     switch (tab) {
@@ -1462,6 +2021,8 @@ GameGUI *Game::getScreenGUI() const {
         return _partySelect.get();
     case Screen::SaveLoad:
         return _saveLoad.get();
+    case Screen::SwoopRace:
+        return nullptr; // race skeleton has no HUD yet
     default:
         return nullptr;
     }
@@ -1646,6 +2207,12 @@ void Game::consoleGiveXP(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 1, "amount");
     auto creature = getConsoleTargetCreature();
     creature->giveXP(args.get<int>(1).value());
+}
+
+void Game::consoleGiveGold(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 1, 1, "amount");
+    _party.giveGold(args.get<int>(1).value());
+    _console.printLine(str(boost::format("party gold: %d") % _party.gold()));
 }
 
 void Game::consoleWarp(const ConsoleArgs &args) {
@@ -2120,6 +2687,165 @@ void Game::consoleLoadGame(const ConsoleArgs &args) {
     auto name = _saveNames.begin();
     std::advance(name, id);
     loadGame(*name);
+}
+
+void Game::consoleMiniGameInfo(const ConsoleArgs &args) {
+    auto area = getConsoleArea();
+    if (!area->hasMinigame()) {
+        _console.printLine("minigame: none");
+        return;
+    }
+    const auto &mg = area->miniGame();
+    _console.printLine(str(boost::format("minigame: type=%s camfov=%.1f lataccel=%.3f movePerSec=%.3f inertia=%d bumpPlane=%u doBumping=%d")
+                           % minigameTypeName(mg.type)
+                           % mg.cameraViewAngle
+                           % mg.lateralAccel
+                           % mg.movementPerSec
+                           % static_cast<int>(mg.useInertia)
+                           % mg.bumpPlane
+                           % static_cast<int>(mg.doBumping)));
+    _console.printLine(str(boost::format("  player: cam=%s track=%s spd=[%.1f,%.1f] accel=%.3f hp=%u models=%zu")
+                           % mg.player.cameraResRef
+                           % mg.player.trackResRef
+                           % mg.player.minimumSpeed
+                           % mg.player.maximumSpeed
+                           % mg.player.accelSecs
+                           % mg.player.hitPoints
+                           % mg.player.modelResRefs.size()));
+    _console.printLine(str(boost::format("  tunnel (deg): X=[%.1f,%.1f] Y=[%.1f,%.1f] Z=[%.1f,%.1f]")
+                           % mg.player.tunnelXNeg % mg.player.tunnelXPos
+                           % mg.player.tunnelYNeg % mg.player.tunnelYPos
+                           % mg.player.tunnelZNeg % mg.player.tunnelZPos));
+    _console.printLine(str(boost::format("  tracks=%zu enemies=%zu obstacles=%zu")
+                           % mg.trackResRefs.size()
+                           % mg.enemies.size()
+                           % mg.obstacles.size()));
+    for (size_t i = 0; i < mg.trackResRefs.size(); ++i) {
+        _console.printLine(str(boost::format("    track[%zu] %s") % i % mg.trackResRefs[i]));
+    }
+    for (size_t i = 0; i < mg.enemies.size(); ++i) {
+        const auto &e = mg.enemies[i];
+        _console.printLine(str(boost::format("    enemy[%zu] track=%s hp=%u models=%zu")
+                               % i % e.trackResRef % e.hitPoints % e.modelResRefs.size()));
+    }
+    for (size_t i = 0; i < mg.obstacles.size(); ++i) {
+        _console.printLine(str(boost::format("    obstacle[%zu] name=%s") % i % mg.obstacles[i].name));
+    }
+    if (auto layout = _services.resource.layouts.get(area->name())) {
+        auto placement = layout->findTrackByName(mg.player.trackResRef);
+        if (placement) {
+            const auto &p = placement->get().position;
+            _console.printLine(str(boost::format("  lyt tracks=%zu playerTrack=%s pos=[%.1f,%.1f,%.1f]")
+                                   % layout->tracks.size() % mg.player.trackResRef % p.x % p.y % p.z));
+        } else {
+            _console.printLine(str(boost::format("  lyt tracks=%zu playerTrack=%s pos=<not found>")
+                                   % layout->tracks.size() % mg.player.trackResRef));
+        }
+        size_t obstaclesMatched = 0;
+        for (const auto &obs : mg.obstacles) {
+            if (layout->findObstacleByName(obs.name)) {
+                ++obstaclesMatched;
+            }
+        }
+        _console.printLine(str(boost::format("  lyt obstacles=%zu (matched %zu of %zu .are obstacles)")
+                               % layout->obstacles.size() % obstaclesMatched % mg.obstacles.size()));
+    }
+    const auto &sc = mg.player.scripts;
+    if (!sc.onCreate.empty() || !sc.onDeath.empty() || !sc.onTrackLoop.empty()) {
+        _console.printLine(str(boost::format("  scripts: create=%s death=%s loop=%s damage=%s")
+                               % sc.onCreate % sc.onDeath % sc.onTrackLoop % sc.onDamage));
+    }
+}
+
+void Game::consoleStartSwoop(const ConsoleArgs &args) {
+    openSwoopRace();
+}
+
+void Game::consoleStopSwoop(const ConsoleArgs &args) {
+    // If a lifecycle race is active, return to origin safely; otherwise stop in place.
+    exitSwoopRace();
+}
+
+void Game::consoleStartSwoopRace(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 1, 1, "module");
+
+    if (_swoopLifecycle.active) {
+        _console.printLine("swoop: lifecycle already active");
+        return;
+    }
+    if (!_module) {
+        _console.printLine("swoop: no origin module loaded");
+        return;
+    }
+    std::string target(boost::to_lower_copy(std::string(args[1].value())));
+    if (_moduleNames.count(target) == 0) {
+        _console.printLine("swoop: unknown module '" + target + "'");
+        return;
+    }
+
+    // Capture origin module/state before transitioning.
+    SwoopLifecycle session;
+    session.originModule = _module->name();
+    session.forcedSuccess = true;
+    if (auto leader = _party.getLeader()) {
+        session.originPosition = leader->position();
+        session.originFacing = leader->getFacing();
+        session.haveOrigin = true;
+    }
+
+    // Transition to the target swoop module and auto-start the race.
+    loadModule(target);
+    openSwoopRace();
+
+    if (!_swoopRace.isActive()) {
+        // Target loaded but is not a swoop minigame (openSwoopRace printed why).
+        // Return to origin so the failed attempt does not strand the player.
+        _console.printLine("swoop: lifecycle aborted, returning to origin=" + session.originModule);
+        loadModule(session.originModule);
+        if (session.haveOrigin) {
+            if (auto mod = _module) {
+                if (auto area = mod->area()) {
+                    if (auto leader = _party.getLeader()) {
+                        leader->setPosition(session.originPosition);
+                        leader->setFacing(session.originFacing);
+                        area->determineObjectRoom(*leader);
+                        area->onPartyLeaderMoved(/*roomChanged=*/true);
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    _swoopLifecycle = session;
+    _swoopLifecycle.active = true;
+    _console.printLine(str(boost::format("swoop: lifecycle start origin=%s target=%s forcedSuccess=yes")
+                           % session.originModule % target));
+}
+
+void Game::consoleFinishSwoop(const ConsoleArgs &args) {
+    if (!_swoopLifecycle.active) {
+        _console.printLine("swoop: no lifecycle race active");
+        return;
+    }
+    finishSwoopLifecycle(/*success=*/true);
+}
+
+void Game::consoleSwoopState(const ConsoleArgs &args) {
+    if (!_swoopRace.isActive()) {
+        _console.printLine("swoop: not active");
+        return;
+    }
+    glm::vec3 pos = _swoopRace.position();
+    _console.printLine(str(boost::format("swoop: progress=%.1f finish=%.1f lateral=%.2f speed=%.1f elapsed=%.1f pos=[%.1f,%.1f,%.1f] bounds=[-%.1f,+%.1f] mode=track-progress")
+                           % _swoopRace.progress()
+                           % _swoopRace.finishProgress()
+                           % _swoopRace.lateralOffset()
+                           % _swoopRace.speed()
+                           % _swoopRace.elapsed()
+                           % pos.x % pos.y % pos.z
+                           % _swoopRace.lateralLeftBound()
+                           % _swoopRace.lateralRightBound()));
 }
 
 } // namespace game

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/object/area.h"
 
+#include "reone/game/minigame.h"
+
 #include "reone/game/camerastyles.h"
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
@@ -147,6 +149,7 @@ void Area::loadARE(const resource::generated::ARE &are) {
     loadStealthXP(are);
     loadGrass(are);
     loadFog(are);
+    loadMiniGame(are);
 }
 
 void Area::loadCameraStyle(const resource::generated::ARE &are) {
@@ -213,6 +216,77 @@ void Area::loadFog(const resource::generated::ARE &are) {
     _fogColor = Gff::colorFromUint32(are.SunFogColor);
 
     applySceneProperties();
+}
+
+void Area::loadMiniGame(const resource::generated::ARE &are) {
+    if (are.MiniGame.Type == 0) {
+        return;
+    }
+    MinigameSpec spec;
+    spec.type = minigameTypeFromUint(are.MiniGame.Type);
+    spec.cameraViewAngle = are.MiniGame.CameraViewAngle;
+    spec.lateralAccel = are.MiniGame.LateralAccel;
+    spec.movementPerSec = are.MiniGame.MovementPerSec;
+    spec.useInertia = are.MiniGame.UseInertia != 0;
+    spec.bumpPlane = are.MiniGame.Bump_Plane;
+    spec.doBumping = are.MiniGame.DoBumping != 0;
+
+    const auto &src = are.MiniGame.Player;
+    spec.player.cameraResRef = src.Camera;
+    spec.player.trackResRef = src.Track;
+    spec.player.minimumSpeed = src.Minimum_Speed;
+    spec.player.maximumSpeed = src.Maximum_Speed;
+    spec.player.accelSecs = src.Accel_Secs;
+    spec.player.sphereRadius = src.Sphere_Radius;
+    spec.player.hitPoints = src.Hit_Points;
+    spec.player.tunnelXPos = src.TunnelXPos;
+    spec.player.tunnelXNeg = src.TunnelXNeg;
+    spec.player.tunnelYPos = src.TunnelYPos;
+    spec.player.tunnelYNeg = src.TunnelYNeg;
+    spec.player.tunnelZPos = src.TunnelZPos;
+    spec.player.tunnelZNeg = src.TunnelZNeg;
+    spec.player.scripts.onCreate = src.Scripts.OnCreate;
+    spec.player.scripts.onDeath = src.Scripts.OnDeath;
+    spec.player.scripts.onTrackLoop = src.Scripts.OnTrackLoop;
+    spec.player.scripts.onDamage = src.Scripts.OnDamage;
+    spec.player.scripts.onAccelerate = src.Scripts.OnAccelerate;
+    spec.player.scripts.onHeartbeat = src.Scripts.OnHeartbeat;
+    for (const auto &m : src.Models) {
+        if (!m.Model.empty()) {
+            spec.player.modelResRefs.push_back(m.Model);
+        }
+    }
+
+    std::set<std::string> seenTracks;
+    auto addTrack = [&](const std::string &ref) {
+        if (!ref.empty() && seenTracks.insert(ref).second) {
+            spec.trackResRefs.push_back(ref);
+        }
+    };
+    addTrack(src.Track);
+
+    for (const auto &e : are.MiniGame.Enemies) {
+        MinigameEnemySpec enemy;
+        enemy.trackResRef = e.Track;
+        enemy.hitPoints = e.Hit_Points;
+        enemy.onCreate = e.Scripts.OnCreate;
+        for (const auto &m : e.Models) {
+            if (!m.Model.empty()) {
+                enemy.modelResRefs.push_back(m.Model);
+            }
+        }
+        spec.enemies.push_back(std::move(enemy));
+        addTrack(e.Track);
+    }
+
+    for (const auto &o : are.MiniGame.Obstacles) {
+        MinigameObstacleSpec obs;
+        obs.name = o.Name;
+        obs.onCreate = o.Scripts.OnCreate;
+        spec.obstacles.push_back(std::move(obs));
+    }
+
+    _miniGameSpec = std::move(spec);
 }
 
 void Area::applySceneProperties() {
@@ -542,6 +616,14 @@ void Area::doDestroyObject(uint32_t objectId) {
         room->removeTenant(object.get());
     }
 
+    // Drop the object from any trigger it was standing inside. A destroyed
+    // object never moves, so Trigger::update would otherwise keep it as a tenant
+    // indefinitely (leaking it and leaving the trigger stuck in the Inside
+    // state). Destruction is not an "exit", so no OnExit is fired.
+    for (auto &triggerObject : _objectsByType[ObjectType::Trigger]) {
+        static_cast<Trigger &>(*triggerObject).removeTenant(object.get());
+    }
+
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
     auto sceneNode = object->sceneNode();
     if (sceneNode) {
@@ -639,6 +721,18 @@ void Area::loadParty(const glm::vec3 &position, float facing, bool fromSave) {
 
     for (int i = 0; i < party.getSize(); ++i) {
         auto member = party.getMember(i);
+
+        // Reset the action queue on module (re)entry. The party uses persistent
+        // creature objects, and actions are area-local: a queued action (e.g. a
+        // pre-race "run to waypoint") must not survive the module transition and
+        // resume in the new area. Mirrors vanilla, which clears the player's
+        // actions between modules. force=true so a mid-flight action is dropped.
+        if (!member->actions().empty()) {
+            debug(str(boost::format("loadParty: clearing %zu pending action(s) on party member '%s'") %
+                      member->actions().size() % member->tag()));
+            member->clearAllActions(true);
+        }
+
         if (!fromSave) {
             member->setPosition(position);
             member->setFacing(facing);
@@ -686,6 +780,7 @@ void Area::update(float dt) {
     for (auto &object : _objects) {
         object->update(dt);
     }
+    updateLeaderTriggerOccupancy();
     updatePerception(dt);
     updateMessageBus();
     updateHeartbeat(dt);
@@ -908,7 +1003,7 @@ void Area::updateVisibility() {
     }
 }
 
-void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer) {
+void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer, bool fireTransitions) {
     glm::vec2 position2d(triggerrer->position());
 
     for (auto &object : _objectsByType[ObjectType::Trigger]) {
@@ -918,15 +1013,35 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer) 
         if (trigger->isTenant(triggerrer) || !inside) {
             continue;
         }
-        debug(str(boost::format("Trigger '%s' triggerred by '%s'") % trigger->tag() % triggerrer->tag()));
+        bool transition = !trigger->linkedToModule().empty();
+        if (transition && !fireTransitions) {
+            // Leave module-transition triggers to movement-based firing so a
+            // creature placed inside one is not immediately warped out.
+            continue;
+        }
+        debug(str(boost::format("trigger: onenter tag=%s script=%s entering=%s") %
+                  trigger->tag() %
+                  (trigger->getOnEnter().empty() ? std::string("<none>") : trigger->getOnEnter()) %
+                  triggerrer->tag()));
         trigger->addTenant(triggerrer);
         trigger->markDebugEntered();
 
-        if (!trigger->linkedToModule().empty()) {
+        if (transition) {
             _game.scheduleModuleTransition(trigger->linkedToModule(), trigger->linkedTo());
             return;
         }
     }
+}
+
+void Area::updateLeaderTriggerOccupancy() {
+    auto leader = _game.party().getLeader();
+    if (!leader) {
+        return;
+    }
+    // Fire occupancy-based OnEnter for script triggers (transitions excluded),
+    // so authored module-entry/cutscene triggers run even when the leader is
+    // placed inside them rather than walking across the boundary.
+    checkTriggersIntersection(leader, /*fireTransitions=*/false);
 }
 
 void Area::updateHeartbeat(float dt) {

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -189,6 +189,16 @@ void Trigger::addTenant(const std::shared_ptr<Object> &object) {
           script::Variable::ofObject(object->id())}});
 }
 
+void Trigger::removeTenant(const Object *object) {
+    for (auto it = _tenants.begin(); it != _tenants.end(); ++it) {
+        if (it->get() == object) {
+            _tenants.erase(it);
+            syncDebugVisual();
+            return;
+        }
+    }
+}
+
 bool Trigger::isIn(const glm::vec2 &point) const {
     return static_cast<TriggerSceneNode *>(_sceneNode.get())->isIn(point);
 }

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -99,6 +99,17 @@ void Party::clear() {
     _members.clear();
 }
 
+void Party::giveGold(int amount) {
+    _gold += amount;
+}
+
+void Party::takeGold(int amount) {
+    _gold -= amount;
+    if (_gold < 0) {
+        _gold = 0;
+    }
+}
+
 void Party::switchLeader() {
     if (_members.size() <= 1) {
         return;

--- a/src/libs/game/script/routine/impl/action.cpp
+++ b/src/libs/game/script/routine/impl/action.cpp
@@ -377,13 +377,8 @@ static Variable ActionStartConversation(const std::vector<Variable> &args, const
     auto bDontClearAllActions = getIntOrElse(args, 14, 0);
 
     // Transform
-    std::string dialogResRef;
+    std::string dialogResRef(sDialogResRef);
     auto caller = getCaller(ctx);
-    if (!sDialogResRef.empty()) {
-        dialogResRef = sDialogResRef;
-    } else {
-        dialogResRef = caller->conversation();
-    }
     auto privateConversation = static_cast<bool>(bPrivateConversation);
     auto conversationType = static_cast<resource::ConversationType>(nConversationType);
     auto ignoreStartRange = static_cast<bool>(bIgnoreStartRange);

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3032,7 +3032,11 @@ static Variable GiveGoldToCreature(const std::vector<Variable> &args, const Rout
     auto creature = checkCreature(oCreature);
 
     // Execute
-    creature->giveGold(nGP);
+    if (creature && ctx.game.party().isMember(*creature)) {
+        ctx.game.party().giveGold(nGP);
+    } else {
+        creature->giveGold(nGP);
+    }
     return Variable::ofNull();
 }
 
@@ -3833,6 +3837,11 @@ static Variable GetGold(const std::vector<Variable> &args, const RoutineContext 
     auto creature = checkCreature(oTarget);
 
     // Execute
+    // Credits are a single party-shared pool in KOTOR; party members (incl. the
+    // PC speaker / leader) report the party total.
+    if (creature && ctx.game.party().isMember(*creature)) {
+        return Variable::ofInt(ctx.game.party().gold());
+    }
     return Variable::ofInt(creature->gold());
 }
 
@@ -4062,11 +4071,21 @@ static Variable TakeGoldFromCreature(const std::vector<Variable> &args, const Ro
 
     // Execute
     if (creatureToTakeFrom) {
-        creatureToTakeFrom->takeGold(nAmount);
+        if (ctx.game.party().isMember(*creatureToTakeFrom)) {
+            ctx.game.party().takeGold(nAmount);
+        } else {
+            creatureToTakeFrom->takeGold(nAmount);
+        }
     }
     if (!destroy) {
         auto caller = checkCreature(getCaller(ctx));
-        caller->giveGold(nAmount);
+        if (caller) {
+            if (ctx.game.party().isMember(*caller)) {
+                ctx.game.party().giveGold(nAmount);
+            } else {
+                caller->giveGold(nAmount);
+            }
+        }
     }
     return Variable::ofNull();
 }

--- a/src/libs/game/swooprace.cpp
+++ b/src/libs/game/swooprace.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/swooprace.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object/camera/firstperson.h"
+#include "reone/graphics/types.h"
+#include "reone/scene/node/camera.h"
+#include "reone/scene/node/model.h"
+
+namespace reone {
+
+namespace game {
+
+// Fallback forward speed when metadata movement is unspecified.
+static constexpr float kFallbackMovePerSec = 10.0f;
+
+// The forward target speed is reached in this many seconds, to avoid an
+// instantaneous jump at race start.
+static constexpr float kSpeedRampSeconds = 3.0f;
+
+// Dev steering tuning. The parsed lateralAccel (e.g. 300) ramps the sideways
+// velocity quickly; the velocity cap keeps it controllable while still snappy
+// relative to the high forward speed. Values are tuned for testing feel, not
+// vanilla accuracy.
+static constexpr float kMaxLateralSpeed = 20.0f; // units per second
+static constexpr float kLateralDecay = 40.0f;    // units per second^2 when not steering
+
+// Lateral travel bounds (world units). The dev proxy moves the bike laterally
+// in world space, so it needs a positional limit. Vanilla tunnel values are
+// angular (deg) lean/rotation limits and do not directly bound lateral
+// position (the track walkmesh does), so the tunnel X magnitude is reused here
+// only as a per-module hint, safety-clamped to this range. A proper positional
+// bound awaits track-rail following.
+static constexpr float kMinLateralBound = 3.0f;
+static constexpr float kMaxLateralBound = 8.0f;
+static constexpr float kFallbackLateralBound = 8.0f;
+
+// Chase camera placement relative to the bike.
+static constexpr float kChaseDistance = 4.5f; // behind the bike
+static constexpr float kChaseHeight = 2.5f;   // above the bike
+static constexpr float kLookAtHeight = 1.0f;  // look-at point above the bike
+
+// Maximum cosmetic bank applied while strafing. Purely visual: it does not
+// affect movement, progress, or facing/heading.
+static constexpr float kMaxLeanRadians = 0.20f; // ~11.5 degrees
+
+// Engine default field of view, restored to the reused first-person camera on
+// exit (mirrors Area's default camera FOV).
+static constexpr float kDefaultCameraFovDegrees = 75.0f;
+
+void SwoopRace::start(const MinigameSpec &spec,
+                      FirstPersonCamera *camera,
+                      std::vector<std::shared_ptr<scene::ModelSceneNode>> bikeNodes,
+                      const glm::vec3 &startPosition,
+                      float startFacing,
+                      float finishProgress) {
+    _type = spec.type;
+    _movePerSec = spec.movementPerSec;
+    _lateralAccel = spec.lateralAccel;
+    _camFov = spec.cameraViewAngle;
+    _trackResRef = spec.player.trackResRef;
+    _modelCount = spec.player.modelResRefs.size();
+    _finishProgress = finishProgress;
+
+    computeLateralBounds(spec.player);
+
+    _camera = camera;
+    _bikeNodes = std::move(bikeNodes);
+
+    // Build the track-relative frame once. The bike faces down-course and never
+    // turns from input; engine facing convention is forward = (-sin f, cos f).
+    _trackStart = startPosition;
+    _facing = startFacing;
+    _trackForward = glm::vec3(-glm::sin(_facing), glm::cos(_facing), 0.0f);
+    _trackRight = glm::vec3(glm::cos(_facing), glm::sin(_facing), 0.0f);
+
+    _speed = 0.0f;
+    _progress = 0.0f;
+    _lateralOffset = 0.0f;
+    _lateralVel = 0.0f;
+    _elapsed = 0.0f;
+    _steerDir = 0;
+
+    _active = true;
+
+    setCameraFieldOfView(_camFov > 0.0f ? _camFov : kDefaultCameraFovDegrees);
+    applyBikeTransform();
+    applyChaseCamera();
+}
+
+void SwoopRace::stop() {
+    // Restore the reused camera's field of view before releasing it.
+    setCameraFieldOfView(kDefaultCameraFovDegrees);
+
+    _active = false;
+    _steerDir = 0;
+    _camera = nullptr;
+    _bikeNodes.clear();
+}
+
+void SwoopRace::computeLateralBounds(const MinigamePlayerSpec &player) {
+    // Lateral axis is X: KotOR.js applies the steering force to the track's X
+    // (forceVector.x = lateralForce), so tunnel X is the matching axis. The raw
+    // tunnel X values are angular in vanilla; we only use their magnitude as a
+    // per-module hint and safety-clamp it into a controllable positional range.
+    float rawPos = glm::abs(player.tunnelXPos);
+    float rawNeg = glm::abs(player.tunnelXNeg);
+    if (rawPos > 0.0f || rawNeg > 0.0f) {
+        _lateralRightBound = glm::clamp(rawPos > 0.0f ? rawPos : kFallbackLateralBound,
+                                        kMinLateralBound, kMaxLateralBound);
+        _lateralLeftBound = glm::clamp(rawNeg > 0.0f ? rawNeg : kFallbackLateralBound,
+                                       kMinLateralBound, kMaxLateralBound);
+        _lateralBoundSource = "tunnelX";
+    } else {
+        _lateralRightBound = kFallbackLateralBound;
+        _lateralLeftBound = kFallbackLateralBound;
+        _lateralBoundSource = "fallback";
+    }
+}
+
+void SwoopRace::update(float dt) {
+    if (!_active || dt <= 0.0f) {
+        return;
+    }
+    _elapsed += dt;
+
+    // Forward speed ramps toward the metadata movement rate.
+    float targetSpeed = _movePerSec > 0.0f ? _movePerSec : kFallbackMovePerSec;
+    if (_speed < targetSpeed) {
+        _speed = glm::min(targetSpeed, _speed + (targetSpeed / kSpeedRampSeconds) * dt);
+    }
+
+    // Lateral strafe: parsed lateral acceleration drives a conservatively
+    // clamped sideways velocity and offset. This is strafe-only - it never
+    // changes the bike's heading.
+    if (_steerDir != 0) {
+        _lateralVel += static_cast<float>(_steerDir) * _lateralAccel * dt;
+        _lateralVel = glm::clamp(_lateralVel, -kMaxLateralSpeed, kMaxLateralSpeed);
+    } else if (_lateralVel != 0.0f) {
+        float decay = kLateralDecay * dt;
+        if (glm::abs(_lateralVel) <= decay) {
+            _lateralVel = 0.0f;
+        } else {
+            _lateralVel -= glm::sign(_lateralVel) * decay;
+        }
+    }
+    _lateralOffset += _lateralVel * dt;
+    if (_lateralOffset > _lateralRightBound) {
+        _lateralOffset = _lateralRightBound;
+        _lateralVel = 0.0f;
+    } else if (_lateralOffset < -_lateralLeftBound) {
+        _lateralOffset = -_lateralLeftBound;
+        _lateralVel = 0.0f;
+    }
+
+    // Advance forward progress down the fixed track frame.
+    _progress += _speed * dt;
+
+    applyBikeTransform();
+    applyChaseCamera();
+}
+
+glm::vec3 SwoopRace::bikePosition() const {
+    glm::vec3 centerline = _trackStart + _trackForward * _progress;
+    return centerline + _trackRight * _lateralOffset;
+}
+
+void SwoopRace::applyBikeTransform() {
+    if (_bikeNodes.empty()) {
+        return;
+    }
+    glm::vec3 bikePos = bikePosition();
+
+    // Down-course yaw (fixed), plus a small cosmetic bank into the strafe. The
+    // lean is visual only: it does not affect heading, progress, or strafe.
+    float lean = 0.0f;
+    if (kMaxLateralSpeed > 0.0f) {
+        lean = glm::clamp(_lateralVel / kMaxLateralSpeed, -1.0f, 1.0f) * kMaxLeanRadians;
+    }
+
+    glm::mat4 transform(1.0f);
+    transform *= glm::translate(bikePos);
+    transform *= glm::mat4_cast(glm::quat(glm::vec3(0.0f, 0.0f, _facing)));
+    transform *= glm::mat4_cast(glm::quat(glm::vec3(0.0f, lean, 0.0f)));
+
+    // All loaded models share the same bike transform for this dev slice.
+    for (auto &node : _bikeNodes) {
+        if (node) {
+            node->setLocalTransform(transform);
+        }
+    }
+}
+
+void SwoopRace::applyChaseCamera() {
+    if (!_camera) {
+        return;
+    }
+    static const glm::vec3 up(0.0f, 0.0f, 1.0f);
+
+    glm::vec3 bikePos = bikePosition();
+
+    glm::vec3 cameraPos = bikePos - _trackForward * kChaseDistance;
+    cameraPos.z += kChaseHeight;
+
+    glm::vec3 target = bikePos;
+    target.z += kLookAtHeight;
+
+    glm::quat orientation(glm::quatLookAt(glm::normalize(target - cameraPos), up));
+
+    glm::mat4 transform(1.0f);
+    transform *= glm::translate(cameraPos);
+    transform *= glm::mat4_cast(orientation);
+    _camera->cameraSceneNode()->setLocalTransform(transform);
+}
+
+void SwoopRace::setCameraFieldOfView(float fovDegrees) {
+    if (!_camera) {
+        return;
+    }
+    _camera->cameraSceneNode()->setPerspectiveProjection(
+        glm::radians(fovDegrees),
+        cameraAspect(),
+        graphics::kDefaultClipPlaneNear,
+        graphics::kDefaultClipPlaneFar);
+}
+
+float SwoopRace::cameraAspect() const {
+    const auto &graphicsOpts = _game.options().graphics;
+    if (graphicsOpts.height <= 0) {
+        return 1.0f;
+    }
+    return graphicsOpts.width / static_cast<float>(graphicsOpts.height);
+}
+
+bool SwoopRace::handle(const input::Event &event) {
+    switch (event.type) {
+    case input::EventType::KeyDown:
+        return handleKeyDown(event.key);
+    case input::EventType::KeyUp:
+        return handleKeyUp(event.key);
+    default:
+        return false;
+    }
+}
+
+bool SwoopRace::handleKeyDown(const input::KeyEvent &event) {
+    switch (event.code) {
+    case input::KeyCode::Left:
+    case input::KeyCode::A:
+        _steerDir = -1;
+        return true;
+    case input::KeyCode::Right:
+    case input::KeyCode::D:
+        _steerDir = 1;
+        return true;
+    case input::KeyCode::Space:
+        // Jump is stubbed for the skeleton: accepted but has no gameplay effect.
+        return true;
+    case input::KeyCode::Escape:
+        _game.exitSwoopRace();
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool SwoopRace::handleKeyUp(const input::KeyEvent &event) {
+    switch (event.code) {
+    case input::KeyCode::Left:
+    case input::KeyCode::A:
+        if (_steerDir == -1) {
+            _steerDir = 0;
+        }
+        return true;
+    case input::KeyCode::Right:
+    case input::KeyCode::D:
+        if (_steerDir == 1) {
+            _steerDir = 0;
+        }
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/resource/format/lytreader.cpp
+++ b/src/libs/resource/format/lytreader.cpp
@@ -55,11 +55,39 @@ void LytReader::processLine(const std::string &line) {
                 _layout.rooms.reserve(_roomCount);
                 _state = State::Rooms;
             }
+        } else if (first == "trackcount") {
+            // Minigame track placements (optional; absent in normal modules).
+            _trackCount = stoi(tokens[1]);
+            if (_trackCount > 0) {
+                _layout.tracks.reserve(_trackCount);
+                _state = State::Tracks;
+            }
+        } else if (first == "obstaclecount") {
+            // Minigame obstacle placements (optional; absent in normal modules).
+            _obstacleCount = stoi(tokens[1]);
+            if (_obstacleCount > 0) {
+                _layout.obstacles.reserve(_obstacleCount);
+                _state = State::Obstacles;
+            }
         }
+        // Other sections (doorhookcount, ...) and their entries are
+        // intentionally ignored here.
         break;
     case State::Rooms:
         appendRoom(tokens);
-        if (_layout.rooms.size() == _roomCount) {
+        if (_layout.rooms.size() == static_cast<size_t>(_roomCount)) {
+            _state = State::Layout;
+        }
+        break;
+    case State::Tracks:
+        appendTrack(tokens);
+        if (_layout.tracks.size() == static_cast<size_t>(_trackCount)) {
+            _state = State::Layout;
+        }
+        break;
+    case State::Obstacles:
+        appendObstacle(tokens);
+        if (_layout.obstacles.size() == static_cast<size_t>(_obstacleCount)) {
             _state = State::Layout;
         }
         break;
@@ -74,6 +102,34 @@ void LytReader::appendRoom(const std::vector<std::string> &tokens) {
         stof(tokens[2]),
         stof(tokens[3]));
     _layout.rooms.push_back(std::move(room));
+}
+
+void LytReader::appendTrack(const std::vector<std::string> &tokens) {
+    // Track entry format: "<name> <x> <y> <z>" (position only, no rotation).
+    if (tokens.size() < 4) {
+        return;
+    }
+    Layout::Track track;
+    track.name = boost::to_lower_copy(tokens[0]);
+    track.position = glm::vec3(
+        stof(tokens[1]),
+        stof(tokens[2]),
+        stof(tokens[3]));
+    _layout.tracks.push_back(std::move(track));
+}
+
+void LytReader::appendObstacle(const std::vector<std::string> &tokens) {
+    // Obstacle entry format: "<name> <x> <y> <z>" (position only, no rotation).
+    if (tokens.size() < 4) {
+        return;
+    }
+    Layout::Obstacle obstacle;
+    obstacle.name = boost::to_lower_copy(tokens[0]);
+    obstacle.position = glm::vec3(
+        stof(tokens[1]),
+        stof(tokens[2]),
+        stof(tokens[3]));
+    _layout.obstacles.push_back(std::move(obstacle));
 }
 
 } // namespace resource


### PR DESCRIPTION

## Summary

Adds the K1 swoop race skeleton.  Although Tatooine and Manaan swoop races also initiate successfully, Taris was the focus to clear the game progression blocker so the Taris story can progress through the swoop championship sequence.  The PR wires the Taris swoop race into the vanilla dialogue/module flow.  

Included:

* parses K1 module minigame/swoop metadata
* adds a dev-startable swoop race mode
* loads the swoop bike model set and chase camera
* follows authored swoop track layout placement
* applies lateral/tunnel movement bounds (placeholder only)
* starts the Taris swoop race through the vanilla race handler flow
* hides/restores party actors during the race
* auto-finishes the current PR1 race skeleton as a forced success
* returns to the authored Taris post-race waypoint
* writes the vanilla race output globals required by `k_ptar_postswoop`
* uses beat-relative forced times so repeated heats remain beatable
* lets vanilla post-race trigger/dialogue scripts advance story state
* routes blank `ActionStartConversation` calls to non-party dialogue anchors, including invisible placeables like `converse`
* clears party action queues on module transitions
* removes destroyed objects from trigger tenants without firing `OnExit`
* gates swoop diagnostics behind dev commands / debug logging
* Added command "givegold" to enable player to add credits to party pool and thus successfully initiate credit-gated races

## Testing
Warping to an 'MG' module generally puts player on the track.  To test racing organically from the race announcer:
* Taris:  Warp to module TAR_M03AF
* Tatooine:  TAT_M17AE (requires givegold to pay for entry)
* Manaan:  MAN_M26AB (requires givegold to pay for entry)

## Notes

The Taris finale handoff uses the vanilla invisible placeable dialogue-anchor pattern:

* `k_ptar_postrace` creates Brejik and guards
* `RaceAnnoun031` starts conversation with the invisible `converse` placeable
* `converse` owns `tar03_brejik031`
* the Brejik/finale dialogue starts without hardcoding Brejik, globals, or coordinates

The `StartConversation` owner-selection change is generic: blank dialogue resrefs now preserve the distinction between party-member listeners and non-party dialogue anchors.

## Deferred

* enemy racer / Redros post event visual polish
* competitive racing logic/timer/HUD
* race start lights
* boosts/gears/damage/obstacles
* accurate track limits
* swoop sounds
* graphics/far-clip work, tracked separately on `recce/swoop-skybox-draw-distance`
