### PR TITLE
[system] Destroy input streams polymorphically

### DIFF
--- a/include/reone/system/stream/input.h
+++ b/include/reone/system/stream/input.h
@@ -23,6 +23,8 @@ namespace reone {
 
 class IInputStream : boost::noncopyable {
 public:
+    virtual ~IInputStream() = default;
+
     virtual void seek(int64_t offset, SeekOrigin origin = SeekOrigin::Begin) = 0;
 
     virtual int readByte() = 0;

--- a/test/system/stream/fileinput.cpp
+++ b/test/system/stream/fileinput.cpp
@@ -23,6 +23,40 @@
 
 using namespace reone;
 
+namespace {
+
+class DestructionTrackingInputStream final : public IInputStream {
+public:
+    explicit DestructionTrackingInputStream(bool &destroyed) :
+        _destroyed(destroyed) {
+    }
+
+    ~DestructionTrackingInputStream() override {
+        _destroyed = true;
+    }
+
+    void seek(int64_t, SeekOrigin) override {}
+    int readByte() override { return -1; }
+    int read(char *, int) override { return 0; }
+    size_t position() override { return 0; }
+    size_t length() override { return 0; }
+
+private:
+    bool &_destroyed;
+};
+
+} // namespace
+
+TEST(IInputStream, should_support_polymorphic_destruction) {
+    bool destroyed = false;
+
+    {
+        std::unique_ptr<IInputStream> stream = std::make_unique<DestructionTrackingInputStream>(destroyed);
+    }
+
+    EXPECT_TRUE(destroyed);
+}
+
 TEST(FileInputStream, should_read_from_file) {
     // given
 


### PR DESCRIPTION
## Summary

Adds a virtual destructor to `IInputStream` so derived input streams are
destroyed correctly through base-class pointers.

Without a virtual destructor, `FileInputStream` instances returned as
`std::unique_ptr<IInputStream>` were not destroyed correctly, leaking file
descriptors during repeated resource reads.

On Windows this eventually exhausted MSVC's stream-descriptor limit and caused
later resource reads to fail.

A focused regression test verifies that destroying an input stream through the
base interface invokes the derived destructor.

## How this was found

The issue was exposed during controlled testing of an alternative resource
backend.

A module initially failed while loading `i_solo.tpc`. Comparison showed that
both resource backends selected the same resource from `swpc_tex_gui.erf` with
the same metadata and bytes. The eventual failed reads were caused by
`errno=24` after the process exhausted its available stream descriptors.

Adding the virtual destructor removed the leak, after which controlled module
loads succeeded in both K1 and K2.