### PR TITLE
[script] Implement SpawnAvailableNPC

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -5423,10 +5423,22 @@ static Variable SpawnAvailableNPC(const std::vector<Variable> &args, const Routi
     auto nNPC = getInt(args, 0);
     auto lPosition = getLocationArgument(args, 1);
 
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("SpawnAvailableNPC");
+    auto member = ctx.game.party().getAvailableMember(nNPC);
+    if (!member) {
+        return Variable::ofObject(kObjectInvalid);
+    }
+    auto module = ctx.game.module();
+    auto area = module ? module->area() : nullptr;
+    if (!area) {
+        return Variable::ofObject(kObjectInvalid);
+    }
+    member->setPosition(lPosition->position());
+    member->setFacing(lPosition->facing());
+    area->landObject(*member);
+    area->add(member);
+    member->runSpawnScript();
+    return Variable::ofObject(member->id());
 }
 
 static Variable IsNPCPartyMember(const std::vector<Variable> &args, const RoutineContext &ctx) {


### PR DESCRIPTION
## Summary

Refs #151.

Implements `SpawnAvailableNPC`.

`Mod_OnModLoad` already runs, but the Taris hideout / Ebon Hawk population script `k_pebn_pophawk` calls `SpawnAvailableNPC` to place available companions. That routine was still an unimplemented stub returning `OBJECT_INVALID`.

The routine now resolves the requested available NPC from the party roster, spawns that creature in the current module area at the requested location, and returns the spawned object. If the NPC is unavailable or no module/area exists, it returns `OBJECT_INVALID`.

## Validation
  * available NPC id 0 spawned `p_bastilla` / `bastila`
  * available NPC id 2 spawned `p_carth` / `carth`
  * unavailable NPC id returned invalid/no spawn
  * log check found no `Routine not implemented: SpawnAvailableNPC`, crash, or exception