### PR TITLE
[game] Run module and linked door scripts for party progression

### DIFF
--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -43,6 +43,8 @@ struct ModuleInfo {
     std::string entryArea;
     glm::vec3 entryPosition {0.0f};
     float entryFacing {0.0f};
+    std::string onModLoad;
+    std::string onModStart;
 };
 
 class Door;
@@ -69,6 +71,8 @@ public:
     void load(std::string name, const resource::Gff &ifo, bool fromSave = false);
     void activate();
     void loadParty(const std::string &entry = "", bool fromSave = false);
+    void runOnLoadScript();
+    void runOnStartScript();
 
     bool handle(const input::Event &event);
     void update(float dt);

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -543,6 +543,10 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
                 }
             }
 
+            if (!fromSave) {
+                _module->runOnLoadScript();
+            }
+
             _module->loadParty(entry, fromSave);
 
             info("Module '" + name + "' loaded successfully");

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -297,7 +297,7 @@ void Module::onCreatureClick(const std::shared_ptr<Creature> &creature) {
 }
 
 void Module::onDoorClick(const std::shared_ptr<Door> &door) {
-    if (!door->linkedToModule().empty()) {
+    if (!door->linkedToModule().empty() && door->getOnOpen().empty()) {
         _game.scheduleModuleTransition(door->linkedToModule(), door->linkedTo());
         return;
     }

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -25,12 +25,15 @@
 #include "reone/game/game.h"
 #include "reone/game/party.h"
 #include "reone/game/reputes.h"
+#include "reone/game/script/runner.h"
 #include "reone/resource/di/services.h"
 #include "reone/resource/exception/notfound.h"
 #include "reone/resource/provider/gffs.h"
 #include "reone/resource/resources.h"
 #include "reone/system/exception/validation.h"
 #include "reone/system/logutil.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
 
 using namespace reone::graphics;
 using namespace reone::resource;
@@ -103,6 +106,9 @@ void Module::loadInfo(const resource::generated::IFO &ifo) {
     float dirX = ifo.Mod_Entry_Dir_X;
     float dirY = ifo.Mod_Entry_Dir_Y;
     _info.entryFacing = -glm::atan(dirX, dirY);
+
+    _info.onModLoad = boost::to_lower_copy(ifo.Mod_OnModLoad);
+    _info.onModStart = boost::to_lower_copy(ifo.Mod_OnModStart);
 }
 
 void Module::loadArea(const resource::generated::IFO &ifo, bool fromSave) {
@@ -139,6 +145,20 @@ void Module::loadParty(const std::string &entry, bool fromSave) {
     if (!fromSave) {
         _area->runOnEnterScript();
     }
+}
+
+void Module::runOnLoadScript() {
+    if (_info.onModLoad.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(_info.onModLoad, id());
+}
+
+void Module::runOnStartScript() {
+    if (_info.onModStart.empty()) {
+        return;
+    }
+    _game.scriptRunner().run(_info.onModStart, id());
 }
 
 void Module::getEntryPoint(const std::string &waypoint, glm::vec3 &position, float &facing) const {


### PR DESCRIPTION
## Summary

Fixes the first K1/K2 party progression blocker from issue #151 by restoring two generic vanilla script contracts:

* stores and runs module `Mod_OnModLoad` scripts on non-save module loads
* preserves linked-door immediate transitions only for linked doors without `OnOpen`
* routes linked doors with `OnOpen` through the normal `OpenDoorAction` / `Door::onOpen()` path so vanilla scripts can own party selection or transition flow