### PR TITLE
[game] Convert looted credits to party gold

### DIFF
--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -36,6 +36,9 @@ namespace game {
 
 class Item : public Object {
 public:
+    // itemclass of the Credits base item in baseitems.2da, lower-cased
+    static constexpr char kCreditsItemClass[] = "i_credits";
+
     struct AmmunitionType {
         std::shared_ptr<graphics::Model> model;
         std::shared_ptr<graphics::Model> muzzleFlash;
@@ -82,6 +85,7 @@ public:
 
     bool isEquippable() const;
     bool isEquippable(int slot) const;
+    bool isCredits() const { return _itemClass == kCreditsItemClass; }
     bool isDropable() const { return _dropable; }
     bool isIdentified() const { return _identified; }
     bool isEquipped() const { return _equipped; }

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -337,6 +337,7 @@ void Object::faceAwayFrom(const Object &other) {
 }
 
 void Object::moveDropableItemsTo(Object &other) {
+    bool otherInParty = _game.party().isMember(other);
     for (auto it = _items.begin(); it != _items.end();) {
         if ((*it)->isDropable()) {
             std::shared_ptr<Item> item(*it);
@@ -344,7 +345,13 @@ void Object::moveDropableItemsTo(Object &other) {
             if (Creature *creature = dyn_cast<Creature>(this)) {
                 creature->itemAttributes().removeItem(item);
             }
-            other.addItem(item);
+            // Credits looted by the party feed the shared gold pool instead of
+            // the inventory; the stack size is the credit amount.
+            if (otherInParty && item->isCredits()) {
+                _game.party().giveGold(item->stackSize());
+            } else {
+                other.addItem(item);
+            }
         } else {
             ++it;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
+    ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/bwmreader.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -22,6 +22,7 @@
 #include "reone/game/di/services.h"
 #include "reone/system/exception/notimplemented.h"
 
+#include "reone/game/animations.h"
 #include "reone/game/camerastyles.h"
 #include "reone/game/d20/classes.h"
 #include "reone/game/d20/feats.h"
@@ -31,9 +32,11 @@
 #include "reone/game/gui/sounds.h"
 #include "reone/game/options.h"
 #include "reone/game/portraits.h"
+#include "reone/game/projectiles.h"
 #include "reone/game/reputes.h"
 #include "reone/game/surfaces.h"
 #include "reone/game/types.h"
+#include "reone/game/visualeffects.h"
 
 namespace reone {
 
@@ -84,6 +87,7 @@ public:
 class MockReputes : public IReputes, boost::noncopyable {
 public:
     MOCK_METHOD(bool, getIsEnemy, (const Creature &left, const Creature &right), (const override));
+    MOCK_METHOD(bool, getIsEnemy, (Faction left, Faction right), (const override));
     MOCK_METHOD(bool, getIsFriend, (const Creature &left, const Creature &right), (const override));
     MOCK_METHOD(bool, getIsNeutral, (const Creature &left, const Creature &right), (const override));
 };
@@ -112,6 +116,24 @@ public:
     MOCK_METHOD(std::set<uint32_t>, getLineOfSightSurfaces, (), (const override));
 };
 
+class MockProjectiles : public IProjectiles, boost::noncopyable {
+public:
+    MOCK_METHOD(void, clear, (), (override));
+    MOCK_METHOD(ProjectileSpec *, get, (ProjectileAttackType attack, CreatureWieldType wield, int appearance), (override));
+};
+
+class MockAnimations : public IAnimations, boost::noncopyable {
+public:
+    MOCK_METHOD(void, clear, (), (override));
+    MOCK_METHOD(std::string, getNameById, (uint32_t id), (const override));
+    MOCK_METHOD(std::string, getAttackResult, (std::string attackAnim, CreatureWieldType targetWield, AttackResultType result), (const override));
+};
+
+class MockVisualEffects : public IVisualEffects, boost::noncopyable {
+public:
+    MOCK_METHOD(std::optional<const VisualEffectDesc *>, get, (uint32_t id), (const override));
+};
+
 class TestGameModule : boost::noncopyable {
 public:
     void init() {
@@ -125,6 +147,9 @@ public:
         _skills = std::make_unique<MockSkills>();
         _spells = std::make_unique<MockSpells>();
         _surfaces = std::make_unique<MockSurfaces>();
+        _projectiles = std::make_unique<MockProjectiles>();
+        _animations = std::make_unique<MockAnimations>();
+        _visualEffects = std::make_unique<MockVisualEffects>();
 
         _services = std::make_unique<GameServices>(
             *_cameraStyles,
@@ -136,7 +161,10 @@ public:
             *_reputes,
             *_skills,
             *_spells,
-            *_surfaces);
+            *_surfaces,
+            *_projectiles,
+            *_animations,
+            *_visualEffects);
     }
 
     GameServices &services() {
@@ -154,6 +182,9 @@ private:
     std::unique_ptr<MockSkills> _skills;
     std::unique_ptr<MockSpells> _spells;
     std::unique_ptr<MockSurfaces> _surfaces;
+    std::unique_ptr<MockProjectiles> _projectiles;
+    std::unique_ptr<MockAnimations> _animations;
+    std::unique_ptr<MockVisualEffects> _visualEffects;
 
     std::unique_ptr<GameServices> _services;
 };

--- a/test/fixtures/gui.h
+++ b/test/fixtures/gui.h
@@ -30,11 +30,11 @@ class MockGUI : public IGUI, boost::noncopyable {
 public:
     MOCK_METHOD(void, load, (const resource::Gff &), (override));
 
-    MOCK_METHOD(bool, handle, (const SDL_Event &), (override));
+    MOCK_METHOD(bool, handle, (const input::Event &), (override));
     MOCK_METHOD(void, update, (float), (override));
     MOCK_METHOD(void, render, (), (override));
 
-    MOCK_METHOD(void, resetFocus, (), (override));
+    MOCK_METHOD(void, clearSelection, (), (override));
 
     MOCK_METHOD(Control &, rootControl, (), (override));
 
@@ -49,7 +49,8 @@ public:
     MOCK_METHOD(void, setBackground, (std::shared_ptr<graphics::Texture>), (override));
 
     MOCK_METHOD(std::unique_ptr<Control>, newControl, (ControlType, std::string), (override));
-    MOCK_METHOD(void, addControl, (std::shared_ptr<Control>), (override));
+    MOCK_METHOD(void, addControlToFront, (std::shared_ptr<Control>), (override));
+    MOCK_METHOD(void, addControlToBack, (std::shared_ptr<Control>), (override));
 
     MOCK_METHOD(std::shared_ptr<Control>, findControl, (const std::string &), (const override));
 };

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -254,6 +254,10 @@ public:
         return *_models;
     }
 
+    MockTextures &textures() {
+        return *_textures;
+    }
+
     MockWalkmeshes &walkmeshes() {
         return *_walkmeshes;
     }

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/object/item.h"
+#include "reone/game/object/placeable.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/gff.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+
+class StubConsole : public IConsole, boost::noncopyable {
+public:
+    void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
+    void printLine(const std::string &text) override {}
+};
+
+// TestEngine initializes the Logger singleton, which only tolerates a single
+// init per process.
+TestEngine &testEngine() {
+    static TestEngine engine;
+    static bool initialized = false;
+    if (!initialized) {
+        engine.init();
+        initialized = true;
+    }
+    return engine;
+}
+
+std::shared_ptr<TwoDA> makeBaseItemsTable() {
+    TwoDA::Builder builder;
+    builder.columns({"maxattackrange", "crithitmult", "critthreat", "damageflags", "dietoroll",
+                     "equipableslots", "itemclass", "numdice", "weapontype", "weaponwield",
+                     "ammunitiontype"});
+    builder.row({"", "", "", "", "", "", "I_Credits", "", "", "", ""});
+    builder.row({"", "", "", "", "", "", "I_Datapad", "", "", "", ""});
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int stackSize) {
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newCExoString("Tag", std::move(tag)))
+                   .field(Gff::Field::newInt("BaseItem", baseItem))
+                   .field(Gff::Field::newWord("StackSize", stackSize))
+                   .build();
+    auto item = game.newItem();
+    item->deserialize(*gff);
+    item->setDropable(true);
+    return item;
+}
+
+} // namespace
+
+TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeBaseItemsTable()));
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    auto footlocker = game.newPlaceable();
+    footlocker->addItem(makeItem(game, "g_i_credits001", 0, 5));
+    footlocker->addItem(makeItem(game, "g_i_credits002", 0, 10));
+    footlocker->addItem(makeItem(game, "g_i_datapad001", 1, 1));
+
+    footlocker->moveDropableItemsTo(*player);
+
+    EXPECT_EQ(game.party().gold(), 15);
+    ASSERT_EQ(player->items().size(), 1);
+    EXPECT_EQ(player->items().front()->tag(), "g_i_datapad001");
+    EXPECT_EQ(player->items().front()->stackSize(), 1);
+    EXPECT_TRUE(footlocker->items().empty());
+}
+
+TEST(Object, should_move_credits_as_items_when_destination_is_not_in_party) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeBaseItemsTable()));
+
+    auto thug = game.newCreature();
+
+    auto footlocker = game.newPlaceable();
+    footlocker->addItem(makeItem(game, "g_i_credits001", 0, 5));
+
+    footlocker->moveDropableItemsTo(*thug);
+
+    EXPECT_EQ(game.party().gold(), 0);
+    ASSERT_EQ(thug->items().size(), 1);
+    EXPECT_EQ(thug->items().front()->tag(), "g_i_credits001");
+    EXPECT_TRUE(footlocker->items().empty());
+}

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -83,6 +83,10 @@ TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {
     EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
         .Times(AnyNumber())
         .WillRepeatedly(Return(makeBaseItemsTable()));
+    // Item deserialization incidentally looks up inventory icons; no texture
+    // is needed.
+    EXPECT_CALL(engine.resourceModule().textures(), get(AnyOf("ii_credits_000", "ii_datapad_000"), _))
+        .Times(AnyNumber());
 
     auto player = game.newCreature();
     game.party().addMember(kNpcPlayer, player);
@@ -109,6 +113,10 @@ TEST(Object, should_move_credits_as_items_when_destination_is_not_in_party) {
     EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
         .Times(AnyNumber())
         .WillRepeatedly(Return(makeBaseItemsTable()));
+    // Item deserialization incidentally looks up inventory icons; no texture
+    // is needed.
+    EXPECT_CALL(engine.resourceModule().textures(), get("ii_credits_000", _))
+        .Times(AnyNumber());
 
     auto thug = game.newCreature();
 


### PR DESCRIPTION
## Summary

Routes looted credit item stacks into the shared party gold pool instead of adding them to player inventory as ordinary items.

Credit items are detected from the loaded `baseitems.2da` item class (`I_Credits`), not by resref/tag lists. The awarded amount comes from the item stack size, matching the credit UTI denominations.