### PR TITLE
[game] Ignore Trigger orientation

### DIFF
--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -105,12 +105,17 @@ void Trigger::deserializeAll(const resource::Gff &gff) {
     gff.readFloat(_position[0], "XPosition");
     gff.readFloat(_position[1], "YPosition");
     gff.readFloat(_position[2], "ZPosition");
-    {
-        float cosine, sine;
-        if (gff.readFloat(cosine, "XOrientation") && gff.readFloat(sine, "YOrientation")) {
-            _orientation = glm::quat(glm::vec3(0.0f, 0.0f, -glm::atan(cosine, sine)));
-        }
-    }
+
+    // Ignore XOrientation and YOrientation.
+    //
+    // The vanilla engine applies orientation only when instantiating
+    // from a template, and it does not apply orientation when loading
+    // from a savegame. It also uses script Facing only to the Trigger
+    // object and not to the corresponding mesh.
+    //
+    // It appears that no script in the game relies on this behavior,
+    // therefore we do not support it.
+
     gff.readWord(_loadScreenId, "LoadScreenID");
     gff.readLocString(_transitionDestin, "TransitionDestin", _services.resource.strings);
     gff.readBool(_setByPlayerParty, "SetByPlayerParty");


### PR DESCRIPTION
Triggers in savegames have X and YOrientation set to (1.0f, 0.0f),
causing incorrect trigger mesh rotation. The original engine does not
seem to apply orientation to the mesh. It appears that no script in
the game relies on Facing of Trigger object either.

Therefore we disable deserialization of X and Orientation. It is still
possible to use SetFacing script routine, and it would rotate the
mesh, but these changes will not be persistent across save and load.