### PR TITLE
[game] Implement journal quest state

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -43,6 +43,7 @@
 #include "gui/map.h"
 #include "gui/partyselect.h"
 #include "gui/saveload.h"
+#include "journal.h"
 #include "location.h"
 #include "object/area.h"
 #include "object/camera/animated.h"
@@ -113,7 +114,8 @@ public:
         _console(console),
         _party(*this),
         _combat(*this, services),
-        _swoopRace(*this) {
+        _swoopRace(*this),
+        _journal(services.resource.gffs, services.resource.strings) {
     }
 
     void init();
@@ -133,6 +135,7 @@ public:
     const OptionsView &options() const { return _options; }
     Party &party() { return _party; }
     Combat &combat() { return _combat; }
+    Journal &journal() { return _journal; }
     ScriptRunner &scriptRunner() { return *_scriptRunner; }
     Map &map() { return *_map; }
     script::IRoutines &routines() { return *_routines; }
@@ -358,6 +361,7 @@ public:
     void deserializeParty(resource::Gff &ifoGff);
     void deserializePartyTable(resource::Gff &ptGff);
     void deserializePartyMembers(resource::Gff &ptGff);
+    void deserializeJournal(const resource::Gff &ptGff);
     void deserializeInventory(resource::Gff &inventoryGff);
 
 private:
@@ -415,6 +419,7 @@ private:
     Party _party;
     Combat _combat;
     SwoopRace _swoopRace;
+    Journal _journal;
 
     std::unique_ptr<script::IRoutines> _routines;
     std::unique_ptr<ScriptRunner> _scriptRunner;

--- a/include/reone/game/gui/confirmpopup.h
+++ b/include/reone/game/gui/confirmpopup.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "../gui.h"
+
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/listbox.h"
+
+namespace reone {
+
+namespace game {
+
+/**
+ * Centered in-game message popup based on the game's confirmation dialog,
+ * dismissed with the OK button.
+ */
+class ConfirmPopup : public GameGUI {
+public:
+    ConfirmPopup(Game &game, ServicesView &services) :
+        GameGUI(game, services) {
+        _resRef = guiResRef("confirm");
+    }
+
+    void show(const std::string &message);
+    void hide();
+
+    bool isVisible() const { return _visible; }
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Button> BTN_CANCEL;
+        std::shared_ptr<gui::Button> BTN_OK;
+        std::shared_ptr<gui::ListBox> LB_MESSAGE;
+    };
+
+    Controls _controls;
+    bool _visible {false};
+
+    void preload(gui::IGUI &gui) override;
+    void onGUILoaded() override;
+
+    void bindControls() {
+        _controls.BTN_CANCEL = findControl<gui::Button>("BTN_CANCEL");
+        _controls.BTN_OK = findControl<gui::Button>("BTN_OK");
+        _controls.LB_MESSAGE = findControl<gui::ListBox>("LB_MESSAGE");
+    }
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/gui/confirmpopup.h
+++ b/include/reone/game/gui/confirmpopup.h
@@ -24,11 +24,18 @@
 
 namespace reone {
 
+namespace graphics {
+
+class Texture;
+
+}
+
 namespace game {
 
 /**
  * Centered in-game message popup based on the game's confirmation dialog,
- * dismissed with the OK button.
+ * dismissed with the OK button. An optional icon is shown left of the
+ * message text.
  */
 class ConfirmPopup : public GameGUI {
 public:
@@ -37,7 +44,7 @@ public:
         _resRef = guiResRef("confirm");
     }
 
-    void show(const std::string &message);
+    void show(const std::string &message, std::shared_ptr<graphics::Texture> icon = nullptr);
     void hide();
 
     bool isVisible() const { return _visible; }
@@ -51,6 +58,9 @@ private:
 
     Controls _controls;
     bool _visible {false};
+
+    std::shared_ptr<gui::Control> _icon;
+    gui::Control::Extent _messageExtent;
 
     void preload(gui::IGUI &gui) override;
     void onGUILoaded() override;

--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -108,6 +108,7 @@ private:
     bool evaluateCondition(const std::string &scriptResRef, const resource::Dialog::EntryReplyLink::ConditionParams &params);
     void runScript(const std::string &scriptResRef, const resource::Dialog::EntryReply::ActionParams &params);
     void runScripts(const resource::Dialog::EntryReply &node);
+    void applyQuestEntry(const resource::Dialog::EntryReply &node);
 
     virtual void setMessage(std::string message) = 0;
 

--- a/include/reone/game/gui/hud.h
+++ b/include/reone/game/gui/hud.h
@@ -28,6 +28,7 @@
 
 #include "actionbar.h"
 #include "barkbubble.h"
+#include "confirmpopup.h"
 #include "selectoverlay.h"
 
 namespace reone {
@@ -152,6 +153,7 @@ private:
     SelectionOverlay _select;
     ActionBar _actionBar;
     std::unique_ptr<BarkBubble> _barkBubble;
+    std::unique_ptr<ConfirmPopup> _confirmPopup;
     Timer _journalNotificationTimer;
 
     void preload(gui::IGUI &gui) override;

--- a/include/reone/game/gui/hud.h
+++ b/include/reone/game/gui/hud.h
@@ -22,6 +22,7 @@
 #include "reone/gui/control/progressbar.h"
 #include "reone/gui/control/togglebutton.h"
 #include "reone/resource/types.h"
+#include "reone/system/timer.h"
 
 #include "../gui.h"
 
@@ -47,6 +48,9 @@ public:
     void render() override;
 
     BarkBubble &barkBubble() const { return *_barkBubble; }
+
+    /** Show the journal icon for a few seconds. */
+    void showJournalNotification();
 
 private:
     struct Controls {
@@ -148,6 +152,7 @@ private:
     SelectionOverlay _select;
     ActionBar _actionBar;
     std::unique_ptr<BarkBubble> _barkBubble;
+    Timer _journalNotificationTimer;
 
     void preload(gui::IGUI &gui) override;
     void onGUILoaded() override;

--- a/include/reone/game/gui/ingame/journal.h
+++ b/include/reone/game/gui/ingame/journal.h
@@ -40,6 +40,9 @@ public:
         _resRef = guiResRef("journal");
     }
 
+    /** Reload the quest list from the journal. */
+    void refresh();
+
 private:
     struct Controls {
         std::shared_ptr<gui::Button> BTN_EXIT;
@@ -64,6 +67,8 @@ private:
     Controls _controls;
 
     void onGUILoaded() override;
+
+    void refreshEntryText(const std::string &plotId);
 
     void bindControls() {
         _controls.BTN_EXIT = findControl<gui::Button>("BTN_EXIT");

--- a/include/reone/game/journal.h
+++ b/include/reone/game/journal.h
@@ -79,6 +79,12 @@ public:
     /** Quests in the order they were received. */
     const std::vector<Quest> &quests() const { return _quests; }
 
+    /**
+     * Set a listener invoked whenever addEntry changes quest state. Not
+     * invoked by removeEntry or restoreEntry.
+     */
+    void setOnQuestChanged(std::function<void()> fn) { _onQuestChanged = std::move(fn); }
+
     const resource::JRL::Category *findCategory(const std::string &plotId);
     const resource::JRL::Entry *findEntry(const std::string &plotId, int state);
 
@@ -89,8 +95,10 @@ private:
     bool _loaded {false};
     resource::JRL _jrl;
     std::vector<Quest> _quests;
+    std::function<void()> _onQuestChanged;
 
     void ensureLoaded();
+    void notifyQuestChanged();
     Quest *findQuest(const std::string &plotId);
     std::string resolveLocText(const resource::JRL::LocText &text);
 };

--- a/include/reone/game/journal.h
+++ b/include/reone/game/journal.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/resource/parser/gff/jrl.h"
+
+namespace reone {
+
+namespace resource {
+
+class IGffs;
+class IStrings;
+
+} // namespace resource
+
+namespace game {
+
+/**
+ * Tracks quest journal state. Static quest definitions (categories and their
+ * entries) come from the global journal resource, while dynamic state is a
+ * list of quests keyed by plot ID, each holding the ID of its current entry.
+ */
+class Journal {
+public:
+    struct Quest {
+        std::string plotId;
+        int state {0};
+        uint32_t date {0};
+        uint32_t time {0};
+    };
+
+    Journal(resource::IGffs &gffs, resource::IStrings &strings) :
+        _gffs(gffs),
+        _strings(strings) {
+    }
+
+    /** Clear quest state and force a reload of the global journal. */
+    void reset();
+
+    /**
+     * Add a quest, or advance an existing one to a higher state. A lower or
+     * equal state is only applied when allowOverrideHigher is true.
+     *
+     * @param state ID of a journal entry within the quest category
+     * @return true if quest state changed
+     */
+    bool addEntry(const std::string &plotId, int state, bool allowOverrideHigher = false);
+
+    /** @return true if a quest with the given plot ID was removed */
+    bool removeEntry(const std::string &plotId);
+
+    /** Set quest state verbatim, e.g. when restoring from a savegame. */
+    void restoreEntry(std::string plotId, int state, uint32_t date, uint32_t time);
+
+    /** @return state of the quest with the given plot ID, or 0 if not present */
+    int getEntryState(const std::string &plotId) const;
+
+    /** @return true if the current entry of the quest ends it */
+    bool isCompleted(const std::string &plotId);
+
+    std::string getQuestName(const std::string &plotId);
+    std::string getEntryText(const std::string &plotId, int state);
+
+    /** Quests in the order they were received. */
+    const std::vector<Quest> &quests() const { return _quests; }
+
+    const resource::JRL::Category *findCategory(const std::string &plotId);
+    const resource::JRL::Entry *findEntry(const std::string &plotId, int state);
+
+private:
+    resource::IGffs &_gffs;
+    resource::IStrings &_strings;
+
+    bool _loaded {false};
+    resource::JRL _jrl;
+    std::vector<Quest> _quests;
+
+    void ensureLoaded();
+    Quest *findQuest(const std::string &plotId);
+    std::string resolveLocText(const resource::JRL::LocText &text);
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/resource/dialog.h
+++ b/include/reone/resource/dialog.h
@@ -69,6 +69,8 @@ struct Dialog {
         std::string script2;
         std::string sound;
         std::string listener;
+        std::string quest;
+        uint32_t questEntry {0};
         ActionParams actionParams;
         ActionParams actionParams2;
         int delay {0};

--- a/include/reone/resource/parser/gff/jrl.h
+++ b/include/reone/resource/parser/gff/jrl.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace resource {
+
+class Gff;
+
+struct JRL {
+    /** Localized string as a (strref, embedded text) pair. A strref of -1 means
+        the embedded text is authoritative. */
+    using LocText = std::pair<int32_t, std::string>;
+
+    struct Entry {
+        uint32_t id {0};
+        bool end {false};
+        LocText text {-1, ""};
+        float xpPercentage {0.0f};
+    };
+
+    struct Category {
+        std::string tag;
+        LocText name {-1, ""};
+        uint32_t priority {0};
+        int planetId {-1};
+        int plotIndex {-1};
+        std::string comment;
+        std::vector<Entry> entries;
+    };
+
+    std::vector<Category> categories;
+};
+
+JRL parseJRL(const Gff &gff);
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -202,6 +202,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/chargen/quickorcustom.h
     ${GAME_INCLUDE_DIR}/gui/chargen/skills.h
     ${GAME_INCLUDE_DIR}/gui/computer.h
+    ${GAME_INCLUDE_DIR}/gui/confirmpopup.h
     ${GAME_INCLUDE_DIR}/gui/container.h
     ${GAME_INCLUDE_DIR}/gui/conversation.h
     ${GAME_INCLUDE_DIR}/gui/dialog.h
@@ -475,6 +476,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/chargen/skills.cpp
     ${GAME_SOURCE_DIR}/gui/chargen.cpp
     ${GAME_SOURCE_DIR}/gui/computer.cpp
+    ${GAME_SOURCE_DIR}/gui/confirmpopup.cpp
     ${GAME_SOURCE_DIR}/gui/container.cpp
     ${GAME_SOURCE_DIR}/gui/conversation.cpp
     ${GAME_SOURCE_DIR}/gui/dialog.cpp

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -287,6 +287,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/saveload.h
     ${GAME_INCLUDE_DIR}/gui/selectoverlay.h
     ${GAME_INCLUDE_DIR}/gui/sounds.h
+    ${GAME_INCLUDE_DIR}/journal.h
     ${GAME_INCLUDE_DIR}/location.h
     ${GAME_INCLUDE_DIR}/messagebus.h
     ${GAME_INCLUDE_DIR}/minigame.h
@@ -495,6 +496,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/saveload.cpp
     ${GAME_SOURCE_DIR}/gui/selectoverlay.cpp
     ${GAME_SOURCE_DIR}/gui/sounds.cpp
+    ${GAME_SOURCE_DIR}/journal.cpp
     ${GAME_SOURCE_DIR}/messagebus.cpp
     ${GAME_SOURCE_DIR}/object.cpp
     ${GAME_SOURCE_DIR}/object/area.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -226,6 +226,12 @@ void Game::init() {
     setSceneSurfaces();
     setCursorType(CursorType::Default);
 
+    _journal.setOnQuestChanged([this]() {
+        if (_hud) {
+            _hud->showJournalNotification();
+        }
+    });
+
     _moduleNames = _services.resource.director.moduleNames();
     _saveNames = _services.resource.director.saveNames();
 

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -648,6 +648,7 @@ void Game::resetGame() {
 
     _party.reset();
     _combat.reset();
+    _journal.reset();
     _module.reset();
     _loadedModules.clear();
 }
@@ -754,6 +755,7 @@ void Game::deserializeParty(resource::Gff &ifoGff) {
 
     deserializePartyTable(*ptGff);
     deserializePartyMembers(*ptGff);
+    deserializeJournal(*ptGff);
 }
 
 void Game::deserializePartyTable(resource::Gff &ptGff) {
@@ -811,6 +813,20 @@ void Game::deserializePartyMembers(resource::Gff &ptGff) {
     // Then add other members.
     for (auto it = members.begin(), end = leader; it != end; ++it) {
         addMember(**it);
+    }
+}
+
+void Game::deserializeJournal(const resource::Gff &ptGff) {
+    for (const auto &jnlEntry : ptGff.getList("JNL_Entries")) {
+        std::string plotId(jnlEntry->getString("JNL_PlotID"));
+        if (plotId.empty()) {
+            warn("Game: missing JNL_PlotID");
+            continue;
+        }
+        int state = jnlEntry->getInt("JNL_State");
+        uint32_t date = jnlEntry->getUint("JNL_Date");
+        uint32_t time = jnlEntry->getUint("JNL_Time");
+        _journal.restoreEntry(std::move(plotId), state, date, time);
     }
 }
 

--- a/src/libs/game/gui/confirmpopup.cpp
+++ b/src/libs/game/gui/confirmpopup.cpp
@@ -25,8 +25,18 @@ namespace reone {
 
 namespace game {
 
+static const char kIconControlTag[] = "LBL_POPUPICON";
+
+static constexpr int kIconSize = 32;
+static constexpr int kIconPadding = 6;
+
 void ConfirmPopup::preload(IGUI &gui) {
-    gui.setScaling(GUI::ScalingMode::PositionRelativeToCenter);
+    GameGUI::preload(gui);
+
+    // The confirmation dialog is authored for 640x480 in both games. Center
+    // it on the screen.
+    gui.setResolution(640, 480);
+    gui.setScaling(GUI::ScalingMode::Center);
 }
 
 void ConfirmPopup::onGUILoaded() {
@@ -37,11 +47,38 @@ void ConfirmPopup::onGUILoaded() {
         hide();
     });
     _controls.LB_MESSAGE->setItemsInteractive(false);
+
+    _messageExtent = _controls.LB_MESSAGE->protoItem().extent();
+
+    auto icon = _gui->newControl(ControlType::Label, kIconControlTag);
+    Control::Extent iconExtent;
+    iconExtent.left = _messageExtent.left;
+    iconExtent.top = _messageExtent.top + (_messageExtent.height - kIconSize) / 2;
+    iconExtent.width = kIconSize;
+    iconExtent.height = kIconSize;
+    icon->setExtent(std::move(iconExtent));
+    icon->setVisible(false);
+    _icon = std::shared_ptr<Control>(std::move(icon));
+    _gui->addControlToFront(_icon);
 }
 
-void ConfirmPopup::show(const std::string &message) {
+void ConfirmPopup::show(const std::string &message, std::shared_ptr<graphics::Texture> icon) {
+    // Reserve a gutter for the icon, if any, before the message is broken
+    // into lines.
+    bool hasIcon = static_cast<bool>(icon);
+    Control::Extent textExtent(_messageExtent);
+    if (hasIcon) {
+        int gutter = kIconSize + kIconPadding;
+        textExtent.left += gutter;
+        textExtent.width = std::max(0, textExtent.width - gutter);
+        _icon->setBorderFill(std::move(icon));
+    }
+    _icon->setVisible(hasIcon);
+    _controls.LB_MESSAGE->protoItem().setExtent(std::move(textExtent));
+
     _controls.LB_MESSAGE->clearItems();
     _controls.LB_MESSAGE->addTextLinesAsItems(message);
+
     _visible = true;
 }
 

--- a/src/libs/game/gui/confirmpopup.cpp
+++ b/src/libs/game/gui/confirmpopup.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/gui/confirmpopup.h"
+
+#include "reone/game/game.h"
+
+using namespace reone::gui;
+
+namespace reone {
+
+namespace game {
+
+void ConfirmPopup::preload(IGUI &gui) {
+    gui.setScaling(GUI::ScalingMode::PositionRelativeToCenter);
+}
+
+void ConfirmPopup::onGUILoaded() {
+    bindControls();
+
+    _controls.BTN_CANCEL->setVisible(false);
+    _controls.BTN_OK->setOnClick([this]() {
+        hide();
+    });
+    _controls.LB_MESSAGE->setItemsInteractive(false);
+}
+
+void ConfirmPopup::show(const std::string &message) {
+    _controls.LB_MESSAGE->clearItems();
+    _controls.LB_MESSAGE->addTextLinesAsItems(message);
+    _visible = true;
+}
+
+void ConfirmPopup::hide() {
+    _visible = false;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -173,6 +173,13 @@ void Conversation::runScripts(const Dialog::EntryReply &node) {
     runScript(node.script2, node.actionParams2);
 }
 
+void Conversation::applyQuestEntry(const Dialog::EntryReply &node) {
+    if (node.quest.empty()) {
+        return;
+    }
+    _game.journal().addEntry(node.quest, static_cast<int>(node.questEntry));
+}
+
 void Conversation::finish() {
     onFinish();
 
@@ -202,6 +209,8 @@ void Conversation::cleanupForModuleTransition() {
 void Conversation::loadEntry(int index, bool start) {
     debug("Load entry " + std::to_string(index), LogChannel::Conversation);
     _currentEntry = &_dialog->getEntry(index);
+
+    applyQuestEntry(*_currentEntry);
 
     std::string entryText(_game.substituteCustomTokens(_currentEntry->text));
     setMessage(entryText);
@@ -323,6 +332,8 @@ void Conversation::refreshReplies() {
 void Conversation::pickReply(int index) {
     debug("Pick reply " + std::to_string(index), LogChannel::Conversation);
     const Dialog::EntryReply &reply = *_replies[index];
+
+    applyQuestEntry(reply);
 
     // Run reply scripts
     runScripts(reply);

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -49,6 +49,9 @@ static std::string g_attackIcon("i_attack");
 
 static constexpr float kJournalNotificationDuration = 10.0f;
 
+// "Journal Entry Added", same in K1 and TSL
+static constexpr int kStrRefJournalEntryAdded = 42436;
+
 static void tintK2HUDMenuButton(const std::shared_ptr<Button> &button, const glm::vec3 &baseColor) {
     if (!button) {
         return;
@@ -221,6 +224,9 @@ void HUD::onGUILoaded() {
 
     _barkBubble = std::make_unique<BarkBubble>(_game, _services);
     _barkBubble->init();
+
+    _confirmPopup = std::make_unique<ConfirmPopup>(_game, _services);
+    _confirmPopup->init();
 }
 
 void HUD::showJournalNotification() {
@@ -229,9 +235,16 @@ void HUD::showJournalNotification() {
     }
     _controls.LBL_JOURNAL->setVisible(true);
     _journalNotificationTimer.reset(kJournalNotificationDuration);
+
+    if (_confirmPopup) {
+        _confirmPopup->show(_services.resource.strings.getText(kStrRefJournalEntryAdded));
+    }
 }
 
 bool HUD::handle(const input::Event &event) {
+    if (_confirmPopup->isVisible() && _confirmPopup->handle(event)) {
+        return true;
+    }
     if (_select.handle(event)) {
         return true;
     }
@@ -305,6 +318,9 @@ void HUD::update(float dt) {
     _select.update();
     _actionBar.update();
     _barkBubble->update(dt);
+    if (_confirmPopup->isVisible()) {
+        _confirmPopup->update(dt);
+    }
 
     // Hide minimap when there is no image to display
     _controls.LBL_MAPBORDER->setVisible(_game.map().isLoaded());
@@ -323,6 +339,10 @@ void HUD::render() {
     _barkBubble->render();
     _select.render();
     _actionBar.render();
+
+    if (_confirmPopup->isVisible()) {
+        _confirmPopup->render();
+    }
 }
 
 void HUD::renderMinimap() {

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -237,7 +237,9 @@ void HUD::showJournalNotification() {
     _journalNotificationTimer.reset(kJournalNotificationDuration);
 
     if (_confirmPopup) {
-        _confirmPopup->show(_services.resource.strings.getText(kStrRefJournalEntryAdded));
+        // Reuse the HUD journal icon texture inside the popup.
+        std::shared_ptr<Texture> icon(_controls.LBL_JOURNAL->border().fill);
+        _confirmPopup->show(_services.resource.strings.getText(kStrRefJournalEntryAdded), std::move(icon));
     }
 }
 

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -47,6 +47,8 @@ namespace game {
 
 static std::string g_attackIcon("i_attack");
 
+static constexpr float kJournalNotificationDuration = 10.0f;
+
 static void tintK2HUDMenuButton(const std::shared_ptr<Button> &button, const glm::vec3 &baseColor) {
     if (!button) {
         return;
@@ -221,6 +223,14 @@ void HUD::onGUILoaded() {
     _barkBubble->init();
 }
 
+void HUD::showJournalNotification() {
+    if (!_controls.LBL_JOURNAL) {
+        return;
+    }
+    _controls.LBL_JOURNAL->setVisible(true);
+    _journalNotificationTimer.reset(kJournalNotificationDuration);
+}
+
 bool HUD::handle(const input::Event &event) {
     if (_select.handle(event)) {
         return true;
@@ -283,6 +293,13 @@ void HUD::update(float dt) {
         refreshActionQueueItems();
     } else {
         toggleCombat(false);
+    }
+
+    if (_controls.LBL_JOURNAL->isVisible()) {
+        _journalNotificationTimer.update(dt);
+        if (_journalNotificationTimer.elapsed()) {
+            _controls.LBL_JOURNAL->setVisible(false);
+        }
     }
 
     _select.update();

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -383,6 +383,7 @@ void InGameMenu::openMessages() {
 }
 
 void InGameMenu::openJournal() {
+    _journal->refresh();
     changeTab(InGameMenuTab::Journal);
 }
 

--- a/src/libs/game/gui/ingame/journal.cpp
+++ b/src/libs/game/gui/ingame/journal.cpp
@@ -49,6 +49,39 @@ void JournalMenu::onGUILoaded() {
         _controls.BTN_QUESTITEMS->setDisabled(true);
         _controls.BTN_SORT->setDisabled(true);
     }
+
+    _controls.LB_ITEMS->setSelectionMode(ListBox::SelectionMode::OnClick);
+    _controls.LB_ITEMS->setOnItemClick([this](const std::string &plotId) {
+        refreshEntryText(plotId);
+    });
+}
+
+void JournalMenu::refresh() {
+    _controls.LB_ITEMS->clearItems();
+    _controls.LB_ITEMS->clearSelection();
+    _controls.LBL_ITEM_DESCRIPTION->clearItems();
+
+    Journal &journal = _game.journal();
+    for (const auto &quest : journal.quests()) {
+        std::string name(journal.getQuestName(quest.plotId));
+        if (name.empty()) {
+            name = quest.plotId;
+        }
+        ListBox::Item item;
+        item.tag = quest.plotId;
+        item.text = std::move(name);
+        _controls.LB_ITEMS->addItem(std::move(item));
+    }
+}
+
+void JournalMenu::refreshEntryText(const std::string &plotId) {
+    _controls.LBL_ITEM_DESCRIPTION->clearItems();
+
+    Journal &journal = _game.journal();
+    std::string text(journal.getEntryText(plotId, journal.getEntryState(plotId)));
+    if (!text.empty()) {
+        _controls.LBL_ITEM_DESCRIPTION->addTextLinesAsItems(text);
+    }
 }
 
 } // namespace game

--- a/src/libs/game/journal.cpp
+++ b/src/libs/game/journal.cpp
@@ -95,6 +95,7 @@ bool Journal::addEntry(const std::string &plotId, int state, bool allowOverrideH
     Quest *quest = findQuest(plotId);
     if (!quest) {
         _quests.push_back({plotId, state, 0, 0});
+        notifyQuestChanged();
         return true;
     }
     if (quest->state == state) {
@@ -104,7 +105,14 @@ bool Journal::addEntry(const std::string &plotId, int state, bool allowOverrideH
         return false;
     }
     quest->state = state;
+    notifyQuestChanged();
     return true;
+}
+
+void Journal::notifyQuestChanged() {
+    if (_onQuestChanged) {
+        _onQuestChanged();
+    }
 }
 
 bool Journal::removeEntry(const std::string &plotId) {

--- a/src/libs/game/journal.cpp
+++ b/src/libs/game/journal.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/journal.h"
+
+#include "reone/resource/gff.h"
+#include "reone/resource/provider/gffs.h"
+#include "reone/resource/strings.h"
+#include "reone/system/logutil.h"
+
+using namespace reone::resource;
+
+namespace reone {
+
+namespace game {
+
+static const char kGlobalJournalResRef[] = "global";
+
+void Journal::reset() {
+    _quests.clear();
+    _jrl.categories.clear();
+    _loaded = false;
+}
+
+void Journal::ensureLoaded() {
+    if (_loaded) {
+        return;
+    }
+    _loaded = true;
+
+    std::shared_ptr<Gff> jrl(_gffs.get(kGlobalJournalResRef, ResType::Jrl));
+    if (!jrl) {
+        warn("Journal: global journal resource not found");
+        return;
+    }
+    _jrl = parseJRL(*jrl);
+}
+
+Journal::Quest *Journal::findQuest(const std::string &plotId) {
+    for (auto &quest : _quests) {
+        if (boost::iequals(quest.plotId, plotId)) {
+            return &quest;
+        }
+    }
+    return nullptr;
+}
+
+const JRL::Category *Journal::findCategory(const std::string &plotId) {
+    ensureLoaded();
+    for (const auto &category : _jrl.categories) {
+        if (boost::iequals(category.tag, plotId)) {
+            return &category;
+        }
+    }
+    return nullptr;
+}
+
+const JRL::Entry *Journal::findEntry(const std::string &plotId, int state) {
+    const JRL::Category *category = findCategory(plotId);
+    if (!category) {
+        return nullptr;
+    }
+    for (const auto &entry : category->entries) {
+        if (entry.id == static_cast<uint32_t>(state)) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+bool Journal::addEntry(const std::string &plotId, int state, bool allowOverrideHigher) {
+    if (plotId.empty()) {
+        return false;
+    }
+    if (!findCategory(plotId)) {
+        warn("Journal: plot ID not found in global journal: " + plotId);
+    } else if (!findEntry(plotId, state)) {
+        warn(str(boost::format("Journal: entry %d not found in category '%s'") % state % plotId));
+    }
+
+    Quest *quest = findQuest(plotId);
+    if (!quest) {
+        _quests.push_back({plotId, state, 0, 0});
+        return true;
+    }
+    if (quest->state == state) {
+        return false;
+    }
+    if (state < quest->state && !allowOverrideHigher) {
+        return false;
+    }
+    quest->state = state;
+    return true;
+}
+
+bool Journal::removeEntry(const std::string &plotId) {
+    for (auto it = _quests.begin(); it != _quests.end(); ++it) {
+        if (boost::iequals(it->plotId, plotId)) {
+            _quests.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+void Journal::restoreEntry(std::string plotId, int state, uint32_t date, uint32_t time) {
+    Quest *quest = findQuest(plotId);
+    if (quest) {
+        quest->state = state;
+        quest->date = date;
+        quest->time = time;
+        return;
+    }
+    _quests.push_back({std::move(plotId), state, date, time});
+}
+
+int Journal::getEntryState(const std::string &plotId) const {
+    for (const auto &quest : _quests) {
+        if (boost::iequals(quest.plotId, plotId)) {
+            return quest.state;
+        }
+    }
+    return 0;
+}
+
+bool Journal::isCompleted(const std::string &plotId) {
+    const Quest *quest = findQuest(plotId);
+    if (!quest) {
+        return false;
+    }
+    const JRL::Entry *entry = findEntry(plotId, quest->state);
+    return entry && entry->end;
+}
+
+std::string Journal::resolveLocText(const JRL::LocText &text) {
+    if (text.first != -1) {
+        return _strings.getText(text.first);
+    }
+    return text.second;
+}
+
+std::string Journal::getQuestName(const std::string &plotId) {
+    const JRL::Category *category = findCategory(plotId);
+    if (!category) {
+        return "";
+    }
+    return resolveLocText(category->name);
+}
+
+std::string Journal::getEntryText(const std::string &plotId, int state) {
+    const JRL::Entry *entry = findEntry(plotId, state);
+    if (!entry) {
+        return "";
+    }
+    return resolveLocText(entry->text);
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -29,6 +29,8 @@
 #include "reone/game/script/routine/objectutil.h"
 #include "reone/game/script/routines.h"
 #include "reone/game/talent.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/provider/2das.h"
 #include "reone/resource/strings.h"
 #include "reone/scene/collision.h"
 #include "reone/script/executioncontext.h"
@@ -3530,29 +3532,28 @@ static Variable AddJournalQuestEntry(const std::vector<Variable> &args, const Ro
     auto bAllowOverrideHigher = getIntOrElse(args, 2, 0);
 
     // Transform
+    auto allowOverrideHigher = static_cast<bool>(bAllowOverrideHigher);
 
     // Execute
-    throw RoutineNotImplementedException("AddJournalQuestEntry");
+    ctx.game.journal().addEntry(szPlotID, nState, allowOverrideHigher);
+    return Variable::ofNull();
 }
 
 static Variable RemoveJournalQuestEntry(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto szPlotID = getString(args, 0);
 
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("RemoveJournalQuestEntry");
+    ctx.game.journal().removeEntry(szPlotID);
+    return Variable::ofNull();
 }
 
 static Variable GetJournalEntry(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto szPlotID = getString(args, 0);
 
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("GetJournalEntry");
+    return Variable::ofInt(ctx.game.journal().getEntryState(szPlotID));
 }
 
 static Variable PlayRumblePattern(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -3651,10 +3652,17 @@ static Variable GetJournalQuestExperience(const std::vector<Variable> &args, con
     // Load
     auto szPlotID = getString(args, 0);
 
-    // Transform
-
     // Execute
-    throw RoutineNotImplementedException("GetJournalQuestExperience");
+    std::shared_ptr<resource::TwoDA> plotTable(ctx.services.resource.twoDas.get("plot"));
+    if (!plotTable) {
+        return Variable::ofInt(0);
+    }
+    for (int row = 0; row < plotTable->getRowCount(); ++row) {
+        if (boost::iequals(plotTable->getString(row, "label"), szPlotID)) {
+            return Variable::ofInt(plotTable->getInt(row, "xp"));
+        }
+    }
+    return Variable::ofInt(0);
 }
 
 static Variable JumpToObject(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -64,6 +64,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/parser/gff/gui.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/gvt.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/ifo.h
+    ${RESOURCE_INCLUDE_DIR}/parser/gff/jrl.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/nfo.h
     ${RESOURCE_INCLUDE_DIR}/parser/gff/pth.h
     ${RESOURCE_INCLUDE_DIR}/path.h
@@ -133,6 +134,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/parser/gff/gui.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/gvt.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/ifo.cpp
+    ${RESOURCE_SOURCE_DIR}/parser/gff/jrl.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/nfo.cpp
     ${RESOURCE_SOURCE_DIR}/parser/gff/pth.cpp
     ${RESOURCE_SOURCE_DIR}/provider/2das.cpp

--- a/src/libs/resource/parser/gff/jrl.cpp
+++ b/src/libs/resource/parser/gff/jrl.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/parser/gff/jrl.h"
+
+#include "reone/resource/gff.h"
+
+namespace reone {
+
+namespace resource {
+
+static JRL::Entry parseEntry(const Gff &gff) {
+    JRL::Entry entry;
+    entry.id = gff.getUint("ID");
+    entry.end = gff.getBool("End");
+    entry.text = std::make_pair(gff.getInt("Text", -1), gff.getString("Text"));
+    entry.xpPercentage = gff.getFloat("XP_Percentage");
+    return entry;
+}
+
+static JRL::Category parseCategory(const Gff &gff) {
+    JRL::Category category;
+    category.tag = gff.getString("Tag");
+    category.name = std::make_pair(gff.getInt("Name", -1), gff.getString("Name"));
+    category.priority = gff.getUint("Priority");
+    category.planetId = gff.getInt("PlanetID", -1);
+    category.plotIndex = gff.getInt("PlotIndex", -1);
+    category.comment = gff.getString("Comment");
+    for (const auto &entry : gff.getList("EntryList")) {
+        category.entries.push_back(parseEntry(*entry));
+    }
+    return category;
+}
+
+JRL parseJRL(const Gff &gff) {
+    JRL jrl;
+    for (const auto &category : gff.getList("Categories")) {
+        jrl.categories.push_back(parseCategory(*category));
+    }
+    return jrl;
+}
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/resource/provider/dialogs.cpp
+++ b/src/libs/resource/provider/dialogs.cpp
@@ -86,6 +86,8 @@ Dialog::EntryReply Dialogs::getEntryReply(const resource::generated::DLG_EntryRe
     entry.script2 = dlg.Script2;
     entry.sound = dlg.Sound;
     entry.listener = dlg.Listener;
+    entry.quest = dlg.Quest;
+    entry.questEntry = dlg.QuestEntry;
     entry.actionParams.ints = {dlg.ActionParam1, dlg.ActionParam2, dlg.ActionParam3, dlg.ActionParam4, dlg.ActionParam5};
     entry.actionParams.str = dlg.ActionParamStrA;
     entry.actionParams2.ints = {dlg.ActionParam1b, dlg.ActionParam2b, dlg.ActionParam3b, dlg.ActionParam4b, dlg.ActionParam5b};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/audio/format/wavreader.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
+    ${TESTS_SOURCE_DIR}/game/journal.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
@@ -63,7 +64,9 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/format/rimwriter.cpp
     ${TESTS_SOURCE_DIR}/resource/format/tlkreader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/tlkwriter.cpp
+    ${TESTS_SOURCE_DIR}/resource/parser/jrl.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/2das.cpp
+    ${TESTS_SOURCE_DIR}/resource/provider/dialogs.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/gffs.cpp
     ${TESTS_SOURCE_DIR}/resource/resources.cpp
     ${TESTS_SOURCE_DIR}/resource/resref.cpp

--- a/test/game/journal.cpp
+++ b/test/game/journal.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/game/journal.h"
+#include "reone/resource/gff.h"
+
+#include "../fixtures/resource.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+
+class JournalTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        auto entry1 = std::make_shared<Gff>(
+            0,
+            std::vector<Gff::Field> {
+                Gff::Field::newDword("ID", 10),
+                Gff::Field::newWord("End", 0),
+                Gff::Field::newCExoLocString("Text", -1, "first step"),
+                Gff::Field::newFloat("XP_Percentage", 0.5f)});
+
+        auto entry2 = std::make_shared<Gff>(
+            0,
+            std::vector<Gff::Field> {
+                Gff::Field::newDword("ID", 20),
+                Gff::Field::newWord("End", 1),
+                Gff::Field::newCExoLocString("Text", 123, ""),
+                Gff::Field::newFloat("XP_Percentage", 1.0f)});
+
+        auto category = std::make_shared<Gff>(
+            0,
+            std::vector<Gff::Field> {
+                Gff::Field::newCExoString("Tag", "test_plot"),
+                Gff::Field::newCExoLocString("Name", 42, ""),
+                Gff::Field::newList("EntryList", {entry1, entry2})});
+
+        _jrlGff = std::make_shared<Gff>(
+            0xffffffff,
+            std::vector<Gff::Field> {
+                Gff::Field::newList("Categories", {category})});
+
+        ON_CALL(_gffs, get(_, _)).WillByDefault(Return(_jrlGff));
+
+        _journal = std::make_unique<Journal>(_gffs, _strings);
+    }
+
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockStrings> _strings;
+    std::shared_ptr<Gff> _jrlGff;
+    std::unique_ptr<Journal> _journal;
+};
+
+TEST_F(JournalTest, should_add_entry_and_advance_to_higher_state) {
+    EXPECT_TRUE(_journal->addEntry("test_plot", 10));
+    EXPECT_EQ(10, _journal->getEntryState("test_plot"));
+
+    EXPECT_TRUE(_journal->addEntry("test_plot", 20));
+    EXPECT_EQ(20, _journal->getEntryState("test_plot"));
+
+    EXPECT_EQ(1ll, _journal->quests().size());
+}
+
+TEST_F(JournalTest, should_not_regress_to_lower_state_without_override) {
+    _journal->addEntry("test_plot", 20);
+
+    EXPECT_FALSE(_journal->addEntry("test_plot", 10));
+    EXPECT_EQ(20, _journal->getEntryState("test_plot"));
+}
+
+TEST_F(JournalTest, should_regress_to_lower_state_with_override) {
+    _journal->addEntry("test_plot", 20);
+
+    EXPECT_TRUE(_journal->addEntry("test_plot", 10, true));
+    EXPECT_EQ(10, _journal->getEntryState("test_plot"));
+}
+
+TEST_F(JournalTest, should_treat_equal_state_as_no_change) {
+    _journal->addEntry("test_plot", 10);
+
+    EXPECT_FALSE(_journal->addEntry("test_plot", 10));
+    EXPECT_FALSE(_journal->addEntry("test_plot", 10, true));
+    EXPECT_EQ(10, _journal->getEntryState("test_plot"));
+}
+
+TEST_F(JournalTest, should_match_plot_ids_case_insensitively) {
+    _journal->addEntry("Test_Plot", 10);
+
+    EXPECT_EQ(10, _journal->getEntryState("TEST_PLOT"));
+
+    _journal->addEntry("test_plot", 20);
+    EXPECT_EQ(1ll, _journal->quests().size());
+}
+
+TEST_F(JournalTest, should_remove_entry) {
+    _journal->addEntry("test_plot", 10);
+
+    EXPECT_TRUE(_journal->removeEntry("test_plot"));
+    EXPECT_EQ(0, _journal->getEntryState("test_plot"));
+    EXPECT_TRUE(_journal->quests().empty());
+
+    EXPECT_FALSE(_journal->removeEntry("test_plot"));
+}
+
+TEST_F(JournalTest, should_return_zero_state_for_unknown_plot) {
+    EXPECT_EQ(0, _journal->getEntryState("unknown_plot"));
+}
+
+TEST_F(JournalTest, should_look_up_current_entry_by_id_not_index) {
+    const JRL::Entry *entry = _journal->findEntry("test_plot", 20);
+
+    ASSERT_TRUE(entry);
+    EXPECT_EQ(20u, entry->id);
+
+    EXPECT_FALSE(_journal->findEntry("test_plot", 1));
+}
+
+TEST_F(JournalTest, should_derive_completion_from_current_entry_end_flag) {
+    _journal->addEntry("test_plot", 10);
+    EXPECT_FALSE(_journal->isCompleted("test_plot"));
+
+    _journal->addEntry("test_plot", 20);
+    EXPECT_TRUE(_journal->isCompleted("test_plot"));
+}
+
+TEST_F(JournalTest, should_resolve_quest_name_and_entry_text) {
+    EXPECT_CALL(_strings, getText(42)).WillOnce(Return("Test Quest"));
+    EXPECT_EQ("Test Quest", _journal->getQuestName("test_plot"));
+
+    EXPECT_EQ("first step", _journal->getEntryText("test_plot", 10));
+
+    EXPECT_CALL(_strings, getText(123)).WillOnce(Return("all done"));
+    EXPECT_EQ("all done", _journal->getEntryText("test_plot", 20));
+}
+
+TEST_F(JournalTest, should_restore_entry_verbatim) {
+    _journal->addEntry("test_plot", 20);
+
+    _journal->restoreEntry("test_plot", 10, 1, 2);
+
+    EXPECT_EQ(10, _journal->getEntryState("test_plot"));
+    ASSERT_EQ(1ll, _journal->quests().size());
+    EXPECT_EQ(1u, _journal->quests()[0].date);
+    EXPECT_EQ(2u, _journal->quests()[0].time);
+}
+
+TEST_F(JournalTest, should_track_state_for_plot_missing_from_global_journal) {
+    EXPECT_TRUE(_journal->addEntry("unlisted_plot", 5));
+    EXPECT_EQ(5, _journal->getEntryState("unlisted_plot"));
+    EXPECT_FALSE(_journal->isCompleted("unlisted_plot"));
+    EXPECT_EQ("", _journal->getQuestName("unlisted_plot"));
+}
+
+TEST_F(JournalTest, should_clear_state_on_reset) {
+    _journal->addEntry("test_plot", 10);
+
+    _journal->reset();
+
+    EXPECT_EQ(0, _journal->getEntryState("test_plot"));
+    EXPECT_TRUE(_journal->quests().empty());
+}

--- a/test/game/journal.cpp
+++ b/test/game/journal.cpp
@@ -173,6 +173,37 @@ TEST_F(JournalTest, should_track_state_for_plot_missing_from_global_journal) {
     EXPECT_EQ("", _journal->getQuestName("unlisted_plot"));
 }
 
+TEST_F(JournalTest, should_notify_listener_only_when_state_changes) {
+    int notified = 0;
+    _journal->setOnQuestChanged([&notified]() { ++notified; });
+
+    _journal->addEntry("test_plot", 10);
+    EXPECT_EQ(1, notified) << "new quest should notify";
+
+    _journal->addEntry("test_plot", 10);
+    EXPECT_EQ(1, notified) << "same state should not notify";
+
+    _journal->addEntry("test_plot", 5);
+    EXPECT_EQ(1, notified) << "lower state without override should not notify";
+
+    _journal->addEntry("test_plot", 20);
+    EXPECT_EQ(2, notified) << "higher state should notify";
+
+    _journal->addEntry("test_plot", 10, true);
+    EXPECT_EQ(3, notified) << "lower state with override should notify";
+}
+
+TEST_F(JournalTest, should_not_notify_listener_on_restore_or_remove) {
+    int notified = 0;
+    _journal->setOnQuestChanged([&notified]() { ++notified; });
+
+    _journal->restoreEntry("test_plot", 10, 0, 0);
+    EXPECT_EQ(0, notified);
+
+    _journal->removeEntry("test_plot");
+    EXPECT_EQ(0, notified);
+}
+
 TEST_F(JournalTest, should_clear_state_on_reset) {
     _journal->addEntry("test_plot", 10);
 

--- a/test/resource/parser/jrl.cpp
+++ b/test/resource/parser/jrl.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/gff.h"
+#include "reone/resource/parser/gff/jrl.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+TEST(Jrl, should_parse_categories_and_entries) {
+    // given
+
+    auto entry1 = std::make_shared<Gff>(
+        0,
+        std::vector<Gff::Field> {
+            Gff::Field::newDword("ID", 10),
+            Gff::Field::newWord("End", 0),
+            Gff::Field::newCExoLocString("Text", -1, "first step"),
+            Gff::Field::newFloat("XP_Percentage", 0.5f)});
+
+    auto entry2 = std::make_shared<Gff>(
+        0,
+        std::vector<Gff::Field> {
+            Gff::Field::newDword("ID", 20),
+            Gff::Field::newWord("End", 1),
+            Gff::Field::newCExoLocString("Text", 123, ""),
+            Gff::Field::newFloat("XP_Percentage", 1.0f)});
+
+    auto category = std::make_shared<Gff>(
+        0,
+        std::vector<Gff::Field> {
+            Gff::Field::newCExoString("Tag", "test_plot"),
+            Gff::Field::newCExoLocString("Name", 42, ""),
+            Gff::Field::newDword("Priority", 2),
+            Gff::Field::newInt("PlanetID", 3),
+            Gff::Field::newInt("PlotIndex", 4),
+            Gff::Field::newCExoString("Comment", "test comment"),
+            Gff::Field::newList("EntryList", {entry1, entry2})});
+
+    auto root = Gff(
+        0xffffffff,
+        std::vector<Gff::Field> {
+            Gff::Field::newList("Categories", {category})});
+
+    // when
+
+    JRL jrl = parseJRL(root);
+
+    // then
+
+    ASSERT_EQ(1ll, jrl.categories.size());
+
+    const JRL::Category &cat = jrl.categories[0];
+    EXPECT_EQ("test_plot", cat.tag);
+    EXPECT_EQ(42, cat.name.first);
+    EXPECT_EQ(2u, cat.priority);
+    EXPECT_EQ(3, cat.planetId);
+    EXPECT_EQ(4, cat.plotIndex);
+    EXPECT_EQ("test comment", cat.comment);
+
+    ASSERT_EQ(2ll, cat.entries.size());
+
+    EXPECT_EQ(10u, cat.entries[0].id);
+    EXPECT_FALSE(cat.entries[0].end);
+    EXPECT_EQ(-1, cat.entries[0].text.first);
+    EXPECT_EQ("first step", cat.entries[0].text.second);
+    EXPECT_EQ(0.5f, cat.entries[0].xpPercentage);
+
+    EXPECT_EQ(20u, cat.entries[1].id);
+    EXPECT_TRUE(cat.entries[1].end);
+    EXPECT_EQ(123, cat.entries[1].text.first);
+    EXPECT_EQ(1.0f, cat.entries[1].xpPercentage);
+}
+
+TEST(Jrl, should_parse_empty_journal) {
+    auto root = Gff(0xffffffff, std::vector<Gff::Field> {});
+
+    JRL jrl = parseJRL(root);
+
+    EXPECT_TRUE(jrl.categories.empty());
+}

--- a/test/resource/provider/dialogs.cpp
+++ b/test/resource/provider/dialogs.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/container/memory.h"
+#include "reone/resource/format/gffwriter.h"
+#include "reone/resource/gff.h"
+#include "reone/resource/provider/dialogs.h"
+#include "reone/resource/provider/gffs.h"
+#include "reone/resource/resources.h"
+#include "reone/resource/strings.h"
+#include "reone/system/stream/memoryoutput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+TEST(Dialogs, should_preserve_quest_fields_from_dlg) {
+    // given
+
+    auto entry = std::make_shared<Gff>(
+        0,
+        std::vector<Gff::Field> {
+            Gff::Field::newCExoLocString("Text", -1, "greetings"),
+            Gff::Field::newCExoString("Quest", "test_plot"),
+            Gff::Field::newDword("QuestEntry", 10)});
+
+    auto reply = std::make_shared<Gff>(
+        0,
+        std::vector<Gff::Field> {
+            Gff::Field::newCExoLocString("Text", -1, "farewell"),
+            Gff::Field::newCExoString("Quest", "other_plot"),
+            Gff::Field::newDword("QuestEntry", 20)});
+
+    auto root = Gff(
+        0xffffffff,
+        std::vector<Gff::Field> {
+            Gff::Field::newList("EntryList", {entry}),
+            Gff::Field::newList("ReplyList", {reply})});
+
+    auto dlgBytes = ByteBuffer();
+    auto dlgStream = MemoryOutputStream(dlgBytes);
+    GffWriter(ResType::Dlg, root).save(dlgStream);
+
+    auto resources = Resources();
+    auto container = std::make_unique<MemoryResourceContainer>();
+    container->add(ResourceId("sample", ResType::Dlg), std::move(dlgBytes));
+    resources.add(std::move(container));
+
+    auto gffs = Gffs(resources);
+    auto strings = Strings();
+    auto dialogs = Dialogs(gffs, strings);
+
+    // when
+
+    auto dialog = dialogs.get("sample");
+
+    // then
+
+    ASSERT_TRUE(static_cast<bool>(dialog));
+
+    ASSERT_EQ(1ll, dialog->entries.size());
+    EXPECT_EQ("test_plot", dialog->entries[0].quest);
+    EXPECT_EQ(10u, dialog->entries[0].questEntry);
+
+    ASSERT_EQ(1ll, dialog->replies.size());
+    EXPECT_EQ("other_plot", dialog->replies[0].quest);
+    EXPECT_EQ(20u, dialog->replies[0].questEntry);
+}


### PR DESCRIPTION
## Summary

Implements the first functional journal / quest vertical slice.

This adds:

- typed `global.jrl` parsing
- runtime journal quest state
- core journal script routines:
  - `AddJournalQuestEntry`
  - `RemoveJournalQuestEntry`
  - `GetJournalEntry`
  - `GetJournalQuestExperience`
- DLG `Quest` / `QuestEntry` passthrough into runtime dialogue data
- conversation hooks that apply journal updates from entries/replies
- vanilla save-load import of `PARTYTABLE` `JNL_Entries`
- minimal Journal menu population
- HUD journal notification icon on quest state changes
- vanilla-style centred `Journal Entry Added` popup with journal icon

Journal state treats quest state as the JRL entry `ID`, not a list index. Updates advance only to higher states unless override is allowed, and repeated same-state dialogue applications are no-ops.