### PR TITLE
[game] Process module object actions each frame

### DIFF
--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -325,6 +325,11 @@ void Module::onPlaceableClick(const std::shared_ptr<Placeable> &placeable) {
 }
 
 void Module::update(float dt) {
+    // Process the module object's own action queue so delayed/assigned commands
+    // scheduled by module scripts (e.g. Mod_OnModLoad) execute. Without this the
+    // module is never ticked and its DelayCommand continuations never run.
+    Object::update(dt);
+
     if (_game.cameraType() == CameraType::ThirdPerson) {
         _player->update(dt);
     }


### PR DESCRIPTION
## Summary

Follow-up to #151.

Processes the module object’s own action queue each frame.

`Mod_OnModLoad` scripts run with the module as the caller, and scripts such as `k_pebn_pophawk` defer work through `DelayCommand`, which queues continuations on that caller. Since `Module::update` never ticked the module object itself, those deferred actions never ran.

This calls `Object::update(dt)` from `Module::update`, before the existing player/area update path. `OBJECT_SELF` semantics remain unchanged, and `SpawnAvailableNPC` is not touched.

## Verification

manual smoke:
- reproduced the post-swoop apartment return path
- Bastila appeared in the apartment