### PR TITLE
[system] Add safe resource path helpers

### DIFF
--- a/include/reone/system/fileutil.h
+++ b/include/reone/system/fileutil.h
@@ -22,4 +22,16 @@ namespace reone {
 std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath);
 std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath);
 
+/** KotOR ResRef rules: 1-16 alphanumeric or underscore characters. */
+bool isValidResRef(std::string_view name, size_t maxLen = 16);
+
+/**
+ * Whether name is safe to use as a single path component under a trusted
+ * parent directory. Permits characters found in the wild, e.g. in savegame
+ * directory names ("000043 - Game42"), while rejecting anything that could
+ * escape the parent: ".", "..", separators, drive qualifiers and absolute
+ * paths. Not a ResRef check - use isValidResRef for ResRefs.
+ */
+bool isSafePathComponent(std::string_view name);
+
 } // namespace reone

--- a/src/libs/system/fileutil.cpp
+++ b/src/libs/system/fileutil.cpp
@@ -21,9 +21,21 @@
 
 namespace reone {
 
+static bool splitRelativePath(std::string_view relPath, std::vector<std::string> &tokens) {
+    boost::split(tokens, relPath, boost::is_any_of("/\\"), boost::token_compress_off);
+    for (const auto &token : tokens) {
+        if (token.empty() || token == "." || token == "..") {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
     std::vector<std::string> tokens;
-    boost::split(tokens, relPath, boost::is_any_of("/"), boost::token_compress_on);
+    if (!splitRelativePath(relPath, tokens)) {
+        throw FileNotFoundException((dir / relPath).string());
+    }
 
     for (auto &entry : std::filesystem::directory_iterator(dir)) {
         auto filename = boost::to_lower_copy(entry.path().filename().string());
@@ -41,7 +53,9 @@ std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::s
 
 std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
     std::vector<std::string> tokens;
-    boost::split(tokens, relPath, boost::is_any_of("/"), boost::token_compress_on);
+    if (!splitRelativePath(relPath, tokens)) {
+        return std::nullopt;
+    }
 
     for (auto &entry : std::filesystem::directory_iterator(dir)) {
         auto filename = boost::to_lower_copy(entry.path().filename().string());
@@ -55,6 +69,44 @@ std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::p
     }
 
     return std::nullopt;
+}
+
+bool isValidResRef(std::string_view name, size_t maxLen) {
+    if (name.empty() || name.size() > maxLen) {
+        return false;
+    }
+    for (char c : name) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool isSafePathComponent(std::string_view name) {
+    if (name.empty() || name == "." || name == "..") {
+        return false;
+    }
+    for (char c : name) {
+        if (static_cast<unsigned char>(c) < 0x20) {
+            return false;
+        }
+        switch (c) {
+        case '/':
+        case '\\':
+        case ':':
+        case '<':
+        case '>':
+        case '"':
+        case '|':
+        case '?':
+        case '*':
+            return false;
+        default:
+            break;
+        }
+    }
+    return true;
 }
 
 } // namespace reone

--- a/test/system/fileutil.cpp
+++ b/test/system/fileutil.cpp
@@ -17,9 +17,34 @@
 
 #include <gtest/gtest.h>
 
+#include "reone/system/exception/filenotfound.h"
 #include "reone/system/fileutil.h"
 
 using namespace reone;
+
+namespace {
+
+/// Temporary directory with a nested file, removed on destruction.
+struct TmpTree {
+    std::filesystem::path root;
+    std::filesystem::path subDir;
+    std::filesystem::path file;
+
+    TmpTree() {
+        root = std::filesystem::temp_directory_path() / "reone_test_file_util_tree";
+        subDir = root / "SubDir";
+        file = subDir / "MiXeD";
+        std::filesystem::create_directories(subDir);
+        std::ofstream(file, std::ios::binary).flush();
+    }
+
+    ~TmpTree() {
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+    }
+};
+
+} // namespace
 
 TEST(FileUtilities, should_find_file_ignoring_case) {
     // given
@@ -44,4 +69,73 @@ TEST(FileUtilities, should_find_file_ignoring_case) {
 
     // cleanup
     std::filesystem::remove_all(tmpDirPath);
+}
+
+TEST(FileUtilities, should_find_nested_file_with_either_separator) {
+    TmpTree tree;
+
+    auto slashPath = findFileIgnoreCase(tree.root, "subdir/mixed");
+    auto backslashPath = findFileIgnoreCase(tree.root, "subdir\\mixed");
+
+    ASSERT_TRUE(slashPath);
+    EXPECT_EQ(tree.file, *slashPath);
+    ASSERT_TRUE(backslashPath);
+    EXPECT_EQ(tree.file, *backslashPath);
+}
+
+TEST(FileUtilities, should_not_find_file_by_unsafe_relative_path) {
+    TmpTree tree;
+
+    EXPECT_FALSE(findFileIgnoreCase(tree.subDir, ""));
+    EXPECT_FALSE(findFileIgnoreCase(tree.subDir, "."));
+    EXPECT_FALSE(findFileIgnoreCase(tree.subDir, ".."));
+    EXPECT_FALSE(findFileIgnoreCase(tree.subDir, "../subdir/mixed"));
+    EXPECT_FALSE(findFileIgnoreCase(tree.subDir, "..\\subdir\\mixed"));
+    EXPECT_FALSE(findFileIgnoreCase(tree.root, "subdir/../subdir/mixed"));
+    EXPECT_FALSE(findFileIgnoreCase(tree.root, "subdir//mixed"));
+
+    EXPECT_THROW(getFileIgnoreCase(tree.subDir, ".."), FileNotFoundException);
+    EXPECT_THROW(getFileIgnoreCase(tree.subDir, "../subdir/mixed"), FileNotFoundException);
+}
+
+TEST(FileUtilities, should_validate_resrefs) {
+    EXPECT_TRUE(isValidResRef("a"));
+    EXPECT_TRUE(isValidResRef("abc_123"));
+    EXPECT_TRUE(isValidResRef("abcdefgh12345678"));
+
+    EXPECT_FALSE(isValidResRef(""));
+    EXPECT_FALSE(isValidResRef("abcdefgh123456789"));
+    EXPECT_FALSE(isValidResRef("a b"));
+    EXPECT_FALSE(isValidResRef("a-b"));
+    EXPECT_FALSE(isValidResRef("a/b"));
+    EXPECT_FALSE(isValidResRef("a.b"));
+}
+
+TEST(FileUtilities, should_accept_safe_path_components) {
+    EXPECT_TRUE(isSafePathComponent("000001"));
+    EXPECT_TRUE(isSafePathComponent("QUICKSAVE"));
+    EXPECT_TRUE(isSafePathComponent("AUTOSAVE"));
+    EXPECT_TRUE(isSafePathComponent("000043 - Game42"));
+    EXPECT_TRUE(isSafePathComponent("a_b-c 1"));
+    EXPECT_TRUE(isSafePathComponent("name.with.dots"));
+}
+
+TEST(FileUtilities, should_reject_unsafe_path_components) {
+    EXPECT_FALSE(isSafePathComponent(""));
+    EXPECT_FALSE(isSafePathComponent("."));
+    EXPECT_FALSE(isSafePathComponent(".."));
+    EXPECT_FALSE(isSafePathComponent("a/b"));
+    EXPECT_FALSE(isSafePathComponent("a\\b"));
+    EXPECT_FALSE(isSafePathComponent("/absolute"));
+    EXPECT_FALSE(isSafePathComponent("\\absolute"));
+    EXPECT_FALSE(isSafePathComponent("C:"));
+    EXPECT_FALSE(isSafePathComponent("C:\\saves"));
+    EXPECT_FALSE(isSafePathComponent("../escape"));
+    EXPECT_FALSE(isSafePathComponent("..\\escape"));
+    EXPECT_FALSE(isSafePathComponent("bad\nname"));
+    EXPECT_FALSE(isSafePathComponent("bad*name"));
+    EXPECT_FALSE(isSafePathComponent("bad?name"));
+    EXPECT_FALSE(isSafePathComponent("bad|name"));
+    EXPECT_FALSE(isSafePathComponent("bad<name>"));
+    EXPECT_FALSE(isSafePathComponent("bad\"name"));
 }


### PR DESCRIPTION
> **Resource-loader migration: A — system/path prerequisites**

## Summary

Adds safe path helpers needed by the new resource loader.

This change:

- adds strict KotOR ResRef validation
- adds a separate safe directory-component check
- blocks traversal in case-insensitive lookups
- supports both `/` and `\`
- accepts valid save-folder names such as `QUICKSAVE`, `AUTOSAVE`, and `000043 - Game42`

No resource precedence, save-loading, or gameplay behavior changes.