### PR TITLE
[dialog] Apply player stunt animation to real player

### DIFF
--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -152,6 +152,8 @@ void DialogGUI::loadStuntParticipants() {
         std::shared_ptr<Creature> creature;
         if (stunt.participant == kObjectTagOwner) {
             creature = std::dynamic_pointer_cast<Creature>(_owner);
+        } else if (boost::iequals(stunt.participant, kObjectTagPlayer)) {
+            creature = _game.party().player();
         } else {
             creature = std::dynamic_pointer_cast<Creature>(_game.module()->area()->getObjectByTag(stunt.participant));
         }
@@ -276,6 +278,7 @@ void DialogGUI::updateParticipantAnimations() {
             std::shared_ptr<Animation> animation(participant.model->getAnimation(animName));
             if (animation) {
                 AnimationProperties properties;
+                properties.flags = AnimationFlags::propagate;
                 properties.scale = 1.0f;
                 participant.creature->playAnimation(animation, std::move(properties));
             }


### PR DESCRIPTION
## Summary

Fixes animated dialogue stunt playback for player participants.

Some animated cutscenes reference the player with the stunt participant tag `player`. Previously this path tried to resolve that tag through area object lookup, which does not reliably select the actual party player creature. This change resolves `player` through `Party::player()`.

The stunt animation playback now also uses `AnimationFlags::propagate`, matching normal creature animation behavior so attached/composed models such as the player head/eyes receive the stunt animation.