### PR TITLE
[scene] Keep lip animations alive in model channels

### DIFF
--- a/include/reone/scene/node/model.h
+++ b/include/reone/scene/node/model.h
@@ -67,7 +67,7 @@ public:
 
     struct AnimationChannel {
         graphics::Animation *anim;
-        graphics::LipAnimation *lipAnim;
+        std::shared_ptr<graphics::LipAnimation> lipAnim;
         AnimationProperties properties;
         float time {0.0f};
         std::unordered_map<uint16_t, AnimationState> stateByNodeNumber;
@@ -75,9 +75,9 @@ public:
         bool transition {false}; /**< when computing states, use animation transition time as channel time */
         bool finished {false};   /**< finished channels will be erased from the queue */
 
-        AnimationChannel(graphics::Animation &anim, graphics::LipAnimation *lipAnim, AnimationProperties properties) :
+        AnimationChannel(graphics::Animation &anim, std::shared_ptr<graphics::LipAnimation> lipAnim, AnimationProperties properties) :
             anim(&anim),
-            lipAnim(lipAnim),
+            lipAnim(std::move(lipAnim)),
             properties(std::move(properties)) {
         }
     };
@@ -126,8 +126,8 @@ public:
 
     // Animation
 
-    void playAnimation(const std::string &name, graphics::LipAnimation *lipAnim = nullptr, AnimationProperties properties = AnimationProperties());
-    void playAnimation(graphics::Animation &anim, graphics::LipAnimation *lipAnim = nullptr, AnimationProperties properties = AnimationProperties());
+    void playAnimation(const std::string &name, std::shared_ptr<graphics::LipAnimation> lipAnim = nullptr, AnimationProperties properties = AnimationProperties());
+    void playAnimation(graphics::Animation &anim, std::shared_ptr<graphics::LipAnimation> lipAnim = nullptr, AnimationProperties properties = AnimationProperties());
 
     void pauseAnimation();
     void resumeAnimation();

--- a/src/apps/toolkit/view/resource/modelpanel.cpp
+++ b/src/apps/toolkit/view/resource/modelpanel.cpp
@@ -200,7 +200,7 @@ void ModelResourcePanel::OnLipLoadCommand(wxCommandEvent &event) {
     auto reader = LipReader(lip, "");
     reader.load();
     m_lipAnim = reader.animation();
-    m_viewModel.playAnimation("talk", m_lipAnim.get());
+    m_viewModel.playAnimation("talk", m_lipAnim);
 }
 
 } // namespace reone

--- a/src/apps/toolkit/viewmodel/resource/model.cpp
+++ b/src/apps/toolkit/viewmodel/resource/model.cpp
@@ -120,11 +120,11 @@ void ModelResourceViewModel::render3D(int w, int h) {
     });
 }
 
