### PR TITLE
[resource] Add Extract Installation resolver

### DIFF
--- a/include/reone/extract/installation.h
+++ b/include/reone/extract/installation.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "capsule.h"
+#include "fileresource.h"
+#include "finder.h"
+#include "lookupcontext.h"
+
+#include "reone/resource/types.h"
+
+namespace reone {
+
+namespace extract {
+
+/// Game installation indexer and resolver (PyKotor Installation).
+class Installation {
+public:
+    Installation(resource::GameID game, std::filesystem::path root);
+
+    resource::GameID game() const { return _game; }
+    const std::filesystem::path &root() const { return _root; }
+
+    void loadChitin();
+    void loadModules();
+    void loadOverride();
+    void loadTexturePacks();
+    void loadStreams();
+    void loadLips();
+    void loadRims();
+    void loadRoot();
+    void loadMovies();
+    void loadExecutable();
+
+    std::vector<LocationResult> locations(const resource::ResourceId &id,
+                                          const SearchScope &order,
+                                          const ResourceLookupContext &ctx = {});
+    std::unordered_map<resource::ResourceId, std::vector<LocationResult>> locations(
+        const std::vector<resource::ResourceId> &ids,
+        const SearchScope &order = canonicalSearchOrder(),
+        const ResourceLookupContext &ctx = {});
+
+    std::optional<LocationResult> resource(const resource::ResourceId &id,
+                                           const SearchScope &order = canonicalSearchOrder(),
+                                           const ResourceLookupContext &ctx = {});
+
+    void setModuleRoot(std::optional<std::string> root);
+    void setCustomFolders(std::vector<std::filesystem::path> folders);
+    void setGlobalCustomFolders(std::vector<std::filesystem::path> folders);
+    void setGlobalCustomCapsules(std::vector<std::filesystem::path> capsules);
+    void setCustomCapsules(std::vector<std::filesystem::path> capsules);
+    void appendSaveScope(std::filesystem::path saveDir, std::filesystem::path savegameSav);
+    void clearModuleScope();
+    void clearSaveScope();
+
+    const std::optional<std::string> &moduleRoot() const { return _moduleRoot; }
+    const std::vector<std::filesystem::path> &customFolders() const { return _customFolders; }
+    const std::vector<std::filesystem::path> &customCapsules() const { return _customCapsules; }
+
+    /// Module root of a module archive filename, e.g. "foo" for "foo_s.rim".
+    static std::string getModuleRoot(std::string_view capsuleFilename);
+
+    /// Relative paths under the game root at which archives of the given
+    /// module root may reside.
+    static std::vector<std::string> moduleArchiveRelPaths(std::string_view moduleRoot);
+
+    std::optional<std::filesystem::path> moviePath(std::string_view name);
+
+    /// Indexed chitin resources (requires loadChitin()).
+    const std::vector<FileResource> &chitinResources();
+
+    /// Resolve a loose file relative to the game root (e.g. dialog.tlk, movies/foo.bik).
+    std::optional<std::filesystem::path> resolveLooseRelativePath(
+        std::string_view relativePath,
+        const SearchScope &order = canonicalSearchOrder());
+
+private:
+    resource::GameID _game;
+    std::filesystem::path _root;
+
+    bool _chitinLoaded {false};
+    bool _modulesLoaded {false};
+    bool _overrideLoaded {false};
+    bool _texturePacksLoaded {false};
+    bool _streamsLoaded {false};
+    bool _lipsLoaded {false};
+    bool _rimsLoaded {false};
+    bool _rootLoaded {false};
+    bool _moviesLoaded {false};
+    bool _executableLoaded {false};
+
+    std::vector<FileResource> _chitin;
+    std::unordered_map<std::string, std::filesystem::path> _moduleCapsulePaths;
+    std::unordered_map<std::string, std::vector<FileResource>> _override;
+    std::unordered_map<resource::ResourceId, FileResource> _overrideIndex;
+    std::unordered_map<std::string, std::vector<FileResource>> _texturePacks;
+    std::unordered_map<std::string, std::unordered_map<resource::ResourceId, FileResource>> _texturePackIndex;
+    std::vector<FileResource> _streamMusic;
+    std::vector<FileResource> _streamSounds;
+    std::vector<FileResource> _streamVoice;
+    std::unordered_map<std::string, std::vector<FileResource>> _lips;
+    std::unordered_map<std::string, std::vector<FileResource>> _rims;
+    std::vector<FileResource> _rootLoose;
+    std::unordered_map<std::string, std::filesystem::path> _movies;
+    std::vector<FileResource> _executable;
+
+    std::optional<std::string> _moduleRoot;
+    std::vector<std::filesystem::path> _globalCustomFolders;
+    std::vector<std::filesystem::path> _globalCustomCapsules;
+    std::vector<std::filesystem::path> _customFolders;
+    std::vector<std::filesystem::path> _customCapsules;
+
+    mutable std::unordered_map<std::string, std::shared_ptr<LazyCapsule>> _capsuleCache;
+
+    /// Per-list lookup indexes, keyed by a stable name and invalidated
+    /// whenever an indexed location (re)loads.
+    std::unordered_map<std::string, std::unordered_map<resource::ResourceId, FileResource>> _listCache;
+
+    void clearLocationCaches();
+
+    void indexLooseFiles(const std::filesystem::path &dir, std::vector<FileResource> &out);
+    void indexCapsuleDict(const std::filesystem::path &dir,
+                          bool (*filter)(const std::filesystem::path &),
+                          std::unordered_map<std::string, std::vector<FileResource>> &out);
+
+    void checkList(const std::string &cacheKey,
+                   const std::vector<FileResource> &list,
+                   const resource::ResourceId &id,
+                   std::vector<LocationResult> &out);
+
+    void checkDict(const std::string &cachePrefix,
+                   const std::unordered_map<std::string, std::vector<FileResource>> &dict,
+                   const resource::ResourceId &id,
+                   std::vector<LocationResult> &out);
+
+    void checkFolders(const std::vector<std::filesystem::path> &folders,
+                      const resource::ResourceId &id,
+                      std::vector<LocationResult> &out);
+
+    void checkCapsules(const std::vector<std::filesystem::path> &capsules,
+                       const resource::ResourceId &id,
+                       std::vector<LocationResult> &out);
+
+    void checkModules(const resource::ResourceId &id, std::vector<LocationResult> &out);
+
+    void checkTexturePack(const char *packName,
+                          const resource::ResourceId &id,
+                          std::vector<LocationResult> &out);
+
+    void checkOverride(const resource::ResourceId &id, std::vector<LocationResult> &out);
+
+    const LazyCapsule &cachedCapsule(const std::filesystem::path &path) const;
+};
+
+} // namespace extract
+
+} // namespace reone

