### PR TITLE
[game] Fix doubled creature class levels on blueprint load

### DIFF
--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -109,7 +109,11 @@ void Creature::loadFromBlueprint(const std::string &resRef) {
     if (!utc) {
         return;
     }
-    deserialize(*utc);
+    // A blueprint is a single source, so deserialize it once. Routing through
+    // deserialize() would re-read the self-referential TemplateResRef and
+    // deserialize the same data twice, doubling accumulated class levels.
+    deserializeAll(*utc);
+    updateTransform();
     loadAppearance();
 }
 


### PR DESCRIPTION
## Summary

Fixes #190.

Fixes doubled creature class levels when loading creatures directly from UTC blueprints.

`Creature::loadFromBlueprint` previously routed the UTC through `Creature::deserialize()`, which is intended for GIT instance overlay loading. For a UTC blueprint whose `TemplateResRef` points back to itself, that caused the same blueprint to be deserialized twice. Ability scores were overwritten safely, but class levels were accumulated via `addClassLevels`, so blueprint-spawned creatures could end up at double their intended level.

This caused Calo Nord’s `tar08_calo082` UTC to load as Soldier level 28 instead of level 14, which then overran the 20-row soldier attack bonus table.

## Summary

The fix deserializes blueprint UTCs once in `loadFromBlueprint`, preserving the existing post-load transform/appearance setup. GIT instance template-overlay loading remains unchanged.

## Validation
manual smoke:
  * Calo/Davik path no longer crashes with `Level out of range: 28/20`
  * log check found no `Level out of range`, `out_of_range`, or `terminate`
  * prior diagnostic confirmed `tar08_calo082` now loads as aggregate level 14 instead of 28
  * level-1 blueprint spawn remained level 1 rather than doubling to 2