### PR TITLE
[game][script] Add party credit routines

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -524,6 +524,7 @@ private:
     void consoleKill(const ConsoleArgs &tokens);
     void consoleAddItem(const ConsoleArgs &tokens);
     void consoleGiveXP(const ConsoleArgs &tokens);
+    void consoleGiveGold(const ConsoleArgs &tokens);
     void consoleWarp(const ConsoleArgs &tokens);
     void consoleRunScript(const ConsoleArgs &tokens);
     void consoleShowAABB(const ConsoleArgs &tokens);

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -93,6 +93,18 @@ public:
 
     // END Default party
 
+    // Credits
+    //
+    // KOTOR stores credits as a single party-shared pool, not per creature.
+    // Gold script routines (GetGold/GiveGoldToCreature/TakeGoldFromCreature)
+    // that target a party member operate on this pool.
+
+    int gold() const { return _gold; }
+    void giveGold(int amount);
+    void takeGold(int amount);
+
+    // END Credits
+
 private:
     Game &_game;
 
@@ -100,6 +112,7 @@ private:
     std::map<int, std::shared_ptr<Creature>> _availableMembers;
     std::vector<Member> _members;
     bool _solo {false};
+    int _gold {0};
 
     bool handleKeyDown(const input::KeyEvent &event);
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -239,6 +239,7 @@ void Game::initConsole() {
     registerConsoleCommand("kill", "kill selected object", &Game::consoleKill);
     registerConsoleCommand("additem", "add item to selected object", &Game::consoleAddItem);
     registerConsoleCommand("givexp", "give experience to selected creature", &Game::consoleGiveXP);
+    registerConsoleCommand("givegold", "give credits to the party", &Game::consoleGiveGold);
     registerConsoleCommand("showaabb", "toggle rendering AABB", &Game::consoleShowAABB);
     registerConsoleCommand("showwalkmesh", "toggle rendering walkmesh", &Game::consoleShowWalkmesh);
     registerConsoleCommand("showtriggers", "toggle rendering triggers", &Game::consoleShowTriggers);
@@ -1646,6 +1647,12 @@ void Game::consoleGiveXP(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 1, "amount");
     auto creature = getConsoleTargetCreature();
     creature->giveXP(args.get<int>(1).value());
+}
+
+void Game::consoleGiveGold(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 1, 1, "amount");
+    _party.giveGold(args.get<int>(1).value());
+    _console.printLine(str(boost::format("party gold: %d") % _party.gold()));
 }
 
 void Game::consoleWarp(const ConsoleArgs &args) {

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -99,6 +99,17 @@ void Party::clear() {
     _members.clear();
 }
 
+void Party::giveGold(int amount) {
+    _gold += amount;
+}
+
+void Party::takeGold(int amount) {
+    _gold -= amount;
+    if (_gold < 0) {
+        _gold = 0;
+    }
+}
+
 void Party::switchLeader() {
     if (_members.size() <= 1) {
         return;

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3032,7 +3032,11 @@ static Variable GiveGoldToCreature(const std::vector<Variable> &args, const Rout
     auto creature = checkCreature(oCreature);
 
     // Execute
-    creature->giveGold(nGP);
+    if (creature && ctx.game.party().isMember(*creature)) {
+        ctx.game.party().giveGold(nGP);
+    } else {
+        creature->giveGold(nGP);
+    }
     return Variable::ofNull();
 }
 
@@ -3833,6 +3837,11 @@ static Variable GetGold(const std::vector<Variable> &args, const RoutineContext 
     auto creature = checkCreature(oTarget);
 
     // Execute
+    // Credits are a single party-shared pool in KOTOR; party members (incl. the
+    // PC speaker / leader) report the party total.
+    if (creature && ctx.game.party().isMember(*creature)) {
+        return Variable::ofInt(ctx.game.party().gold());
+    }
     return Variable::ofInt(creature->gold());
 }
 
@@ -4062,11 +4071,21 @@ static Variable TakeGoldFromCreature(const std::vector<Variable> &args, const Ro
 
     // Execute
     if (creatureToTakeFrom) {
-        creatureToTakeFrom->takeGold(nAmount);
+        if (ctx.game.party().isMember(*creatureToTakeFrom)) {
+            ctx.game.party().takeGold(nAmount);
+        } else {
+            creatureToTakeFrom->takeGold(nAmount);
+        }
     }
     if (!destroy) {
         auto caller = checkCreature(getCaller(ctx));
-        caller->giveGold(nAmount);
+        if (caller) {
+            if (ctx.game.party().isMember(*caller)) {
+                ctx.game.party().giveGold(nAmount);
+            } else {
+                caller->giveGold(nAmount);
+            }
+        }
     }
     return Variable::ofNull();
 }


### PR DESCRIPTION
Adds shared party credit support for script gold routines and developer smoke testing.

Credits are party-shared in KOTOR, but Reone was effectively treating them as per-creature for script checks. This meant gold-gated dialogue conditionals such as swoop registration checks could fail when asking the PC speaker/leader for credits.

This change:

- adds a shared party credit pool
- routes GetGold / GiveGoldToCreature / TakeGoldFromCreature through the party pool for party members
- preserves per-creature gold behaviour for non-party creatures
- adds a dev givegold console command for testing credit-gated flows

The party pool still starts at 0 because save/party-table credit deserialization is deferred.