### PR TITLE
[game] Generate linked-door transition regions

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -365,6 +365,8 @@ public:
     void deserializeInventory(resource::Gff &inventoryGff);
 
 private:
+    friend class TestGameModule;
+
     resource::GameID _gameId;
     std::filesystem::path _path;
     OptionsView &_options;

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -72,7 +72,10 @@ public:
     Faction faction() const { return _faction; }
     const std::string &linkedToModule() const { return _linkedToModule; }
     const std::string &linkedTo() const { return _linkedTo; }
+    uint8_t linkedToFlags() const { return _linkedToFlags; }
     const std::string &transitionDestin() const { return _transitionDestin.str(); }
+    const resource::LocString &transitionDestination() const { return _transitionDestin; }
+    const std::vector<glm::vec3> &linkedTransitionGeometry() const { return _linkedTransitionGeometry; }
 
     void setLocked(bool locked);
 
@@ -141,6 +144,7 @@ private:
     std::shared_ptr<scene::WalkmeshSceneNode> _walkmeshOpen1;
     std::shared_ptr<scene::WalkmeshSceneNode> _walkmeshOpen2;
     std::shared_ptr<scene::WalkmeshSceneNode> _walkmeshClosed;
+    std::vector<glm::vec3> _linkedTransitionGeometry;
 
     // END Walkmeshes
 
@@ -153,6 +157,7 @@ private:
 
     void deserializeAll(const resource::Gff &gff);
     void loadAppearance();
+    void loadLinkedTransitionGeometry(const graphics::Walkmesh &walkmesh);
     void updateTransform() override;
 };
 

