### PR TITLE
[scene] Add drawdebug functions

### DIFF
--- a/glsl/v_billboard.glsl
+++ b/glsl/v_billboard.glsl
@@ -16,7 +16,7 @@ void main() {
         vec3 right = vec3(uView[0][0], uView[1][0], uView[2][0]);
         vec3 up = vec3(uView[0][1], uView[1][1], uView[2][1]);
         vec4 P = vec4(
-            vec3(uModel[3]) + right * aPosition.x + up * aPosition.y,
+            vec3(uModel[3]) + right * uModel[0][0] * aPosition.x + up * uModel[1][1] * aPosition.y,
             1.0);
 
         gl_Position = uProjection * uView * P;

--- a/glsl/v_textBillboard.glsl
+++ b/glsl/v_textBillboard.glsl
@@ -1,0 +1,26 @@
+#include "u_globals.glsl"
+#include "u_locals.glsl"
+#include "u_text.glsl"
+
+layout(location = 0) in vec3 aPosition;
+layout(location = 2) in vec2 aUV1;
+
+out vec2 fragUV1;
+flat out int fragInstanceID;
+
+void main() {
+    vec3 right = vec3(uView[0][0], uView[1][0], uView[2][0]);
+    vec3 up = vec3(uView[0][1], uView[1][1], uView[2][1]);
+
+    vec3 pos = aPosition;
+    pos.x += uTextChars[gl_InstanceID].posScale[0] + aPosition.x * uTextChars[gl_InstanceID].posScale[2];
+    pos.y += uTextChars[gl_InstanceID].posScale[1] + aPosition.y * uTextChars[gl_InstanceID].posScale[3];
+
+    // Apply scale transform and rotate to face the camera.
+    vec3 modelPos = vec3(uModel[3]) +  right * uModel[0][0] * pos.x + up * uModel[1][1] * pos.y;
+    vec4 P = vec4(modelPos, 1.0f);
+
+    gl_Position = uProjection * uView * P;
+    fragUV1 = aUV1;
+    fragInstanceID = gl_InstanceID;
+}

--- a/include/reone/graphics/font.h
+++ b/include/reone/graphics/font.h
@@ -56,7 +56,13 @@ public:
 
     float measure(std::string_view text) const;
 
+    void renderLine(std::string_view line,
+                    const glm::vec3 &position,
+                    glm::vec3 &textOffset);
+
     float height() const { return _height; }
+
+    Texture &texture() { return *_texture; }
 
 private:
     struct Glyph {

--- a/include/reone/graphics/shaderregistry.h
+++ b/include/reone/graphics/shaderregistry.h
@@ -39,6 +39,7 @@ struct ShaderProgramId {
     static constexpr char pbrWalkmesh[] = "pbr_walkmesh";
     static constexpr char dirLightShadows[] = "dir_light_shadows";
     static constexpr char mvpColor[] = "mvp_color";
+    static constexpr char aabbColor[] = "aabb_color";
     static constexpr char mvpTexture[] = "mvp_texture";
     static constexpr char ndcTexture[] = "ndc_texture";
     static constexpr char oitBlend[] = "oit_blend";
@@ -53,6 +54,7 @@ struct ShaderProgramId {
     static constexpr char postMedianFilter5[] = "post_median_filter5";
     static constexpr char postSharpen[] = "post_sharpen";
     static constexpr char text[] = "text";
+    static constexpr char textBillboard[] = "textBillboard";
     static constexpr char pbrIrradiance[] = "pbr_irradiance";
     static constexpr char brdfLUT[] = "pbr_brdf";
     static constexpr char pbrPrefilter[] = "pbr_prefilter";

--- a/include/reone/scene/drawdebug.h
+++ b/include/reone/scene/drawdebug.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace reone {
+
+namespace graphics {
+class GraphicsServices;
+}
+
+namespace scene {
+class IRenderPass;
+}
+
+namespace resource {
+class ResourceServices;
+}
+
+void updateDrawDebug(float dt);
+
+void renderDrawDebug(scene::IRenderPass &pass,
+                     graphics::GraphicsServices &services,
+                     resource::ResourceServices &resources,
+                     std::string_view sceneName);
+
+namespace drawdebug {
+/**
+ * DrawDebug ID opens a new scope for elements to go to.
+ *
+ * All operations (such as clear(), line(), box(), etc.) operate implicitly on
+ * the list of elements of the current scope.
+ */
+void pushId(uint64_t id);
+
+/**
+ * Convenience wrapper to use any pointer as an ID.
+ */
+void pushId(const void *id);
+
+/**
+ * Close the current scope.
+ */
+void popId();
+
+/**
+ * Set lifetime (in seconds) for all subsequent elements. Elements are removed
+ * by updateDrawDebug once their lifetime is over, or when clear() is called
+ * explicitly.
+ */
+void pushLifetime(float lifetime);
+
+/**
+ * Set the previous lifetime value.
+ */
+void popLifetime();
+
+/**
+ * Set scene graph name for all subsequent elements.
+ */
+void pushScene(std::string sceneName);
+
+/**
+ * Set the previous scene graph.
+ */
+void popScene();
+
+/**
+ * Remove all elements in the current scope (which is defined by pushId()).
+ */
+void clear();
+
+void line(glm::vec3 start, glm::vec3 end, uint32_t colorRgba, float thickness);
+void triangle(glm::vec3 v0, glm::vec3 v1, glm::vec3 v2, uint32_t colorRgba);
+void text(const std::string &str, glm::vec3 position, uint32_t colorRgba, float scale = 1.0);
+void point(glm::vec3 position, uint32_t colorRgba, float scale = 1.0);
+void box(glm::vec3 min, glm::vec3 max, uint32_t colorRgba);
+
+} // namespace drawdebug
+
+} // namespace reone

--- a/include/reone/scene/render/pass.h
+++ b/include/reone/scene/render/pass.h
@@ -47,7 +47,8 @@ enum class RenderPassName {
     PointLightShadows,
     OpaqueGeometry,
     TransparentGeometry,
-    PostProcessing
+    PostProcessing,
+    Debug
 };
 
 struct ParticleInstance {

--- a/include/reone/scene/render/pipeline/pbr.h
+++ b/include/reone/scene/render/pipeline/pbr.h
@@ -109,12 +109,14 @@ private:
     void beginOpaqueGeometryPass();
     void beginTransparentGeometryPass();
     void beginPostProcessingPass();
+    void beginDebugPass();
 
     void endDirLightShadowsPass();
     void endPointLightShadowsPass();
     void endOpaqueGeometryPass();
     void endTransparentGeometryPass();
     void endPostProcessingPass();
+    void endDebugPass();
 
     // END Render Passes
 };

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -71,6 +71,7 @@
 #include "reone/resource/provider/walkmeshes.h"
 #include "reone/resource/resources.h"
 #include "reone/scene/di/services.h"
+#include "reone/scene/drawdebug.h"
 #include "reone/scene/graphs.h"
 #include "reone/scene/render/pipeline.h"
 #include "reone/script/di/services.h"
@@ -372,6 +373,9 @@ void Game::update(float frameTime) {
         gui->update(dt);
     }
     updateSceneGraph(dt);
+    if (!_paused) {
+        updateDrawDebug(dt);
+    }
 }
 
 void Game::render() {

--- a/src/libs/graphics/font.cpp
+++ b/src/libs/graphics/font.cpp
@@ -71,23 +71,8 @@ void Font::render(std::string_view text, const glm::vec3 &position, const glm::v
     glm::vec3 textOffset(getTextOffset(text, gravity), 0.0f);
     for (int i = 0; i < numBlocks; ++i) {
         int numChars = glm::min(kMaxTextChars, static_cast<int>(text.size()) - i * kMaxTextChars);
-        _uniforms.setText([this, &text, &position, &textOffset, &i, &numChars](auto &uniforms) {
-            for (int j = 0; j < numChars; ++j) {
-                const Glyph &glyph = _glyphs[static_cast<unsigned char>(text[i * kMaxTextChars + j])];
-
-                glm::vec4 posScale;
-                posScale[0] = position.x + textOffset.x;
-                posScale[1] = position.y + textOffset.y;
-                posScale[2] = glyph.size.x;
-                posScale[3] = glyph.size.y;
-
-                uniforms.chars[j].posScale = std::move(posScale);
-                uniforms.chars[j].uv = glm::vec4(glyph.ul.x, glyph.lr.y, glyph.lr.x - glyph.ul.x, glyph.ul.y - glyph.lr.y);
-
-                textOffset.x += glyph.size.x;
-            }
-        });
-        _meshRegistry.get(MeshName::quad).drawInstanced(numChars, _statistic);
+        std::string_view line = text.substr(i * kMaxTextChars, numChars);
+        renderLine(line, position, textOffset);
     }
 }
 
@@ -121,6 +106,30 @@ float Font::measure(std::string_view text) const {
         w += _glyphs[reinterpret_cast<const unsigned char &>(glyph)].size.x;
     }
     return w;
+}
+
+void Font::renderLine(std::string_view line, const glm::vec3 &position, glm::vec3 &textOffset) {
+    if (line.empty()) {
+        return;
+    }
+
+    _uniforms.setText([this, &line, &position, &textOffset](auto &uniforms) {
+        for (int j = 0; j < line.size(); ++j) {
+            const Glyph &glyph = _glyphs[static_cast<unsigned char>(line[j])];
+
+            glm::vec4 posScale;
+            posScale[0] = position.x + textOffset.x;
+            posScale[1] = position.y + textOffset.y;
+            posScale[2] = glyph.size.x;
+            posScale[3] = glyph.size.y;
+
+            uniforms.chars[j].posScale = std::move(posScale);
+            uniforms.chars[j].uv = glm::vec4(glyph.ul.x, glyph.lr.y, glyph.lr.x - glyph.ul.x, glyph.ul.y - glyph.lr.y);
+
+            textOffset.x += glyph.size.x;
+        }
+    });
+    _meshRegistry.get(MeshName::quad).drawInstanced(line.size(), _statistic);
 }
 
 } // namespace graphics

--- a/src/libs/resource/provider/shaders.cpp
+++ b/src/libs/resource/provider/shaders.cpp
@@ -42,6 +42,7 @@ static const std::string kVertParticles = "v_particles";
 static const std::string kVertPassthrough = "v_passthrough";
 static const std::string kVertShadows = "v_shadows";
 static const std::string kVertText = "v_text";
+static const std::string kVertTextBillboard = "v_textBillboard";
 static const std::string kVertWalkmesh = "v_walkmesh";
 
 static const std::string kGeometryDirLightShadows = "g_dirlightshadow";
@@ -96,6 +97,7 @@ void Shaders::init() {
     auto vertPassthrough = initShader(ShaderType::Vertex, kVertPassthrough);
     auto vertShadows = initShader(ShaderType::Vertex, kVertShadows);
     auto vertText = initShader(ShaderType::Vertex, kVertText);
+    auto vertTextBillboard = initShader(ShaderType::Vertex, kVertTextBillboard);
     auto vertWalkmesh = initShader(ShaderType::Vertex, kVertWalkmesh);
 
     auto geomDirLightShadows = initShader(ShaderType::Geometry, kGeometryDirLightShadows);
@@ -134,6 +136,7 @@ void Shaders::init() {
     auto fragProfiler = initShader(ShaderType::Fragment, kFragProfiler);
 
     // Shader Programs
+    _shaderRegistry.add(ShaderProgramId::aabbColor, initShaderProgram({vertAABB, fragColor}));
     _shaderRegistry.add(ShaderProgramId::billboard, initShaderProgram({vertBillboard, fragTexture}));
     _shaderRegistry.add(ShaderProgramId::retroOpaqueModel, initShaderProgram({vertModel, fragRetroOpaqueModel}));
     _shaderRegistry.add(ShaderProgramId::retroGrass, initShaderProgram({vertGrass, fragRetroGrass}));
@@ -162,6 +165,7 @@ void Shaders::init() {
     _shaderRegistry.add(ShaderProgramId::postMedianFilter5, initShaderProgram({vertPassthrough, fragPostMedianFilter5}));
     _shaderRegistry.add(ShaderProgramId::postSharpen, initShaderProgram({vertPassthrough, fragPostSharpen}));
     _shaderRegistry.add(ShaderProgramId::text, initShaderProgram({vertText, fragText}));
+    _shaderRegistry.add(ShaderProgramId::textBillboard, initShaderProgram({vertTextBillboard, fragText}));
     _shaderRegistry.add(ShaderProgramId::pbrIrradiance, initShaderProgram({vertMVP, fragIrradiance}));
     _shaderRegistry.add(ShaderProgramId::brdfLUT, initShaderProgram({vertMVP, fragPBRBRDF}));
     _shaderRegistry.add(ShaderProgramId::pbrPrefilter, initShaderProgram({vertMVP, fragPBRPrefilter}));

--- a/src/libs/scene/CMakeLists.txt
+++ b/src/libs/scene/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCENE_HEADERS
     ${SCENE_INCLUDE_DIR}/collision.h
     ${SCENE_INCLUDE_DIR}/di/module.h
     ${SCENE_INCLUDE_DIR}/di/services.h
+    ${SCENE_INCLUDE_DIR}/drawdebug.h
     ${SCENE_INCLUDE_DIR}/fogproperties.h
     ${SCENE_INCLUDE_DIR}/graph.h
     ${SCENE_INCLUDE_DIR}/graphs.h
@@ -51,6 +52,7 @@ set(SCENE_HEADERS
 
 set(SCENE_SOURCES
     ${SCENE_SOURCE_DIR}/di/module.cpp
+    ${SCENE_SOURCE_DIR}/drawdebug.cpp
     ${SCENE_SOURCE_DIR}/graph.cpp
     ${SCENE_SOURCE_DIR}/graphs.cpp
     ${SCENE_SOURCE_DIR}/node.cpp

--- a/src/libs/scene/drawdebug.cpp
+++ b/src/libs/scene/drawdebug.cpp
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/scene/drawdebug.h"
+#include "reone/graphics/context.h"
+#include "reone/graphics/di/services.h"
+#include "reone/graphics/font.h"
+#include "reone/graphics/material.h"
+#include "reone/graphics/mesh.h"
+#include "reone/graphics/meshregistry.h"
+#include "reone/graphics/shaderprogram.h"
+#include "reone/graphics/shaderregistry.h"
+#include "reone/graphics/uniforms.h"
+#include "reone/resource/di/services.h"
+#include "reone/resource/provider/fonts.h"
+#include "reone/resource/provider/textures.h"
+#include "reone/scene/render/pass.h"
+
+#include <limits>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace reone {
+
+using namespace graphics;
+using namespace scene;
+
+enum class Shape {
+    Invalid = 0,
+    Line,
+    Triangle,
+    Text,
+    Point,
+    Box,
+};
+
+struct Line {
+    glm::vec3 start;
+    glm::vec3 end;
+    glm::vec4 color;
+    float thickness;
+};
+
+struct Triangle {
+    glm::vec3 v[3];
+    glm::vec4 color;
+};
+
+struct Text {
+    glm::vec3 position;
+    glm::vec4 color;
+    float scale;
+};
+
+struct Point {
+    glm::vec3 position;
+    glm::vec4 color;
+    float scale;
+};
+
+struct Box {
+    glm::vec3 min;
+    glm::vec3 max;
+    glm::vec4 color;
+};
+
+struct Element {
+    Element() :
+        kind(Shape::Invalid) {}
+
+    Element(Line line, float lifeTime) :
+        kind(Shape::Line), lifeTime(lifeTime) {
+        shape.line = line;
+    }
+
+    Element(Triangle triangle, float lifeTime) :
+        kind(Shape::Triangle), lifeTime(lifeTime) {
+        shape.triangle = triangle;
+    }
+
+    Element(Text text, const std::string &str, float lifeTime) :
+        kind(Shape::Text), lifeTime(lifeTime), str(str) {
+        shape.text = text;
+    }
+
+    Element(Point point, float lifeTime) :
+        kind(Shape::Point), lifeTime(lifeTime) {
+        shape.point = point;
+    }
+
+    Element(Box box, float lifeTime) :
+        kind(Shape::Box), lifeTime(lifeTime) {
+        shape.box = box;
+    }
+
+    union {
+        Line line;
+        Triangle triangle;
+        Text text;
+        Point point;
+        Box box;
+    } shape;
+
+    Shape kind;
+    std::string str; // only used for Text
+    float lifeTime;
+};
+
+struct DrawContext {
+    DrawContext(GraphicsServices &s, resource::ResourceServices &res) :
+        services(s),
+        mvpColor(s.shaderRegistry.get(ShaderProgramId::mvpColor)),
+        aabbColor(s.shaderRegistry.get(ShaderProgramId::aabbColor)),
+        textBillboard(s.shaderRegistry.get(ShaderProgramId::textBillboard)),
+        textureBillboard(s.shaderRegistry.get(ShaderProgramId::billboard)),
+        billboard(s.meshRegistry.get(MeshName::billboard)),
+        aabb(s.meshRegistry.get(MeshName::aabb)),
+        font(res.fonts.get("fnt_console")),
+        point(res.textures.get("whitetarget")) {}
+
+    ShaderProgram &mvpColor;
+    ShaderProgram &aabbColor;
+    ShaderProgram &textBillboard;
+    ShaderProgram &textureBillboard;
+    Mesh &billboard;
+    Mesh &aabb;
+    GraphicsServices &services;
+    std::shared_ptr<graphics::Font> font;
+    std::shared_ptr<graphics::Texture> point;
+};
+
+glm::mat4 transformLine(glm::vec3 start, glm::vec3 end, float thickness) {
+    glm::vec3 seg = end - start;
+    float scaleY = glm::length(seg);
+    glm::vec3 dir = seg / glm::vec3(scaleY);
+
+    // Change of basis to align Y-axis to dir.
+    glm::vec3 newY, newX, newZ;
+    if ((1.0f - std::abs(dir.z)) < 0.001) {
+        // When a direction is parallel to the UP unit vector, the cross product
+        // with UP is invalid.
+        if (dir.z < 0.0f) {
+            newY = -dir;
+            newX = glm::vec3(1.0f, 0.0f, 0.0f);
+            newZ = glm::vec3(0.0f, 0.0f, -1.0f);
+        } else {
+            newY = dir;
+            newX = glm::vec3(1.0f, 0.0f, 0.0f);
+            newZ = glm::vec3(0.0f, 0.0f, 1.0f);
+        }
+    } else {
+        newY = dir;
+        newX = glm::normalize(cross(newY, glm::vec3(0.0f, 0.0f, 1.0f)));
+        newZ = glm::normalize(cross(newY, newX));
+    }
+
+    // Billboard mesh is centered at 0, so translate it to the center of the line.
+    glm::vec3 pos = glm::mix(start, end, glm::vec3(0.5f, 0.5f, 0.5f));
+
+    // Combine change of basis, scale to length of the segment, and translate.
+    return glm::mat4(
+        glm::vec4(newX * thickness, 0.0f),
+        glm::vec4(newY * scaleY, 0.0f),
+        glm::vec4(newZ, 0.0f),
+        glm::vec4(pos, 1.0f));
+}
+
+static void renderLine(const Line &line, const DrawContext &ctx, IRenderPass &pass) {
+    ctx.services.context.useProgram(ctx.mvpColor);
+    ctx.services.uniforms.setLocals([&line](LocalUniforms &locals) {
+        locals.reset();
+        locals.model = transformLine(line.start, line.end, line.thickness); // glm::translate(glm::mat4(1.0), line.start);
+        locals.color = line.color;
+    });
+
+    ctx.billboard.draw(ctx.services.statistic);
+}
+
+static void renderTriangle(const Triangle &tri, const DrawContext &ctx, IRenderPass &pass) {
+    ShaderProgram &program = ctx.aabbColor;
+    ctx.services.context.useProgram(program);
+
+    // FIXME: change setUniform to take an ArrayRef instead of a vector.
+    // Then replace this vector with a C array.
+
+    std::vector<glm::vec4> corners = {glm::vec4(tri.v[0], 1.0f), glm::vec4(tri.v[1], 1.0f),
+                                      glm::vec4(tri.v[2], 1.0f), glm::vec4(tri.v[0], 1.0f)};
+    program.setUniform("uCorners", corners);
+    ctx.services.uniforms.setLocals([&](LocalUniforms &locals) {
+        locals.reset();
+        locals.color = tri.color;
+    });
+
+    ctx.billboard.draw(ctx.services.statistic);
+}
+
+static void renderText(const Text &text, const std::string &str, const DrawContext &ctx, IRenderPass &pass) {
+    ctx.services.context.useProgram(ctx.textBillboard);
+    ctx.services.context.bindTexture(ctx.font->texture());
+
+    float scale = text.scale * 0.2 / ctx.font->height();
+    ctx.services.uniforms.setLocals([&](LocalUniforms &locals) {
+        locals.reset();
+        locals.color = text.color;
+        locals.model = glm::translate(locals.model, text.position);
+        locals.model = glm::scale(locals.model, glm::vec3(scale, -scale, 1.0f));
+    });
+
+    glm::vec3 zeroPosition(0.0f);
+    glm::vec3 zeroOffset(0.0f);
+    ctx.font->renderLine(str, zeroPosition, zeroOffset);
+}
+
+static void renderPoint(const Point &point, const DrawContext &ctx, IRenderPass &pass) {
+    ctx.services.context.useProgram(ctx.textureBillboard);
+    ctx.services.context.bindTexture(*ctx.point);
+
+    ctx.services.uniforms.setLocals([&](LocalUniforms &locals) {
+        locals.reset();
+        locals.color = point.color;
+        locals.model = glm::translate(locals.model, point.position);
+        locals.model = glm::scale(locals.model, glm::vec3(point.scale * 0.15f));
+    });
+
+    ctx.billboard.draw(ctx.services.statistic);
+}
+
+static void renderBox(const Box &box, const DrawContext &ctx, IRenderPass &pass) {
+    ShaderProgram &program = ctx.aabbColor;
+    ctx.services.context.useProgram(program);
+
+    // FIXME: change setUniform to take an ArrayRef instead of a vector.
+    // Then replace this vector with a C array.
+
+    std::vector<glm::vec4> corners = {
+        glm::vec4(box.min.x, box.min.y, box.min.z, 1.0f),
+        glm::vec4(box.min.x, box.min.y, box.max.z, 1.0f),
+        glm::vec4(box.min.x, box.max.y, box.min.z, 1.0f),
+        glm::vec4(box.min.x, box.max.y, box.max.z, 1.0f),
+        glm::vec4(box.max.x, box.min.y, box.min.z, 1.0f),
+        glm::vec4(box.max.x, box.min.y, box.max.z, 1.0f),
+        glm::vec4(box.max.x, box.max.y, box.min.z, 1.0f),
+        glm::vec4(box.max.x, box.max.y, box.max.z, 1.0f),
+    };
+    program.setUniform("uCorners", corners);
+    ctx.services.uniforms.setLocals([&](LocalUniforms &locals) {
+        locals.reset();
+        locals.color = box.color;
+    });
+
+    ctx.services.context.pushPolygonMode(PolygonMode::Line);
+    ctx.aabb.draw(ctx.services.statistic);
+    ctx.services.context.popPolygonMode();
+}
+
+static void doRender(const Element &e, IRenderPass &pass, DrawContext &ctx) {
+    switch (e.kind) {
+    case Shape::Invalid:
+        break;
+    case Shape::Line:
+        renderLine(e.shape.line, ctx, pass);
+        break;
+    case Shape::Triangle:
+        renderTriangle(e.shape.triangle, ctx, pass);
+        break;
+    case Shape::Text:
+        renderText(e.shape.text, e.str, ctx, pass);
+        break;
+    case Shape::Point:
+        renderPoint(e.shape.point, ctx, pass);
+        break;
+    case Shape::Box:
+        renderBox(e.shape.box, ctx, pass);
+        break;
+    }
+}
+
+/// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+static uint64_t hash64(uint64_t id, uint64_t basis) {
+    constexpr uint64_t prime = 0x00000100000001B3;
+    uint64_t result = basis;
+    for (uint64_t shift = 0; shift < 64; shift += 8) {
+        uint64_t byte = (id >> shift) & 0xFF;
+        result ^= byte;
+        result *= prime;
+    }
+    return result;
+}
+
+static glm::vec4 rgbaToVec(uint32_t argb) {
+    uint32_t r = 0xFF & (argb >> 24);
+    uint32_t g = 0xFF & (argb >> 16);
+    uint32_t b = 0xFF & (argb >> 8);
+    uint32_t a = 0xFF & argb;
+    return glm::vec4(r, g, b, a) / 255.0f;
+}
+
+using ElementsMap = std::map<uint64_t, std::vector<Element>>;
+using SceneElements = std::map<std::string, ElementsMap, std::less<>>;
+
+struct DrawDebugState {
+    std::unique_ptr<DrawContext> ctx;
+    SceneElements sceneElements;
+    std::deque<std::string> sceneStack;
+    std::deque<uint64_t> idStack;
+    std::deque<float> lifetimeStack;
+
+    ElementsMap &elementsMap(std::string_view scene) {
+        auto it = sceneElements.find(scene);
+        if (it == sceneElements.end()) {
+            return sceneElements[std::string(scene)];
+        }
+        return it->second;
+    }
+
+    std::vector<Element> &elements() {
+        return elementsMap(scene())[hashId()];
+    }
+
+    uint64_t hashId() {
+        uint64_t result = 0xCBF29CE484222325;
+        for (const uint64_t &id : idStack) {
+            result = hash64(id, result);
+        }
+        return result;
+    }
+
+    float lifetime() {
+        if (lifetimeStack.empty()) {
+            return std::numeric_limits<float>::max();
+        }
+        return lifetimeStack.back();
+    }
+
+    std::string scene() {
+        if (sceneStack.empty()) {
+            return "main";
+        }
+        return sceneStack.back();
+    }
+};
+
+static DrawDebugState g_state;
+
+/// Update and remove expired elements.
+void updateDrawDebug(float dt) {
+    for (auto &[sceneName, elementsById] : g_state.sceneElements) {
+        for (auto &[id, elements] : elementsById) {
+            for (auto &element : elements) {
+                element.lifeTime -= dt;
+            }
+            auto it = std::remove_if(elements.begin(), elements.end(), [dt](const auto &element) {
+                return element.lifeTime < 0;
+            });
+            elements.erase(it, elements.end());
+        }
+    }
+}
+
+/// Render elements for a scene.
+void renderDrawDebug(scene::IRenderPass &pass,
+                     graphics::GraphicsServices &services,
+                     resource::ResourceServices &resources,
+                     std::string_view scene) {
+    if (!g_state.ctx) {
+        g_state.ctx.reset(new DrawContext(services, resources));
+    }
+
+    auto &renderCtx = g_state.ctx->services.context;
+
+    renderCtx.pushFaceCullMode(FaceCullMode::None);
+    renderCtx.pushBlendMode(BlendMode::Normal);
+    renderCtx.pushPolygonMode(PolygonMode::Fill);
+
+    for (auto &[id, elements] : g_state.elementsMap(scene)) {
+        for (auto &element : elements) {
+            doRender(element, pass, *g_state.ctx);
+        }
+    }
+
+    renderCtx.popPolygonMode();
+    renderCtx.popBlendMode();
+    renderCtx.popFaceCullMode();
+}
+
+namespace drawdebug {
+void pushId(uint64_t id) {
+    g_state.idStack.push_back(id);
+}
+
+void pushId(const void *id) {
+    pushId(reinterpret_cast<uint64_t>(id));
+}
+
+void popId() {
+    g_state.idStack.pop_back();
+}
+
+void pushLifetime(float lifetime) {
+    g_state.lifetimeStack.push_back(lifetime);
+}
+
+void popLifetime() {
+    g_state.lifetimeStack.pop_back();
+}
+
+void pushScene(std::string sceneName) {
+    g_state.sceneStack.push_back(std::move(sceneName));
+}
+
+void popScene() {
+    g_state.sceneStack.pop_back();
+}
+
+void clear() {
+    g_state.elements().clear();
+}
+
+void line(glm::vec3 start, glm::vec3 end, uint32_t colorRgba, float thickness) {
+    g_state.elements().emplace_back(
+        Line {start, end, rgbaToVec(colorRgba), thickness}, g_state.lifetime());
+}
+
+void triangle(glm::vec3 v0, glm::vec3 v1, glm::vec3 v2, uint32_t colorRgba) {
+    g_state.elements().emplace_back(
+        Triangle {{v0, v1, v2}, rgbaToVec(colorRgba)}, g_state.lifetime());
+}
+
+void text(const std::string &str, glm::vec3 position, uint32_t colorRgba, float scale) {
+    g_state.elements().emplace_back(
+        Text {position, rgbaToVec(colorRgba), scale}, str, g_state.lifetime());
+}
+
+void point(glm::vec3 position, uint32_t colorRgba, float scale) {
+    g_state.elements().emplace_back(
+        Point {position, rgbaToVec(colorRgba), scale}, g_state.lifetime());
+}
+
+void box(glm::vec3 min, glm::vec3 max, uint32_t colorRgba) {
+    g_state.elements().emplace_back(
+        Box {min, max, rgbaToVec(colorRgba)}, g_state.lifetime());
+}
+
+} // namespace drawdebug
+} // namespace reone

--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -27,6 +27,7 @@
 #include "reone/graphics/uniforms.h"
 #include "reone/graphics/walkmesh.h"
 #include "reone/scene/collision.h"
+#include "reone/scene/drawdebug.h"
 #include "reone/scene/node/camera.h"
 #include "reone/scene/node/emitter.h"
 #include "reone/scene/node/grass.h"
@@ -523,6 +524,9 @@ Texture &SceneGraph::render(const glm::ivec2 &dim) {
             if (!_flareLights.empty()) {
                 renderLensFlares(pass);
             }
+        });
+        pipeline.inRenderPass(RenderPassName::Debug, [this, &camera](auto &pass) {
+            renderDrawDebug(pass, _graphicsSvc, _resourceSvc, name());
         });
     }
 

--- a/src/libs/scene/render/pipeline/pbr.cpp
+++ b/src/libs/scene/render/pipeline/pbr.cpp
@@ -395,6 +395,13 @@ Texture &PBRRenderPipeline::render() {
                 screenRect, screenRect);
         }
 
+        // Draw debug elements (lines, points, etc.)
+        beginDebugPass();
+        if (_passCallbacks.count(RenderPassName::Debug) > 0) {
+            _passCallbacks.at(RenderPassName::Debug)(pass);
+        }
+        endDebugPass();
+
         _context.resetDrawFramebuffer();
     });
 
