### PR TITLE
[game] Share XP across party

### DIFF
--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -109,6 +109,18 @@ public:
 
     // END Credits
 
+    // Experience
+    //
+    // KOTOR stores experience as a single party-shared pool. XP awarded to a
+    // party member feeds this pool; current members derive their creature XP
+    // from it, and members added later are synced to it.
+
+    int xp() const { return _xp; }
+    void giveXP(int amount);
+    void setXP(int xp);
+
+    // END Experience
+
 private:
     Game &_game;
 
@@ -117,8 +129,12 @@ private:
     std::vector<Member> _members;
     bool _solo {false};
     int _gold {0};
+    int _xp {0};
 
     bool handleKeyDown(const input::KeyEvent &event);
+
+    // Apply the party XP pool value to every current member's creature XP.
+    void syncMembersXP();
 
     void onLeaderChanged();
 };

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -744,7 +744,8 @@ void Game::deserializeParty(resource::Gff &ifoGff) {
 
     uint32_t xp = 0;
     if (ptGff->readDword(xp, "PT_XP_POOL")) {
-        player->setXP(xp);
+        // Populate the shared party XP pool. Members added below are synced to it.
+        _party.setXP(xp);
     }
 
     deserializePartyTable(*ptGff);
@@ -2394,7 +2395,12 @@ void Game::consoleAddItem(const ConsoleArgs &args) {
 void Game::consoleGiveXP(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 1, "amount");
     auto creature = getConsoleTargetCreature();
-    creature->giveXP(args.get<int>(1).value());
+    int amount = args.get<int>(1).value();
+    if (_party.isMember(*creature)) {
+        _party.giveXP(amount);
+    } else {
+        creature->giveXP(amount);
+    }
 }
 
 void Game::consoleGiveGold(const ConsoleArgs &args) {

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -87,6 +87,11 @@ bool Party::removeAvailableMember(int npc) {
 }
 
 bool Party::addMember(int npc, std::shared_ptr<Creature> creature) {
+    // A creature joining the party derives its XP from the shared party pool.
+    if (creature) {
+        creature->setXP(_xp);
+    }
+
     Member member;
     member.npc = npc;
     member.creature = creature;
@@ -115,6 +120,26 @@ void Party::takeGold(int amount) {
     _gold -= amount;
     if (_gold < 0) {
         _gold = 0;
+    }
+}
+
+void Party::giveXP(int amount) {
+    _xp += amount;
+    syncMembersXP();
+}
+
+void Party::setXP(int xp) {
+    _xp = xp;
+    syncMembersXP();
+}
+
+void Party::syncMembersXP() {
+    // Set each member's creature XP to the pool value rather than adding, so the
+    // award is not double-counted and members converge on the shared total.
+    for (auto &member : _members) {
+        if (member.creature) {
+            member.creature->setXP(_xp);
+        }
     }
 }
 

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3723,7 +3723,11 @@ static Variable GiveXPToCreature(const std::vector<Variable> &args, const Routin
     auto creature = checkCreature(oCreature);
 
     // Execute
-    creature->giveXP(nXpAmount);
+    if (ctx.game.party().isMember(*creature)) {
+        ctx.game.party().giveXP(nXpAmount);
+    } else {
+        creature->giveXP(nXpAmount);
+    }
     return Variable::ofNull();
 }
 
@@ -3736,7 +3740,11 @@ static Variable SetXP(const std::vector<Variable> &args, const RoutineContext &c
     auto creature = checkCreature(oCreature);
 
     // Execute
-    creature->setXP(nXpAmount);
+    if (ctx.game.party().isMember(*creature)) {
+        ctx.game.party().setXP(nXpAmount);
+    } else {
+        creature->setXP(nXpAmount);
+    }
     return Variable::ofNull();
 }
 

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -130,3 +130,72 @@ TEST(Object, should_move_credits_as_items_when_destination_is_not_in_party) {
     EXPECT_EQ(thug->items().front()->tag(), "g_i_credits001");
     EXPECT_TRUE(footlocker->items().empty());
 }
+
+TEST(Party, should_award_xp_to_pool_and_sync_current_members) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    auto companion = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    game.party().addMember(0, companion);
+
+    game.party().giveXP(100);
+
+    EXPECT_EQ(game.party().xp(), 100);
+    EXPECT_EQ(player->xp(), 100);
+    EXPECT_EQ(companion->xp(), 100);
+}
+TEST(Party, should_set_xp_pool_and_sync_current_members) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    auto companion = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    game.party().addMember(0, companion);
+
+    game.party().setXP(250);
+
+    EXPECT_EQ(game.party().xp(), 250);
+    EXPECT_EQ(player->xp(), 250);
+    EXPECT_EQ(companion->xp(), 250);
+}
+TEST(Party, should_sync_member_added_after_xp_gain) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    game.party().giveXP(100);
+
+    auto latecomer = game.newCreature();
+    game.party().addMember(0, latecomer);
+
+    EXPECT_EQ(latecomer->xp(), 100);
+    EXPECT_EQ(game.party().xp(), 100);
+}
+TEST(Party, should_keep_non_party_creature_xp_local) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+
+    auto thug = game.newCreature();
+    thug->giveXP(50);
+    game.party().giveXP(100);
+
+    EXPECT_EQ(thug->xp(), 50);
+    EXPECT_EQ(player->xp(), 100);
+    EXPECT_EQ(game.party().xp(), 100);
+}


### PR DESCRIPTION
## Summary

Adds a shared party XP pool.

XP awarded to a party member now updates the party XP pool and syncs current party members to that value. Members added later are also synced to the pool, so newly joined companions align with the party’s current XP instead of keeping blueprint/local XP.

`PT_XP_POOL` now populates the party XP pool on load. Non-party creatures keep creature-local XP behaviour.

## Validation

* manual smoke:
  * `givexp 1000` synced current party members to 1000 XP
  * adding a companion afterward synced that member to 1000 XP
  * `givexp 500` then synced all three members to 1500 XP