### PR TITLE
[game] Fix disguise item icon and equipped appearance

### DIFF
--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -279,6 +279,8 @@ private:
     RacialType _race {RacialType::Unknown};
     Subrace _subrace {Subrace::None};
     uint32_t _appearance {0};
+    uint32_t _appearanceBeforeDisguise {0};
+    bool _disguised {false};
     Gender _gender {Gender::Male};
     uint16_t _portraitId {0};
     bool _isPC {false};
@@ -366,6 +368,15 @@ private:
     void loadTransformFromGIT(const resource::generated::GIT_Creature_List &git);
 
     void updateModel();
+
+    // Refresh appearance-derived state (model type, speeds, footstep, envmap,
+    // portrait) for the current _appearance, without building a scene node.
+    void loadAppearanceProperties();
+
+    // Recompute the disguise appearance override from equipped items: switch to a
+    // disguise item's appearance when one is equipped, and restore the original
+    // appearance when none remains. Updates _appearance only; callers rebuild the model.
+    void updateDisguise();
     void updateCombat(float dt);
 
     void runDeathScript(uint32_t damagerId);

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -114,6 +114,9 @@ public:
     std::optional<SpellType> activateSpell() const { return _activateSpell; }
     const std::vector<PropertyEntry> &properties() const { return _properties; }
 
+    bool hasDisguise() const { return _disguiseAppearance >= 0; }
+    int disguiseAppearance() const { return _disguiseAppearance; }
+
     void setDropable(bool dropable);
     void setStackSize(int size);
     void setIdentified(bool value);
@@ -156,6 +159,7 @@ private:
     int _criticalHitMultiplier {0};
 
     std::optional<SpellType> _activateSpell;
