### PR TITLE
[game] Fix stuttering death animation

### DIFF
--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -250,7 +250,12 @@ void Creature::updateModelAnimation() {
         model->playAnimation(*talkAnim, _lipAnimation.get(), AnimationProperties::fromFlags(AnimationFlags::loopOverlay | AnimationFlags::propagate));
     } else {
         if (anim) {
-            model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(AnimationFlags::loopBlend | AnimationFlags::propagate));
+            // The corpse pose is a short clip; looping/blending it makes the
+            // model jerk and never settle, so play it once and hold the final
+            // frame. Living poses keep looping and blending.
+            int animFlags = _dead ? AnimationFlags::propagate
+                                  : (AnimationFlags::loopBlend | AnimationFlags::propagate);
+            model->playAnimation(*anim, nullptr, AnimationProperties::fromFlags(animFlags));
         }
 
         if (talkAnim) {


### PR DESCRIPTION
## Summary

Fixes the death-animation jitter where dead creatures jerk back and forth instead of settling.

The corpse pose was being played with `loopBlend`. The short `dead` clip could loop before the blend transition completed, leaving it permanently cross-fading against the finished `die` animation.

This changes the dead/corpse pose to play once without looping or blending, so the model clears the spent `die` channel and holds the final corpse pose. Living idle, movement, attack, and talk animation paths are unchanged.

## Notes

This only changes the corpse/dead animation flags. Combat damage, death effects, action clearing, and the model animation system are otherwise unchanged.