--- a/include/reone/extract/lookupcontext.h
+++ b/include/reone/extract/lookupcontext.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace extract {
+
+/// Per-lookup extra search locations, merged with (but not mutating) the
+/// installation-wide custom folders and capsules.
+struct ResourceLookupContext {
+    std::vector<std::filesystem::path> customFolders;
+    std::vector<std::filesystem::path> customCapsules;
+};
+
+} // namespace extract
+
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -31,6 +31,8 @@ set(RESOURCE_HEADERS
     ${REONE_INCLUDE_DIR}/reone/extract/chitin.h
     ${REONE_INCLUDE_DIR}/reone/extract/fileresource.h
     ${REONE_INCLUDE_DIR}/reone/extract/finder.h
+    ${REONE_INCLUDE_DIR}/reone/extract/installation.h
+    ${REONE_INCLUDE_DIR}/reone/extract/lookupcontext.h
     ${REONE_INCLUDE_DIR}/reone/extract/searchlocation.h
     ${RESOURCE_INCLUDE_DIR}/dialog.h
     ${RESOURCE_INCLUDE_DIR}/director.h
@@ -105,6 +107,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/extract/chitin.cpp
     ${RESOURCE_SOURCE_DIR}/extract/fileresource.cpp
     ${RESOURCE_SOURCE_DIR}/extract/finder.cpp
+    ${RESOURCE_SOURCE_DIR}/extract/installation.cpp
     ${RESOURCE_SOURCE_DIR}/container/erf.cpp
     ${RESOURCE_SOURCE_DIR}/container/exe.cpp
     ${RESOURCE_SOURCE_DIR}/container/folder.cpp

--- a/src/libs/resource/extract/installation.cpp
+++ b/src/libs/resource/extract/installation.cpp
@@ -1,0 +1,775 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/extract/installation.h"
+
+#include "reone/extract/chitin.h"
+#include "reone/resource/format/pereader.h"
+#include "reone/system/fileutil.h"
+#include "reone/system/stream/gameinput.h"
+
+#include <algorithm>
+
+namespace reone {
+
+namespace extract {
+
+static constexpr char kKeyFilename[] = "chitin.key";
+static constexpr char kPatchFilename[] = "patch.erf";
+static constexpr char kTexturePackDirectoryName[] = "texturepacks";
+static constexpr char kMusicDirectoryName[] = "streammusic";
+static constexpr char kSoundsDirectoryName[] = "streamsounds";
+static constexpr char kWavesDirectoryName[] = "streamwaves";
+static constexpr char kVoiceDirectoryName[] = "streamvoice";
+static constexpr char kLipsDirectoryName[] = "lips";
+static constexpr char kOverrideDirectoryName[] = "override";
+static constexpr char kRimsDirectoryName[] = "rims";
+static constexpr char kMoviesDirectoryName[] = "movies";
+static constexpr char kExeFilenameKotor[] = "swkotor.exe";
+static constexpr char kExeFilenameTsl[] = "swkotor2.exe";
+
+static constexpr char kTexturePackTpa[] = "swpc_tex_tpa.erf";
+static constexpr char kTexturePackTpb[] = "swpc_tex_tpb.erf";
+static constexpr char kTexturePackTpc[] = "swpc_tex_tpc.erf";
+static constexpr char kTexturePackGui[] = "swpc_tex_gui.erf";
+
+static const std::unordered_map<resource::PEResType, resource::ResType> kPEResTypeToResType {
+    {resource::PEResType::Cursor, resource::ResType::Cursor},
+    {resource::PEResType::CursorGroup, resource::ResType::CursorGroup},
+};
+
+static void appendLocation(const FileResource &file, std::vector<LocationResult> &out) {
+    LocationResult loc(file.filepath(), file.offset(), file.size());
+    loc.setFileResource(file);
+    out.push_back(std::move(loc));
+}
+
+static std::string pathCacheKey(const std::filesystem::path &path) {
+    auto key = path.lexically_normal().string();
+    boost::replace_all(key, "\\", "/");
+    boost::to_lower(key);
+    return key;
+}
+
+static void sortResources(std::vector<FileResource> &resources, size_t first = 0) {
+    std::sort(resources.begin() + first, resources.end(), [](const auto &lhs, const auto &rhs) {
+        return pathCacheKey(lhs.filepath()) < pathCacheKey(rhs.filepath());
+    });
+}
+
+template <typename T>
+static std::vector<std::string> sortedKeys(const std::unordered_map<std::string, T> &dict) {
+    std::vector<std::string> keys;
+    keys.reserve(dict.size());
+    for (const auto &[key, _] : dict) {
+        keys.push_back(key);
+    }
+    std::sort(keys.begin(), keys.end());
+    return keys;
+}
+
+Installation::Installation(resource::GameID game, std::filesystem::path root) :
+    _game(game),
+    _root(std::move(root)) {
+}
+
+void Installation::clearLocationCaches() {
+    _listCache.clear();
+}
+
+void Installation::loadChitin() {
+    if (_chitinLoaded) {
+        return;
+    }
+    auto keyPath = findFileIgnoreCase(_root, kKeyFilename);
+    if (keyPath) {
+        Chitin chitin(*keyPath);
+        _chitin = chitin.resources();
+    }
+    _chitinLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadModules() {
+    if (_modulesLoaded) {
+        return;
+    }
+    _modulesLoaded = true;
+    _moduleCapsulePaths.clear();
+    if (!_moduleRoot) {
+        return;
+    }
+    for (auto &rel : moduleArchiveRelPaths(*_moduleRoot)) {
+        if (auto path = findFileIgnoreCase(_root, rel)) {
+            auto filename = boost::to_lower_copy(path->filename().string());
+            _moduleCapsulePaths.emplace(filename, *path);
+        }
+    }
+    clearLocationCaches();
+}
+
+const std::vector<FileResource> &Installation::chitinResources() {
+    loadChitin();
+    return _chitin;
+}
+
+void Installation::indexLooseFiles(const std::filesystem::path &dir, std::vector<FileResource> &out) {
+    if (!std::filesystem::exists(dir)) {
+        return;
+    }
+    auto first = out.size();
+    for (auto &entry : std::filesystem::recursive_directory_iterator(dir)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto id = resourceIdFromPath(entry.path());
+        if (!id) {
+            continue;
+        }
+        auto size = static_cast<uint32_t>(entry.file_size());
+        out.emplace_back(id->resRef.value(), id->type, size, 0, entry.path());
+    }
+    sortResources(out, first);
+}
+
+void Installation::indexCapsuleDict(const std::filesystem::path &dir,
+                                    bool (*filter)(const std::filesystem::path &),
+                                    std::unordered_map<std::string, std::vector<FileResource>> &out) {
+    if (!std::filesystem::exists(dir)) {
+        return;
+    }
+    for (auto &entry : std::filesystem::directory_iterator(dir)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        if (filter && !filter(entry.path())) {
+            continue;
+        }
+        auto filename = boost::to_lower_copy(entry.path().filename().string());
+        LazyCapsule capsule(entry.path());
+        out[filename] = capsule.resources();
+    }
+}
+
+void Installation::loadOverride() {
+    if (_overrideLoaded) {
+        return;
+    }
+    auto overridePath = findFileIgnoreCase(_root, kOverrideDirectoryName);
+    if (!overridePath) {
+        _overrideIndex.clear();
+        _overrideLoaded = true;
+        return;
+    }
+
+    std::vector<FileResource> loose;
+    for (auto &entry : std::filesystem::directory_iterator(*overridePath)) {
+        if (entry.is_regular_file()) {
+            auto id = resourceIdFromPath(entry.path());
+            if (id) {
+                loose.emplace_back(
+                    id->resRef.value(),
+                    id->type,
+                    static_cast<uint32_t>(entry.file_size()),
+                    0,
+                    entry.path());
+            }
+            continue;
+        }
+        if (!entry.is_directory()) {
+            continue;
+        }
+        auto relKey = entry.path().filename().string();
+        std::vector<FileResource> subdir;
+        indexLooseFiles(entry.path(), subdir);
+        if (!subdir.empty()) {
+            _override[relKey] = std::move(subdir);
+        }
+    }
+    if (!loose.empty()) {
+        sortResources(loose);
+        _override["."] = std::move(loose);
+    }
+    _overrideIndex.clear();
+    for (const auto &key : sortedKeys(_override)) {
+        auto &list = _override.at(key);
+        for (auto &res : list) {
+            _overrideIndex.emplace(res.id(), res);
+        }
+    }
+    _overrideLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadTexturePacks() {
+    if (_texturePacksLoaded) {
+        return;
+    }
+    auto texPacksPath = findFileIgnoreCase(_root, kTexturePackDirectoryName);
+    if (!texPacksPath) {
+        _texturePacksLoaded = true;
+        return;
+    }
+    for (auto name : {kTexturePackTpa, kTexturePackTpb, kTexturePackTpc, kTexturePackGui}) {
+        auto packPath = findFileIgnoreCase(*texPacksPath, name);
+        if (!packPath) {
+            continue;
+        }
+        LazyCapsule capsule(*packPath);
+        auto resources = capsule.resources();
+        _texturePacks[name] = resources;
+        auto &index = _texturePackIndex[name];
+        index.clear();
+        for (auto &res : resources) {
+            index.emplace(res.id(), res);
+        }
+    }
+    _texturePacksLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadStreams() {
+    if (_streamsLoaded) {
+        return;
+    }
+    if (auto musicPath = findFileIgnoreCase(_root, kMusicDirectoryName)) {
+        indexLooseFiles(*musicPath, _streamMusic);
+    }
+    if (auto soundsPath = findFileIgnoreCase(_root, kSoundsDirectoryName)) {
+        indexLooseFiles(*soundsPath, _streamSounds);
+    }
+    if (_game == resource::GameID::TSL) {
+        if (auto voicePath = findFileIgnoreCase(_root, kVoiceDirectoryName)) {
+            indexLooseFiles(*voicePath, _streamVoice);
+        }
+    } else if (auto wavesPath = findFileIgnoreCase(_root, kWavesDirectoryName)) {
+        indexLooseFiles(*wavesPath, _streamVoice);
+    }
+    _streamsLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadLips() {
+    if (_lipsLoaded) {
+        return;
+    }
+    auto lipsPath = findFileIgnoreCase(_root, kLipsDirectoryName);
+    if (lipsPath) {
+        indexCapsuleDict(*lipsPath, isCapsuleFile, _lips);
+    }
+    _lipsLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadRims() {
+    if (_rimsLoaded) {
+        return;
+    }
+    auto rimsPath = findFileIgnoreCase(_root, kRimsDirectoryName);
+    if (rimsPath) {
+        indexCapsuleDict(*rimsPath, isCapsuleFile, _rims);
+    }
+    _rimsLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadRoot() {
+    if (_rootLoaded) {
+        return;
+    }
+    if (!std::filesystem::exists(_root)) {
+        _rootLoaded = true;
+        return;
+    }
+    for (auto &entry : std::filesystem::directory_iterator(_root)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto id = resourceIdFromPath(entry.path());
+        if (!id) {
+            continue;
+        }
+        _rootLoose.emplace_back(
+            id->resRef.value(),
+            id->type,
+            static_cast<uint32_t>(entry.file_size()),
+            0,
+            entry.path());
+    }
+    sortResources(_rootLoose);
+    _rootLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::loadMovies() {
+    if (_moviesLoaded) {
+        return;
+    }
+    auto moviesPath = findFileIgnoreCase(_root, kMoviesDirectoryName);
+    if (!moviesPath || !std::filesystem::exists(*moviesPath)) {
+        _moviesLoaded = true;
+        return;
+    }
+    for (auto &entry : std::filesystem::directory_iterator(*moviesPath)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto ext = boost::to_lower_copy(entry.path().extension().string());
+        if (ext != ".bik") {
+            continue;
+        }
+        auto name = boost::to_lower_copy(entry.path().stem().string());
+        _movies[name] = entry.path();
+    }
+    _moviesLoaded = true;
+}
+
+std::optional<std::filesystem::path> Installation::moviePath(std::string_view name) {
+    auto stem = boost::to_lower_copy(std::string(name));
+    auto rel = std::string("movies/") + stem + ".bik";
+    if (auto path = resolveLooseRelativePath(rel, movieSearchOrder())) {
+        return path;
+    }
+    loadMovies();
+    auto it = _movies.find(stem);
+    if (it != _movies.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void Installation::loadExecutable() {
+    if (_executableLoaded) {
+        return;
+    }
+    auto exeName = _game == resource::GameID::TSL ? kExeFilenameTsl : kExeFilenameKotor;
+    auto exePath = findFileIgnoreCase(_root, exeName);
+    if (!exePath) {
+        _executableLoaded = true;
+        return;
+    }
+    try {
+        auto stream = openGameInputStream(*exePath);
+        resource::PeReader reader(*stream);
+        reader.load();
+        for (auto &peRes : reader.resources()) {
+            auto resType = kPEResTypeToResType.find(peRes.type);
+            if (resType == kPEResTypeToResType.end()) {
+                continue;
+            }
+            _executable.emplace_back(
+                std::to_string(peRes.name),
+                resType->second,
+                peRes.size,
+                peRes.offset,
+                *exePath);
+        }
+    } catch (const std::exception &) {
+        _executable.clear();
+    }
+    _executableLoaded = true;
+    clearLocationCaches();
+}
+
+void Installation::setModuleRoot(std::optional<std::string> root) {
+    if (root) {
+        boost::to_lower(*root);
+    }
+    _moduleRoot = std::move(root);
+    _modulesLoaded = false;
+    _moduleCapsulePaths.clear();
+    clearLocationCaches();
+}
+
+void Installation::setCustomFolders(std::vector<std::filesystem::path> folders) {
+    _customFolders = std::move(folders);
+    clearLocationCaches();
+}
+
+void Installation::setGlobalCustomFolders(std::vector<std::filesystem::path> folders) {
+    _globalCustomFolders = std::move(folders);
+    _customFolders = _globalCustomFolders;
+    clearLocationCaches();
+}
+
+void Installation::setGlobalCustomCapsules(std::vector<std::filesystem::path> capsules) {
+    _globalCustomCapsules = std::move(capsules);
+    _customCapsules = _globalCustomCapsules;
+    clearLocationCaches();
+}
+
+void Installation::setCustomCapsules(std::vector<std::filesystem::path> capsules) {
+    _customCapsules = std::move(capsules);
+    clearLocationCaches();
+}
+
+void Installation::appendSaveScope(std::filesystem::path saveDir, std::filesystem::path savegameSav) {
+    auto folders = _customFolders;
+    folders.push_back(std::move(saveDir));
+    auto capsules = _customCapsules;
+    capsules.push_back(std::move(savegameSav));
+    setCustomFolders(std::move(folders));
+    setCustomCapsules(std::move(capsules));
+}
+
+void Installation::clearModuleScope() {
+    _moduleRoot.reset();
+    _modulesLoaded = false;
+    _moduleCapsulePaths.clear();
+    clearLocationCaches();
+}
+
+void Installation::clearSaveScope() {
+    _customFolders = _globalCustomFolders;
+    _customCapsules = _globalCustomCapsules;
+    _capsuleCache.clear();
+    clearLocationCaches();
+}
+
+std::string Installation::getModuleRoot(std::string_view capsuleFilename) {
+    auto stem = std::filesystem::path(capsuleFilename).stem().string();
+    boost::to_lower(stem);
+    if (boost::ends_with(stem, "_s")) {
+        stem.resize(stem.size() - 2);
+    }
+    if (boost::ends_with(stem, "_dlg")) {
+        stem.resize(stem.size() - 4);
+    }
+    if (boost::ends_with(stem, "_loc")) {
+        stem.resize(stem.size() - 4);
+    }
+    return stem;
+}
+
+std::vector<std::string> Installation::moduleArchiveRelPaths(std::string_view moduleRoot) {
+    auto low = boost::to_lower_copy(std::string(moduleRoot));
+    return {
+        "modules/" + low + ".mod",
+        "modules/" + low + "_s.rim",
+        "modules/" + low + ".rim",
+        "modules/" + low + ".erf",
+        "modules/" + low + "_loc.mod",
+        "modules/" + low + "_loc.erf",
+        "modules/" + low + "_dlg.mod",
+        "modules/" + low + "_dlg.erf",
+        "lips/" + low + "_loc.mod",
+        "lips/" + low + "_loc.erf",
+    };
+}
+
+static std::string normalizeRelativePath(std::string_view relativePath) {
+    auto path = std::filesystem::path(relativePath).lexically_normal().string();
+    boost::replace_all(path, "\\", "/");
+    boost::to_lower(path);
+    return path;
+}
+
+static std::optional<std::filesystem::path> findInFolders(const std::vector<std::filesystem::path> &folders,
+                                                          std::string_view relativePath) {
+    auto target = normalizeRelativePath(relativePath);
+    for (auto &folder : folders) {
+        if (!std::filesystem::exists(folder)) {
+            continue;
+        }
+        for (auto &entry : std::filesystem::recursive_directory_iterator(folder)) {
+            if (!entry.is_regular_file()) {
+                continue;
+            }
+            auto candidate = entry.path().lexically_relative(folder).string();
+            boost::replace_all(candidate, "\\", "/");
+            boost::to_lower(candidate);
+            if (candidate == target) {
+                return entry.path();
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+static std::optional<std::filesystem::path> findInRoot(const std::filesystem::path &root,
+                                                       std::string_view relativePath) {
+    auto normalized = normalizeRelativePath(relativePath);
+    if (auto path = findFileIgnoreCase(root, normalized)) {
+        return path;
+    }
+    auto direct = root / std::filesystem::path(relativePath);
+    if (std::filesystem::exists(direct)) {
+        return direct;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::path> Installation::resolveLooseRelativePath(std::string_view relativePath,
+                                                                            const SearchScope &order) {
+    auto target = normalizeRelativePath(relativePath);
+
+    for (auto location : order) {
+        switch (location) {
+        case SearchLocation::CustomFolders: {
+            if (auto path = findInFolders(_customFolders, target)) {
+                return path;
+            }
+            break;
+        }
+        case SearchLocation::Root:
+        case SearchLocation::Movies: {
+            if (auto path = findInRoot(_root, target)) {
+                return path;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return std::nullopt;
+}
+
+void Installation::checkList(const std::string &cacheKey,
+                             const std::vector<FileResource> &list,
+                             const resource::ResourceId &id,
+                             std::vector<LocationResult> &out) {
+    auto &cache = _listCache[cacheKey];
+    if (cache.empty()) {
+        for (auto &res : list) {
+            cache.emplace(res.id(), res);
+        }
+    }
+    auto it = cache.find(id);
+    if (it != cache.end()) {
+        appendLocation(it->second, out);
+    }
+}
+
+void Installation::checkDict(const std::string &cachePrefix,
+                             const std::unordered_map<std::string, std::vector<FileResource>> &dict,
+                             const resource::ResourceId &id,
+                             std::vector<LocationResult> &out) {
+    for (const auto &name : sortedKeys(dict)) {
+        const auto &list = dict.at(name);
+        checkList(cachePrefix + "/" + name, list, id, out);
+    }
+}
+
+void Installation::checkFolders(const std::vector<std::filesystem::path> &folders,
+                                const resource::ResourceId &id,
+                                std::vector<LocationResult> &out) {
+    for (auto &folder : folders) {
+        if (!std::filesystem::exists(folder)) {
+            continue;
+        }
+        std::vector<FileResource> matches;
+        for (auto &entry : std::filesystem::recursive_directory_iterator(folder)) {
+            if (!entry.is_regular_file()) {
+                continue;
+            }
+            auto fileId = resourceIdFromPath(entry.path());
+            if (fileId && *fileId == id) {
+                FileResource res(
+                    fileId->resRef.value(),
+                    fileId->type,
+                    static_cast<uint32_t>(entry.file_size()),
+                    0,
+                    entry.path());
+                matches.push_back(std::move(res));
+            }
+        }
+        sortResources(matches);
+        for (const auto &res : matches) {
+            appendLocation(res, out);
+        }
+    }
+}
+
+void Installation::checkCapsules(const std::vector<std::filesystem::path> &capsules,
+                                 const resource::ResourceId &id,
+                                 std::vector<LocationResult> &out) {
+    for (auto &path : capsules) {
+        if (auto res = cachedCapsule(path).find(id)) {
+            appendLocation(*res, out);
+        }
+    }
+}
+
+const LazyCapsule &Installation::cachedCapsule(const std::filesystem::path &path) const {
+    auto key = pathCacheKey(path);
+    auto it = _capsuleCache.find(key);
+    if (it != _capsuleCache.end()) {
+        return *it->second;
+    }
+    auto inserted = _capsuleCache.emplace(key, std::make_shared<LazyCapsule>(path));
+    return *inserted.first->second;
+}
+
+void Installation::checkOverride(const resource::ResourceId &id, std::vector<LocationResult> &out) {
+    loadOverride();
+    auto it = _overrideIndex.find(id);
+    if (it != _overrideIndex.end()) {
+        appendLocation(it->second, out);
+    }
+}
+
+void Installation::checkModules(const resource::ResourceId &id, std::vector<LocationResult> &out) {
+    if (!_moduleRoot) {
+        return;
+    }
+    loadModules();
+    for (const auto &rel : moduleArchiveRelPaths(*_moduleRoot)) {
+        auto filename = boost::to_lower_copy(std::filesystem::path(rel).filename().string());
+        auto it = _moduleCapsulePaths.find(filename);
+        if (it != _moduleCapsulePaths.end()) {
+            auto res = cachedCapsule(it->second).find(id);
+            if (res) {
+                appendLocation(*res, out);
+            }
+        }
+    }
+}
+
+void Installation::checkTexturePack(const char *packName,
+                                    const resource::ResourceId &id,
+                                    std::vector<LocationResult> &out) {
+    loadTexturePacks();
+    auto packIt = _texturePackIndex.find(packName);
+    if (packIt == _texturePackIndex.end()) {
+        return;
+    }
+    auto resIt = packIt->second.find(id);
+    if (resIt != packIt->second.end()) {
+        appendLocation(resIt->second, out);
+    }
+}
+
+std::vector<LocationResult> Installation::locations(const resource::ResourceId &id,
+                                                    const SearchScope &order,
+                                                    const ResourceLookupContext &ctx) {
+    std::vector<LocationResult> results;
+
+    std::vector<std::filesystem::path> mergedFolders;
+    const std::vector<std::filesystem::path> *folderView = &_customFolders;
+    if (!ctx.customFolders.empty()) {
+        mergedFolders = _customFolders;
+        mergedFolders.insert(mergedFolders.end(), ctx.customFolders.begin(), ctx.customFolders.end());
+        folderView = &mergedFolders;
+    }
+
+    std::vector<std::filesystem::path> mergedCapsules;
+    const std::vector<std::filesystem::path> *capsuleView = &_customCapsules;
+    if (!ctx.customCapsules.empty()) {
+        mergedCapsules = _customCapsules;
+        mergedCapsules.insert(mergedCapsules.end(), ctx.customCapsules.begin(), ctx.customCapsules.end());
+        capsuleView = &mergedCapsules;
+    }
+
+    for (auto location : order) {
+        switch (location) {
+        case SearchLocation::CustomFolders:
+            checkFolders(*folderView, id, results);
+            break;
+        case SearchLocation::Override:
+            checkOverride(id, results);
+            break;
+        case SearchLocation::Root:
+            loadRoot();
+            checkList("root", _rootLoose, id, results);
+            break;
+        case SearchLocation::CustomModules:
+            checkCapsules(*capsuleView, id, results);
+            break;
+        case SearchLocation::Modules:
+            checkModules(id, results);
+            break;
+        case SearchLocation::Chitin: {
+            loadChitin();
+            checkList("chitin", _chitin, id, results);
+            if (results.empty()) {
+                if (auto patchPath = findFileIgnoreCase(_root, kPatchFilename)) {
+                    if (auto res = cachedCapsule(*patchPath).find(id)) {
+                        appendLocation(*res, results);
+                    }
+                }
+            }
+            break;
+        }
+        case SearchLocation::TexturesTpa:
+            checkTexturePack(kTexturePackTpa, id, results);
+            break;
+        case SearchLocation::TexturesTpb:
+            checkTexturePack(kTexturePackTpb, id, results);
+            break;
+        case SearchLocation::TexturesTpc:
+            checkTexturePack(kTexturePackTpc, id, results);
+            break;
+        case SearchLocation::TexturesGui:
+            checkTexturePack(kTexturePackGui, id, results);
+            break;
+        case SearchLocation::Music:
+            loadStreams();
+            checkList("music", _streamMusic, id, results);
+            break;
+        case SearchLocation::Sound:
+            loadStreams();
+            checkList("sound", _streamSounds, id, results);
+            break;
+        case SearchLocation::Voice:
+            loadStreams();
+            checkList("voice", _streamVoice, id, results);
+            break;
+        case SearchLocation::Lips:
+            loadLips();
+            checkDict("lips", _lips, id, results);
+            break;
+        case SearchLocation::Rims:
+            loadRims();
+            checkDict("rims", _rims, id, results);
+            break;
+        case SearchLocation::Executable:
+            loadExecutable();
+            checkList("exe", _executable, id, results);
+            break;
+        default:
+            break;
+        }
+    }
+
+    return results;
+}
+
+std::optional<LocationResult> Installation::resource(const resource::ResourceId &id,
+                                                     const SearchScope &order,
+                                                     const ResourceLookupContext &ctx) {
+    auto locs = locations(id, order, ctx);
+    if (locs.empty()) {
+        return std::nullopt;
+    }
+    return locs.front();
+}
+
+std::unordered_map<resource::ResourceId, std::vector<LocationResult>> Installation::locations(
+    const std::vector<resource::ResourceId> &ids,
+    const SearchScope &order,
+    const ResourceLookupContext &ctx) {
+    std::unordered_map<resource::ResourceId, std::vector<LocationResult>> result;
+    for (auto &id : ids) {
+        result.emplace(id, locations(id, order, ctx));
+    }
+    return result;
+}
+
+} // namespace extract
+
+} // namespace reone

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/extract/chitin.cpp
     ${TESTS_SOURCE_DIR}/extract/fileresource.cpp
     ${TESTS_SOURCE_DIR}/extract/finder.cpp
+    ${TESTS_SOURCE_DIR}/extract/installation.cpp
     ${TESTS_SOURCE_DIR}/fixtures/engine.cpp
     ${TESTS_SOURCE_DIR}/game/action.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp

--- a/test/extract/installation.cpp
+++ b/test/extract/installation.cpp
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/installation.h"
+#include "reone/graphics/types.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::extract;
+using namespace reone::resource;
+using namespace reone::test;
+
+using ErfType = ErfWriter::FileType;
+
+static std::string str(const ByteBuffer &buf) {
+    return std::string(buf.begin(), buf.end());
+}
+
+TEST(InstallationSearchOrder, override_beats_modules_and_chitin) {
+    TmpDir tmp("reone_test_installation_order");
+    std::filesystem::create_directories(tmp.path / "modules");
+    std::filesystem::create_directories(tmp.path / "override");
+
+    writeKeyBif(tmp.path, "data\\sample.bif", {{"probe", ResType::Txt, "chitin"}});
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"probe", ResType::Txt, "module"}});
+    detail::writeFile(tmp.path / "override" / "probe.txt", "override");
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("modfoo");
+
+    auto loc = installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("override", str(loc->readData()));
+}
+
+TEST(InstallationSearchOrder, override_duplicate_subdirectories_use_deterministic_first_directory) {
+    TmpDir tmp("reone_test_installation_override_duplicate");
+    std::filesystem::create_directories(tmp.path / "override" / "z_last");
+    std::filesystem::create_directories(tmp.path / "override" / "a_first");
+    detail::writeFile(tmp.path / "override" / "z_last" / "probe.txt", "z");
+    detail::writeFile(tmp.path / "override" / "a_first" / "probe.txt", "a");
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto loc = installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("a", str(loc->readData()));
+}
+
+TEST(InstallationSearchOrder, empty_search_order_returns_no_locations) {
+    TmpDir tmp("reone_test_installation_empty_order");
+    std::filesystem::create_directories(tmp.path / "override");
+    detail::writeFile(tmp.path / "override" / "probe.txt", "override");
+
+    Installation installation(GameID::KotOR, tmp.path);
+    SearchScope empty;
+
+    EXPECT_TRUE(installation.locations(ResourceId("probe", ResType::Txt), empty).empty());
+    EXPECT_FALSE(installation.resource(ResourceId("probe", ResType::Txt), empty).has_value());
+}
+
+TEST(InstallationSearchOrder, chitin_lookup_falls_back_to_patch_capsule) {
+    TmpDir tmp("reone_test_installation_patch");
+
+    writeKeyBif(tmp.path, "sample.bif", {{"in_chitin", ResType::Txt, "chitin"}});
+    writeErf(tmp.path / "patch.erf", ErfType::ERF,
+             {{"in_chitin", ResType::Txt, "patch shadowed"},
+              {"in_patch", ResType::Txt, "patch"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto chitinLoc = installation.resource(ResourceId("in_chitin", ResType::Txt), canonicalSearchOrder());
+    ASSERT_TRUE(chitinLoc.has_value());
+    EXPECT_EQ("chitin", str(chitinLoc->readData())) << "chitin entry must shadow patch.erf";
+
+    auto patchLoc = installation.resource(ResourceId("in_patch", ResType::Txt), canonicalSearchOrder());
+    ASSERT_TRUE(patchLoc.has_value());
+    EXPECT_EQ("patch", str(patchLoc->readData())) << "patch.erf must serve entries missing from chitin";
+}
+
+TEST(InstallationLocations, collects_matches_across_search_order_in_priority_order) {
+    TmpDir tmp("reone_test_installation_all_locations");
+    std::filesystem::create_directories(tmp.path / "modules");
+    std::filesystem::create_directories(tmp.path / "override");
+
+    detail::writeFile(tmp.path / "override" / "probe.txt", "o");
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"probe", ResType::Txt, "m"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("modfoo");
+
+    auto locs = installation.locations(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+
+    ASSERT_EQ(2u, locs.size());
+    EXPECT_EQ("o", str(locs[0].readData()));
+    EXPECT_EQ("m", str(locs[1].readData()));
+    EXPECT_FALSE(locs[0].asFileResource().insideCapsule());
+    EXPECT_TRUE(locs[1].asFileResource().insideCapsule());
+    EXPECT_EQ(tmp.path / "modules" / "modfoo.rim" / "probe.txt",
+              locs[1].asFileResource().pathIdentifier());
+
+    auto selected = installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+    ASSERT_TRUE(selected.has_value());
+    EXPECT_EQ("o", str(selected->readData()));
+}
+
+TEST(InstallationModuleRoot, filters_module_capsules_by_root) {
+    TmpDir tmp("reone_test_installation_module_root");
+    std::filesystem::create_directories(tmp.path / "modules");
+
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"probe", ResType::Txt, "foo"}});
+    writeRim(tmp.path / "modules" / "modbar.rim", {{"probe", ResType::Txt, "bar"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("modfoo");
+
+    auto loc = installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("foo", str(loc->readData()));
+}
+
+TEST(InstallationModuleRoot, prioritizes_mod_then_static_rim_then_rim) {
+    TmpDir tmp("reone_test_installation_module_archive_order");
+    std::filesystem::create_directories(tmp.path / "modules");
+
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"probe", ResType::Txt, "rim"}});
+    writeRim(tmp.path / "modules" / "modfoo_s.rim", {{"probe", ResType::Txt, "static rim"}});
+    writeErf(tmp.path / "modules" / "modfoo.mod", ErfType::MOD, {{"probe", ResType::Txt, "mod"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("modfoo");
+
+    auto locations = installation.locations(ResourceId("probe", ResType::Txt), SearchScope {SearchLocation::Modules});
+
+    ASSERT_EQ(3u, locations.size());
+    EXPECT_EQ("mod", str(locations[0].readData()));
+    EXPECT_EQ("static rim", str(locations[1].readData()));
+    EXPECT_EQ("rim", str(locations[2].readData()));
+}
+
+TEST(InstallationModuleRoot, getModuleRoot_strips_suffixes) {
+    EXPECT_EQ("foo", Installation::getModuleRoot("foo_s.rim"));
+    EXPECT_EQ("foo", Installation::getModuleRoot("foo_dlg.erf"));
+    EXPECT_EQ("modbar", Installation::getModuleRoot("modbar.mod"));
+    EXPECT_EQ("modbar", Installation::getModuleRoot("modbar_loc.mod"));
+    EXPECT_EQ("modbar", Installation::getModuleRoot("MODBAR.RIM"));
+}
+
+TEST(InstallationModuleRoot, loads_lips_loc_capsule_for_module) {
+    TmpDir tmp("reone_test_installation_lips_loc");
+    std::filesystem::create_directories(tmp.path / "modules");
+    std::filesystem::create_directories(tmp.path / "lips");
+
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"area_res", ResType::Txt, "m"}});
+    writeErf(tmp.path / "lips" / "modfoo_loc.mod", ErfType::MOD, {{"lipsync", ResType::Lip, "l"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("modfoo");
+
+    auto loc = installation.resource(ResourceId("lipsync", ResType::Lip), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("l", str(loc->readData()));
+}
+
+TEST(InstallationModuleRoot, skips_module_index_until_module_root_set) {
+    TmpDir tmp("reone_test_installation_module_lazy");
+    std::filesystem::create_directories(tmp.path / "modules");
+
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"probe", ResType::Txt, "foo"}});
+    writeRim(tmp.path / "modules" / "modbar.rim", {{"probe", ResType::Txt, "bar"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    EXPECT_FALSE(installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder()).has_value());
+
+    installation.setModuleRoot("modfoo");
+    auto loc = installation.resource(ResourceId("probe", ResType::Txt), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("foo", str(loc->readData()));
+}
+
+TEST(InstallationSearchOrder, soundSearchOrder_finds_streammusic) {
+    TmpDir tmp("reone_test_installation_streammusic");
+    std::filesystem::create_directories(tmp.path / "streammusic");
+    detail::writeFile(tmp.path / "streammusic" / "theme.wav", "wav");
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto loc = installation.resource(ResourceId("theme", ResType::Wav), soundSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("wav", str(loc->readData()));
+}
+
+TEST(InstallationResolveLooseRelativePath, finds_root_dialog_tlk) {
+    TmpDir tmp("reone_test_installation_root_files");
+    std::filesystem::create_directories(tmp.path / "override");
+    detail::writeFile(tmp.path / "dialog.tlk", "root");
+    detail::writeFile(tmp.path / "override" / "dialog.tlk", "override");
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto path = installation.resolveLooseRelativePath("dialog.tlk", talkTableSearchOrder());
+
+    ASSERT_TRUE(path.has_value());
+    EXPECT_EQ(std::filesystem::weakly_canonical(tmp.path / "dialog.tlk"),
+              std::filesystem::weakly_canonical(*path));
+}
+
+TEST(InstallationLookupContext, searches_extra_locations_without_mutating_installation_scope) {
+    TmpDir tmp("reone_test_installation_lookup_context");
+    std::filesystem::create_directories(tmp.path / "ctx_folder");
+    detail::writeFile(tmp.path / "ctx_folder" / "folder_probe.txt", "f");
+    writeErf(tmp.path / "ctx.erf", ErfType::ERF, {{"capsule_probe", ResType::Txt, "c"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    ResourceLookupContext ctx;
+    ctx.customFolders = {tmp.path / "ctx_folder"};
+    ctx.customCapsules = {tmp.path / "ctx.erf"};
+
+    auto folderLocs = installation.locations(
+        ResourceId("folder_probe", ResType::Txt),
+        SearchScope {SearchLocation::CustomFolders},
+        ctx);
+    ASSERT_EQ(1u, folderLocs.size());
+    EXPECT_EQ("f", str(folderLocs[0].readData()));
+
+    auto capsuleLocs = installation.locations(
+        ResourceId("capsule_probe", ResType::Txt),
+        SearchScope {SearchLocation::CustomModules},
+        ctx);
+    ASSERT_EQ(1u, capsuleLocs.size());
+    EXPECT_EQ("c", str(capsuleLocs[0].readData()));
+
+    EXPECT_TRUE(installation.customFolders().empty());
+    EXPECT_TRUE(installation.customCapsules().empty());
+}
+
+TEST(InstallationLocations, batch_lookup_returns_locations_for_each_resource_id) {
+    TmpDir tmp("reone_test_installation_batch");
+    std::filesystem::create_directories(tmp.path / "override");
+    detail::writeFile(tmp.path / "override" / "one.txt", "1");
+    detail::writeFile(tmp.path / "override" / "two.txt", "2");
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto batch = installation.locations(
+        std::vector<ResourceId> {
+            ResourceId("one", ResType::Txt),
+            ResourceId("two", ResType::Txt),
+            ResourceId("missing", ResType::Txt),
+        },
+        canonicalSearchOrder());
+
+    ASSERT_EQ(3u, batch.size());
+    ASSERT_EQ(1u, batch.at(ResourceId("one", ResType::Txt)).size());
+    ASSERT_EQ(1u, batch.at(ResourceId("two", ResType::Txt)).size());
+    EXPECT_TRUE(batch.at(ResourceId("missing", ResType::Txt)).empty());
+    EXPECT_EQ("1", str(batch.at(ResourceId("one", ResType::Txt)).front().readData()));
+    EXPECT_EQ("2", str(batch.at(ResourceId("two", ResType::Txt)).front().readData()));
+}
+
+TEST(InstallationSaveScope, clearSaveScope_resets_scope_to_global_baseline) {
+    TmpDir tmp("reone_test_installation_save_scope");
+    std::filesystem::create_directories(tmp.path / "global");
+    std::filesystem::create_directories(tmp.path / "save_a");
+
+    writeErf(tmp.path / "global.erf", ErfType::ERF, {{"shader", ResType::Txi, "g"}});
+    writeErf(tmp.path / "savegame.sav", ErfType::ERF, {{"save_res", ResType::Gff, "s"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setGlobalCustomFolders({tmp.path / "global"});
+    installation.setGlobalCustomCapsules({tmp.path / "global.erf"});
+    installation.setCustomFolders({tmp.path / "global", tmp.path / "save_a"});
+    installation.setCustomCapsules({tmp.path / "global.erf", tmp.path / "savegame.sav"});
+
+    installation.clearSaveScope();
+
+    ASSERT_EQ(1u, installation.customFolders().size());
+    EXPECT_EQ(tmp.path / "global", installation.customFolders().front());
+    ASSERT_EQ(1u, installation.customCapsules().size());
+    EXPECT_EQ(tmp.path / "global.erf", installation.customCapsules().front());
+}
+
+TEST(InstallationSaveScope, save_load_merges_save_capsule_with_global_baseline) {
+    TmpDir tmp("reone_test_installation_save_capsules");
+    std::filesystem::create_directories(tmp.path / "saves" / "slot_a");
+
+    writeErf(tmp.path / "shaderpack.erf", ErfType::ERF, {{"shader", ResType::Txi, "g"}});
+    writeErf(tmp.path / "saves" / "slot_a" / "savegame.sav", ErfType::ERF,
+             {{"save_res", ResType::Gff, "s"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setGlobalCustomCapsules({tmp.path / "shaderpack.erf"});
+
+    installation.clearSaveScope();
+    installation.appendSaveScope(tmp.path / "saves" / "slot_a",
+                                 tmp.path / "saves" / "slot_a" / "savegame.sav");
+
+    ASSERT_EQ(2u, installation.customCapsules().size());
+    EXPECT_EQ(tmp.path / "shaderpack.erf", installation.customCapsules().front());
+    EXPECT_EQ(tmp.path / "saves" / "slot_a" / "savegame.sav", installation.customCapsules().back());
+
+    auto shader = installation.resource(ResourceId("shader", ResType::Txi), canonicalSearchOrder());
+    ASSERT_TRUE(shader.has_value());
+    EXPECT_EQ("g", str(shader->readData()));
+
+    auto saveRes = installation.resource(ResourceId("save_res", ResType::Gff), canonicalSearchOrder());
+    ASSERT_TRUE(saveRes.has_value());
+    EXPECT_EQ("s", str(saveRes->readData()));
+}
+
+TEST(InstallationSaveScope, module_transition_preserves_save_scope_after_game_load) {
+    TmpDir tmp("reone_test_installation_save_module");
+    std::filesystem::create_directories(tmp.path / "modules");
+    std::filesystem::create_directories(tmp.path / "saves" / "slot_a");
+
+    writeRim(tmp.path / "modules" / "modfoo.rim", {{"mod_res", ResType::Txt, "m"}});
+    writeErf(tmp.path / "shaderpack.erf", ErfType::ERF, {{"shader", ResType::Txi, "g"}});
+    writeErf(tmp.path / "saves" / "slot_a" / "savegame.sav", ErfType::ERF,
+             {{"save_res", ResType::Gff, "s"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setGlobalCustomCapsules({tmp.path / "shaderpack.erf"});
+
+    installation.clearSaveScope();
+    installation.appendSaveScope(tmp.path / "saves" / "slot_a",
+                                 tmp.path / "saves" / "slot_a" / "savegame.sav");
+
+    installation.setModuleRoot("modfoo");
+
+    ASSERT_EQ(1u, installation.customFolders().size());
+    EXPECT_EQ(tmp.path / "saves" / "slot_a", installation.customFolders().front());
+    ASSERT_EQ(2u, installation.customCapsules().size());
+
+    auto saveRes = installation.resource(ResourceId("save_res", ResType::Gff), canonicalSearchOrder());
+    ASSERT_TRUE(saveRes.has_value());
+    EXPECT_EQ("s", str(saveRes->readData()));
+
+    auto modRes = installation.resource(ResourceId("mod_res", ResType::Txt), canonicalSearchOrder());
+    ASSERT_TRUE(modRes.has_value());
+    EXPECT_EQ("m", str(modRes->readData()));
+}
+
+TEST(InstallationSaveScope, save_switch_replaces_prior_save_folder) {
+    TmpDir tmp("reone_test_installation_save_switch");
+    std::filesystem::create_directories(tmp.path / "saves" / "slot_a");
+    std::filesystem::create_directories(tmp.path / "saves" / "slot_b");
+
+    writeErf(tmp.path / "saves" / "slot_a" / "savegame.sav", ErfType::ERF,
+             {{"save_res", ResType::Gff, "a"}});
+    writeErf(tmp.path / "saves" / "slot_b" / "savegame.sav", ErfType::ERF,
+             {{"save_res", ResType::Gff, "b"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    installation.clearSaveScope();
+    installation.appendSaveScope(tmp.path / "saves" / "slot_a",
+                                 tmp.path / "saves" / "slot_a" / "savegame.sav");
+
+    installation.clearSaveScope();
+    installation.appendSaveScope(tmp.path / "saves" / "slot_b",
+                                 tmp.path / "saves" / "slot_b" / "savegame.sav");
+
+    ASSERT_EQ(1u, installation.customFolders().size());
+    EXPECT_EQ(tmp.path / "saves" / "slot_b", installation.customFolders().front());
+    ASSERT_EQ(1u, installation.customCapsules().size());
+
+    auto loc = installation.resource(ResourceId("save_res", ResType::Gff), canonicalSearchOrder());
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("b", str(loc->readData()));
+}
+
+TEST(InstallationTextureQuality, medium_prefers_tpb_over_tpa) {
+    TmpDir tmp("reone_test_installation_tex_quality");
+    std::filesystem::create_directories(tmp.path / "texturepacks");
+
+    writeErf(tmp.path / "texturepacks" / "swpc_tex_tpa.erf", ErfType::ERF,
+             {{"probe", ResType::Tga, "a"}});
+    writeErf(tmp.path / "texturepacks" / "swpc_tex_tpb.erf", ErfType::ERF,
+             {{"probe", ResType::Tga, "b"}});
+    writeErf(tmp.path / "texturepacks" / "swpc_tex_gui.erf", ErfType::ERF,
+             {{"gui_probe", ResType::Tga, "g"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto loc = installation.resource(
+        ResourceId("probe", ResType::Tga),
+        textureSearchOrder(graphics::TextureQuality::Medium));
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("b", str(loc->readData()));
+
+    auto guiLoc = installation.resource(
+        ResourceId("gui_probe", ResType::Tga),
+        textureSearchOrder(graphics::TextureQuality::Medium));
+    ASSERT_TRUE(guiLoc.has_value());
+    EXPECT_EQ("g", str(guiLoc->readData()));
+}
+
+TEST(InstallationSearchOrder, lips_directory_reachable_via_canonical_order) {
+    TmpDir tmp("reone_test_installation_lips");
+    std::filesystem::create_directories(tmp.path / "lips");
+
+    writeErf(tmp.path / "lips" / "global.mod", ErfType::MOD, {{"lip_anim", ResType::Lip, "l"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto loc = installation.resource(ResourceId("lip_anim", ResType::Lip), canonicalSearchOrder());
+
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ("l", str(loc->readData()));
+}
+
+TEST(InstallationSearchOrder, capsule_dictionary_order_is_stable) {
+    TmpDir tmp("reone_test_installation_lips_order");
+    std::filesystem::create_directories(tmp.path / "lips");
+
+    writeErf(tmp.path / "lips" / "z_last.mod", ErfType::MOD, {{"lip_anim", ResType::Lip, "z"}});
+    writeErf(tmp.path / "lips" / "a_first.mod", ErfType::MOD, {{"lip_anim", ResType::Lip, "a"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+
+    auto locations = installation.locations(ResourceId("lip_anim", ResType::Lip), SearchScope {SearchLocation::Lips});
+
+    ASSERT_EQ(2u, locations.size());
+    EXPECT_EQ("a", str(locations[0].readData()));
+    EXPECT_EQ("z", str(locations[1].readData()));
+}


### PR DESCRIPTION
> **Resource-loader migration: B2 — Installation resolver**
>
> Depends on B1.

## Summary

Adds the Extract `Installation` resolver on top of the archive and lookup primitives from B1.

This includes:

- canonical K1/K2 resource locations
- override, Chitin, patch, texture, stream, lips, rims, movies, and executable sources
- module-root handling
- explicit save scope
- `LookupContext`
- stable normalized cache keys
- deterministic location and module ordering

This slice remains additive. It does not change the active Legacy backend or production runtime behavior.