--- a/include/reone/game/object/trigger.h
+++ b/include/reone/game/object/trigger.h
@@ -25,6 +25,8 @@ namespace reone {
 
 namespace game {
 
+class Door;
+
 class Trigger : public Object {
 public:
     enum class DebugState {
@@ -53,6 +55,7 @@ public:
 
     void loadFromBlueprint(const std::string &resRef);
     void deserialize(const resource::Gff &gff);
+    void configureLinkedDoorTransition(const std::shared_ptr<Door> &door);
 
     void update(float dt) override;
 
@@ -66,6 +69,10 @@ public:
 
     bool isIn(const glm::vec2 &point) const;
     bool isTenant(const std::shared_ptr<Object> &object) const;
+    bool isActive() const;
+    bool isLinkedDoorTransition() const { return _linkedDoorTransition; }
+    bool acceptsTransitionActivator(const std::shared_ptr<Object> &activator) const;
+    bool detachLinkedDoorTransition(const Door &door);
 
     const std::vector<glm::vec3> &geometry() const { return _geometry; }
     DebugState debugState() const;
@@ -79,6 +86,8 @@ public:
 
     const std::string &linkedToModule() const { return _linkedToModule; }
     const std::string &linkedTo() const { return _linkedTo; }
+    uint8_t linkedToFlags() const { return _linkedToFlags; }
+    const std::string &transitionDestin() const { return _transitionDestin.str(); }
 
 private:
     // Serializable
@@ -107,6 +116,8 @@ private:
     // END Serializable
 
     std::set<std::shared_ptr<Object>> _tenants;
+    std::weak_ptr<Door> _linkedDoor;
+    bool _linkedDoorTransition {false};
     float _debugTestAge {0.0f};
     float _debugInsideAge {0.0f};
     float _debugEnterAge {0.0f};

--- a/include/reone/scene/node/trigger.h
+++ b/include/reone/scene/node/trigger.h
@@ -46,6 +46,7 @@ public:
             audioSvc,
             resourceSvc),
         _geometry(std::move(geometry)) {
+        initGeometry();
     }
 
     void init();
@@ -62,6 +63,8 @@ private:
     glm::vec4 _debugColor {0.48f, 0.74f, 1.0f, 1.0f};
 
     std::unique_ptr<graphics::Mesh> _mesh;
+
+    void initGeometry();
 };
 
 } // namespace scene

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -537,6 +537,17 @@ void Area::add(const std::shared_ptr<Object> &object) {
 
     determineObjectRoom(*object);
     attachObjectToSceneGraph(object);
+
+    if (auto door = dyn_cast<Door>(object)) {
+        if ((door->linkedToFlags() == 1 || door->linkedToFlags() == 2) &&
+            !door->linkedToModule().empty() &&
+            !door->linkedTo().empty() &&
+            !door->linkedTransitionGeometry().empty()) {
+            auto trigger = _game.newTrigger(_sceneName);
+            trigger->configureLinkedDoorTransition(door);
+            add(trigger);
+        }
+    }
 }
 
 void Area::attachRoomToSceneGraph(Room &room) {
@@ -611,6 +622,20 @@ void Area::doDestroyObject(uint32_t objectId) {
     if (!object) {
         return;
     }
+
+    if (auto door = dyn_cast<Door>(object)) {
+        std::vector<uint32_t> linkedTriggerIds;
+        for (auto &triggerObject : _objectsByType[ObjectType::Trigger]) {
+            auto trigger = std::static_pointer_cast<Trigger>(triggerObject);
+            if (trigger->detachLinkedDoorTransition(*door)) {
+                linkedTriggerIds.push_back(trigger->id());
+            }
+        }
+        for (auto triggerId : linkedTriggerIds) {
+            doDestroyObject(triggerId);
+        }
+    }
+
     auto room = object->room();
     if (room) {
         room->removeTenant(object.get());
@@ -996,6 +1021,10 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer, 
 
     for (auto &object : _objectsByType[ObjectType::Trigger]) {
         auto trigger = std::static_pointer_cast<Trigger>(object);
+        if (!trigger->isActive()) {
+            trigger->removeTenant(triggerrer.get());
+            continue;
+        }
         bool inside = trigger->isIn(position2d);
         trigger->markDebugTested(inside);
         if (trigger->isTenant(triggerrer) || !inside) {
@@ -1011,6 +1040,10 @@ void Area::checkTriggersIntersection(const std::shared_ptr<Object> &triggerrer, 
                   trigger->tag() %
                   (trigger->getOnEnter().empty() ? std::string("<none>") : trigger->getOnEnter()) %
                   triggerrer->tag()));
+
+        if (transition && !trigger->acceptsTransitionActivator(triggerrer)) {
+            continue;
+        }
         trigger->addTenant(triggerrer);
         trigger->markDebugEntered();
 

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -140,6 +140,12 @@ void Door::loadAppearance() {
     std::shared_ptr<TwoDA> doors(_services.resource.twoDas.get("genericdoors"));
     std::string modelName(boost::to_lower_copy(doors->getString(_genericType, "modelname")));
 
+    _linkedTransitionGeometry.clear();
+    auto walkmeshClosed = _services.resource.walkmeshes.get(modelName + "0", ResType::Dwk);
+    if (walkmeshClosed) {
+        loadLinkedTransitionGeometry(*walkmeshClosed);
+    }
+
     auto model = _services.resource.models.get(modelName);
     if (!model) {
         return;
@@ -151,7 +157,6 @@ void Door::loadAppearance() {
     // modelSceneNode->setDrawDistance(_game.options().graphics.drawDistance);
     _sceneNode = std::move(modelSceneNode);
 
-    auto walkmeshClosed = _services.resource.walkmeshes.get(modelName + "0", ResType::Dwk);
     if (walkmeshClosed) {
         _walkmeshClosed = sceneGraph.newWalkmesh(*walkmeshClosed);
         _walkmeshClosed->setUser(*this);
@@ -170,6 +175,25 @@ void Door::loadAppearance() {
         _walkmeshOpen2->setUser(*this);
         _walkmeshOpen2->setEnabled(false);
     }
+}
+
+void Door::loadLinkedTransitionGeometry(const Walkmesh &walkmesh) {
+    AABB bounds;
+    for (const auto &face : walkmesh.faces()) {
+        for (const auto &vertex : face.vertices) {
+            bounds.expand(vertex);
+        }
+    }
+    if (bounds.isDegenerate() || bounds.min().x == bounds.max().x || bounds.min().y == bounds.max().y) {
+        return;
+    }
+
+    float z = bounds.min().z;
+    _linkedTransitionGeometry = {
+        glm::vec3(bounds.min().x, bounds.min().y, z),
+        glm::vec3(bounds.min().x, bounds.max().y, z),
+        glm::vec3(bounds.max().x, bounds.max().y, z),
+        glm::vec3(bounds.max().x, bounds.min().y, z)};
 }
 
 bool Door::isSelectable() const {

--- a/src/libs/game/object/trigger.cpp
+++ b/src/libs/game/object/trigger.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
+#include "reone/game/object/door.h"
 #include "reone/game/script/runner.h"
 #include "reone/resource/di/services.h"
 #include "reone/resource/provider/gffs.h"
@@ -70,6 +71,22 @@ void Trigger::deserialize(const resource::Gff &gff) {
         }
     }
     deserializeAll(gff);
+    loadAppearance();
+    updateTransform();
+}
+
+void Trigger::configureLinkedDoorTransition(const std::shared_ptr<Door> &door) {
+    _linkedDoor = door;
+    _linkedDoorTransition = true;
+    _linkedToModule = door->linkedToModule();
+    _linkedTo = door->linkedTo();
+    _linkedToFlags = door->linkedToFlags();
+    _transitionDestin = door->transitionDestination();
+    _name = _transitionDestin.str();
+    _geometry = door->linkedTransitionGeometry();
+
+    setPosition(door->position());
+    setFacing(door->getFacing());
     loadAppearance();
     updateTransform();
 }
@@ -144,6 +161,9 @@ void Trigger::deserializeAll(const resource::Gff &gff) {
 void Trigger::loadAppearance() {
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
     _sceneNode = sceneGraph.newTrigger(_geometry);
+    if (!_sceneNode) {
+        return;
+    }
     _sceneNode->setLocalTransform(glm::translate(_position));
     syncDebugVisual();
 }
@@ -154,6 +174,12 @@ void Trigger::update(float dt) {
     _debugTestAge = glm::max(0.0f, _debugTestAge - dt);
     _debugInsideAge = glm::max(0.0f, _debugInsideAge - dt);
     _debugEnterAge = glm::max(0.0f, _debugEnterAge - dt);
+
+    if (!isActive()) {
+        _tenants.clear();
+        syncDebugVisual();
+        return;
+    }
 
     std::set<std::shared_ptr<Object>> tenantsToRemove;
     for (auto &tenant : _tenants) {
@@ -206,12 +232,45 @@ void Trigger::removeTenant(const Object *object) {
 }
 
 bool Trigger::isIn(const glm::vec2 &point) const {
-    return static_cast<TriggerSceneNode *>(_sceneNode.get())->isIn(point);
+    auto sceneNode = std::static_pointer_cast<TriggerSceneNode>(_sceneNode);
+    return sceneNode && sceneNode->isIn(point);
 }
 
 bool Trigger::isTenant(const std::shared_ptr<Object> &object) const {
     auto maybeTenant = find(_tenants.begin(), _tenants.end(), object);
     return maybeTenant != _tenants.end();
+}
+
+bool Trigger::isActive() const {
+    if (!_linkedDoorTransition) {
+        return true;
+    }
+    auto door = _linkedDoor.lock();
+    return door && door->isOpen();
+}
+
+bool Trigger::acceptsTransitionActivator(const std::shared_ptr<Object> &activator) const {
+    if (_linkedToModule.empty() || !isActive()) {
+        return false;
+    }
+    if (_linkedDoorTransition && (!activator || activator != _game.party().getLeader())) {
+        return false;
+    }
+    return true;
+}
+
+bool Trigger::detachLinkedDoorTransition(const Door &door) {
+    auto linkedDoor = _linkedDoor.lock();
+    if (!_linkedDoorTransition || linkedDoor.get() != &door) {
+        return false;
+    }
+
+    _linkedDoor.reset();
+    _linkedToModule.clear();
+    _linkedTo.clear();
+    _tenants.clear();
+    syncDebugVisual();
+    return true;
 }
 
 Trigger::DebugState Trigger::debugState() const {

--- a/src/libs/scene/node/trigger.cpp
+++ b/src/libs/scene/node/trigger.cpp
@@ -32,7 +32,7 @@ namespace reone {
 
 namespace scene {
 
-void TriggerSceneNode::init() {
+void TriggerSceneNode::initGeometry() {
     size_t numVertices = _geometry.size();
 
     std::vector<glm::vec3> normals(numVertices + 1, glm::vec3(0.0f));
@@ -94,11 +94,14 @@ void TriggerSceneNode::init() {
         std::move(vertices),
         std::move(vertexLayout),
         std::move(faces));
-    _mesh->init();
 
     for (auto &point : _geometry) {
         _aabb.expand(point);
     }
+}
+
+void TriggerSceneNode::init() {
+    _mesh->init();
 }
 
 void TriggerSceneNode::render(IRenderPass &pass) {

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -42,6 +42,8 @@ namespace reone {
 
 namespace game {
 
+class Game;
+
 class MockCameraStyles : public ICameraStyles, boost::noncopyable {
 public:
     MOCK_METHOD(std::shared_ptr<CameraStyle>, get, (int index), (const override));
@@ -136,6 +138,8 @@ public:
 
 class TestGameModule : boost::noncopyable {
 public:
+    static std::pair<std::string, std::string> scheduledTransition(const Game &game);
+
     void init() {
         _cameraStyles = std::make_unique<MockCameraStyles>();
         _classes = std::make_unique<MockClasses>();

--- a/test/fixtures/scene.h
+++ b/test/fixtures/scene.h
@@ -47,7 +47,7 @@ public:
     MOCK_METHOD(void, removeRoot, (GrassSceneNode &), (override));
     MOCK_METHOD(void, removeRoot, (SoundSceneNode &), (override));
 
-    MOCK_METHOD(bool, testElevation, (const glm::vec2 &, Collision &), (const override));
+    MOCK_METHOD(bool, testElevation, (const glm::vec3 &, Collision &), (const override));
     MOCK_METHOD(bool, testLineOfSight, (const glm::vec3 &, const glm::vec3 &, Collision &), (const override));
     MOCK_METHOD(bool, testWalk, (const glm::vec3 &, const glm::vec3 &, const IUser *, Collision &), (const override));
 

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -22,18 +22,30 @@
 
 #include "../fixtures/engine.h"
 
+#include "reone/game/action/closedoor.h"
 #include "reone/game/action/unlockobject.h"
 #include "reone/game/game.h"
+#include "reone/game/object/area.h"
 #include "reone/game/object/creature.h"
+#include "reone/game/object/door.h"
 #include "reone/game/object/item.h"
 #include "reone/game/object/placeable.h"
+#include "reone/game/object/trigger.h"
+#include "reone/graphics/walkmesh.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/gff.h"
+#include "reone/scene/collision.h"
+#include "reone/scene/node/trigger.h"
+#include "reone/script/program.h"
 
 using namespace reone;
 using namespace reone::game;
 using namespace reone::resource;
 using namespace testing;
+
+std::pair<std::string, std::string> reone::game::TestGameModule::scheduledTransition(const Game &game) {
+    return {game._nextModule, game._nextEntry};
+}
 
 namespace {
 
@@ -55,6 +67,10 @@ TestEngine &testEngine() {
     return engine;
 }
 
+std::pair<std::string, std::string> scheduledTransition(TestEngine &engine, const Game &game) {
+    return engine.gameModule().scheduledTransition(game);
+}
+
 std::shared_ptr<TwoDA> makeBaseItemsTable() {
     TwoDA::Builder builder;
     builder.columns({"maxattackrange", "crithitmult", "critthreat", "damageflags", "dietoroll",
@@ -73,6 +89,160 @@ std::shared_ptr<TwoDA> makeAppearanceTable() {
     builder.row({"S", "1", "1", "-1", "", "", ""});
     builder.row({"S", "1", "1", "-1", "", "", ""});
     return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<TwoDA> makeGenericDoorsTable() {
+    TwoDA::Builder builder;
+    builder.columns({"modelname"});
+    builder.row({""});
+    builder.row({"testdoor"});
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+scene::MockSceneGraph &testSceneGraph(TestEngine &engine) {
+    static NiceMock<scene::MockSceneGraph> graph;
+    static bool initialized = false;
+    if (!initialized) {
+        EXPECT_CALL(engine.sceneModule().graphs(), get(_))
+            .Times(AnyNumber())
+            .WillRepeatedly(ReturnRef(graph));
+        ON_CALL(graph, newTrigger(_))
+            .WillByDefault(Invoke([&engine](std::vector<glm::vec3> geometry) {
+                return std::make_shared<scene::TriggerSceneNode>(
+                    std::move(geometry),
+                    graph,
+                    engine.services().graphics,
+                    engine.services().audio,
+                    engine.services().resource);
+            }));
+        ON_CALL(graph, testWalk(_, _, _, _))
+            .WillByDefault(Return(false));
+        ON_CALL(graph, testElevation(_, _))
+            .WillByDefault(Invoke([](const glm::vec3 &position, scene::Collision &collision) {
+                collision.intersection = position;
+                collision.intersection.z = 0.0f;
+                collision.material = 0;
+                collision.user = nullptr;
+                return true;
+            }));
+        initialized = true;
+    }
+    return graph;
+}
+
+std::shared_ptr<graphics::Walkmesh> makeDoorWalkmesh() {
+    auto walkmesh = std::make_shared<graphics::Walkmesh>();
+    walkmesh->add(graphics::Walkmesh::Face {
+        0,
+        0,
+        {glm::vec3(-2.0f, -0.5f, 0.0f),
+         glm::vec3(2.0f, -0.5f, 3.0f),
+         glm::vec3(2.0f, 0.5f, 0.0f)},
+        glm::vec3(0.0f, 0.0f, 1.0f)});
+    return walkmesh;
+}
+
+std::shared_ptr<Door> makeTransitionDoor(
+    Game &game,
+    TestEngine &engine,
+    uint8_t linkedToFlags = 1,
+    std::string linkedToModule = "destination_module",
+    std::string linkedTo = "destination_waypoint",
+    glm::vec3 position = glm::vec3(0.0f),
+    float bearing = 0.0f) {
+
+    testSceneGraph(engine);
+    auto walkmesh = makeDoorWalkmesh();
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("genericdoors"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeGenericDoorsTable()));
+    EXPECT_CALL(engine.resourceModule().models(), get(_))
+        .Times(AnyNumber());
+    EXPECT_CALL(engine.resourceModule().walkmeshes(), get("testdoor0", ResType::Dwk))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(walkmesh));
+
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newByte("GenericType", 1))
+                   .field(Gff::Field::newByte("Static", 0))
+                   .field(Gff::Field::newFloat("X", position.x))
+                   .field(Gff::Field::newFloat("Y", position.y))
+                   .field(Gff::Field::newFloat("Z", position.z))
+                   .field(Gff::Field::newFloat("Bearing", bearing))
+                   .field(Gff::Field::newByte("LinkedToFlags", linkedToFlags))
+                   .field(Gff::Field::newResRef("LinkedToModule", std::move(linkedToModule)))
+                   .field(Gff::Field::newCExoString("LinkedTo", std::move(linkedTo)))
+                   .field(Gff::Field::newCExoLocString("TransitionDestin", -1, "Destination Area"))
+                   .build();
+    auto door = game.newDoor();
+    door->deserialize(*gff);
+    return door;
+}
+
+std::shared_ptr<Creature> makeMovingCreature(Game &game, TestEngine &engine) {
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("appearance"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeAppearanceTable()));
+    EXPECT_CALL(engine.resourceModule().models(), get(_))
+        .Times(AnyNumber());
+    EXPECT_CALL(static_cast<MockPortraits &>(engine.services().game.portraits), getTextureByAppearance(_))
+        .Times(AnyNumber());
+
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newDword("Appearance_Type", 0))
+                   .field(Gff::Field::newWord("SoundSetFile", 0xffff))
+                   .field(Gff::Field::newByte("BodyBag", 0xff))
+                   .field(Gff::Field::newByte("PerceptionRange", 0xff))
+                   .build();
+    auto creature = game.newCreature();
+    creature->deserialize(*gff);
+    return creature;
+}
+
+std::shared_ptr<Gff> makeTransitionTriggerGff(
+    std::string linkedToModule,
+    std::string linkedTo,
+    std::string onEnter = "") {
+
+    std::vector<std::shared_ptr<Gff>> geometry;
+    for (const auto &point : std::vector<glm::vec2> {
+             {-1.0f, -1.0f},
+             {-1.0f, 1.0f},
+             {1.0f, 1.0f},
+             {1.0f, -1.0f}}) {
+        geometry.push_back(
+            Gff::Builder()
+                .field(Gff::Field::newFloat("PointX", point.x))
+                .field(Gff::Field::newFloat("PointY", point.y))
+                .field(Gff::Field::newFloat("PointZ", 0.0f))
+                .build());
+    }
+
+    Gff::Builder builder;
+    builder.field(Gff::Field::newInt("Type", 1))
+        .field(Gff::Field::newByte("LinkedToFlags", 2))
+        .field(Gff::Field::newResRef("LinkedToModule", std::move(linkedToModule)))
+        .field(Gff::Field::newCExoString("LinkedTo", std::move(linkedTo)))
+        .field(Gff::Field::newList("Geometry", std::move(geometry)));
+    if (!onEnter.empty()) {
+        builder.field(Gff::Field::newResRef("ScriptOnEnter", std::move(onEnter)));
+    }
+    return builder.build();
+}
+
+std::shared_ptr<script::ScriptProgram> makeStartNewModuleScript(
+    std::string module,
+    std::string waypoint) {
+
+    auto program = std::make_shared<script::ScriptProgram>("override_transition");
+    for (int i = 0; i < 6; ++i) {
+        program->add(script::Instruction::newCONSTS(""));
+    }
+    program->add(script::Instruction::newCONSTS(std::move(waypoint)));
+    program->add(script::Instruction::newCONSTS(std::move(module)));
+    program->add(script::Instruction::newACTION(509, 8)); // StartNewModule
+    program->add(script::Instruction(script::InstructionType::RETN));
+    return program;
 }
 
 std::shared_ptr<Gff> makeDisguiseItemGff(int appearance) {
@@ -232,6 +402,319 @@ TEST(UnlockObjectAction, should_complete_safely_for_missing_destroyed_or_unsuppo
     EXPECT_TRUE(destroyedAction->isCompleted());
     EXPECT_TRUE(destroyed->isLocked());
     EXPECT_TRUE(unsupportedAction->isCompleted());
+}
+
+TEST(LinkedDoorTransition, should_derive_threshold_from_closed_dwk_and_follow_door_state) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto door = makeTransitionDoor(
+        game,
+        engine,
+        1,
+        "destination_module",
+        "destination_waypoint",
+        glm::vec3(10.0f, 20.0f, 0.0f),
+        -glm::half_pi<float>());
+
+    area->add(door);
+
+    auto &triggers = area->getObjectsByType(ObjectType::Trigger);
+    ASSERT_EQ(triggers.size(), 1);
+    auto trigger = std::static_pointer_cast<Trigger>(triggers.front());
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+    EXPECT_TRUE(trigger->isLinkedDoorTransition());
+    ASSERT_TRUE(trigger->sceneNode());
+    EXPECT_EQ(trigger->sceneNode()->type(), scene::SceneNodeType::Trigger);
+    EXPECT_FALSE(trigger->isActive());
+    EXPECT_TRUE(door->isSelectable());
+    EXPECT_EQ(trigger->linkedToModule(), "destination_module");
+    EXPECT_EQ(trigger->linkedTo(), "destination_waypoint");
+    EXPECT_EQ(trigger->linkedToFlags(), 1);
+    EXPECT_EQ(trigger->transitionDestin(), "Destination Area");
+    ASSERT_EQ(trigger->geometry().size(), 4);
+    EXPECT_EQ(trigger->geometry()[0], glm::vec3(-2.0f, -0.5f, 0.0f));
+    EXPECT_EQ(trigger->geometry()[2], glm::vec3(2.0f, 0.5f, 0.0f));
+
+    door->open();
+
+    EXPECT_TRUE(trigger->isActive());
+    EXPECT_FALSE(door->isSelectable());
+    EXPECT_TRUE(trigger->isIn(glm::vec2(door->position())));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+
+    door->close();
+
+    EXPECT_FALSE(trigger->isActive());
+
+    door->open();
+
+    EXPECT_TRUE(trigger->isActive());
+    EXPECT_FALSE(door->isSelectable());
+}
+
+TEST(LinkedDoorTransition, should_destroy_generated_threshold_with_its_source_door) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto door = makeTransitionDoor(game, engine);
+    auto leader = makeMovingCreature(game, engine);
+    leader->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+
+    auto authored = game.newTrigger();
+    authored->deserialize(*Gff::Builder().build());
+    area->add(authored);
+    area->add(door);
+    area->add(leader);
+
+    auto &triggers = area->getObjectsByType(ObjectType::Trigger);
+    ASSERT_EQ(triggers.size(), 2);
+    auto generated = std::static_pointer_cast<Trigger>(triggers.back());
+    auto generatedSceneNode = std::static_pointer_cast<scene::TriggerSceneNode>(generated->sceneNode());
+    ASSERT_TRUE(generatedSceneNode);
+    door->open();
+    generated->addTenant(leader);
+    ASSERT_TRUE(generated->isActive());
+    ASSERT_TRUE(generated->isTenant(leader));
+
+    auto &sceneGraph = testSceneGraph(engine);
+    EXPECT_CALL(sceneGraph, removeRoot(A<scene::TriggerSceneNode &>()))
+        .WillOnce(Invoke([expected = generatedSceneNode.get()](scene::TriggerSceneNode &node) {
+            EXPECT_EQ(&node, expected);
+        }));
+
+    area->destroyObject(*door);
+    area->update(0.0f);
+
+    ASSERT_EQ(triggers.size(), 1);
+    EXPECT_EQ(triggers.front(), authored);
+    EXPECT_FALSE(generated->isActive());
+    EXPECT_FALSE(generated->isTenant(leader));
+    EXPECT_TRUE(generated->linkedToModule().empty());
+    EXPECT_TRUE(generated->linkedTo().empty());
+
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+}
+
+TEST(LinkedDoorTransition, should_rearm_after_party_unload_and_exit_reentry) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto door = makeTransitionDoor(game, engine);
+    auto leader = makeMovingCreature(game, engine);
+    leader->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+    area->add(door);
+    area->add(leader);
+    auto trigger = std::static_pointer_cast<Trigger>(area->getObjectsByType(ObjectType::Trigger).front());
+
+    door->open();
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 0.75f));
+
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(trigger->linkedToModule(), "destination_module");
+    EXPECT_EQ(trigger->linkedTo(), "destination_waypoint");
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("destination_module"), std::string("destination_waypoint")));
+
+    // Remaining inside uses the existing tenant latch and does not generate a
+    // second enter event while the first transition is pending.
+    game.scheduleModuleTransition("sentinel_module", "sentinel_waypoint");
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(1.0f, 0.0f), false, 0.1f));
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("sentinel_module"), std::string("sentinel_waypoint")));
+
+    // Module transitions cache Area/Trigger instances. Party unload removes
+    // the old tenant, and loading the party again models revisiting the module.
+    area->unloadParty();
+    EXPECT_FALSE(trigger->isTenant(leader));
+    area->loadParty(glm::vec3(0.0f, -1.0f, 0.0f), 0.0f);
+    game.scheduleModuleTransition("", "");
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("destination_module"), std::string("destination_waypoint")));
+
+    game.scheduleModuleTransition("", "");
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 1.0f));
+    trigger->update(0.0f);
+    EXPECT_FALSE(trigger->isTenant(leader));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, -1.0f), false, 0.75f));
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("destination_module"), std::string("destination_waypoint")));
+}
+
+TEST(LinkedDoorTransition, should_reject_npcs_and_companions) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto door = makeTransitionDoor(game, engine);
+    auto leader = makeMovingCreature(game, engine);
+    auto companion = makeMovingCreature(game, engine);
+    auto npc = makeMovingCreature(game, engine);
+    leader->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    companion->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    npc->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+    game.party().addMember(0, companion);
+    area->add(door);
+    area->add(leader);
+    area->add(companion);
+    area->add(npc);
+    auto trigger = std::static_pointer_cast<Trigger>(area->getObjectsByType(ObjectType::Trigger).front());
+    door->open();
+
+    ASSERT_TRUE(area->moveCreature(companion, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    EXPECT_FALSE(trigger->isTenant(companion));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+
+    ASSERT_TRUE(area->moveCreature(npc, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    EXPECT_FALSE(trigger->isTenant(npc));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("destination_module"), std::string("destination_waypoint")));
+}
+
+TEST(LinkedDoorTransition, should_support_authored_cross_module_flag_values) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto flag1Door = makeTransitionDoor(game, engine, 1, "flag1_module", "flag1_waypoint");
+    auto flag2Door = makeTransitionDoor(game, engine, 2, "flag2_module", "flag2_waypoint");
+
+    area->add(flag1Door);
+    area->add(flag2Door);
+
+    auto &triggers = area->getObjectsByType(ObjectType::Trigger);
+    ASSERT_EQ(triggers.size(), 2);
+    auto flag1Trigger = std::static_pointer_cast<Trigger>(triggers[0]);
+    auto flag2Trigger = std::static_pointer_cast<Trigger>(triggers[1]);
+    EXPECT_EQ(flag1Trigger->linkedToFlags(), 1);
+    EXPECT_EQ(flag1Trigger->linkedToModule(), "flag1_module");
+    EXPECT_EQ(flag1Trigger->linkedTo(), "flag1_waypoint");
+    EXPECT_EQ(flag2Trigger->linkedToFlags(), 2);
+    EXPECT_EQ(flag2Trigger->linkedToModule(), "flag2_module");
+    EXPECT_EQ(flag2Trigger->linkedTo(), "flag2_waypoint");
+}
+
+TEST(LinkedDoorTransition, should_reject_unlinked_unsupported_or_incomplete_metadata) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto unlinkedDoor = makeTransitionDoor(game, engine, 0);
+    auto unsupportedDoor = makeTransitionDoor(game, engine, 3);
+    auto missingModuleDoor = makeTransitionDoor(game, engine, 1, "", "destination_waypoint");
+    auto missingTargetDoor = makeTransitionDoor(game, engine, 2, "destination_module", "");
+
+    area->add(unlinkedDoor);
+    area->add(unsupportedDoor);
+    area->add(missingModuleDoor);
+    area->add(missingTargetDoor);
+    unlinkedDoor->open();
+
+    EXPECT_TRUE(area->getObjectsByType(ObjectType::Trigger).empty());
+}
+
+TEST(LinkedDoorTransition, should_preserve_reusable_authored_type1_trigger_lifecycle) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    game.initLocalServices();
+    testSceneGraph(engine);
+    auto onEnter = makeStartNewModuleScript("script_module", "script_waypoint");
+    EXPECT_CALL(engine.resourceModule().scripts(), get("override_transition"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(onEnter));
+    auto gff = makeTransitionTriggerGff(
+        "authored_module",
+        "authored_waypoint",
+        "override_transition");
+    auto trigger = game.newTrigger();
+    trigger->deserialize(*gff);
+    auto area = game.newArea();
+    auto npc = makeMovingCreature(game, engine);
+    npc->setPosition(glm::vec3(0.0f, -2.0f, 0.0f));
+    area->add(trigger);
+    area->add(npc);
+
+    EXPECT_FALSE(trigger->isLinkedDoorTransition());
+    EXPECT_TRUE(trigger->isActive());
+    ASSERT_TRUE(area->moveCreature(npc, glm::vec2(0.0f, 1.0f), false, 1.25f));
+    EXPECT_TRUE(trigger->isTenant(npc));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("authored_module"), std::string("authored_waypoint")));
+
+    ASSERT_TRUE(area->moveCreature(npc, glm::vec2(0.0f, 1.0f), false, 2.0f));
+    trigger->update(0.0f);
+    EXPECT_FALSE(trigger->isTenant(npc));
+
+    ASSERT_TRUE(area->moveCreature(npc, glm::vec2(0.0f, -1.0f), false, 0.5f));
+    EXPECT_TRUE(trigger->isTenant(npc));
+}
+
+TEST(LinkedDoorTransition, should_allow_normal_close_action_and_reactivate_when_reopened) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto linkedDoor = makeTransitionDoor(game, engine);
+    auto leader = makeMovingCreature(game, engine);
+    leader->setPosition(glm::vec3(0.0f, -1.0f, 0.0f));
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+    area->add(linkedDoor);
+    area->add(leader);
+    auto trigger = std::static_pointer_cast<Trigger>(area->getObjectsByType(ObjectType::Trigger).front());
+    linkedDoor->open();
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 0.75f));
+    ASSERT_TRUE(trigger->isTenant(leader));
+    game.scheduleModuleTransition("", "");
+    auto linkedClose = game.newAction<CloseDoorAction>(linkedDoor);
+
+    linkedClose->execute(linkedClose, *linkedDoor, 0.0f);
+    trigger->update(0.0f);
+
+    EXPECT_TRUE(linkedClose->isCompleted());
+    EXPECT_FALSE(linkedDoor->isOpen());
+    EXPECT_FALSE(trigger->isActive());
+    EXPECT_FALSE(trigger->isTenant(leader));
+
+    linkedDoor->open();
+
+    EXPECT_TRUE(linkedDoor->isOpen());
+    EXPECT_TRUE(trigger->isActive());
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 1.0f));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+    ASSERT_TRUE(area->moveCreature(leader, glm::vec2(0.0f, -1.0f), false, 0.75f));
+    EXPECT_TRUE(trigger->isTenant(leader));
+    EXPECT_EQ(
+        scheduledTransition(engine, game),
+        std::make_pair(std::string("destination_module"), std::string("destination_waypoint")));
 }
 
 TEST(Party, should_award_xp_to_pool_and_sync_current_members) {


### PR DESCRIPTION
## Summary

Generates reusable transition thresholds for linked doors from authored metadata and closed-DWK geometry.

KOTOR uses both `LinkedToFlags` values 1 and 2 for cross-module waypoint destinations; both are supported. Same-module relocation and true door-to-door links were not found in KOTOR content and remain outside this change.

- Active only while the door is open.
- Uses natural doorway crossing, not a second door click.
- Preserves authored locking, Security, failure scripts, and auto-close behavior.
- Restricts activation to the current party leader.
- Rearms after exit/re-entry, close/reopen, party unload, and module revisits.
- Removes the generated threshold with its source door.
- Leaves authored triggers and non-linked doors unchanged.

## Testing

Manual verification confirmed:

- both Taris Sith elevator routes (`tar_m02ab` and `tar_m03aa`);
- repeated travel away and back;
- other previously broken linked-door transitions, including the Endar Spire.