### PR TITLE
[game] Present transition destinations

### DIFF
--- a/include/reone/game/gui/areatransition.h
+++ b/include/reone/game/gui/areatransition.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "../gui.h"
+
+#include "reone/gui/control/label.h"
+
+namespace reone {
+
+namespace game {
+
+/**
+ * Top-centre module transition banner: destination text over the banner
+ * background, with the running-person icon beneath. Purely presentational -
+ * accepts a destination string, never a live object, so it cannot hold stale
+ * state across module unloads.
+ */
+class AreaTransition : public GameGUI {
+public:
+    AreaTransition(Game &game, ServicesView &services);
+
+    /** Show the banner and icon for a transition with the given destination. */
+    void show(const std::string &destination);
+    void hide();
+
+    bool isVisible() const { return _visible; }
+
+protected:
+    void preload(gui::IGUI &gui) override;
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Label> LBL_DESCRIPTION;
+        std::shared_ptr<gui::Label> LBL_ICON;
+        std::shared_ptr<gui::Label> LBL_TEXTBG;
+    };
+
+    Controls _controls;
+    bool _visible {false};
+    std::string _destination;
+
+    void onGUILoaded() override;
+
+    void bindControls() {
+        _controls.LBL_DESCRIPTION = findControl<gui::Label>("LBL_DESCRIPTION");
+        _controls.LBL_ICON = findControl<gui::Label>("LBL_ICON");
+        _controls.LBL_TEXTBG = findControl<gui::Label>("LBL_TEXTBG");
+    }
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/gui/hud.h
+++ b/include/reone/game/gui/hud.h
@@ -25,8 +25,10 @@
 #include "reone/system/timer.h"
 
 #include "../gui.h"
+#include "../transitioncandidate.h"
 
 #include "actionbar.h"
+#include "areatransition.h"
 #include "barkbubble.h"
 #include "confirmpopup.h"
 #include "selectoverlay.h"
@@ -40,7 +42,8 @@ public:
     HUD(Game &game, ServicesView &services) :
         GameGUI(game, services),
         _select(game, services),
-        _actionBar(game, services) {
+        _actionBar(game, services),
+        _areaTransition(nullptr) {
         _resRef = guiResRef("mipc28x6");
     }
 
@@ -154,6 +157,7 @@ private:
     ActionBar _actionBar;
     std::unique_ptr<BarkBubble> _barkBubble;
     std::unique_ptr<ConfirmPopup> _confirmPopup;
+    std::unique_ptr<AreaTransition> _areaTransition;
     Timer _journalNotificationTimer;
 
     void preload(gui::IGUI &gui) override;
@@ -255,6 +259,8 @@ private:
 
     void toggleCombat(bool enabled);
     void refreshActionQueueItems() const;
+    void updateTransitionPresentation();
+    std::optional<TransitionPortal> currentTransitionCandidate() const;
 
     void renderHealth(int memberIndex);
     void renderMinimap();

--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -19,6 +19,7 @@
 
 #include "reone/game/messagebus.h"
 #include "reone/game/minigame.h"
+#include "reone/game/transitioncandidate.h"
 #include "reone/graphics/texture.h"
 #include "reone/graphics/types.h"
 #include "reone/input/event.h"
@@ -47,6 +48,7 @@ class Creature;
 class Location;
 class Object;
 class Room;
+class Trigger;
 
 using RoomMap = std::unordered_map<std::string, std::shared_ptr<Room>>;
 using ObjectList = std::vector<std::shared_ptr<Object>>;
@@ -102,6 +104,10 @@ public:
     const MinigameSpec &miniGame() const { return *_miniGameSpec; }
 
     Object *getObjectAt(int x, int y) const;
+
+    // Presentation-active module transitions, for the destination banner.
+    // Read-only: no tenants, scripts or transitions are touched.
+    std::vector<TransitionPortal> transitionPresentationPortals() const;
     glm::vec3 getSelectableScreenCoords(const std::shared_ptr<Object> &object, const glm::mat4 &projection, const glm::mat4 &view) const;
 
     const CameraStyle &camStyleDefault() const { return _camStyleDefault; }

--- a/include/reone/game/transitioncandidate.h
+++ b/include/reone/game/transitioncandidate.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace reone {
+
+namespace game {
+
+/**
+ * Maximum distance from the party leader to a transition portal at which the
+ * destination banner is shown. Mirrors the presentation band that KotOR.js
+ * uses for door transition lines; not a verified original-engine constant.
+ */
+constexpr float kMaxTransitionPresentationDistance = 5.0f;
+
+/**
+ * Maximum horizontal displacement from the screen centre, in NDC, at which a
+ * portal is considered camera-facing. A manual parity-tuning value rather
+ * than a verified original-engine constant.
+ */
+constexpr float kTransitionViewHorizontalNdcLimit = 0.6f;
+
+/// Height above portal ground used for the camera-facing aim point.
+constexpr float kTransitionPortalAimHeight = 1.5f;
+
+/// World-space presentation geometry of one module transition.
+struct TransitionPortal {
+    uint32_t objectId {0};
+    std::string destination;
+    std::vector<glm::vec3> points; /**< polygon vertices, world space */
+};
+
+/// Party leader and gameplay camera state a candidate is evaluated against.
+struct TransitionView {
+    glm::vec3 leaderPosition {0.0f};
+    glm::mat4 cameraViewProjection {1.0f};
+};
+
+/**
+ * Distance from a point to the portal polygon in the XY plane: zero when the
+ * point is inside the polygon, distance to the nearest edge otherwise.
+ */
+float distanceToTransitionPortal(const glm::vec2 &point, const std::vector<glm::vec3> &portalPoints);
+
+/**
+ * Whether the portal boundary's nearest point to the leader, raised to body
+ * height, falls inside the viewport and central horizontal presentation band.
+ * The leader itself is never used as the aim point when already inside the
+ * polygon, because that would remain centred while looking away from the exit.
+ */
+bool isTransitionPortalInView(const std::vector<glm::vec3> &portalPoints,
+                              const glm::vec3 &leaderPosition,
+                              const glm::mat4 &cameraViewProjection,
+                              float horizontalNdcLimit = kTransitionViewHorizontalNdcLimit);
+
+/**
+ * Convert an authored transition destination into the concise banner label.
+ * K1 commonly prefixes a place with its planet using " - "; K2 generally
+ * stores the concise label already. Unprefixed labels are returned unchanged.
+ */
+std::string transitionDestinationDisplayName(const std::string &destination);
+
+/**
+ * Pick the presentation candidate: the nearest portal within presentation
+ * distance of the leader that is also in the camera view. Ties are broken by
+ * object id for determinism. Purely observational: no game state is touched.
+ */
+std::optional<TransitionPortal> pickTransitionPortal(
+    std::vector<TransitionPortal> portals,
+    const TransitionView &view,
+    float maxDistance = kMaxTransitionPresentationDistance);
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/gui/gui.h
+++ b/include/reone/gui/gui.h
@@ -50,6 +50,7 @@ class IGUI {
 public:
     enum class ScalingMode {
         Center,
+        CenterHorizontal,
         PositionRelativeToCenter,
         Stretch
     };

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -188,6 +188,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui.h
     ${GAME_INCLUDE_DIR}/gui/actionbar.h
     ${GAME_INCLUDE_DIR}/gui/actionslot.h
+    ${GAME_INCLUDE_DIR}/gui/areatransition.h
     ${GAME_INCLUDE_DIR}/gui/barkbubble.h
     ${GAME_INCLUDE_DIR}/gui/chargen.h
     ${GAME_INCLUDE_DIR}/gui/chargen/abilities.h
@@ -329,6 +330,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/surfaces.h
     ${GAME_INCLUDE_DIR}/swooprace.h
     ${GAME_INCLUDE_DIR}/talent.h
+    ${GAME_INCLUDE_DIR}/transitioncandidate.h
     ${GAME_INCLUDE_DIR}/types.h
     ${GAME_INCLUDE_DIR}/visualeffects.h)
 
@@ -462,6 +464,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/itemdescription.cpp
     ${GAME_SOURCE_DIR}/gui/actionbar.cpp
     ${GAME_SOURCE_DIR}/gui/actionslot.cpp
+    ${GAME_SOURCE_DIR}/gui/areatransition.cpp
     ${GAME_SOURCE_DIR}/gui/barkbubble.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/abilities.cpp
     ${GAME_SOURCE_DIR}/gui/chargen/classselect.cpp
@@ -533,6 +536,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/script/runner.cpp
     ${GAME_SOURCE_DIR}/surfaces.cpp
     ${GAME_SOURCE_DIR}/swooprace.cpp
+    ${GAME_SOURCE_DIR}/transitioncandidate.cpp
     ${GAME_SOURCE_DIR}/visualeffects.cpp)
 
 add_library(game STATIC ${GAME_HEADERS} ${GAME_SOURCES} ${CLANG_FORMAT_PATH})

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -32,6 +32,7 @@
 #include "reone/game/d20/spells.h"
 #include "reone/game/debug.h"
 #include "reone/game/di/services.h"
+#include "reone/game/gui/hud.h"
 #include "reone/game/gui/sounds.h"
 #include "reone/game/location.h"
 #include "reone/game/party.h"

--- a/src/libs/game/gui/areatransition.cpp
+++ b/src/libs/game/gui/areatransition.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/gui/areatransition.h"
+
+#include "reone/game/game.h"
+#include "reone/game/transitioncandidate.h"
+
+using namespace reone::gui;
+
+namespace reone {
+
+namespace game {
+
+AreaTransition::AreaTransition(Game &game, ServicesView &services) :
+    GameGUI(game, services) {
+    // The dedicated transition banner GUI is named differently per game.
+    _resRef = game.isTSL() ? guiResRef("areatrans") : "areatransition";
+}
+
+void AreaTransition::preload(IGUI &gui) {
+    GameGUI::preload(gui);
+
+    // Authored for 640x480 in both games. Keep the authored top coordinate,
+    // while centering the banner horizontally in the current viewport.
+    gui.setResolution(640, 480);
+    gui.setScaling(GUI::ScalingMode::CenterHorizontal);
+}
+
+void AreaTransition::onGUILoaded() {
+    bindControls();
+    hide();
+}
+
+void AreaTransition::show(const std::string &destination) {
+    if (destination.empty()) {
+        hide();
+        return;
+    }
+    std::string displayName(transitionDestinationDisplayName(destination));
+    if (_visible && displayName == _destination) {
+        return;
+    }
+    _destination = std::move(displayName);
+    if (_controls.LBL_DESCRIPTION) {
+        _controls.LBL_DESCRIPTION->setTextMessage(_destination);
+        _controls.LBL_DESCRIPTION->setVisible(true);
+    }
+    if (_controls.LBL_TEXTBG) {
+        _controls.LBL_TEXTBG->setVisible(true);
+    }
+    if (_controls.LBL_ICON) {
+        _controls.LBL_ICON->setVisible(true);
+    }
+    _visible = true;
+}
+
+void AreaTransition::hide() {
+    _destination.clear();
+    if (_controls.LBL_DESCRIPTION) {
+        _controls.LBL_DESCRIPTION->setTextMessage("");
+        _controls.LBL_DESCRIPTION->setVisible(false);
+    }
+    if (_controls.LBL_TEXTBG) {
+        _controls.LBL_TEXTBG->setVisible(false);
+    }
+    if (_controls.LBL_ICON) {
+        _controls.LBL_ICON->setVisible(false);
+    }
+    _visible = false;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -33,6 +33,9 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
+#include "reone/game/object/area.h"
+#include "reone/game/object/camera.h"
+#include "reone/game/object/module.h"
 #include "reone/game/party.h"
 
 using namespace reone::audio;
@@ -227,6 +230,9 @@ void HUD::onGUILoaded() {
 
     _confirmPopup = std::make_unique<ConfirmPopup>(_game, _services);
     _confirmPopup->init();
+
+    _areaTransition = std::make_unique<AreaTransition>(_game, _services);
+    _areaTransition->init();
 }
 
 void HUD::showJournalNotification() {
@@ -319,6 +325,7 @@ void HUD::update(float dt) {
 
     _select.update();
     _actionBar.update();
+    updateTransitionPresentation();
     _barkBubble->update(dt);
     if (_confirmPopup->isVisible()) {
         _confirmPopup->update(dt);
@@ -326,6 +333,44 @@ void HUD::update(float dt) {
 
     // Hide minimap when there is no image to display
     _controls.LBL_MAPBORDER->setVisible(_game.map().isLoaded());
+}
+
+void HUD::updateTransitionPresentation() {
+    if (!_areaTransition) {
+        return;
+    }
+    auto candidate = currentTransitionCandidate();
+    if (candidate) {
+        _areaTransition->show(candidate->destination);
+    } else {
+        _areaTransition->hide();
+    }
+}
+
+std::optional<TransitionPortal> HUD::currentTransitionCandidate() const {
+    auto module = _game.module();
+    if (!module || !module->area()) {
+        return std::nullopt;
+    }
+    auto leader = _game.party().getLeader();
+    if (!leader) {
+        return std::nullopt;
+    }
+    auto camera = _game.getActiveCamera();
+    if (!camera) {
+        return std::nullopt;
+    }
+    auto cameraSceneNode = camera->cameraSceneNode();
+    if (!cameraSceneNode || !cameraSceneNode->camera()) {
+        return std::nullopt;
+    }
+    auto &graphicsCamera = *cameraSceneNode->camera();
+
+    TransitionView view;
+    view.leaderPosition = leader->position();
+    view.cameraViewProjection = graphicsCamera.projection() * graphicsCamera.view();
+
+    return pickTransitionPortal(module->area()->transitionPresentationPortals(), view);
 }
 
 void HUD::render() {
@@ -339,6 +384,9 @@ void HUD::render() {
     }
 
     _barkBubble->render();
+    if (_areaTransition && _areaTransition->isVisible()) {
+        _areaTransition->render();
+    }
     _select.render();
     _actionBar.render();
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1457,6 +1457,33 @@ Object *Area::getObjectAt(int x, int y) const {
     return dynamic_cast<Object *>(model->user());
 }
 
+std::vector<TransitionPortal> Area::transitionPresentationPortals() const {
+    std::vector<TransitionPortal> portals;
+    auto maybeTriggers = _objectsByType.find(ObjectType::Trigger);
+    if (maybeTriggers == _objectsByType.end()) {
+        return portals;
+    }
+    for (auto &object : maybeTriggers->second) {
+        auto trigger = std::static_pointer_cast<Trigger>(object);
+        if (trigger->linkedToModule().empty() || !trigger->isActive()) {
+            continue;
+        }
+        const auto &geometry = trigger->geometry();
+        if (geometry.size() < 3) {
+            continue;
+        }
+        TransitionPortal portal;
+        portal.objectId = trigger->id();
+        portal.destination = trigger->transitionDestin();
+        portal.points.reserve(geometry.size());
+        for (const auto &vertex : geometry) {
+            portal.points.push_back(glm::vec3(trigger->transform() * glm::vec4(vertex, 1.0f)));
+        }
+        portals.push_back(std::move(portal));
+    }
+    return portals;
+}
+
 scene::ISceneGraph &Area::graph() {
     return _services.scene.graphs.get(_sceneName);
 }

--- a/src/libs/game/transitioncandidate.cpp
+++ b/src/libs/game/transitioncandidate.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/transitioncandidate.h"
+
+namespace reone {
+
+namespace game {
+
+static float segmentParameter2D(const glm::vec2 &point, const glm::vec2 &a, const glm::vec2 &b) {
+    glm::vec2 ab(b - a);
+    float lengthSq = glm::dot(ab, ab);
+    if (lengthSq <= 0.0f) {
+        return 0.0f;
+    }
+    return glm::clamp(glm::dot(point - a, ab) / lengthSq, 0.0f, 1.0f);
+}
+
+static float distanceToSegment2D(const glm::vec2 &point, const glm::vec2 &a, const glm::vec2 &b) {
+    float t = segmentParameter2D(point, a, b);
+    return glm::distance(point, a + t * (b - a));
+}
+
+static bool isInPolygon2D(const glm::vec2 &point, const std::vector<glm::vec3> &points) {
+    bool inside = false;
+    size_t count = points.size();
+    for (size_t i = 0, j = count - 1; i < count; j = i++) {
+        glm::vec2 a(points[i]);
+        glm::vec2 b(points[j]);
+        if ((a.y > point.y) != (b.y > point.y) &&
+            point.x < (b.x - a.x) * (point.y - a.y) / (b.y - a.y) + a.x) {
+            inside = !inside;
+        }
+    }
+    return inside;
+}
+
+float distanceToTransitionPortal(const glm::vec2 &point, const std::vector<glm::vec3> &portalPoints) {
+    if (portalPoints.empty()) {
+        return std::numeric_limits<float>::max();
+    }
+    if (portalPoints.size() >= 3 && isInPolygon2D(point, portalPoints)) {
+        return 0.0f;
+    }
+    float minDistance = std::numeric_limits<float>::max();
+    size_t count = portalPoints.size();
+    for (size_t i = 0; i < count; ++i) {
+        glm::vec2 a(portalPoints[i]);
+        glm::vec2 b(portalPoints[(i + 1) % count]);
+        minDistance = glm::min(minDistance, distanceToSegment2D(point, a, b));
+    }
+    return minDistance;
+}
+
+static glm::vec3 nearestPointOnTransitionPortal(const glm::vec3 &leaderPosition,
+                                                const std::vector<glm::vec3> &portalPoints) {
+    glm::vec3 nearest(portalPoints.front());
+    float minDistance = std::numeric_limits<float>::max();
+    size_t count = portalPoints.size();
+    for (size_t i = 0; i < count; ++i) {
+        const glm::vec3 &a = portalPoints[i];
+        const glm::vec3 &b = portalPoints[(i + 1) % count];
+        float t = segmentParameter2D(glm::vec2(leaderPosition), glm::vec2(a), glm::vec2(b));
+        glm::vec3 point(a + t * (b - a));
+        float distance = glm::distance(glm::vec2(leaderPosition), glm::vec2(point));
+        if (distance < minDistance) {
+            minDistance = distance;
+            nearest = point;
+        }
+    }
+    return nearest;
+}
+
+static bool isPointInView(const glm::vec3 &point,
+                          const glm::mat4 &viewProjection,
+                          float horizontalNdcLimit) {
+    glm::vec4 clip(viewProjection * glm::vec4(point, 1.0f));
+    if (clip.w <= 0.0f) {
+        return false;
+    }
+    float x = clip.x / clip.w;
+    float y = clip.y / clip.w;
+    float z = clip.z / clip.w;
+    return x >= -horizontalNdcLimit && x <= horizontalNdcLimit &&
+           y >= -1.0f && y <= 1.0f &&
+           z >= -1.0f && z <= 1.0f;
+}
+
+bool isTransitionPortalInView(const std::vector<glm::vec3> &portalPoints,
+                              const glm::vec3 &leaderPosition,
+                              const glm::mat4 &cameraViewProjection,
+                              float horizontalNdcLimit) {
+    if (portalPoints.empty()) {
+        return false;
+    }
+    glm::vec3 aimPoint(nearestPointOnTransitionPortal(leaderPosition, portalPoints));
+    aimPoint.z += kTransitionPortalAimHeight;
+    return isPointInView(aimPoint, cameraViewProjection, horizontalNdcLimit);
+}
+
+std::string transitionDestinationDisplayName(const std::string &destination) {
+    static const std::string separator(" - ");
+    size_t separatorPosition = destination.rfind(separator);
+    if (separatorPosition == std::string::npos ||
+        separatorPosition == 0 ||
+        separatorPosition + separator.size() == destination.size()) {
+        return destination;
+    }
+    return destination.substr(separatorPosition + separator.size());
+}
+
+std::optional<TransitionPortal> pickTransitionPortal(
+    std::vector<TransitionPortal> portals,
+    const TransitionView &view,
+    float maxDistance) {
+
+    std::optional<TransitionPortal> best;
+    float bestDistance = std::numeric_limits<float>::max();
+
+    for (auto &portal : portals) {
+        float distance = distanceToTransitionPortal(glm::vec2(view.leaderPosition), portal.points);
+        if (distance > maxDistance) {
+            continue;
+        }
+        if (!isTransitionPortalInView(portal.points, view.leaderPosition, view.cameraViewProjection)) {
+            continue;
+        }
+        bool closer = distance < bestDistance;
+        bool tieBreak = distance == bestDistance && best && portal.objectId < best->objectId;
+        if (closer || tieBreak) {
+            bestDistance = distance;
+            best = std::move(portal);
+        }
+    }
+    return best;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/gui/gui.cpp
+++ b/src/libs/gui/gui.cpp
@@ -68,6 +68,9 @@ void GUI::load(const Gff &gui) {
         _rootOffset.x = _screenCenter.x - _resolutionX / 2;
         _rootOffset.y = _screenCenter.y - _resolutionY / 2;
         break;
+    case ScalingMode::CenterHorizontal:
+        _rootOffset.x = _screenCenter.x - _resolutionX / 2;
+        break;
     case ScalingMode::Stretch:
         stretchControl(*_rootControl);
         break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
+    ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/bwmreader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/mdlmdxreader.cpp

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -25,6 +25,8 @@
 #include "reone/game/action/closedoor.h"
 #include "reone/game/action/unlockobject.h"
 #include "reone/game/game.h"
+#include "reone/game/gui/areatransition.h"
+#include "reone/game/gui/hud.h"
 #include "reone/game/object/area.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/door.h"
@@ -53,6 +55,12 @@ class StubConsole : public IConsole, boost::noncopyable {
 public:
     void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
     void printLine(const std::string &text) override {}
+};
+
+class TestAreaTransition : public AreaTransition {
+public:
+    using AreaTransition::AreaTransition;
+    using AreaTransition::preload;
 };
 
 // TestEngine initializes the Logger singleton, which only tolerates a single
@@ -202,7 +210,8 @@ std::shared_ptr<Creature> makeMovingCreature(Game &game, TestEngine &engine) {
 std::shared_ptr<Gff> makeTransitionTriggerGff(
     std::string linkedToModule,
     std::string linkedTo,
-    std::string onEnter = "") {
+    std::string onEnter = "",
+    std::optional<std::string> transitionDestin = std::nullopt) {
 
     std::vector<std::shared_ptr<Gff>> geometry;
     for (const auto &point : std::vector<glm::vec2> {
@@ -226,6 +235,9 @@ std::shared_ptr<Gff> makeTransitionTriggerGff(
         .field(Gff::Field::newList("Geometry", std::move(geometry)));
     if (!onEnter.empty()) {
         builder.field(Gff::Field::newResRef("ScriptOnEnter", std::move(onEnter)));
+    }
+    if (transitionDestin) {
+        builder.field(Gff::Field::newCExoLocString("TransitionDestin", -1, std::move(*transitionDestin)));
     }
     return builder.build();
 }
@@ -402,6 +414,132 @@ TEST(UnlockObjectAction, should_complete_safely_for_missing_destroyed_or_unsuppo
     EXPECT_TRUE(destroyedAction->isCompleted());
     EXPECT_TRUE(destroyed->isLocked());
     EXPECT_TRUE(unsupportedAction->isCompleted());
+}
+
+TEST(TransitionPresentationLifecycle, should_construct_and_destroy_hud_before_gameplay_module_exists) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    ASSERT_EQ(game.module(), nullptr);
+    EXPECT_NO_THROW({
+        auto hud = std::make_unique<HUD>(game, engine.services());
+    });
+}
+
+TEST(TransitionPresentationLifecycle, should_hide_empty_destination_before_gui_controls_are_loaded) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    AreaTransition transition(game, engine.services());
+
+    EXPECT_NO_THROW(transition.show("Destination Area"));
+    ASSERT_TRUE(transition.isVisible());
+
+    EXPECT_NO_THROW(transition.show(""));
+    EXPECT_FALSE(transition.isVisible());
+}
+
+TEST(TransitionPresentationLayout, should_top_anchor_and_horizontally_center_authored_gui) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    TestAreaTransition presentation(game, engine.services());
+    NiceMock<gui::MockGUI> gui;
+
+    EXPECT_CALL(gui, setResolution(640, 480));
+    EXPECT_CALL(gui, setScaling(gui::GUI::ScalingMode::CenterHorizontal));
+
+    presentation.preload(gui);
+}
+
+TEST(TransitionPresentationPortals, should_expose_authored_transitions_without_touching_state) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    testSceneGraph(engine);
+    auto area = game.newArea();
+    auto leader = makeMovingCreature(game, engine);
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+
+    auto trigger = game.newTrigger();
+    trigger->deserialize(*makeTransitionTriggerGff(
+        "authored_module",
+        "authored_waypoint",
+        "",
+        "Authored Destination"));
+    trigger->setPosition(glm::vec3(4.0f, 0.0f, 0.0f));
+    area->add(trigger);
+    area->add(leader);
+
+    auto portals = area->transitionPresentationPortals();
+
+    ASSERT_EQ(portals.size(), 1u);
+    EXPECT_EQ(portals[0].objectId, trigger->id());
+    EXPECT_EQ(portals[0].destination, "Authored Destination");
+    ASSERT_EQ(portals[0].points.size(), 4u);
+    EXPECT_NEAR(portals[0].points[0].x, 3.0f, 1e-4f);
+    EXPECT_NEAR(portals[0].points[0].y, -1.0f, 1e-4f);
+
+    // The presentation query is read-only.
+    EXPECT_FALSE(trigger->isTenant(leader));
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
+
+    area->destroyObject(*trigger);
+    area->update(0.0f);
+    EXPECT_TRUE(area->transitionPresentationPortals().empty());
+}
+
+TEST(TransitionPresentationPortals, should_follow_linked_door_state_without_teleporting) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    auto door = makeTransitionDoor(game, engine);
+    auto leader = makeMovingCreature(game, engine);
+    game.party().addMember(kNpcPlayer, leader);
+    game.party().setPlayer(leader);
+    area->add(door);
+    area->add(leader);
+
+    EXPECT_TRUE(area->transitionPresentationPortals().empty()) << "closed door must not present";
+
+    door->open();
+    auto portals = area->transitionPresentationPortals();
+
+    ASSERT_EQ(portals.size(), 1u);
+    EXPECT_EQ(portals[0].destination, "Destination Area");
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()))
+        << "opening the door alone must not schedule travel";
+
+    door->close();
+    EXPECT_TRUE(area->transitionPresentationPortals().empty());
+}
+
+TEST(TransitionPresentationPortals, should_ignore_non_transitions_and_expose_empty_destinations) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    testSceneGraph(engine);
+    auto area = game.newArea();
+
+    auto nonTransition = game.newTrigger();
+    nonTransition->deserialize(*makeTransitionTriggerGff("", "", "", "Not a transition"));
+    auto emptyDestination = game.newTrigger();
+    emptyDestination->deserialize(*makeTransitionTriggerGff("empty_module", "empty_waypoint", "", ""));
+    auto missingDestination = game.newTrigger();
+    missingDestination->deserialize(*makeTransitionTriggerGff("missing_module", "missing_waypoint"));
+    area->add(nonTransition);
+    area->add(emptyDestination);
+    area->add(missingDestination);
+
+    auto portals = area->transitionPresentationPortals();
+
+    ASSERT_EQ(portals.size(), 2u);
+    EXPECT_TRUE(portals[0].destination.empty());
+    EXPECT_TRUE(portals[1].destination.empty());
+    EXPECT_EQ(scheduledTransition(engine, game), std::make_pair(std::string(), std::string()));
 }
 
 TEST(LinkedDoorTransition, should_derive_threshold_from_closed_dwk_and_follow_door_state) {

--- a/test/game/transitioncandidate.cpp
+++ b/test/game/transitioncandidate.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/transitioncandidate.h"
+
+using namespace reone;
+using namespace reone::game;
+
+namespace {
+
+TransitionPortal makePortal(uint32_t id, std::string destination, glm::vec2 center) {
+    TransitionPortal portal;
+    portal.objectId = id;
+    portal.destination = std::move(destination);
+    portal.points = {
+        glm::vec3(center.x - 1.0f, center.y - 1.0f, 0.0f),
+        glm::vec3(center.x - 1.0f, center.y + 1.0f, 0.0f),
+        glm::vec3(center.x + 1.0f, center.y + 1.0f, 0.0f),
+        glm::vec3(center.x + 1.0f, center.y - 1.0f, 0.0f)};
+    return portal;
+}
+
+glm::mat4 viewProjectionLookingAt(glm::vec3 eye, glm::vec3 target) {
+    static const glm::vec3 up(0.0f, 0.0f, 1.0f);
+    auto projection = glm::perspective(glm::radians(55.0f), 4.0f / 3.0f, 0.1f, 500.0f);
+    auto view = glm::lookAt(eye, target, up);
+    return projection * view;
+}
+
+} // namespace
+
+TEST(TransitionCandidate, should_measure_distance_to_portal_polygon) {
+    auto portal = makePortal(1, "somewhere", glm::vec2(0.0f));
+
+    EXPECT_EQ(0.0f, distanceToTransitionPortal(glm::vec2(0.0f), portal.points));
+    EXPECT_EQ(0.0f, distanceToTransitionPortal(glm::vec2(0.9f, -0.9f), portal.points));
+    EXPECT_NEAR(2.0f, distanceToTransitionPortal(glm::vec2(3.0f, 0.0f), portal.points), 1e-4f);
+    EXPECT_NEAR(4.0f, distanceToTransitionPortal(glm::vec2(0.0f, -5.0f), portal.points), 1e-4f);
+}
+
+TEST(TransitionCandidate, should_qualify_nearby_portal_in_camera_view) {
+    glm::vec3 leader(0.0f);
+    auto portals = std::vector<TransitionPortal> {makePortal(7, "Ahead", glm::vec2(4.0f, 0.0f))};
+
+    TransitionView view;
+    view.leaderPosition = leader;
+    view.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(4.0f, 0.0f, 0.5f));
+
+    auto candidate = pickTransitionPortal(portals, view);
+
+    ASSERT_TRUE(candidate.has_value());
+    EXPECT_EQ(candidate->objectId, 7u);
+    EXPECT_EQ(candidate->destination, "Ahead");
+}
+
+TEST(TransitionCandidate, should_reject_portal_inside_viewport_but_well_off_axis) {
+    glm::vec3 leader(0.0f);
+    auto portals = std::vector<TransitionPortal> {makePortal(7, "Off axis", glm::vec2(3.0f, 3.0f))};
+
+    TransitionView view;
+    view.leaderPosition = leader;
+    view.cameraViewProjection = viewProjectionLookingAt(
+        glm::vec3(-2.0f, 0.0f, 1.5f),
+        glm::vec3(4.0f, 0.0f, 1.5f));
+
+    ASSERT_TRUE(isTransitionPortalInView(
+        portals.front().points,
+        leader,
+        view.cameraViewProjection,
+        1.0f)) << "the aim point must remain inside the ordinary viewport";
+    EXPECT_FALSE(pickTransitionPortal(portals, view).has_value());
+}
+
+TEST(TransitionCandidate, should_not_qualify_large_portal_from_favourable_distant_vertex) {
+    TransitionPortal portal;
+    portal.objectId = 7;
+    portal.destination = "Large exit";
+    portal.points = {
+        glm::vec3(3.0f, 3.0f, 0.0f),
+        glm::vec3(4.0f, 4.0f, 0.0f),
+        glm::vec3(30.0f, 0.0f, 0.0f)};
+
+    TransitionView view;
+    view.leaderPosition = glm::vec3(0.0f);
+    view.cameraViewProjection = viewProjectionLookingAt(
+        glm::vec3(-2.0f, 0.0f, 1.5f),
+        glm::vec3(4.0f, 0.0f, 1.5f));
+
+    EXPECT_FALSE(pickTransitionPortal({portal}, view).has_value());
+}
+
+TEST(TransitionCandidate, should_not_qualify_portal_behind_camera) {
+    auto portals = std::vector<TransitionPortal> {makePortal(7, "Behind", glm::vec2(4.0f, 0.0f))};
+
+    TransitionView view;
+    view.leaderPosition = glm::vec3(0.0f);
+    // Same leader position, camera looking the opposite way.
+    view.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(-10.0f, 0.0f, 0.5f));
+
+    EXPECT_FALSE(pickTransitionPortal(portals, view).has_value());
+}
+
+TEST(TransitionCandidate, should_use_portal_boundary_when_leader_is_inside_and_facing_away) {
+    TransitionPortal portal;
+    portal.objectId = 7;
+    portal.destination = "Behind";
+    portal.points = {
+        glm::vec3(-3.0f, -4.0f, 0.0f),
+        glm::vec3(-3.0f, 4.0f, 0.0f),
+        glm::vec3(5.0f, 4.0f, 0.0f),
+        glm::vec3(5.0f, -4.0f, 0.0f)};
+
+    TransitionView facingAway;
+    facingAway.leaderPosition = glm::vec3(0.0f);
+    facingAway.cameraViewProjection = viewProjectionLookingAt(
+        glm::vec3(-2.0f, 0.0f, 1.5f),
+        glm::vec3(5.0f, 0.0f, 1.5f));
+    EXPECT_FALSE(pickTransitionPortal({portal}, facingAway).has_value());
+
+    TransitionView facingPortal;
+    facingPortal.leaderPosition = facingAway.leaderPosition;
+    facingPortal.cameraViewProjection = viewProjectionLookingAt(
+        glm::vec3(2.0f, 0.0f, 1.5f),
+        glm::vec3(-3.0f, 0.0f, 1.5f));
+    EXPECT_TRUE(pickTransitionPortal({portal}, facingPortal).has_value());
+}
+
+TEST(TransitionCandidate, should_clear_when_camera_pans_away_without_moving) {
+    auto portals = std::vector<TransitionPortal> {makePortal(7, "Exit", glm::vec2(4.0f, 0.0f))};
+
+    TransitionView facing;
+    facing.leaderPosition = glm::vec3(0.0f);
+    facing.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(4.0f, 0.0f, 0.5f));
+    ASSERT_TRUE(pickTransitionPortal(portals, facing).has_value());
+
+    TransitionView pannedAway;
+    pannedAway.leaderPosition = facing.leaderPosition;
+    pannedAway.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(-2.0f, 30.0f, 0.5f));
+    EXPECT_FALSE(pickTransitionPortal(portals, pannedAway).has_value());
+
+    EXPECT_TRUE(pickTransitionPortal(portals, facing).has_value()) << "panning back must requalify";
+}
+
+TEST(TransitionCandidate, should_not_qualify_portal_out_of_presentation_range) {
+    auto portals = std::vector<TransitionPortal> {makePortal(7, "Far", glm::vec2(30.0f, 0.0f))};
+
+    TransitionView view;
+    view.leaderPosition = glm::vec3(0.0f);
+    view.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(30.0f, 0.0f, 0.5f));
+
+    EXPECT_FALSE(pickTransitionPortal(portals, view).has_value());
+}
+
+TEST(TransitionCandidate, should_pick_deterministic_best_candidate) {
+    auto near = makePortal(9, "Near", glm::vec2(3.0f, 0.0f));
+    auto far = makePortal(2, "Farther", glm::vec2(5.0f, 0.0f));
+
+    TransitionView view;
+    view.leaderPosition = glm::vec3(0.0f);
+    view.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(5.0f, 0.0f, 0.5f));
+
+    auto candidate = pickTransitionPortal({far, near}, view);
+    ASSERT_TRUE(candidate.has_value());
+    EXPECT_EQ(candidate->destination, "Near");
+
+    // Same geometry at equal distance: lowest object id wins.
+    auto twinA = makePortal(4, "Twin A", glm::vec2(3.0f, 0.0f));
+    auto twinB = makePortal(3, "Twin B", glm::vec2(3.0f, 0.0f));
+    auto twin = pickTransitionPortal({twinA, twinB}, view);
+    ASSERT_TRUE(twin.has_value());
+    EXPECT_EQ(twin->objectId, 3u);
+}
+
+TEST(TransitionCandidate, should_handle_degenerate_portals_safely) {
+    TransitionView view;
+    view.leaderPosition = glm::vec3(0.0f);
+    view.cameraViewProjection = viewProjectionLookingAt(glm::vec3(-2.0f, 0.0f, 1.5f), glm::vec3(4.0f, 0.0f, 0.5f));
+
+    TransitionPortal empty;
+    empty.objectId = 1;
+    EXPECT_FALSE(pickTransitionPortal({empty}, view).has_value());
+    EXPECT_FALSE(pickTransitionPortal({}, view).has_value());
+}
+
+TEST(TransitionDestinationDisplayName, should_remove_authored_k1_location_prefix) {
+    EXPECT_EQ(transitionDestinationDisplayName("Dantooine - Courtyard"), "Courtyard");
+    EXPECT_EQ(transitionDestinationDisplayName("Taris - Lower City"), "Lower City");
+}
+
+TEST(TransitionDestinationDisplayName, should_preserve_bare_destination) {
+    EXPECT_EQ(transitionDestinationDisplayName("Lower City"), "Lower City");
+    EXPECT_TRUE(transitionDestinationDisplayName("").empty());
+}
+
+TEST(TransitionDestinationDisplayName, should_preserve_ordinary_internal_hyphens) {
+    EXPECT_EQ(transitionDestinationDisplayName("Landing-Platform"), "Landing-Platform");
+    EXPECT_EQ(transitionDestinationDisplayName("Taris - Lower-City Annex"), "Lower-City Annex");
+    EXPECT_EQ(transitionDestinationDisplayName("World - District - Annex"), "Annex");
+}


### PR DESCRIPTION
## Summary

Restores the vanilla transition-destination presentation for authored module
transitions and generated linked-door transition regions.

The HUD now displays the dedicated top-centre area-transition banner with:

- the concise `TransitionDestin` label;
- the authored banner background;
- the running-person icon.

Presentation is read-only and independent of transition activation.

## Behaviour

A transition is presented when:

- the party leader is within 5 units of its portal polygon;
- the nearest portal-boundary point is inside the gameplay camera view;
- the point is within the central horizontal presentation band.

Panning the camera away clears the banner, including while the leader is already
inside a broad authored transition polygon.

Generated linked-door transitions present only while their source door is open.

## Presentation details

- Uses the dedicated K1/K2 area-transition GUI.
- Preserves the authored top-screen position while centring horizontally.
- Converts K1 labels such as `Dantooine - Courtyard` to `Courtyard`.
- Leaves already-concise labels and ordinary internal hyphens unchanged.
- Empty destinations suppress the full overlay.