-void ModelResourceViewModel::playAnimation(std::string anim, graphics::LipAnimation *lipAnim) {
+void ModelResourceViewModel::playAnimation(std::string anim, std::shared_ptr<graphics::LipAnimation> lipAnim) {
     if (!_modelNode) {
         return;
     }
-    _modelNode->playAnimation(anim, lipAnim, AnimationProperties::fromFlags(AnimationFlags::loop));
+    _modelNode->playAnimation(anim, std::move(lipAnim), AnimationProperties::fromFlags(AnimationFlags::loop));
     _animationPlaying = true;
 }
 

--- a/src/apps/toolkit/viewmodel/resource/model.h
+++ b/src/apps/toolkit/viewmodel/resource/model.h
@@ -76,7 +76,7 @@ public:
     void update3D();
     void render3D(int w, int h);
 
-    void playAnimation(std::string anim, graphics::LipAnimation *lipAnim = nullptr);
+    void playAnimation(std::string anim, std::shared_ptr<graphics::LipAnimation> lipAnim = nullptr);
     void pauseAnimation();
     void resumeAnimation();
     void setAnimationTime(float time);

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -247,14 +247,14 @@ void Creature::updateModelAnimation() {
 
     if (talkAnim && anim) {
         model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
-        model->playAnimation(*talkAnim, _lipAnimation.get(), AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
+        model->playAnimation(*talkAnim, _lipAnimation, AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
     } else {
         if (anim) {
             model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
         }
 
         if (talkAnim) {
-            model->playAnimation(*talkAnim, _lipAnimation.get(), AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
+            model->playAnimation(*talkAnim, _lipAnimation, AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
         }
     }
 

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -192,14 +192,14 @@ void ModelSceneNode::setEnvironmentMap(Texture *texture) {
     }
 }
 
-void ModelSceneNode::playAnimation(const std::string &name, graphics::LipAnimation *lipAnim, AnimationProperties properties) {
+void ModelSceneNode::playAnimation(const std::string &name, std::shared_ptr<LipAnimation> lipAnim, AnimationProperties properties) {
     auto anim = _model->getAnimation(name);
     if (anim) {
-        playAnimation(*anim, lipAnim, std::move(properties));
+        playAnimation(*anim, std::move(lipAnim), std::move(properties));
     }
 }
 
-void ModelSceneNode::playAnimation(Animation &anim, LipAnimation *lipAnim, AnimationProperties properties) {
+void ModelSceneNode::playAnimation(Animation &anim, std::shared_ptr<LipAnimation> lipAnim, AnimationProperties properties) {
     if (properties.scale == 0.0f) {
         properties.scale = _model->animationScale();
     }

--- a/test/scene/model.cpp
+++ b/test/scene/model.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/game/types.h"
 #include "reone/graphics/animation.h"
+#include "reone/graphics/lipanimation.h"
 #include "reone/graphics/mesh.h"
 #include "reone/graphics/options.h"
 #include "reone/scene/graphs.h"
@@ -417,4 +418,62 @@ TEST(ModelSceneNode, pick_model_at) {
     ModelSceneNode *picked1 =
         scene->pickModelAt(graphicsOpt.width / 2, graphicsOpt.height / 2, nullptr);
     EXPECT_EQ(dummy1.get(), picked1);
+}
+
+TEST(ModelSceneNode, should_keep_lip_animation_alive_for_channel_lifetime) {
+    // given
+    auto graphicsOpt = GraphicsOptions();
+    auto pipelineFactory = MockRenderPipelineFactory();
+
+    auto graphicsModule = TestGraphicsModule();
+    graphicsModule.init();
+
+    auto audioModule = TestAudioModule();
+    audioModule.init();
+
+    auto resourceModule = TestResourceModule();
+    resourceModule.init();
+
+    auto scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt, graphicsModule.services(), audioModule.services(), resourceModule.services());
+
+    auto rootNode = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+
+    auto animRootNode = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), false, nullptr);
+    animRootNode->vectorTracks()[ControllerTypes::position].add(0.0f, glm::vec3(0.0f));
+    animRootNode->vectorTracks()[ControllerTypes::position].add(1.0f, glm::vec3(1.0f, 2.0f, 3.0f));
+
+    auto animations = std::vector<std::shared_ptr<Animation>> {
+        std::make_shared<Animation>("talk", 1.0f, 0.5f, "root_node", animRootNode, std::vector<Animation::Event>())};
+
+    auto model = Model("some_model", 0, rootNode, animations, "", 1.0f);
+    auto modelSceneNode = std::make_shared<ModelSceneNode>(
+        model,
+        ModelUsage::Creature,
+        *scene,
+        graphicsModule.services(),
+        audioModule.services(),
+        resourceModule.services());
+
+    auto lipAnim = std::make_shared<LipAnimation>(
+        "talk", 1.0f, std::vector<LipAnimation::Keyframe> {{0.0f, 0}, {1.0f, 1}});
+
+    // when
+    modelSceneNode->init();
+    modelSceneNode->playAnimation("talk", lipAnim, AnimationProperties::fromFlags(AnimationFlags::loop));
+
+    // then: the channel co-owns the lip animation
+    ASSERT_EQ(1ll, modelSceneNode->animationChannels().size());
+    EXPECT_EQ(2l, lipAnim.use_count());
+
+    // when: the external owner releases while the looping channel is still active
+    modelSceneNode->update(0.5f);
+    lipAnim.reset();
+    modelSceneNode->update(0.5f);
+
+    // then: the lip animation is still alive, kept by the channel, and usable
+    auto &channels = modelSceneNode->animationChannels();
+    ASSERT_EQ(1ll, channels.size());
+    ASSERT_TRUE(static_cast<bool>(channels[0].lipAnim));
+    EXPECT_EQ(1l, channels[0].lipAnim.use_count());
+    EXPECT_NEAR(1.0f, channels[0].lipAnim->length(), 1e-5);
 }


### PR DESCRIPTION
## Summary

Fixes #180.

Fixes a use-after-free when model animation channels play lip animations.

`ModelSceneNode` previously stored lip animations as raw pointers. During module transitions and speaker changes, the owning `Conversation`, `Creature`, and `Lips` cache references can be released while a looping talk channel still uses the old pointer.

This changes `AnimationChannel::lipAnim` to hold a `shared_ptr<LipAnimation>` so the channel keeps the lip animation alive for its own lifetime. Normal model animation ownership is unchanged.

## Validation

* added regression test: `ModelSceneNode.should_keep_lip_animation_alive_for_channel_lifetime`
* manual smoke:
  * loaded `tar_m03aa` and took elevator to `tar_m04aa`
  * engine continued running without crash/assert/lip-animation errors
  * log check found no UAF, terminate, crash, assert, or animation/lip errors