@@ -520,6 +527,14 @@ void PBRRenderPipeline::beginPostProcessingPass() {
 }
 
 void PBRRenderPipeline::endPostProcessingPass() {
+}
+
+void PBRRenderPipeline::beginDebugPass() {
+    _context.bindDrawFramebuffer(*_targets.fbOutput, {0});
+    _context.clearDepth();
+}
+
+void PBRRenderPipeline::endDebugPass() {
 }
 
 } // namespace scene

--- a/src/libs/scene/render/pipeline/retro.cpp
+++ b/src/libs/scene/render/pipeline/retro.cpp
@@ -279,6 +279,13 @@ Texture &RetroRenderPipeline::render() {
             _passCallbacks.at(RenderPassName::PostProcessing)(pass);
         }
 
+        // Draw debug elements (lines, points, etc.)
+        _context.bindDrawFramebuffer(*_targets.output, {0});
+        _context.clearDepth();
+        if (_passCallbacks.count(RenderPassName::Debug) > 0) {
+            _passCallbacks.at(RenderPassName::Debug)(pass);
+        }
+
         _context.resetDrawFramebuffer();
     });
 


### PR DESCRIPTION
These functions allow to draw primitives on the scene from parts of
the engine that don't have direct access to the scene or the rendering
pipeline.

The main purpose is to visualize results of game logic and overlay
them on a scene.

For example:

```c++
#include "reone/scene/drawdebug.h"
drawdebug::pushId("perception"); // open a new scope
drawdebug::clear(); // clear elements from the previous frame
drawdebug::point(object->position(), /*color=*/0xff0000ff);
drawdebug::triangle(
    face->vertices[0],
    face->vertices[1],
    face->vertices[2],
    /*color=*/0x8b008b7f);
[...]
drawdebug::popId(); // close the current scope
```

Here we draw a point to visualize object's position, and a
semi-transparent triangle to highlight a part of a mesh.

The patch also corrects `v_billboard` shader that did not take scale
uniform into account.