### PR TITLE
[game] Honor authored faction dispositions

### DIFF
--- a/include/reone/game/reputes.h
+++ b/include/reone/game/reputes.h
@@ -23,7 +23,7 @@ namespace reone {
 
 namespace resource {
 
-class TwoDAs;
+class ITwoDAs;
 
 }
 
@@ -43,7 +43,7 @@ public:
 
 class Reputes : public IReputes, boost::noncopyable {
 public:
-    Reputes(resource::TwoDAs &twoDas) :
+    Reputes(resource::ITwoDAs &twoDas) :
         _twoDas(twoDas) {
     }
 
@@ -55,7 +55,9 @@ public:
     bool getIsNeutral(const Creature &left, const Creature &right) const override;
 
 private:
-    resource::TwoDAs &_twoDas;
+    resource::ITwoDAs &_twoDas;
+    std::vector<std::string> _factionLabels;
+    std::vector<std::vector<int>> _factionValues;
 
     int getRepute(Faction left, Faction right) const;
 };

--- a/src/libs/game/reputes.cpp
+++ b/src/libs/game/reputes.cpp
@@ -30,45 +30,38 @@ namespace game {
 
 static constexpr int kDefaultRepute = 50;
 
-static std::vector<std::string> g_factionLabels;
-static std::vector<std::vector<int>> g_factionValues;
-
 void Reputes::init() {
     std::shared_ptr<TwoDA> repute(_twoDas.get("repute"));
     if (!repute) {
         return;
     }
 
+    _factionLabels.clear();
+    _factionValues.clear();
+
     for (int row = 0; row < repute->getRowCount(); ++row) {
-        g_factionLabels.push_back(boost::to_lower_copy(repute->getString(row, "label")));
+        _factionLabels.push_back(boost::to_lower_copy(repute->getString(row, "label")));
     }
 
     for (int row = 0; row < repute->getRowCount(); ++row) {
         std::vector<int> values;
-        for (size_t i = 0; i < g_factionLabels.size(); ++i) {
+        for (size_t i = 0; i < _factionLabels.size(); ++i) {
             int value;
 
-            const std::string &label = g_factionLabels[i];
+            const std::string &label = _factionLabels[i];
             if (label == "player" || label == "glb_xor") {
                 value = kDefaultRepute;
             } else {
-                value = repute->getInt(row, g_factionLabels[i], kDefaultRepute);
+                value = repute->getInt(row, _factionLabels[i], kDefaultRepute);
             }
 
             values.push_back(value);
         }
-        g_factionValues.push_back(std::move(values));
+        _factionValues.push_back(std::move(values));
     }
 }
 
 bool Reputes::getIsEnemy(const Creature &left, const Creature &right) const {
-    // HACK: friendlies must not attack each other, unless both are immortal
-    if ((left.faction() == Faction::Friendly1 && right.faction() == Faction::Friendly2) ||
-        (left.faction() == Faction::Friendly2 && right.faction() == Faction::Friendly1)) {
-
-        return left.isMinOneHP() && right.isMinOneHP();
-    }
-
     return getIsEnemy(left.faction(), right.faction());
 }
 
@@ -88,11 +81,11 @@ int Reputes::getRepute(Faction left, Faction right) const {
     int leftFaction = static_cast<int>(left);
     int rightFaction = static_cast<int>(right);
 
-    if (leftFaction < 0 || leftFaction >= g_factionValues.size() ||
-        rightFaction < 0 || rightFaction >= g_factionValues[leftFaction].size())
+    if (leftFaction < 0 || leftFaction >= _factionValues.size() ||
+        rightFaction < 0 || rightFaction >= _factionValues[leftFaction].size())
         return kDefaultRepute;
 
-    return g_factionValues[leftFaction][rightFaction];
+    return _factionValues[leftFaction][rightFaction];
 }
 
 } // namespace game

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -31,6 +31,7 @@
 #include "reone/game/object/item.h"
 #include "reone/game/object/placeable.h"
 #include "reone/game/object/trigger.h"
+#include "reone/game/reputes.h"
 #include "reone/graphics/walkmesh.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/gff.h"
@@ -88,6 +89,18 @@ std::shared_ptr<TwoDA> makeAppearanceTable() {
     builder.row({"S", "1", "1", "-1", "", "", ""});
     builder.row({"S", "1", "1", "-1", "", "", ""});
     builder.row({"S", "1", "1", "-1", "", "", ""});
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<TwoDA> makeReputeTable() {
+    TwoDA::Builder builder;
+    builder.columns({"label", "hostile_1", "friendly_1", "hostile_2", "friendly_2", "neutral"});
+    builder.row({"Player", "0", "100", "0", "100", "50"});
+    builder.row({"Hostile_1", "100", "0", "0", "0", "50"});
+    builder.row({"Friendly_1", "0", "100", "0", "0", "50"});
+    builder.row({"Hostile_2", "0", "0", "100", "0", "50"});
+    builder.row({"Friendly_2", "0", "0", "0", "100", "50"});
+    builder.row({"Neutral", "50", "50", "50", "50", "100"});
     return std::shared_ptr<TwoDA>(builder.build());
 }
 
@@ -888,4 +901,33 @@ TEST(Object, should_restore_saved_appearance_after_unequipping_loaded_disguise) 
     creature->unequip(disguise);
 
     EXPECT_EQ(creature->appearance(), 1);
+}
+
+TEST(Reputes, should_use_authored_creature_faction_dispositions) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    NiceMock<MockTwoDAs> twoDas;
+    ON_CALL(twoDas, get("repute")).WillByDefault(Return(makeReputeTable()));
+
+    Reputes reputes(twoDas);
+    reputes.init();
+
+    auto friendly1 = game.newCreature();
+    friendly1->setFaction(Faction::Friendly1);
+    auto friendly2 = game.newCreature();
+    friendly2->setFaction(Faction::Friendly2);
+    auto hostile1 = game.newCreature();
+    hostile1->setFaction(Faction::Hostile1);
+    auto neutral = game.newCreature();
+    neutral->setFaction(Faction::Neutral);
+
+    EXPECT_TRUE(reputes.getIsEnemy(*friendly1, *friendly2));
+    EXPECT_TRUE(reputes.getIsEnemy(*friendly2, *friendly1));
+    EXPECT_TRUE(reputes.getIsEnemy(*friendly1, *hostile1));
+    EXPECT_TRUE(reputes.getIsEnemy(*hostile1, *friendly1));
+    EXPECT_FALSE(reputes.getIsEnemy(*friendly1, *neutral));
+    EXPECT_FALSE(reputes.getIsEnemy(*neutral, *friendly1));
+    EXPECT_TRUE(reputes.getIsNeutral(*friendly1, *neutral));
+    EXPECT_TRUE(reputes.getIsNeutral(*neutral, *friendly1));
 }


### PR DESCRIPTION
## Summary

Removes the Friendly1/Friendly2 hostility override and consistently uses the authored `repute.2da` faction matrix.

Also makes reputation data instance-owned and safely rebuilt on initialization.

## Verification

- Hendar event-3000 smoke passed: gate opens, once all party members cross gate, rakghoul becomes hostile
- Hendar event-2000 smoke passed: Hendar died and the Rakghoul was hostile.