+    int _disguiseAppearance {-1};
     std::vector<PropertyEntry> _properties;
 
     std::shared_ptr<audio::AudioSource> _audioSource;

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -1417,6 +1417,20 @@ void Creature::deserializeAll(const resource::Gff &gff) {
     // index into appearance.2da
     gff.readEnum(_appearance, "Appearance_Type");
 
+    // Savegames keep the visible disguise appearance in Appearance_Type and
+    // the normal appearance separately. Restore this before equipped items
+    // are loaded, so equipping a saved disguise does not overwrite it.
+    _disguised = false;
+    _appearanceBeforeDisguise = 0;
+    bool disguised;
+    uint16_t appearanceBeforeDisguise;
+    if (gff.readBool(disguised, "PM_IsDisguised") &&
+        disguised &&
+        gff.readWord(appearanceBeforeDisguise, "PM_Appearance")) {
+        _disguised = true;
+        _appearanceBeforeDisguise = appearanceBeforeDisguise;
+    }
+
     // in dex into gender.2da
     gff.readEnum(_gender, "Gender");
 

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -117,7 +117,7 @@ void Creature::loadFromBlueprint(const std::string &resRef) {
     loadAppearance();
 }
 
-void Creature::loadAppearance() {
+void Creature::loadAppearanceProperties() {
     std::shared_ptr<TwoDA> appearances(_services.resource.twoDas.get("appearance"));
     if (!appearances) {
         throw ResourceNotFoundException("appearance 2DA not found");
@@ -134,6 +134,10 @@ void Creature::loadAppearance() {
     } else {
         _portrait = _services.game.portraits.getTextureByAppearance(_appearance);
     }
+}
+
+void Creature::loadAppearance() {
+    loadAppearanceProperties();
 
     auto modelSceneNode = buildModel();
     if (modelSceneNode) {
@@ -382,6 +386,26 @@ bool Creature::equip(const std::string &resRef) {
     return equipped;
 }
 
+void Creature::updateDisguise() {
+    int disguiseAppearance = -1;
+    for (auto &[slot, item] : _equipment) {
+        if (item->hasDisguise()) {
+            disguiseAppearance = item->disguiseAppearance();
+            break;
+        }
+    }
+    if (disguiseAppearance >= 0) {
+        if (!_disguised) {
+            _appearanceBeforeDisguise = _appearance;
+            _disguised = true;
+        }
+        _appearance = static_cast<uint32_t>(disguiseAppearance);
+    } else if (_disguised) {
+        _appearance = _appearanceBeforeDisguise;
+        _disguised = false;
+    }
+}
+
 bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
     if (!item->isEquippable(getEquipabilitySlot(slot))) {
         return false;
@@ -389,6 +413,15 @@ bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
 
     _equipment[slot] = item;
     item->setEquipped(true);
+
+    uint32_t prevAppearance = _appearance;
+    updateDisguise();
+    if (_appearance != prevAppearance) {
+        // Refresh appearance-derived state so the in-place model swap below picks
+        // up the disguise (or restored) model; rebuilding the scene node here would
+        // orphan it from the area scene graph.
+        loadAppearanceProperties();
+    }
 
     if (_sceneNode) {
         updateModel();
@@ -412,6 +445,11 @@ void Creature::unequip(const std::shared_ptr<Item> &item) {
         }
         item->setEquipped(false);
         _equipment.erase(equipped.first);
+        uint32_t prevAppearance = _appearance;
+        updateDisguise();
+        if (_appearance != prevAppearance) {
+            loadAppearanceProperties();
+        }
         if (_sceneNode) {
             updateModel();
         }

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -152,6 +152,12 @@ void Item::deserializeBase(const resource::Gff &gff) {
         iconResRef = str(boost::format("i%s_%03d") % _itemClass % (int)_modelVariation);
     }
     _icon = _services.resource.textures.get(iconResRef, TextureUsage::GUI);
+    if (!_icon && isEquippable(InventorySlots::body)) {
+        // Some body items (e.g. disguises) key the inventory icon on ModelVariation
+        // rather than TextureVar; fall back to it when the primary icon is missing.
+        iconResRef = str(boost::format("i%s_%03d") % _itemClass % (int)_modelVariation);
+        _icon = _services.resource.textures.get(iconResRef, TextureUsage::GUI);
+    }
 }
 
 void Item::loadAmmunitionType() {

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -113,6 +113,9 @@ void Item::deserializeProperties(const resource::Gff &gff) {
             case ItemProperty::ActivateItem:
                 _activateSpell = static_cast<SpellType>(entry.subtype);
                 break;
+            case ItemProperty::Disguise:
+                _disguiseAppearance = entry.subtype;
+                break;
             default:
                 break;
             }

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -56,10 +56,31 @@ std::shared_ptr<TwoDA> makeBaseItemsTable() {
     TwoDA::Builder builder;
     builder.columns({"maxattackrange", "crithitmult", "critthreat", "damageflags", "dietoroll",
                      "equipableslots", "itemclass", "numdice", "weapontype", "weaponwield",
-                     "ammunitiontype"});
-    builder.row({"", "", "", "", "", "", "I_Credits", "", "", "", ""});
-    builder.row({"", "", "", "", "", "", "I_Datapad", "", "", "", ""});
+                     "ammunitiontype", "bodyvar"});
+    builder.row({"", "", "", "", "", "", "I_Credits", "", "", "", "", ""});
+    builder.row({"", "", "", "", "", "", "I_Datapad", "", "", "", "", ""});
+    builder.row({"", "", "", "", "", "2", "I_Disguise", "", "", "", "-1", ""});
     return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<TwoDA> makeAppearanceTable() {
+    TwoDA::Builder builder;
+    builder.columns({"modeltype", "walkdist", "rundist", "footsteptype", "envmap", "race", "racetex"});
+    builder.row({"S", "1", "1", "-1", "", "", ""});
+    builder.row({"S", "1", "1", "-1", "", "", ""});
+    builder.row({"S", "1", "1", "-1", "", "", ""});
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<Gff> makeDisguiseItemGff(int appearance) {
+    auto property = Gff::Builder()
+                        .field(Gff::Field::newWord("PropertyName", static_cast<int>(ItemProperty::Disguise)))
+                        .field(Gff::Field::newWord("Subtype", appearance))
+                        .build();
+    return Gff::Builder()
+        .field(Gff::Field::newInt("BaseItem", 2))
+        .field(Gff::Field::newList("PropertiesList", {std::move(property)}))
+        .build();
 }
 
 std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int stackSize) {
@@ -269,4 +290,37 @@ TEST(Party, should_not_share_inventory_of_non_party_placeable) {
 
     auto footlocker = game.newPlaceable();
     EXPECT_EQ(game.party().sharedInventoryReceiver(footlocker).get(), footlocker.get());
+}
+
+TEST(Object, should_restore_saved_appearance_after_unequipping_loaded_disguise) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("appearance"))
+        .WillRepeatedly(Return(makeAppearanceTable()));
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+        .WillRepeatedly(Return(makeBaseItemsTable()));
+    EXPECT_CALL(engine.resourceModule().textures(), get(_, _))
+        .Times(AnyNumber());
+    EXPECT_CALL(engine.resourceModule().models(), get(_))
+        .Times(AnyNumber());
+    EXPECT_CALL(static_cast<MockPortraits &>(engine.services().game.portraits), getTextureByAppearance(_))
+        .Times(AnyNumber());
+
+    auto creatureGff = Gff::Builder()
+                           .field(Gff::Field::newWord("Appearance_Type", 2))
+                           .field(Gff::Field::newByte("PM_IsDisguised", 1))
+                           .field(Gff::Field::newWord("PM_Appearance", 1))
+                           .field(Gff::Field::newList("Equip_ItemList", {makeDisguiseItemGff(2)}))
+                           .build();
+    auto creature = game.newCreature();
+    creature->deserialize(*creatureGff);
+
+    ASSERT_EQ(creature->appearance(), 2);
+    auto disguise = creature->getEquippedItem(InventorySlots::body);
+    ASSERT_TRUE(disguise);
+
+    creature->unequip(disguise);
+
+    EXPECT_EQ(creature->appearance(), 1);
 }


### PR DESCRIPTION
## Summary

Fixes #179.

Fixes Sith Armor’s blank icon and missing disguise appearance.

This PR handles two bounded item/equipment issues:

* Body-item icon lookup now falls back to `ModelVariation` when the normal `TextureVar` icon lookup fails. This lets disguise items such as Sith Armor resolve icons like `ia_disguise_001` without hardcoding the item or texture.
* Equipped items with the `Disguise` item property now override the wearer’s appearance to the property subtype row from `appearance.2da`, and restore the original appearance when unequipped or replaced.

The live appearance swap uses the existing in-place model update path rather than rebuilding/replacing the creature scene node, so the visible model remains attached to the controllable creature.

## Notes

This implements the equipped item disguise path only, not script-applied disguise effects.
