### PR TITLE
[resource] Add Extract archive and lookup primitives

### DIFF
--- a/include/reone/extract/capsule.h
+++ b/include/reone/extract/capsule.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "fileresource.h"
+
+namespace reone {
+
+namespace extract {
+
+/// Lazy ERF/MOD/RIM/SAV index (PyKotor LazyCapsule).
+class LazyCapsule {
+public:
+    explicit LazyCapsule(std::filesystem::path path);
+
+    const std::filesystem::path &path() const { return _path; }
+    const std::vector<FileResource> &resources() const;
+
+    std::optional<FileResource> find(const resource::ResourceId &id) const;
+
+private:
+    std::filesystem::path _path;
+    mutable std::vector<FileResource> _resources;
+    mutable std::unordered_map<resource::ResourceId, size_t> _index;
+    mutable bool _loaded {false};
+
+    void ensureLoaded() const;
+};
+
+bool isCapsuleFile(const std::filesystem::path &path);
+bool isModFile(const std::filesystem::path &path);
+bool isErfFile(const std::filesystem::path &path);
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/extract/chitin.h
+++ b/include/reone/extract/chitin.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "fileresource.h"
+
+namespace reone {
+
+namespace extract {
+
+/// KEY/BIF virtual resource index (PyKotor Chitin).
+class Chitin {
+public:
+    explicit Chitin(std::filesystem::path keyPath);
+
+    const std::vector<FileResource> &resources() const { return _resources; }
+
+private:
+    std::vector<FileResource> _resources;
+};
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/extract/fileresource.h
+++ b/include/reone/extract/fileresource.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/resource/id.h"
+#include "reone/system/types.h"
+
+namespace reone {
+
+namespace extract {
+
+/// Derive a resource identifier from a filename, e.g. "sample.txt".
+std::optional<resource::ResourceId> resourceIdFromPath(const std::filesystem::path &path);
+
+/// Metadata for a resource entry (PyKotor FileResource).
+class FileResource {
+public:
+    FileResource(std::string resRef,
+                 resource::ResType type,
+                 uint32_t size,
+                 uint32_t offset,
+                 std::filesystem::path filepath);
+
+    static std::optional<FileResource> fromPath(const std::filesystem::path &path);
+
+    const resource::ResourceId &id() const { return _id; }
+    const resource::ResRef &resRef() const { return _id.resRef; }
+    resource::ResType type() const { return _id.type; }
+
+    /// Resource filename, e.g. "sample.txt".
+    std::string filename() const { return _id.string(); }
+
+    /// Path of the file holding the resource: the resource file itself, or
+    /// the containing capsule/BIF.
+    const std::filesystem::path &filepath() const { return _filepath; }
+
+    /// Unique path of the resource: filepath for loose files, or
+    /// filepath/filename for capsule and BIF entries.
+    std::filesystem::path pathIdentifier() const;
+
+    uint32_t offset() const { return _offset; }
+    uint32_t size() const { return _size; }
+    bool insideCapsule() const { return _insideCapsule; }
+    bool insideBif() const { return _insideBif; }
+
+    /// Whether the backing file exists and contains the described range.
+    bool exists() const;
+
+    ByteBuffer readData() const;
+
+private:
+    resource::ResourceId _id;
+    uint32_t _size;
+    uint32_t _offset;
+    std::filesystem::path _filepath;
+    bool _insideCapsule;
+    bool _insideBif;
+};
+
+/// Resolved location before byte load (PyKotor LocationResult).
+class LocationResult {
+public:
+    LocationResult(std::filesystem::path filepath, uint32_t offset, uint32_t size);
+
+    const std::filesystem::path &filepath() const { return _filepath; }
+    uint32_t offset() const { return _offset; }
+    uint32_t size() const { return _size; }
+
+    void setFileResource(FileResource resource);
+    bool hasFileResource() const { return _fileResource.has_value(); }
+    const FileResource &asFileResource() const;
+    const resource::ResourceId &id() const;
+
+    ByteBuffer readData() const;
+
+private:
+    std::filesystem::path _filepath;
+    uint32_t _offset;
+    uint32_t _size;
+    std::optional<FileResource> _fileResource;
+};
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/extract/finder.h
+++ b/include/reone/extract/finder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "searchlocation.h"
+
+#include "reone/graphics/types.h"
+
+namespace reone {
+
+namespace extract {
+
+/// PyKotor tools/finder.canonical_search_order()
+const SearchScope &canonicalSearchOrder();
+
+/// Texture lookup honoring launcher graphics quality (GUI pack + one quality tier).
+SearchScope textureSearchOrder(graphics::TextureQuality quality);
+
+/// Streamed audio lookup (music, SFX, voice). Extends PyKotor sounds() with Music/Voice.
+const SearchScope &soundSearchOrder();
+
+/// Loose installation-root files (e.g. dialog.tlk).
+const SearchScope &talkTableSearchOrder();
+
+/// movies/*.bik lookup order.
+const SearchScope &movieSearchOrder();
+
+const char *searchLocationName(SearchLocation location);
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/extract/searchlocation.h
+++ b/include/reone/extract/searchlocation.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace extract {
+
+/// Mirrors PyKotor SearchLocation (installation.py) plus reone-only Executable.
+enum class SearchLocation {
+    Override = 0,
+    Modules = 1,
+    Chitin = 2,
+    TexturesTpa = 3,
+    TexturesTpb = 4,
+    TexturesTpc = 5,
+    TexturesGui = 6,
+    Music = 7,
+    Sound = 8,
+    Voice = 9,
+    Lips = 10,
+    Rims = 11,
+    CustomModules = 12,
+    CustomFolders = 13,
+    Executable = 14,
+    Root = 15,
+    Movies = 16,
+};
+
+using SearchScope = std::vector<SearchLocation>;
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/system/stream/gameinput.h
+++ b/include/reone/system/stream/gameinput.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "fileinput.h"
+
+namespace reone {
+
+/**
+ * Open a game data file for reading. A dedicated seam, so that alternative
+ * backends can be plugged in without touching call sites.
+ */
+static inline std::unique_ptr<IInputStream> openGameInputStream(const std::filesystem::path &path) {
+    return std::make_unique<FileInputStream>(path);
+}
+
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -27,6 +27,11 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/container/rim.h
     ${RESOURCE_INCLUDE_DIR}/di/module.h
     ${RESOURCE_INCLUDE_DIR}/di/services.h
+    ${REONE_INCLUDE_DIR}/reone/extract/capsule.h
+    ${REONE_INCLUDE_DIR}/reone/extract/chitin.h
+    ${REONE_INCLUDE_DIR}/reone/extract/fileresource.h
+    ${REONE_INCLUDE_DIR}/reone/extract/finder.h
+    ${REONE_INCLUDE_DIR}/reone/extract/searchlocation.h
     ${RESOURCE_INCLUDE_DIR}/dialog.h
     ${RESOURCE_INCLUDE_DIR}/director.h
     ${RESOURCE_INCLUDE_DIR}/exception/notfound.h
@@ -96,6 +101,10 @@ set(RESOURCE_HEADERS
 
 set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/2da.cpp
+    ${RESOURCE_SOURCE_DIR}/extract/capsule.cpp
+    ${RESOURCE_SOURCE_DIR}/extract/chitin.cpp
+    ${RESOURCE_SOURCE_DIR}/extract/fileresource.cpp
+    ${RESOURCE_SOURCE_DIR}/extract/finder.cpp
     ${RESOURCE_SOURCE_DIR}/container/erf.cpp
     ${RESOURCE_SOURCE_DIR}/container/exe.cpp
     ${RESOURCE_SOURCE_DIR}/container/folder.cpp

--- a/src/libs/resource/extract/capsule.cpp
+++ b/src/libs/resource/extract/capsule.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/extract/capsule.h"
+
+#include "reone/resource/format/erfreader.h"
+#include "reone/resource/format/rimreader.h"
+#include "reone/system/exception/endofstream.h"
+#include "reone/system/stream/gameinput.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+
+namespace reone {
+
+namespace extract {
+
+namespace {
+
+std::string extensionLower(const std::filesystem::path &path) {
+    auto ext = path.extension().string();
+    if (!ext.empty() && ext[0] == '.') {
+        ext.erase(0, 1);
+    }
+    boost::to_lower(ext);
+    return ext;
+}
+
+} // namespace
+
+bool isCapsuleFile(const std::filesystem::path &path) {
+    auto ext = extensionLower(path);
+    return ext == "erf" || ext == "mod" || ext == "rim" || ext == "sav" || ext == "hak";
+}
+
+bool isModFile(const std::filesystem::path &path) {
+    return extensionLower(path) == "mod";
+}
+
+bool isErfFile(const std::filesystem::path &path) {
+    auto ext = extensionLower(path);
+    return ext == "erf" || ext == "sav" || ext == "hak";
+}
+
+LazyCapsule::LazyCapsule(std::filesystem::path path) :
+    _path(std::move(path)) {
+}
+
+const std::vector<FileResource> &LazyCapsule::resources() const {
+    ensureLoaded();
+    return _resources;
+}
+
+std::optional<FileResource> LazyCapsule::find(const resource::ResourceId &id) const {
+    ensureLoaded();
+    auto it = _index.find(id);
+    if (it == _index.end()) {
+        return std::nullopt;
+    }
+    return _resources[it->second];
+}
+
+void LazyCapsule::ensureLoaded() const {
+    if (_loaded) {
+        return;
+    }
+    _loaded = true;
+    _resources.clear();
+    _index.clear();
+    if (!std::filesystem::exists(_path)) {
+        return;
+    }
+
+    auto stream = openGameInputStream(_path);
+    auto ext = extensionLower(_path);
+    if (ext == "rim") {
+        resource::RimReader reader(*stream);
+        try {
+            reader.load();
+        } catch (const EndOfStreamException &) {
+            throw std::runtime_error("EOF reading capsule: " + _path.string());
+        }
+        for (auto &entry : reader.resources()) {
+            _resources.emplace_back(
+                entry.resId.resRef.value(),
+                entry.resId.type,
+                entry.size,
+                entry.offset,
+                _path);
+        }
+    } else {
+        resource::ErfReader reader(*stream);
+        try {
+            reader.load();
+        } catch (const EndOfStreamException &) {
+            throw std::runtime_error("EOF reading capsule: " + _path.string());
+        }
+        auto &keys = reader.keys();
+        auto &resEntries = reader.resources();
+        for (size_t i = 0; i < keys.size() && i < resEntries.size(); ++i) {
+            auto &key = keys[i];
+            auto &entry = resEntries[i];
+            _resources.emplace_back(
+                key.resId.resRef.value(),
+                key.resId.type,
+                entry.size,
+                entry.offset,
+                _path);
+        }
+    }
+
+    for (size_t i = 0; i < _resources.size(); ++i) {
+        _index.emplace(_resources[i].id(), i);
+    }
+}
+
+} // namespace extract
+
+} // namespace reone

--- a/src/libs/resource/extract/chitin.cpp
+++ b/src/libs/resource/extract/chitin.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/extract/chitin.h"
+
+#include "reone/resource/format/bifreader.h"
+#include "reone/resource/format/keyreader.h"
+#include "reone/system/exception/endofstream.h"
+#include "reone/system/exception/filenotfound.h"
+#include "reone/system/fileutil.h"
+#include "reone/system/stream/gameinput.h"
+
+namespace reone {
+
+namespace extract {
+
+Chitin::Chitin(std::filesystem::path keyPath) {
+    if (!std::filesystem::exists(keyPath)) {
+        return;
+    }
+
+    auto keyStream = openGameInputStream(keyPath);
+    resource::KeyReader keyReader(*keyStream);
+    try {
+        keyReader.load();
+    } catch (const EndOfStreamException &) {
+        throw std::runtime_error("EOF reading KEY: " + keyPath.string());
+    }
+
+    auto gamePath = keyPath.parent_path();
+    std::unordered_map<int, std::vector<const resource::KeyReader::KeyEntry *>> bifIdxToKey;
+    for (auto &key : keyReader.keys()) {
+        bifIdxToKey[key.bifIdx].push_back(&key);
+    }
+
+    for (size_t i = 0; i < keyReader.files().size(); ++i) {
+        auto &file = keyReader.files()[i];
+
+        // KEY files store BIF paths with backslash separators.
+        auto bifRelPath = boost::replace_all_copy(file.filename, "\\", "/");
+
+        std::filesystem::path bifPath;
+        try {
+            bifPath = getFileIgnoreCase(gamePath, bifRelPath);
+        } catch (const FileNotFoundException &) {
+            continue;
+        }
+
+        auto bifStream = openGameInputStream(bifPath);
+        resource::BifReader bifReader(*bifStream);
+        try {
+            bifReader.load();
+        } catch (const EndOfStreamException &) {
+            throw std::runtime_error("EOF reading BIF: " + bifPath.string());
+        }
+        auto &bifResources = bifReader.resources();
+
+        auto keysIt = bifIdxToKey.find(static_cast<int>(i));
+        if (keysIt == bifIdxToKey.end()) {
+            continue;
+        }
+        for (auto *key : keysIt->second) {
+            if (key->resIdx < 0 || static_cast<size_t>(key->resIdx) >= bifResources.size()) {
+                continue;
+            }
+            auto &bifResource = bifResources[key->resIdx];
+            _resources.emplace_back(
+                key->resId.resRef.value(),
+                key->resId.type,
+                bifResource.fileSize,
+                bifResource.offset,
+                bifPath);
+        }
+    }
+}
+
+} // namespace extract
+
+} // namespace reone

--- a/src/libs/resource/extract/fileresource.cpp
+++ b/src/libs/resource/extract/fileresource.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/extract/fileresource.h"
+
+#include <cassert>
+
+#include "reone/resource/typeutil.h"
+#include "reone/system/stream/gameinput.h"
+
+namespace reone {
+
+namespace extract {
+
+static std::string extensionLower(const std::filesystem::path &path) {
+    auto ext = path.extension().string();
+    if (!ext.empty() && ext[0] == '.') {
+        ext.erase(0, 1);
+    }
+    boost::to_lower(ext);
+    return ext;
+}
+
+static bool isCapsuleExt(const std::string &ext) {
+    return ext == "erf" || ext == "mod" || ext == "rim" || ext == "sav" || ext == "hak";
+}
+
+std::optional<resource::ResourceId> resourceIdFromPath(const std::filesystem::path &path) {
+    auto filename = path.filename().string();
+    if (filename.empty()) {
+        return std::nullopt;
+    }
+    auto dot = filename.find_last_of('.');
+    if (dot == std::string::npos || dot == 0) {
+        return std::nullopt;
+    }
+    auto resRef = boost::to_lower_copy(filename.substr(0, dot));
+    auto ext = boost::to_lower_copy(filename.substr(dot + 1));
+    auto type = resource::getResTypeByExt(ext, false);
+    if (type == resource::ResType::Invalid) {
+        return std::nullopt;
+    }
+    return resource::ResourceId(std::move(resRef), type);
+}
+
+std::optional<FileResource> FileResource::fromPath(const std::filesystem::path &path) {
+    auto id = resourceIdFromPath(path);
+    if (!id || !std::filesystem::is_regular_file(path)) {
+        return std::nullopt;
+    }
+    return FileResource(
+        id->resRef.value(),
+        id->type,
+        static_cast<uint32_t>(std::filesystem::file_size(path)),
+        0,
+        path);
+}
+
+FileResource::FileResource(std::string resRef,
+                           resource::ResType type,
+                           uint32_t size,
+                           uint32_t offset,
+                           std::filesystem::path filepath) :
+    _id(std::move(resRef), type),
+    _size(size),
+    _offset(offset),
+    _filepath(std::move(filepath)) {
+    auto ext = extensionLower(_filepath);
+    _insideCapsule = isCapsuleExt(ext);
+    _insideBif = ext == "bif";
+}
+
+std::filesystem::path FileResource::pathIdentifier() const {
+    if (_insideCapsule || _insideBif) {
+        return _filepath / filename();
+    }
+    return _filepath;
+}
+
+bool FileResource::exists() const {
+    if (!std::filesystem::is_regular_file(_filepath)) {
+        return false;
+    }
+    if (!_insideCapsule && !_insideBif) {
+        return true;
+    }
+    auto fileSize = std::filesystem::file_size(_filepath);
+    auto begin = static_cast<uintmax_t>(_offset);
+    auto length = static_cast<uintmax_t>(_size);
+    if (begin > fileSize) {
+        return false;
+    }
+    return length <= fileSize - begin;
+}
+
+ByteBuffer FileResource::readData() const {
+    auto stream = openGameInputStream(_filepath);
+    stream->seek(static_cast<int64_t>(_offset), SeekOrigin::Begin);
+    ByteBuffer buf;
+    buf.resize(_size);
+    if (_size > 0) {
+        stream->read(buf.data(), buf.size());
+    }
+    return buf;
+}
+
+LocationResult::LocationResult(std::filesystem::path filepath, uint32_t offset, uint32_t size) :
+    _filepath(std::move(filepath)),
+    _offset(offset),
+    _size(size) {
+}
+
+void LocationResult::setFileResource(FileResource resource) {
+    assert(!_fileResource &&
+           "LocationResult file resource can only be assigned once");
+    _fileResource = std::move(resource);
+}
+
+const FileResource &LocationResult::asFileResource() const {
+    if (!_fileResource) {
+        throw std::logic_error("LocationResult does not have file resource metadata");
+    }
+    return *_fileResource;
+}
+
+const resource::ResourceId &LocationResult::id() const {
+    return asFileResource().id();
+}
+
+ByteBuffer LocationResult::readData() const {
+    if (_fileResource) {
+        return _fileResource->readData();
+    }
+    auto stream = openGameInputStream(_filepath);
+    stream->seek(static_cast<int64_t>(_offset), SeekOrigin::Begin);
+    ByteBuffer buf;
+    buf.resize(_size);
+    if (_size > 0) {
+        stream->read(buf.data(), buf.size());
+    }
+    return buf;
+}
+
+} // namespace extract
+
+} // namespace reone

--- a/src/libs/resource/extract/finder.cpp
+++ b/src/libs/resource/extract/finder.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/extract/finder.h"
+
+#include "reone/graphics/types.h"
+
+namespace reone {
+
+namespace extract {
+
+namespace {
+
+SearchScope makeOrder(std::initializer_list<SearchLocation> items) {
+    return SearchScope(items);
+}
+
+} // namespace
+
+const SearchScope &canonicalSearchOrder() {
+    static const SearchScope kOrder = makeOrder({
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::Lips,
+        SearchLocation::Root,
+        SearchLocation::CustomModules,
+        SearchLocation::Modules,
+        SearchLocation::Chitin,
+        SearchLocation::Executable,
+    });
+    return kOrder;
+}
+
+SearchScope textureSearchOrder(graphics::TextureQuality quality) {
+    SearchScope order = makeOrder({
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::CustomModules,
+        SearchLocation::TexturesGui,
+    });
+    switch (quality) {
+    case graphics::TextureQuality::Low:
+        order.push_back(SearchLocation::TexturesTpc);
+        break;
+    case graphics::TextureQuality::Medium:
+        order.push_back(SearchLocation::TexturesTpb);
+        break;
+    default:
+        order.push_back(SearchLocation::TexturesTpa);
+        break;
+    }
+    order.push_back(SearchLocation::Chitin);
+    order.push_back(SearchLocation::Executable);
+    return order;
+}
+
+const SearchScope &soundSearchOrder() {
+    static const SearchScope kOrder = makeOrder({
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::CustomModules,
+        SearchLocation::Music,
+        SearchLocation::Sound,
+        SearchLocation::Voice,
+        SearchLocation::Chitin,
+        SearchLocation::Executable,
+    });
+    return kOrder;
+}
+
+const SearchScope &talkTableSearchOrder() {
+    static const SearchScope kOrder = makeOrder({
+        SearchLocation::Root,
+    });
+    return kOrder;
+}
+
+const SearchScope &movieSearchOrder() {
+    static const SearchScope kOrder = makeOrder({
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::Movies,
+        SearchLocation::Chitin,
+    });
+    return kOrder;
+}
+
+const char *searchLocationName(SearchLocation location) {
+    switch (location) {
+    case SearchLocation::Override:
+        return "Override";
+    case SearchLocation::Modules:
+        return "Modules";
+    case SearchLocation::Chitin:
+        return "Chitin";
+    case SearchLocation::TexturesTpa:
+        return "Texture pack TPA";
+    case SearchLocation::TexturesTpb:
+        return "Texture pack TPB";
+    case SearchLocation::TexturesTpc:
+        return "Texture pack TPC";
+    case SearchLocation::TexturesGui:
+        return "Texture pack GUI";
+    case SearchLocation::Music:
+        return "StreamMusic";
+    case SearchLocation::Sound:
+        return "StreamSounds";
+    case SearchLocation::Voice:
+        return "StreamWaves/StreamVoice";
+    case SearchLocation::Lips:
+        return "Lips";
+    case SearchLocation::Rims:
+        return "RIM files";
+    case SearchLocation::CustomModules:
+        return "Custom modules";
+    case SearchLocation::CustomFolders:
+        return "Custom folders";
+    case SearchLocation::Root:
+        return "Game root";
+    case SearchLocation::Movies:
+        return "Movies";
+    case SearchLocation::Executable:
+        return "Executable";
+    default:
+        return "Unknown";
+    }
+}
+
+} // namespace extract
+
+} // namespace reone

--- a/src/libs/system/CMakeLists.txt
+++ b/src/libs/system/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SYSTEM_HEADERS
     ${SYSTEM_INCLUDE_DIR}/smallset.h
     ${SYSTEM_INCLUDE_DIR}/smallvector.h
     ${SYSTEM_INCLUDE_DIR}/stream/fileinput.h
+    ${SYSTEM_INCLUDE_DIR}/stream/gameinput.h
     ${SYSTEM_INCLUDE_DIR}/stream/fileoutput.h
     ${SYSTEM_INCLUDE_DIR}/stream/input.h
     ${SYSTEM_INCLUDE_DIR}/stream/memoryinput.h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TESTS_SOURCE_DIR ${CMAKE_SOURCE_DIR}/test)
 
 set(TESTS_HEADERS
     ${TESTS_SOURCE_DIR}/checkutil.h
+    ${TESTS_SOURCE_DIR}/fixtures/archive.h
     ${TESTS_SOURCE_DIR}/fixtures/audio.h
     ${TESTS_SOURCE_DIR}/fixtures/data.h
     ${TESTS_SOURCE_DIR}/fixtures/engine.h
@@ -37,6 +38,10 @@ set(TESTS_HEADERS
 
 set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/audio/format/wavreader.cpp
+    ${TESTS_SOURCE_DIR}/extract/capsule.cpp
+    ${TESTS_SOURCE_DIR}/extract/chitin.cpp
+    ${TESTS_SOURCE_DIR}/extract/fileresource.cpp
+    ${TESTS_SOURCE_DIR}/extract/finder.cpp
     ${TESTS_SOURCE_DIR}/fixtures/engine.cpp
     ${TESTS_SOURCE_DIR}/game/action.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp

--- a/test/extract/capsule.cpp
+++ b/test/extract/capsule.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/capsule.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::extract;
+using namespace reone::resource;
+
+static std::string str(const ByteBuffer &buf) {
+    return std::string(buf.begin(), buf.end());
+}
+
+TEST(LazyCapsule, should_index_erf_and_find_resources_by_id) {
+    test::TmpDir tmp("reone_test_extract_capsule_erf");
+    auto path = tmp.path / "archive.erf";
+    test::writeErf(path, ErfWriter::FileType::ERF,
+                   {{"first", ResType::Txt, "first payload"},
+                    {"second", ResType::TwoDA, "second payload"}});
+
+    LazyCapsule capsule(path);
+
+    EXPECT_EQ(2ll, capsule.resources().size());
+
+    auto first = capsule.find(ResourceId("first", ResType::Txt));
+    ASSERT_TRUE(first);
+    EXPECT_TRUE(first->insideCapsule());
+    EXPECT_EQ(path, first->filepath());
+    EXPECT_EQ("first payload", str(first->readData()));
+
+    auto second = capsule.find(ResourceId("second", ResType::TwoDA));
+    ASSERT_TRUE(second);
+    EXPECT_EQ("second payload", str(second->readData()));
+
+    EXPECT_FALSE(capsule.find(ResourceId("first", ResType::TwoDA))) << "type is part of the id";
+    EXPECT_FALSE(capsule.find(ResourceId("missing", ResType::Txt)));
+}
+
+TEST(LazyCapsule, should_index_rim_and_mod_files) {
+    test::TmpDir tmp("reone_test_extract_capsule_rim");
+
+    auto rimPath = tmp.path / "archive.rim";
+    test::writeRim(rimPath, {{"entry", ResType::Txt, "rim payload"}});
+    LazyCapsule rim(rimPath);
+    auto rimRes = rim.find(ResourceId("entry", ResType::Txt));
+    ASSERT_TRUE(rimRes);
+    EXPECT_EQ("rim payload", str(rimRes->readData()));
+
+    auto modPath = tmp.path / "archive.mod";
+    test::writeErf(modPath, ErfWriter::FileType::MOD, {{"entry", ResType::Txt, "mod payload"}});
+    LazyCapsule mod(modPath);
+    auto modRes = mod.find(ResourceId("entry", ResType::Txt));
+    ASSERT_TRUE(modRes);
+    EXPECT_EQ("mod payload", str(modRes->readData()));
+}
+
+TEST(LazyCapsule, should_defer_loading_until_first_access) {
+    test::TmpDir tmp("reone_test_extract_capsule_lazy");
+    auto path = tmp.path / "archive.erf";
+
+    // The file does not exist yet at construction time.
+    LazyCapsule capsule(path);
+
+    test::writeErf(path, ErfWriter::FileType::ERF, {{"entry", ResType::Txt, "late payload"}});
+
+    auto res = capsule.find(ResourceId("entry", ResType::Txt));
+    ASSERT_TRUE(res) << "capsule must not index the file before first access";
+    EXPECT_EQ("late payload", str(res->readData()));
+}
+
+TEST(LazyCapsule, should_be_empty_for_missing_file) {
+    test::TmpDir tmp("reone_test_extract_capsule_missing");
+
+    LazyCapsule capsule(tmp.path / "missing.erf");
+
+    EXPECT_TRUE(capsule.resources().empty());
+    EXPECT_FALSE(capsule.find(ResourceId("entry", ResType::Txt)));
+}
+
+TEST(CapsuleClassification, should_classify_files_by_extension) {
+    EXPECT_TRUE(isCapsuleFile("a.erf"));
+    EXPECT_TRUE(isCapsuleFile("a.MOD"));
+    EXPECT_TRUE(isCapsuleFile("a.rim"));
+    EXPECT_TRUE(isCapsuleFile("a.sav"));
+    EXPECT_TRUE(isCapsuleFile("a.hak"));
+    EXPECT_FALSE(isCapsuleFile("a.txt"));
+
+    EXPECT_TRUE(isModFile("a.mod"));
+    EXPECT_FALSE(isModFile("a.erf"));
+
+    EXPECT_TRUE(isErfFile("a.erf"));
+    EXPECT_TRUE(isErfFile("a.sav"));
+    EXPECT_TRUE(isErfFile("a.hak"));
+    EXPECT_FALSE(isErfFile("a.rim"));
+    EXPECT_FALSE(isErfFile("a.mod"));
+}

--- a/test/extract/chitin.cpp
+++ b/test/extract/chitin.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/chitin.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::extract;
+using namespace reone::resource;
+
+static std::string str(const ByteBuffer &buf) {
+    return std::string(buf.begin(), buf.end());
+}
+
+TEST(Chitin, should_index_key_bif_resources) {
+    test::TmpDir tmp("reone_test_extract_chitin");
+    test::writeKeyBif(tmp.path, "sample.bif",
+                      {{"first", ResType::Txt, "first payload"},
+                       {"second", ResType::TwoDA, "second payload"}});
+
+    Chitin chitin(tmp.path / "chitin.key");
+
+    ASSERT_EQ(2ll, chitin.resources().size());
+
+    const auto &first = chitin.resources()[0];
+    EXPECT_EQ("first", first.resRef().value());
+    EXPECT_EQ(ResType::Txt, first.type());
+    EXPECT_TRUE(first.insideBif());
+    EXPECT_FALSE(first.insideCapsule());
+    EXPECT_TRUE(first.exists());
+    EXPECT_EQ("first payload", str(first.readData()));
+
+    const auto &second = chitin.resources()[1];
+    EXPECT_EQ("second payload", str(second.readData()));
+}
+
+TEST(Chitin, should_resolve_bif_paths_with_backslash_separators) {
+    test::TmpDir tmp("reone_test_extract_chitin_backslash");
+    test::writeKeyBif(tmp.path, "data\\sample.bif",
+                      {{"entry", ResType::Txt, "nested payload"}});
+
+    Chitin chitin(tmp.path / "chitin.key");
+
+    ASSERT_EQ(1ll, chitin.resources().size());
+    EXPECT_EQ("nested payload", str(chitin.resources()[0].readData()));
+}
+
+TEST(Chitin, should_be_empty_for_missing_key) {
+    test::TmpDir tmp("reone_test_extract_chitin_missing");
+
+    Chitin chitin(tmp.path / "chitin.key");
+
+    EXPECT_TRUE(chitin.resources().empty());
+}
+
+TEST(Chitin, should_skip_missing_bifs) {
+    test::TmpDir tmp("reone_test_extract_chitin_missing_bif");
+    test::writeKeyBif(tmp.path, "sample.bif", {{"entry", ResType::Txt, "payload"}});
+    std::filesystem::remove(tmp.path / "sample.bif");
+
+    Chitin chitin(tmp.path / "chitin.key");
+
+    EXPECT_TRUE(chitin.resources().empty());
+}

--- a/test/extract/fileresource.cpp
+++ b/test/extract/fileresource.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/fileresource.h"
+#include "reone/system/stream/fileoutput.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::extract;
+using namespace reone::resource;
+
+static std::string str(const ByteBuffer &buf) {
+    return std::string(buf.begin(), buf.end());
+}
+
+TEST(FileResourceId, should_derive_resource_id_from_filename) {
+    auto id = resourceIdFromPath("some/dir/SaMpLe.TXT");
+    ASSERT_TRUE(id);
+    EXPECT_EQ("sample", id->resRef.value());
+    EXPECT_EQ(ResType::Txt, id->type);
+
+    EXPECT_FALSE(resourceIdFromPath("noextension"));
+    EXPECT_FALSE(resourceIdFromPath(".hidden"));
+    EXPECT_FALSE(resourceIdFromPath("bad.notarestype"));
+    EXPECT_FALSE(resourceIdFromPath(""));
+}
+
+TEST(FileResourceMetadata, should_describe_loose_file) {
+    test::TmpDir tmp("reone_test_extract_fileres_loose");
+    auto path = tmp.path / "sample.txt";
+    test::detail::writeFile(path, "Hello, world!");
+
+    auto res = FileResource::fromPath(path);
+
+    ASSERT_TRUE(res);
+    EXPECT_EQ("sample", res->resRef().value());
+    EXPECT_EQ(ResType::Txt, res->type());
+    EXPECT_EQ("sample.txt", res->filename());
+    EXPECT_EQ(path, res->filepath());
+    EXPECT_EQ(path, res->pathIdentifier());
+    EXPECT_EQ(0u, res->offset());
+    EXPECT_EQ(13u, res->size());
+    EXPECT_FALSE(res->insideCapsule());
+    EXPECT_FALSE(res->insideBif());
+    EXPECT_TRUE(res->exists());
+    EXPECT_EQ("Hello, world!", str(res->readData()));
+
+    EXPECT_FALSE(FileResource::fromPath(tmp.path / "missing.txt"));
+}
+
+TEST(FileResourceMetadata, should_describe_capsule_entry_and_check_bounds) {
+    test::TmpDir tmp("reone_test_extract_fileres_capsule");
+    auto path = tmp.path / "archive.erf";
+    test::detail::writeFile(path, "0123456789");
+
+    FileResource inRange("entry", ResType::Txt, 4, 2, path);
+    EXPECT_TRUE(inRange.insideCapsule());
+    EXPECT_FALSE(inRange.insideBif());
+    EXPECT_EQ(path / "entry.txt", inRange.pathIdentifier());
+    EXPECT_TRUE(inRange.exists());
+    EXPECT_EQ("2345", str(inRange.readData()));
+
+    FileResource outOfRange("entry", ResType::Txt, 20, 2, path);
+    EXPECT_FALSE(outOfRange.exists());
+
+    FileResource missingFile("entry", ResType::Txt, 4, 0, tmp.path / "missing.erf");
+    EXPECT_FALSE(missingFile.exists());
+}
+
+TEST(LocationResultMetadata, should_read_raw_range_and_guard_metadata) {
+    test::TmpDir tmp("reone_test_extract_locresult");
+    auto path = tmp.path / "sample.txt";
+    test::detail::writeFile(path, "0123456789");
+
+    LocationResult location(path, 3, 4);
+    EXPECT_EQ(path, location.filepath());
+    EXPECT_EQ(3u, location.offset());
+    EXPECT_EQ(4u, location.size());
+    EXPECT_EQ("3456", str(location.readData()));
+
+    EXPECT_FALSE(location.hasFileResource());
+    EXPECT_THROW(location.asFileResource(), std::logic_error);
+    EXPECT_THROW(location.id(), std::logic_error);
+
+    location.setFileResource(FileResource("sample", ResType::Txt, 4, 3, path));
+    EXPECT_TRUE(location.hasFileResource());
+    EXPECT_EQ("sample", location.id().resRef.value());
+    EXPECT_EQ("3456", str(location.readData()));
+
+}

--- a/test/extract/finder.cpp
+++ b/test/extract/finder.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/finder.h"
+
+using namespace reone;
+using namespace reone::extract;
+
+using graphics::TextureQuality;
+
+TEST(Finder, canonical_order_prefers_custom_and_override_locations) {
+    const SearchScope expected {
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::Lips,
+        SearchLocation::Root,
+        SearchLocation::CustomModules,
+        SearchLocation::Modules,
+        SearchLocation::Chitin,
+        SearchLocation::Executable,
+    };
+
+    EXPECT_EQ(expected, canonicalSearchOrder());
+}
+
+TEST(Finder, texture_order_selects_pack_by_quality) {
+    auto high = textureSearchOrder(TextureQuality::High);
+    auto medium = textureSearchOrder(TextureQuality::Medium);
+    auto low = textureSearchOrder(TextureQuality::Low);
+
+    const SearchScope expectedHigh {
+        SearchLocation::CustomFolders,
+        SearchLocation::Override,
+        SearchLocation::CustomModules,
+        SearchLocation::TexturesGui,
+        SearchLocation::TexturesTpa,
+        SearchLocation::Chitin,
+        SearchLocation::Executable,
+    };
+    EXPECT_EQ(expectedHigh, high);
+
+    EXPECT_NE(medium.end(), std::find(medium.begin(), medium.end(), SearchLocation::TexturesTpb));
+    EXPECT_EQ(medium.end(), std::find(medium.begin(), medium.end(), SearchLocation::TexturesTpa));
+
+    EXPECT_NE(low.end(), std::find(low.begin(), low.end(), SearchLocation::TexturesTpc));
+    EXPECT_EQ(low.end(), std::find(low.begin(), low.end(), SearchLocation::TexturesTpa));
+}
+
+TEST(Finder, sound_order_covers_all_stream_locations) {
+    const auto &order = soundSearchOrder();
+
+    auto posMusic = std::find(order.begin(), order.end(), SearchLocation::Music);
+    auto posSound = std::find(order.begin(), order.end(), SearchLocation::Sound);
+    auto posVoice = std::find(order.begin(), order.end(), SearchLocation::Voice);
+
+    ASSERT_NE(order.end(), posMusic);
+    ASSERT_NE(order.end(), posSound);
+    ASSERT_NE(order.end(), posVoice);
+    EXPECT_LT(posMusic, posSound);
+    EXPECT_LT(posSound, posVoice);
+}
+
+TEST(Finder, special_purpose_orders) {
+    const SearchScope expectedTalk {SearchLocation::Root};
+    EXPECT_EQ(expectedTalk, talkTableSearchOrder());
+
+    const auto &movies = movieSearchOrder();
+    EXPECT_NE(movies.end(), std::find(movies.begin(), movies.end(), SearchLocation::Movies));
+}
+
+TEST(Finder, location_names_are_distinct_for_debugging) {
+    EXPECT_STREQ("Override", searchLocationName(SearchLocation::Override));
+    EXPECT_STREQ("Chitin", searchLocationName(SearchLocation::Chitin));
+    EXPECT_STRNE(searchLocationName(SearchLocation::TexturesTpa),
+                 searchLocationName(SearchLocation::TexturesTpb));
+}

--- a/test/fixtures/archive.h
+++ b/test/fixtures/archive.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/system/stream/fileoutput.h"
+
+namespace reone {
+
+namespace test {
+
+struct ArchiveRes {
+    std::string resRef;
+    resource::ResType type;
+    std::string data;
+};
+
+inline ByteBuffer toBytes(const std::string &s) {
+    return ByteBuffer(s.begin(), s.end());
+}
+
+inline void writeErf(const std::filesystem::path &path,
+                     resource::ErfWriter::FileType fileType,
+                     const std::vector<ArchiveRes> &resources) {
+    resource::ErfWriter writer;
+    for (const auto &res : resources) {
+        writer.add(resource::ErfWriter::Resource {res.resRef, res.type, toBytes(res.data)});
+    }
+    writer.save(fileType, path);
+}
+
+inline void writeRim(const std::filesystem::path &path,
+                     const std::vector<ArchiveRes> &resources) {
+    resource::RimWriter writer;
+    for (const auto &res : resources) {
+        writer.add(resource::RimWriter::Resource {res.resRef, res.type, toBytes(res.data)});
+    }
+    writer.save(path);
+}
+
+namespace detail {
+
+inline void appendUint16(std::string &out, uint16_t val) {
+    out.push_back(static_cast<char>(val & 0xff));
+    out.push_back(static_cast<char>((val >> 8) & 0xff));
+}
+
+inline void appendUint32(std::string &out, uint32_t val) {
+    out.push_back(static_cast<char>(val & 0xff));
+    out.push_back(static_cast<char>((val >> 8) & 0xff));
+    out.push_back(static_cast<char>((val >> 16) & 0xff));
+    out.push_back(static_cast<char>((val >> 24) & 0xff));
+}
+
+inline void writeFile(const std::filesystem::path &path, const std::string &data) {
+    FileOutputStream stream(path);
+    stream.write(data.data(), data.size());
+}
+
+} // namespace detail
+
+/**
+ * Write a minimal KEY file at dir/chitin.key plus a single BIF holding the
+ * given resources. bifRelPath is stored in the KEY verbatim, e.g.
+ * "data\\sample.bif"; the BIF file is created at the corresponding location
+ * under dir.
+ */
+inline void writeKeyBif(const std::filesystem::path &dir,
+                        const std::string &bifRelPath,
+                        const std::vector<ArchiveRes> &resources) {
+    auto count = static_cast<uint32_t>(resources.size());
+
+    // BIF: header, variable resource table, payloads
+    std::string bif("BIFFV1  ");
+    detail::appendUint32(bif, count);
+    detail::appendUint32(bif, 0);
+    detail::appendUint32(bif, 20);
+    uint32_t dataOffset = 20 + 16 * count;
+    for (uint32_t i = 0; i < count; ++i) {
+        detail::appendUint32(bif, i);
+        detail::appendUint32(bif, dataOffset);
+        detail::appendUint32(bif, static_cast<uint32_t>(resources[i].data.size()));
+        detail::appendUint32(bif, static_cast<uint32_t>(resources[i].type));
+        dataOffset += static_cast<uint32_t>(resources[i].data.size());
+    }
+    for (const auto &res : resources) {
+        bif += res.data;
+    }
+    auto bifPath = dir / boost::replace_all_copy(bifRelPath, "\\", "/");
+    std::filesystem::create_directories(bifPath.parent_path());
+    detail::writeFile(bifPath, bif);
+
+    // KEY: header, file table, filenames, key table
+    auto filenameLen = static_cast<uint32_t>(bifRelPath.size());
+    uint32_t offFiles = 64;
+    uint32_t offFilename = offFiles + 12;
+    uint32_t offKeys = offFilename + filenameLen + 1;
+
+    std::string key("KEY V1  ");
+    detail::appendUint32(key, 1);
+    detail::appendUint32(key, count);
+    detail::appendUint32(key, offFiles);
+    detail::appendUint32(key, offKeys);
+    detail::appendUint32(key, 0);
+    detail::appendUint32(key, 0);
+    key.append(32, '\0');
+
+    detail::appendUint32(key, static_cast<uint32_t>(bif.size()));
+    detail::appendUint32(key, offFilename);
+    detail::appendUint16(key, static_cast<uint16_t>(filenameLen));
+    detail::appendUint16(key, 0);
+
+    key += bifRelPath;
+    key.push_back('\0');
+
+    for (uint32_t i = 0; i < count; ++i) {
+        std::string resRef(resources[i].resRef);
+        resRef.resize(16, '\0');
+        key += resRef;
+        detail::appendUint16(key, static_cast<uint16_t>(resources[i].type));
+        detail::appendUint32(key, i); // bifIdx 0, resIdx i
+    }
+    detail::writeFile(dir / "chitin.key", key);
+}
+
+/// Temporary directory tree, removed on destruction.
+struct TmpDir {
+    std::filesystem::path path;
+
+    explicit TmpDir(const std::string &name) {
+        path = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+};
+
+} // namespace test
+
+} // namespace reone


### PR DESCRIPTION
> **Resource-loader migration: B1 — archive and lookup primitives**
>
> Intended merge order: A -> C -> B1 -> B2 -> D0 -> D1

## Summary

Adds the foundational Extract resource-loading primitives:

- `FileResource` and `LocationResult`
- KEY/BIF lookup through `Chitin`
- lazy ERF/RIM lookup through `LazyCapsule`
- ordered finder and search-location primitives
- `openGameInputStream`
- synthetic archive fixtures and focused tests

This slice is additive. It does not change the active Legacy backend, resource precedence, save loading, or runtime behavior.