### PR TITLE
[game] Apply lock checks to linked-module doors

### DIFF
--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -15,15 +15,42 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "commonactions.h"
+
 #include "reone/game/action.h"
 #include "reone/game/object.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/door.h"
+#include "reone/game/object/item.h"
 #include "reone/game/object/placeable.h"
+#include "reone/game/party.h"
 
 namespace reone {
 
 namespace game {
+
+void tryUnlockDoorWithKey(Door &door, Object &actor, Party &party) {
+    if (!door.isLocked() || !door.isKeyRequired() || door.keyName().empty()) {
+        return;
+    }
+    Object *keyOwner = &actor;
+    auto key = actor.getItemByTag(door.keyName());
+    if (!key) {
+        auto player = party.player();
+        if (player && player->id() != actor.id()) {
+            key = player->getItemByTag(door.keyName());
+            keyOwner = player.get();
+        }
+    }
+    if (!key) {
+        return;
+    }
+    door.setLocked(false);
+    if (door.isAutoRemoveKey()) {
+        bool last;
+        keyOwner->removeItem(key, last);
+    }
+}
 
 bool unlockDoor(Door &door, Object &actor, float distance, float dt) {
     if (actor.type() == ObjectType::Creature) {

--- a/src/libs/game/action/commonactions.h
+++ b/src/libs/game/action/commonactions.h
@@ -23,7 +23,13 @@ namespace game {
 
 class Door;
 class Object;
+class Party;
 class Placeable;
+
+// If the door is locked and requires a named key, look for that key in the
+// actor's inventory and then the party player's, unlock the door if found, and
+// consume one key when AutoRemoveKey is set. Leaves the door locked otherwise.
+void tryUnlockDoorWithKey(Door &door, Object &actor, Party &party);
 
 // Move an actor to a door, unlock and open it. Returns true when this action is
 // complete.

--- a/src/libs/game/action/opendoor.cpp
+++ b/src/libs/game/action/opendoor.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/action/opendoor.h"
 
+#include "commonactions.h"
+
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/door.h"
@@ -36,24 +38,7 @@ void OpenDoorAction::execute(std::shared_ptr<Action> self, Object &actor, float 
         creature.face(*_door);
     }
 
-    if (_door->isLocked() && _door->isKeyRequired() && !_door->keyName().empty()) {
-        Object *keyOwner = &actor;
-        auto key = actor.getItemByTag(_door->keyName());
-        if (!key) {
-            auto player = _game.party().player();
-            if (player && player->id() != actor.id()) {
-                key = player->getItemByTag(_door->keyName());
-                keyOwner = player.get();
-            }
-        }
-        if (key) {
-            _door->setLocked(false);
-            if (_door->isAutoRemoveKey()) {
-                bool last;
-                keyOwner->removeItem(key, last);
-            }
-        }
-    }
+    tryUnlockDoorWithKey(*_door, actor, _game.party());
 
     if (!_door->isLocked()) {
         _door->open();

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -33,6 +33,8 @@
 #include "reone/system/exception/validation.h"
 #include "reone/system/logutil.h"
 
+#include "../action/commonactions.h"
+
 #include <boost/algorithm/string/case_conv.hpp>
 
 using namespace reone::graphics;
@@ -298,6 +300,14 @@ void Module::onCreatureClick(const std::shared_ptr<Creature> &creature) {
 
 void Module::onDoorClick(const std::shared_ptr<Door> &door) {
     if (!door->linkedToModule().empty() && door->getOnOpen().empty()) {
+        std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
+        if (door->isLocked()) {
+            tryUnlockDoorWithKey(*door, *partyLeader, _game.party());
+        }
+        if (door->isLocked()) {
+            door->onFailToOpen(*partyLeader);
+            return;
+        }
         _game.scheduleModuleTransition(door->linkedToModule(), door->linkedTo());
         return;
     }


### PR DESCRIPTION
## Summary

Applies normal lock/key handling to linked-module transition doors exposed / noted in PR #198 

`Module::onDoorClick` previously transitioned immediately through doors with `LinkedToModule` and no `OnOpen` script, before `OpenDoorAction` could run. That let locked/key-required transition doors bypass key checks, `AutoRemoveKey`, and `OnFailToOpen`.

This extracts the existing door-key logic into a shared `tryUnlockDoorWithKey` helper and uses it from both `OpenDoorAction` and the linked-door transition path.

Unlocked linked doors still transition as before. Linked doors with `OnOpen` scripts and non-linked doors are unaffected.

## Validation

  * `ptar_elevdoor` without `ptar_sbpasscrd` stayed blocked and did not transition
  * `ptar_elevdoor` with `ptar_sbpasscrd` transitioned to `tar_m09ab`
  * `ptar_sbpasscrd` was consumed because `AutoRemoveKey=1`
  * unlocked linked door `tar04_elevdoor` still transitioned to `tar_m04aa`
  * non-linked key door `ptar_lockdoor` still used the normal `OpenDoorAction` path

## Notes

`ptar_elevdoor` has no `OnFailToOpen`, `OnClick`, or conversation data, so failing silently without the passcard matches the existing data-driven door behaviour. Doors that define an `OnFailToOpen` script continue to use that script.  
