### PR TITLE
[UI] Show party credits in the inventory menu

### DIFF
--- a/include/reone/game/gui/ingame/inventory.h
+++ b/include/reone/game/gui/ingame/inventory.h
@@ -103,6 +103,7 @@ private:
     void onGUILoaded() override;
     void configureItemsListBox();
     void configureFilterControls();
+    void refreshCredits();
     void refreshStats();
     void advanceK1Filter();
     void setFilter(InventoryFilter filter);

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -371,6 +371,7 @@ void InventoryMenu::configureFilterControls() {
 }
 
 void InventoryMenu::refreshPortraits() {
+    refreshCredits();
     refreshStats();
 
     if (!!_game.isTSL())
@@ -388,6 +389,14 @@ void InventoryMenu::refreshPortraits() {
 
     _controls.BTN_CHANGE2->setBorderFill(partyMember2 ? partyMember2->portrait() : nullptr);
     _controls.BTN_CHANGE2->setHilightFill(partyMember2 ? partyMember2->portrait() : nullptr);
+}
+
+void InventoryMenu::refreshCredits() {
+    if (!_controls.LBL_CREDITS_VALUE) {
+        return;
+    }
+    _controls.LBL_CREDITS_VALUE->setTextMessage(std::to_string(_game.party().gold()));
+    _controls.LBL_CREDITS_VALUE->setVisible(true);
 }
 
 void InventoryMenu::refreshStats() {


### PR DESCRIPTION
## Summary
Implements the shared party credit total in the inventory menu.

`LBL_CREDITS_VALUE` already exists in the inventory GUI but was hidden to avoid showing its baked-in placeholder value. This change keeps the initial hide, then populates the label from `party().gold()` when the inventory tab refreshes and makes it visible once the real value is set.  