### PR TITLE
[game] Support door keys

### DIFF
--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -57,7 +57,10 @@ public:
     bool isLocked() const { return _locked; }
     bool isStatic() const { return _static; }
     bool isKeyRequired() const { return _keyRequired; }
+    bool isAutoRemoveKey() const { return _autoRemoveKey; }
     bool isNotBlastable() const { return _notBlastable; }
+
+    const std::string &keyName() const { return _keyName; }
 
     void onOpen(uint32_t triggererId);
     void onFailToOpen(const Object &triggerer);

--- a/src/libs/game/action/opendoor.cpp
+++ b/src/libs/game/action/opendoor.cpp
@@ -36,6 +36,25 @@ void OpenDoorAction::execute(std::shared_ptr<Action> self, Object &actor, float 
         creature.face(*_door);
     }
 
+    if (_door->isLocked() && _door->isKeyRequired() && !_door->keyName().empty()) {
+        Object *keyOwner = &actor;
+        auto key = actor.getItemByTag(_door->keyName());
+        if (!key) {
+            auto player = _game.party().player();
+            if (player && player->id() != actor.id()) {
+                key = player->getItemByTag(_door->keyName());
+                keyOwner = player.get();
+            }
+        }
+        if (key) {
+            _door->setLocked(false);
+            if (_door->isAutoRemoveKey()) {
+                bool last;
+                keyOwner->removeItem(key, last);
+            }
+        }
+    }
+
     if (!_door->isLocked()) {
         _door->open();
     }

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -90,7 +90,9 @@ void Door::deserializeAll(const resource::Gff &gff) {
     gff.readShort(_currentHitPoints, "CurrentHP");
     gff.readBool(_plot, "Plot");
     gff.readBool(_minOneHP, "Min1HP");
-    gff.readString(_keyName, "KeyName");
+    if (gff.readString(_keyName, "KeyName")) {
+        boost::to_lower(_keyName);
+    }
     gff.readBool(_keyRequired, "KeyRequired");
     gff.readByte(_openLockDC, "OpenLockDC");
     gff.readByte(_closeLockDC, "CloseLockDC");


### PR DESCRIPTION
## Summary

Fixes #186.

Adds door key handling for locked doors with `KeyRequired`, `KeyName`, and `AutoRemoveKey` metadata.

When opening a locked key-required door, the open action now checks the acting creature/player inventory for an item whose tag matches the door `KeyName`. If the key is present, the door unlocks and opens. If `AutoRemoveKey` is set, one matching key item is consumed only after successful key use.

## Validation
Manual smoke:

Taris (no auto remove key):
  * console commands: `warp tar_m10ac`, `additem tar10_garagekey`, `setposition 99 50 0.78`
  * `ptar_lockdoor` without `tar10_garagekey` stayed locked/closed
  * `ptar_lockdoor` with `tar10_garagekey` unlocked/opened and retained the key because `AutoRemoveKey=0`

Manaan (auto remove key):
  * console commands: `warp manm26ae`, `additem w_repkey`, `setposition 77.6 80.0 56.0`
  * `man26ac_door03` without `w_repkey` stayed locked/closed
  * `man26ac_door03` with `w_repkey` unlocked/opened and consumed the key because `AutoRemoveKey=1`

## Note

Linked-module doors appear to bypass `OpenDoorAction` in the click path and will need to be addressed separately. 
