### PR TITLE
[script] Revert SetIsDestroyable

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3046,17 +3046,11 @@ static Variable SetIsDestroyable(const std::vector<Variable> &args, const Routin
     auto bDestroyable = getInt(args, 0);
     auto bRaiseable = getIntOrElse(args, 1, 1);
     auto bSelectableWhenDead = getIntOrElse(args, 2, 0);
-    auto object = getCaller(ctx);
 
     // Transform
-    bool destroyable = static_cast<bool>(bDestroyable);
-    (void)bRaiseable;           // Raiseable dead state is not represented yet.
-    (void)bSelectableWhenDead;  // Dead selectability is driven by object state/items.
 
     // Execute
-    object->setPlotFlag(!destroyable);
-    object->setMinOneHP(!destroyable);
-    return Variable::ofNull();
+    throw RoutineNotImplementedException("SetIsDestroyable");
 }
 
 static Variable SetLocked(const std::vector<Variable> &args, const RoutineContext &ctx) {


### PR DESCRIPTION
SetIsDestroyable should not change MinOneHP or Plot. Accroding to nwscript.nss:

- bDestroyable: If this is FALSE, the caller does not fade out on
death, but sticks around as a corpse.

- bRaiseable: If this is TRUE, the caller can be raised via resurrection.

- bSelectableWhenDead: If this is TRUE, the caller is selectable after death.

This commit partially reverts c0f416e2e "[script] Implement basic
spawn helper routines (#176)" because it breaks "Duros and Sith"
cutscene on tar_m02aa.