### PR TITLE
[script] Implement area object iterator routines

### DIFF
--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -105,6 +105,7 @@ enum class ArgKind {
     LastDamager,
     SpellId,
     SpellLocation,
+    ObjectsInArea,
     ObjectsInShape,
     ScriptParam1,
     ScriptParam2,

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -910,11 +910,7 @@ static std::shared_ptr<Area> getAreaOrCurrent(const std::vector<Variable> &args,
         return currentArea;
     }
 
-    auto object = getObject(args, index, ctx);
-    if (object->type() != ObjectType::Area) {
-        return nullptr;
-    }
-    return std::static_pointer_cast<Area>(object);
+    return dyn_cast<Area>(getObject(args, index, ctx));
 }
 
 static bool matchesObjectFilter(const Object &object, int objectFilter) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -891,26 +891,115 @@ static Variable IntToString(const std::vector<Variable> &args, const RoutineCont
     return Variable::ofString(std::to_string(nInteger));
 }
 
+struct ObjectsInArea : public EngineType {
+    std::vector<uint32_t> objects;
+    uint32_t area {script::kObjectInvalid};
+    int objectFilter {0};
+};
+
+static std::shared_ptr<Area> getAreaOrCurrent(const std::vector<Variable> &args, int index, const RoutineContext &ctx) {
+    auto module = ctx.game.module();
+    auto currentArea = module ? module->area() : nullptr;
+    if (index < 0 || index >= args.size()) {
+        return currentArea;
+    }
+    if (args[index].type != VariableType::Object) {
+        throw RoutineArgumentException("Expected object argument");
+    }
+    if (args[index].objectId == script::kObjectInvalid) {
+        return currentArea;
+    }
+
+    auto object = getObject(args, index, ctx);
+    if (object->type() != ObjectType::Area) {
+        return nullptr;
+    }
+    return std::static_pointer_cast<Area>(object);
+}
+
+static bool matchesObjectFilter(const Object &object, int objectFilter) {
+    return static_cast<int>(object.type()) & objectFilter;
+}
+
 static Variable GetFirstObjectInArea(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
-    auto oArea = getObjectOrNull(args, 0, ctx);
+    auto oArea = getAreaOrCurrent(args, 0, ctx);
     auto nObjectFilter = getIntOrElse(args, 1, 1);
 
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("GetFirstObjectInArea");
+    if (!oArea) {
+        return Variable::ofObject(script::kObjectInvalid);
+    }
+
+    SmallVector<uint32_t, 16> foundObjects;
+    for (auto it = oArea->objects().rbegin(), end = oArea->objects().rend(); it != end; ++it) {
+        const std::shared_ptr<Object> &object = *it;
+        if (!matchesObjectFilter(*object, nObjectFilter)) {
+            continue;
+        }
+        foundObjects.push_back(object->id());
+    }
+
+    if (foundObjects.empty()) {
+        return Variable::ofObject(script::kObjectInvalid);
+    }
+
+    uint32_t firstObject = foundObjects.back();
+    foundObjects.resize(foundObjects.size() - 1);
+    if (foundObjects.empty()) {
+        return Variable::ofObject(firstObject);
+    }
+
+    auto objectsArg = std::make_shared<ObjectsInArea>();
+    objectsArg->objects.reserve(foundObjects.size());
+    for (uint32_t object : foundObjects) {
+        objectsArg->objects.push_back(object);
+    }
+    objectsArg->area = oArea->id();
+    objectsArg->objectFilter = nObjectFilter;
+
+    ctx.execution.args.push_back(
+        Argument(ArgKind::ObjectsInArea, Variable::ofCustom(objectsArg)));
+
+    return Variable::ofObject(firstObject);
 }
 
 static Variable GetNextObjectInArea(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
-    auto oArea = getObjectOrNull(args, 0, ctx);
+    auto oArea = getAreaOrCurrent(args, 0, ctx);
     auto nObjectFilter = getIntOrElse(args, 1, 1);
 
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("GetNextObjectInArea");
+    if (!oArea) {
+        return Variable::ofObject(script::kObjectInvalid);
+    }
+
+    auto &scriptArgs = ctx.execution.args;
+    for (auto it = scriptArgs.rbegin(), end = scriptArgs.rend(); it != end; ++it) {
+        if (it->kind != ArgKind::ObjectsInArea) {
+            continue;
+        }
+        assert(it->var.type == VariableType::Custom);
+
+        auto objects = std::static_pointer_cast<ObjectsInArea>(it->var.engineType);
+        if (objects->area != oArea->id() || objects->objectFilter != nObjectFilter) {
+            continue;
+        }
+
+        if (objects->objects.empty()) {
+            return Variable::ofObject(script::kObjectInvalid);
+        }
+
+        uint32_t nextObject = objects->objects.back();
+        objects->objects.pop_back();
+        return Variable::ofObject(nextObject);
+    }
+
+    return Variable::ofObject(script::kObjectInvalid);
 }
 
 static Variable d2(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -191,6 +191,8 @@ const char *argKindToString(ArgKind kind) {
         return "SpellId";
     case ArgKind::SpellLocation:
         return "SpellLocation";
+    case ArgKind::ObjectsInArea:
+        return "ObjectsInArea";
     case ArgKind::ObjectsInShape:
         return "ObjectsInShape";
     case ArgKind::ScriptParam1:
@@ -375,6 +377,7 @@ void Argument::verify() {
         return;
     }
 
+    case ArgKind::ObjectsInArea:
     case ArgKind::ObjectsInShape: {
         if (var.type != VariableType::Custom) {
             throw std::invalid_argument(toString() + ": expected a custom object");


### PR DESCRIPTION
## Summary

Fixes #187.

Implements the NWScript area object iterator routines:

* `GetFirstObjectInArea`
* `GetNextObjectInArea`

Iterator state is stored in script execution arguments via a new `ArgKind::ObjectsInArea`, mirroring the existing `ObjectsInShape` iterator pattern.

The routines resolve `OBJECT_INVALID` / omitted area to the current module area, filter objects by the supplied object-type bitmask, and return `OBJECT_INVALID` once iteration is exhausted.
