### PR TITLE
[game] Remove destroyed objects from trigger tenants

### DIFF
--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -58,6 +58,12 @@ public:
 
     void addTenant(const std::shared_ptr<Object> &object);
 
+    // Drop an object from the tenant set without firing OnExit. Used when an
+    // object is destroyed while standing inside the trigger: a destroyed object
+    // never moves, so Trigger::update would otherwise keep it as a tenant
+    // forever (leaking it and leaving the trigger stuck in the Inside state).
+    void removeTenant(const Object *object);
+
     bool isIn(const glm::vec2 &point) const;
     bool isTenant(const std::shared_ptr<Object> &object) const;
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -542,6 +542,14 @@ void Area::doDestroyObject(uint32_t objectId) {
         room->removeTenant(object.get());
     }
 
+    // Drop the object from any trigger it was standing inside. A destroyed
+    // object never moves, so Trigger::update would otherwise keep it as a tenant
+    // indefinitely (leaking it and leaving the trigger stuck in the Inside
+    // state). Destruction is not an "exit", so no OnExit is fired.
+    for (auto &triggerObject : _objectsByType[ObjectType::Trigger]) {
+        static_cast<Trigger &>(*triggerObject).removeTenant(object.get());
+    }
+
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
     auto sceneNode = object->sceneNode();
     if (sceneNode) {

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -189,6 +189,16 @@ void Trigger::addTenant(const std::shared_ptr<Object> &object) {
           script::Variable::ofObject(object->id())}});
 }
 
+void Trigger::removeTenant(const Object *object) {
+    for (auto it = _tenants.begin(); it != _tenants.end(); ++it) {
+        if (it->get() == object) {
+            _tenants.erase(it);
+            syncDebugVisual();
+            return;
+        }
+    }
+}
+
 bool Trigger::isIn(const glm::vec2 &point) const {
     return static_cast<TriggerSceneNode *>(_sceneNode.get())->isIn(point);
 }

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -190,11 +190,12 @@ void Trigger::addTenant(const std::shared_ptr<Object> &object) {
 }
 
 void Trigger::removeTenant(const Object *object) {
-    for (auto it = _tenants.begin(); it != _tenants.end(); ++it) {
+    for (auto it = _tenants.begin(); it != _tenants.end();) {
         if (it->get() == object) {
-            _tenants.erase(it);
+            it = _tenants.erase(it);
             syncDebugVisual();
-            return;
+        } else {
+            ++it;
         }
     }
 }


### PR DESCRIPTION
##Summary

Removes destroyed objects from trigger tenant sets during object destruction.

This prevents stale trigger occupancy state when an object is destroyed while still registered inside a trigger.

##Details
adds trigger tenant removal support
removes destroyed objects from trigger tenant sets during object destruction
does not fire OnExit on destruction
leaves ordinary movement-driven OnEnter / OnExit behaviour unchanged
Why

Destroyed objects should not remain registered as trigger tenants. This can leave triggers in a stale occupied/stimulated state after cleanup scripts destroy NPCs or other objects.