### PR TITLE
[tool] Add ncsrun to execute NCS scripts in a standalone VM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(BUILD_TOOLKIT "build toolkit application" ON)
 option(BUILD_DATAMINER "build dataminer application" ON)
 option(BUILD_GFF2JSON "build gff2json application" ON)
 option(BUILD_UNERF "build unerf application" ON)
+option(BUILD_NCSRUN "build ncsrun application" ON)
 
 option(ENABLE_MOVIE "enable movie playback" ON)
 option(ENABLE_ASAN "enable address sanitizer" OFF)
@@ -129,6 +130,10 @@ endif()
 
 if(BUILD_UNERF)
     add_subdirectory(src/apps/unerf) # unpack ERF files
+endif()
+
+if(BUILD_NCSRUN)
+    add_subdirectory(src/apps/ncsrun) # execute NCS program
 endif()
 
 if(BUILD_TESTS)

--- a/src/apps/ncsrun/CMakeLists.txt
+++ b/src/apps/ncsrun/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The reone project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(NCSRUN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/apps/ncsrun)
+
+set(NCSRUN_HEADERS)
+
+set(NCSRUN_SOURCES
+    ${NCSRUN_SOURCE_DIR}/main.cpp)
+
+add_executable(ncsrun ${NCSRUN_SOURCES} ${NCSRUN_HEADERS} ${CLANG_FORMAT_PATH})
+set_target_properties(ncsrun PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}$<$<CONFIG:Debug>:/debug>/bin)
+target_precompile_headers(ncsrun PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_link_libraries(ncsrun PRIVATE script system ${Boost_PROGRAM_OPTIONS_LIBRARY})
+

--- a/src/apps/ncsrun/main.cpp
+++ b/src/apps/ncsrun/main.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/script/executioncontext.h"
+#include "reone/script/format/ncsreader.h"
+#include "reone/script/virtualmachine.h"
+#include "reone/system/logger.h"
+#include "reone/system/stream/fileinput.h"
+#include "reone/system/threadutil.h"
+
+using namespace reone;
+using namespace reone::script;
+
+using CmdArgs = boost::program_options::variables_map;
+
+// Execute an NCS script and return the result.
+static int run(const CmdArgs &args) {
+    if (args["verbose"].as<bool>()) {
+        markMainThread();
+        std::set<LogChannel> channels;
+        channels.insert(LogChannel::Script);
+        channels.insert(LogChannel::Script2);
+        channels.insert(LogChannel::Script3);
+        Logger::instance.init(LogSeverity::Debug, channels, std::nullopt);
+    }
+
+    // Read program from the input NCS file.
+    auto file = FileInputStream(args["input-file"].as<std::string>());
+    auto reader = NcsReader(file, "input");
+    reader.load();
+    auto program = reader.program();
+
+    // Run the program without actual game context. Routines are not handled.
+    auto ctx = std::make_unique<ExecutionContext>();
+    return VirtualMachine(program, std::move(ctx)).run();
+}
+
+static void parseOptions(int argc, char **argv, CmdArgs &vars) {
+    using namespace boost::program_options;
+    options_description description;
+    description.add_options()
+        ("input-file", value<std::string>()->required())
+        ("verbose,v", bool_switch()->default_value(false));
+
+    positional_options_description positional;
+    positional.add("input-file", 1);
+
+    basic_command_line_parser parser(argc, argv);
+    store(parser.options(description).positional(positional).run(),
+          vars, /*utf8=*/true);
+}
+
+int main(int argc, char **argv) {
+    try {
+        CmdArgs args;
+        parseOptions(argc, argv, args);
+        return run(args);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return -1;
+    }
+}


### PR DESCRIPTION
ncsrun tool takes a single argument - a file path to an NCS script. The tool reads and executes the file, and returns the result.

If the script returns a value (e.g. `int main() { return 1; }`), the program returns this value as exit code. On error, -1 is returned. If there is no value to return (e.g. `void main() {...}`), then 0 is returned.

Optional -v argument enables debug loggging to stdout:

    DEBUG [main][script] Instruction: 0000000d RSADDI () -> (%1:0)
    DEBUG [main][script] Instruction: 0000000f JMP 00000037(40)
    DEBUG [main][script] Instruction: 00000037 JMP 00000015(-34)
    DEBUG [main][script] Instruction: 00000015 CONSTI 2 () -> (%2:2)
    DEBUG [main][script] Instruction: 0000001b CONSTI 2 () -> (%3:2)
    DEBUG [main][script] Instruction: 00000021 ADDII (%3:2, %2:2) -> (%4:4)
    DEBUG [main][script] Instruction: 00000023 CPDOWNSP -8, 4
    DEBUG [main][script] Instruction: 0000002b MOVSP -4
    DEBUG [main][script] Instruction: 00000031 JMP 0000003d(12)
    DEBUG [main][script] Instruction: 0000003d RETN