### PR TITLE
[game] Fix blank StartConversation dialog owner selection

### DIFF
--- a/src/libs/game/action/startconversation.cpp
+++ b/src/libs/game/action/startconversation.cpp
@@ -30,9 +30,20 @@ static constexpr float kMaxConversationDistance = 4.0f;
 void StartConversationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     auto actorPtr = _game.getObjectById(actor.id());
 
-    // Creatures should move to the target before starting the dialog.
-    // Triggers and other objects can start the dialog immediately
+    // A creature walks up to its conversation partner before talking. If the
+    // target object is invalid - a script can pass an object that was never
+    // created (e.g. GetObjectByTag on a tag with no instance) or one that has
+    // been destroyed - there is nobody to approach, so the action is dropped
+    // rather than starting a partnerless dialog. This mirrors retail/KotOR.js,
+    // where the creature path requires a valid target (it navigates to and
+    // references the target) and the action otherwise fails. It also prevents a
+    // null dereference below and stops an NPC told to converse with a missing
+    // placeholder from starting a stray dialog.
     if (auto creatureActor = dyn_cast<Creature>(actorPtr)) {
+        if (!_objectToConverse) {
+            complete();
+            return;
+        }
         bool reached =
             _ignoreStartRange ||
             creatureActor->navigateTo(_objectToConverse->position(), true, kMaxConversationDistance, dt);
@@ -42,20 +53,52 @@ void StartConversationAction::execute(std::shared_ptr<Action> self, Object &acto
         }
     }
 
-    // When scripts do not specify DialogResRef, it takes a default
-    // value of caller->conversation() before StartConversationAction
-    // object is constructed.
+    // Dialog owner selection - i.e. which participant's Conversation/DLG plays:
     //
-    // When the player initiates a conversation, DialogResRef should
-    // be empty.
+    //  - Explicit DialogResRef: the named dialog is caller-owned (PR #150).
     //
-    // Therefore, if DialogResRef is empty, we must always select
-    // _objectToConverse and use its conversation() as the dialog.
+    //  - Blank DialogResRef: prefer the participant whose Conversation field
+    //    describes the scene:
+    //      * a player-clicked target with a Conversation owns the dialog when
+    //        the target is not a party member.
+    //      * a scripted NPC/caller conversing with a PC or party member owns
+    //        the dialog when the caller has a Conversation.
+    //      * a non-party target/anchor with a Conversation owns the dialog.
+    //      * otherwise fall back to target ownership when the caller has no
+    //        Conversation and the target does, preserving player-clicked party
+    //        member conversations such as Carth.
     //
-    // Otherwise, if DialogResRef is set, select Actor as the dialog
-    // owner.
+    // Keyed only on party membership and Conversation presence, so it is generic
+    // (it does not depend on whether the PC/leader happens to have a
+    // Conversation field of its own).
+    std::shared_ptr<Object> dialogOwner;
+    if (!_dialogResRef.empty()) {
+        dialogOwner = actorPtr;
+    } else {
+        bool targetHasConversation =
+            _objectToConverse && !_objectToConverse->conversation().empty();
+        bool targetIsPartyMember =
+            _objectToConverse && _game.party().isMember(*_objectToConverse);
+        bool callerHasConversation = actorPtr && !actorPtr->conversation().empty();
 
-    std::shared_ptr<Object> dialogOwner = _dialogResRef.empty() ? _objectToConverse : actorPtr;
+        if (targetHasConversation && !targetIsPartyMember) {
+            dialogOwner = _objectToConverse;
+        } else if (callerHasConversation) {
+            dialogOwner = actorPtr;
+        } else if (targetHasConversation) {
+            dialogOwner = _objectToConverse;
+        }
+    }
+
+    // If no valid owner can be resolved there is no dialogue to start (e.g. an
+    // invalid target combined with an empty resref). Complete the action so it
+    // does not block the queue, but do not dereference a null owner -
+    // Area::startDialog reads owner->conversation() for an empty resref.
+    if (!dialogOwner) {
+        complete();
+        return;
+    }
+
     _game.module()->area()->startDialog(dialogOwner, _dialogResRef);
     complete();
 }

--- a/src/libs/game/script/routine/impl/action.cpp
+++ b/src/libs/game/script/routine/impl/action.cpp
@@ -377,13 +377,8 @@ static Variable ActionStartConversation(const std::vector<Variable> &args, const
     auto bDontClearAllActions = getIntOrElse(args, 14, 0);
 
     // Transform
-    std::string dialogResRef;
+    std::string dialogResRef(sDialogResRef);
     auto caller = getCaller(ctx);
-    if (!sDialogResRef.empty()) {
-        dialogResRef = sDialogResRef;
-    } else {
-        dialogResRef = caller->conversation();
-    }
     auto privateConversation = static_cast<bool>(bPrivateConversation);
     auto conversationType = static_cast<resource::ConversationType>(nConversationType);
     auto ignoreStartRange = static_cast<bool>(bIgnoreStartRange);


### PR DESCRIPTION
Fixes generic ActionStartConversation owner selection when sDialogResRef is blank.

Blank dialogue resrefs now preserve the distinction between party-member listeners and non-party dialogue anchors:

- party-member targets are listeners, so the caller owns the dialogue
- non-party targets with a Conversation field own the dialogue
- player-clicked NPCs/placeables remain target-owned
- explicit dialog resrefs remain caller-owned

This supports vanilla invisible dialogue anchors such as the Taris "converse" placeable without hardcoding Taris, Brejik, or coordinates.