### PR TITLE
[game] Route party-acquired items to the shared inventory

### DIFF
--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -121,6 +121,19 @@ public:
 
     // END Experience
 
+    // Inventory
+    //
+    // KOTOR keeps a single shared party inventory, modelled here as the player
+    // creature's item list. Non-equipped items acquired by any party member
+    // belong to that shared inventory.
+
+    // Returns the object that should receive a newly acquired, non-equipped
+    // item: the player creature when the intended receiver is a party member,
+    // otherwise the receiver unchanged (so non-party inventories stay separate).
+    std::shared_ptr<Object> sharedInventoryReceiver(const std::shared_ptr<Object> &receiver) const;
+
+    // END Inventory
+
 private:
     Game &_game;
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -2393,7 +2393,8 @@ void Game::consoleAddItem(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 2, "item_tpl [size]");
     auto object = getConsoleTargetObject();
     int stackSize = args.get<int>(2).value_or(1);
-    object->addItem(std::string(args[1].value()), stackSize);
+    auto receiver = _party.sharedInventoryReceiver(object);
+    receiver->addItem(std::string(args[1].value()), stackSize);
 }
 
 void Game::consoleGiveXP(const ConsoleArgs &args) {

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -219,6 +219,15 @@ bool Party::isMember(const Object &object) const {
     return false;
 }
 
+std::shared_ptr<Object> Party::sharedInventoryReceiver(const std::shared_ptr<Object> &receiver) const {
+    // A party member's non-equipped items belong to the shared party inventory
+    // (the player creature). Non-party receivers keep their own inventory.
+    if (receiver && _player && isMember(*receiver)) {
+        return _player;
+    }
+    return receiver;
+}
+
 std::shared_ptr<Creature> Party::getLeader() const {
     return !_members.empty() ? _members[0].creature : nullptr;
 }

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -399,7 +399,8 @@ static Variable CreateItemOnObject(const std::vector<Variable> &args, const Rout
     if (itemTemplate.empty()) {
         return Variable::ofObject(kObjectInvalid);
     }
-    auto item = oTarget->addItem(itemTemplate, nStackSize, true);
+    auto receiver = ctx.game.party().sharedInventoryReceiver(oTarget);
+    auto item = receiver->addItem(itemTemplate, nStackSize, true);
     return Variable::ofObject(getObjectIdOrInvalid(item));
 }
 

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -199,3 +199,74 @@ TEST(Party, should_keep_non_party_creature_xp_local) {
     EXPECT_EQ(player->xp(), 100);
     EXPECT_EQ(game.party().xp(), 100);
 }
+
+TEST(Party, should_route_item_acquired_by_companion_to_shared_player_inventory) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeBaseItemsTable()));
+    EXPECT_CALL(engine.resourceModule().textures(), get(_, _)).Times(AnyNumber());
+
+    auto player = game.newCreature();
+    auto companion = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    game.party().addMember(0, companion);
+
+    auto receiver = game.party().sharedInventoryReceiver(companion);
+    ASSERT_EQ(receiver.get(), player.get());
+    receiver->addItem(makeItem(game, "g_i_datapad001", 1, 1));
+
+    ASSERT_EQ(player->items().size(), 1);
+    EXPECT_EQ(player->items().front()->tag(), "g_i_datapad001");
+    EXPECT_TRUE(companion->items().empty());
+}
+
+TEST(Party, should_keep_item_acquired_by_player_in_shared_inventory) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    EXPECT_EQ(game.party().sharedInventoryReceiver(player).get(), player.get());
+}
+
+TEST(Party, should_keep_item_acquired_by_non_party_creature_local) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeBaseItemsTable()));
+    EXPECT_CALL(engine.resourceModule().textures(), get(_, _)).Times(AnyNumber());
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    auto thug = game.newCreature();
+    auto receiver = game.party().sharedInventoryReceiver(thug);
+    ASSERT_EQ(receiver.get(), thug.get());
+    receiver->addItem(makeItem(game, "g_i_datapad001", 1, 1));
+
+    ASSERT_EQ(thug->items().size(), 1);
+    EXPECT_TRUE(player->items().empty());
+}
+
+TEST(Party, should_not_share_inventory_of_non_party_placeable) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    auto footlocker = game.newPlaceable();
+    EXPECT_EQ(game.party().sharedInventoryReceiver(footlocker).get(), footlocker.get());
+}


### PR DESCRIPTION
## Summary

Routes non-equipped items acquired by party members into the shared party inventory.

The shared inventory is currently represented by the player creature’s item list. Previously, `additem` or `CreateItemOnObject` could place an item on the selected companion instead, making it unavailable from the shared inventory.

This adds `Party::sharedInventoryReceiver`, which redirects party-member item grants to the player creature while leaving non-party creatures, placeables, and containers independent.

Equipment and credits/gold handling are unchanged.

## Validation

manual smoke:
- selected a companion
- ran `additem g_a_kghtrobe01`
- confirmed the robe appeared in the shared player inventory rather than remaining only on the companion