### PR TITLE
[dialog] Apply authored player stunts in mixed conversations

### DIFF
--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -96,6 +96,7 @@ private:
     void loadReplies();
 
     bool isSkippableEntry() const;
+    bool isNonPresentationalEntry() const;
 
     void refreshReplies();
 

--- a/include/reone/game/gui/dialog.h
+++ b/include/reone/game/gui/dialog.h
@@ -30,6 +30,8 @@ namespace reone {
 namespace game {
 
 class DialogGUI : public Conversation {
+    friend class MixedStuntTestAccess;
+
 public:
     DialogGUI(Game &game, ServicesView &services) :
         Conversation(game, services) {

--- a/include/reone/game/gui/dialog.h
+++ b/include/reone/game/gui/dialog.h
@@ -42,6 +42,10 @@ private:
     struct Participant {
         std::shared_ptr<graphics::Model> model;
         std::shared_ptr<Creature> creature;
+        bool mixedStuntActive {false};
+        glm::vec3 restorePosition {0.0f};
+        float restoreFacing {0.0f};
+        bool restoreCulling {true};
     };
 
     struct Controls {
@@ -69,11 +73,18 @@ private:
 
     void updateCamera();
     void updateParticipantAnimations();
+    void restoreInactiveStuntParticipants();
+    bool enterMixedStunt(Participant &participant, const std::shared_ptr<graphics::Animation> &animation);
+    void leaveMixedStunt(Participant &participant);
 
     glm::vec3 getTalkPosition(const Object &object) const;
     DialogCamera::Variant getRandomCameraVariant() const;
     std::string getStuntAnimationName(int ordinal) const;
     AnimationType getStuntAnimationType(int ordinal) const;
+    bool hasStuntPresentation() const;
+    std::shared_ptr<graphics::Animation> getStuntParticipantAnimation(
+        const std::string &participant,
+        int ordinal) const;
 
     void setMessage(std::string message) override;
     void setReplyLines(std::vector<std::string> lines) override;

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -159,7 +159,8 @@ public:
 
     void playAnimation(CombatAnimation anim, CreatureWieldType wield, int variant = 1);
     void playAnimation(const std::string &name, scene::AnimationProperties properties = scene::AnimationProperties());
-    void playAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
+    bool playAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
+    void resumeStateDrivenAnimation();
 
     void updateModelAnimation();
 
@@ -399,7 +400,7 @@ private:
 
     // Animation
 
-    void doPlayAnimation(bool fireForget, const std::function<void()> &callback);
+    bool doPlayAnimation(bool fireForget, const std::function<void()> &callback);
 
     std::string getAnimationName(AnimationType anim) const override;
     std::string getAnimationName(CombatAnimation anim, CreatureWieldType wield, int variant) const;

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -160,7 +160,7 @@ public:
     void playAnimation(CombatAnimation anim, CreatureWieldType wield, int variant = 1);
     void playAnimation(const std::string &name, scene::AnimationProperties properties = scene::AnimationProperties());
     bool playAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
-    // Holds an animation owned by an external presentation until resumeStateDrivenAnimation is called.
+    // Protects an externally sourced animation from state-driven replacement until the clip completes.
     bool playExternalAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
     void resumeStateDrivenAnimation();
 

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -160,6 +160,8 @@ public:
     void playAnimation(CombatAnimation anim, CreatureWieldType wield, int variant = 1);
     void playAnimation(const std::string &name, scene::AnimationProperties properties = scene::AnimationProperties());
     bool playAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
+    // Holds an animation owned by an external presentation until resumeStateDrivenAnimation is called.
+    bool playExternalAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
     void resumeStateDrivenAnimation();
 
     void updateModelAnimation();

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -160,7 +160,7 @@ public:
     void playAnimation(CombatAnimation anim, CreatureWieldType wield, int variant = 1);
     void playAnimation(const std::string &name, scene::AnimationProperties properties = scene::AnimationProperties());
     bool playAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
-    // Protects an externally sourced animation from state-driven replacement until the clip completes.
+    // Holds an externally sourced animation until resumeStateDrivenAnimation is called.
     bool playExternalAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
     void resumeStateDrivenAnimation();
 

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -219,8 +219,6 @@ void Conversation::loadEntry(int index, bool start) {
     setMessage(entryText);
     loadReplies();
     loadVoiceOver();
-    scheduleEndOfEntry();
-    onLoadEntry();
 
     // Conversation is a one-liner if there is exactly one empty reply that has no entries
     bool oneLiner = false;
@@ -228,6 +226,15 @@ void Conversation::loadEntry(int index, bool start) {
         const Dialog::EntryReply &reply = *_replies[0];
         oneLiner = reply.text.empty() && reply.entries.empty();
     }
+    if (!oneLiner && isNonPresentationalEntry()) {
+        runScripts(*_currentEntry);
+        pickReply(0);
+        return;
+    }
+
+    scheduleEndOfEntry();
+    onLoadEntry();
+
     if (oneLiner) {
         _game.setBarkBubbleText(std::move(entryText), _entryDuration);
         debug("Dialog: finish (one-liner)");
@@ -377,6 +384,18 @@ bool Conversation::handleMouseButtonDown(const input::MouseButtonEvent &event) {
 
 bool Conversation::isSkippableEntry() const {
     return g_allEntriesSkippable || (_dialog->isSkippable() && !_paused);
+}
+
+bool Conversation::isNonPresentationalEntry() const {
+    return _autoPickFirstReply &&
+           _currentEntry->text.empty() &&
+           _currentEntry->sound.empty() &&
+           _currentEntry->voResRef.empty() &&
+           _currentEntry->cameraAnimation == 0 &&
+           _currentEntry->cameraId == 0 &&
+           _currentEntry->cameraAngle == 0 &&
+           _currentEntry->animations.empty() &&
+           _currentEntry->delay == -1;
 }
 
 void Conversation::endCurrentEntry() {

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -76,6 +76,9 @@ static std::vector<script::Argument> makeScriptArgs(uint32_t callerId, const Par
 }
 
 void Conversation::start(const std::shared_ptr<Dialog> &dialog, const std::shared_ptr<Object> &owner) {
+    if (_dialog) {
+        onFinish();
+    }
     debug("Start " + dialog->resRef, LogChannel::Conversation);
 
     _dialog = dialog;

--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -182,15 +182,12 @@ void DialogGUI::loadStuntParticipants() {
 }
 
 bool DialogGUI::hasStuntPresentation() const {
-    return _dialog->isAnimatedCutscene() || (!_dialog->cameraModel.empty() && !_dialog->stunts.empty());
+    return _dialog->isAnimatedCutscene() || !_dialog->stunts.empty();
 }
 
 std::shared_ptr<Animation> DialogGUI::getStuntParticipantAnimation(
     const std::string &participant,
     int ordinal) const {
-    if (_dialog->cameraModel.empty()) {
-        return nullptr;
-    }
     auto maybeParticipant = _participantByTag.find(participant);
     return maybeParticipant != _participantByTag.end()
                ? maybeParticipant->second.model->getAnimation(getStuntAnimationName(ordinal))
@@ -200,8 +197,8 @@ std::shared_ptr<Animation> DialogGUI::getStuntParticipantAnimation(
 void DialogGUI::onLoadEntry() {
     restoreInactiveStuntParticipants();
     loadCurrentSpeaker();
-    updateCamera();
     updateParticipantAnimations();
+    updateCamera();
     repositionMessage();
 
     _controls.LB_REPLIES->setVisible(false);
@@ -237,7 +234,7 @@ bool DialogGUI::enterMixedStunt(Participant &participant, const std::shared_ptr<
     AnimationProperties properties;
     properties.flags = AnimationFlags::propagate;
     properties.scale = 1.0f;
-    if (!participant.creature->playAnimation(animation, std::move(properties))) {
+    if (!participant.creature->playExternalAnimation(animation, std::move(properties))) {
         return false;
     }
 
@@ -359,7 +356,7 @@ void DialogGUI::updateParticipantAnimations() {
                 AnimationProperties properties;
                 properties.flags = AnimationFlags::propagate;
                 properties.scale = 1.0f;
-                participant.creature->playAnimation(animation, std::move(properties));
+                participant.creature->playExternalAnimation(animation, std::move(properties));
             }
         } else if (auto animation = getStuntParticipantAnimation(anim.participant, anim.animation)) {
             Participant &participant = _participantByTag.at(anim.participant);
@@ -439,6 +436,7 @@ void DialogGUI::releaseStuntParticipants() {
         return;
     }
     for (auto &participant : _participantByTag) {
+        participant.second.creature->resumeStateDrivenAnimation();
         participant.second.creature->stopStuntMode();
         participant.second.creature->setIsInConversation(false);
     }

--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -143,8 +143,9 @@ void DialogGUI::onStart() {
 }
 
 void DialogGUI::loadStuntParticipants() {
-    if (!_dialog->isAnimatedCutscene())
+    if (!hasStuntPresentation()) {
         return;
+    }
 
     _participantByTag.clear();
 
@@ -164,28 +165,106 @@ void DialogGUI::loadStuntParticipants() {
         Participant participant;
         participant.creature = creature;
 
+        std::shared_ptr<Model> model(_services.resource.models.get(stunt.stuntModel));
+        if (!model) {
+            warn("Dialog: stunt model not found: " + stunt.stuntModel);
+            continue;
+        }
+        participant.model = model;
+
         if (_dialog->isAnimatedCutscene()) {
-            std::shared_ptr<Model> model(_services.resource.models.get(stunt.stuntModel));
-            if (!model) {
-                warn("Dialog: stunt model not found: " + stunt.stuntModel);
-                continue;
-            }
-            participant.model = model;
             creature->startStuntMode();
+            participant.creature->setIsInConversation(true);
         }
 
-        participant.creature->setIsInConversation(true);
         _participantByTag.insert(std::make_pair(stunt.participant, std::move(participant)));
     }
 }
 
+bool DialogGUI::hasStuntPresentation() const {
+    return _dialog->isAnimatedCutscene() || (!_dialog->cameraModel.empty() && !_dialog->stunts.empty());
+}
+
+std::shared_ptr<Animation> DialogGUI::getStuntParticipantAnimation(
+    const std::string &participant,
+    int ordinal) const {
+    if (_dialog->cameraModel.empty()) {
+        return nullptr;
+    }
+    auto maybeParticipant = _participantByTag.find(participant);
+    return maybeParticipant != _participantByTag.end()
+               ? maybeParticipant->second.model->getAnimation(getStuntAnimationName(ordinal))
+               : nullptr;
+}
+
 void DialogGUI::onLoadEntry() {
+    restoreInactiveStuntParticipants();
     loadCurrentSpeaker();
     updateCamera();
     updateParticipantAnimations();
     repositionMessage();
 
     _controls.LB_REPLIES->setVisible(false);
+}
+
+void DialogGUI::restoreInactiveStuntParticipants() {
+    if (_dialog->isAnimatedCutscene()) {
+        return;
+    }
+    for (auto &entry : _participantByTag) {
+        if (!entry.second.mixedStuntActive) {
+            continue;
+        }
+        bool drivenThisEntry = false;
+        for (auto &anim : _currentEntry->animations) {
+            if (anim.participant == entry.first && getStuntParticipantAnimation(anim.participant, anim.animation)) {
+                drivenThisEntry = true;
+                break;
+            }
+        }
+        if (!drivenThisEntry) {
+            leaveMixedStunt(entry.second);
+        }
+    }
+}
+
+bool DialogGUI::enterMixedStunt(Participant &participant, const std::shared_ptr<Animation> &animation) {
+    if (!participant.mixedStuntActive && participant.creature->isStuntMode()) {
+        warn("Dialog: participant is already in stunt mode: " + participant.creature->tag());
+        return false;
+    }
+
+    AnimationProperties properties;
+    properties.flags = AnimationFlags::propagate;
+    properties.scale = 1.0f;
+    if (!participant.creature->playAnimation(animation, std::move(properties))) {
+        return false;
+    }
+
+    if (!participant.mixedStuntActive) {
+        participant.restorePosition = participant.creature->position();
+        participant.restoreFacing = participant.creature->getFacing();
+        if (auto node = participant.creature->sceneNode()) {
+            participant.restoreCulling = node->isCullingEnabled();
+        }
+        participant.creature->startStuntMode();
+        participant.mixedStuntActive = true;
+    }
+    return true;
+}
+
+void DialogGUI::leaveMixedStunt(Participant &participant) {
+    if (!participant.mixedStuntActive) {
+        return;
+    }
+    participant.creature->resumeStateDrivenAnimation();
+    participant.creature->setPosition(participant.restorePosition);
+    participant.creature->setFacing(participant.restoreFacing);
+    participant.creature->stopStuntMode();
+    if (auto node = participant.creature->sceneNode()) {
+        node->setCullingEnabled(participant.restoreCulling);
+    }
+    participant.mixedStuntActive = false;
 }
 
 void DialogGUI::loadCurrentSpeaker() {
@@ -282,6 +361,9 @@ void DialogGUI::updateParticipantAnimations() {
                 properties.scale = 1.0f;
                 participant.creature->playAnimation(animation, std::move(properties));
             }
+        } else if (auto animation = getStuntParticipantAnimation(anim.participant, anim.animation)) {
+            Participant &participant = _participantByTag.at(anim.participant);
+            enterMixedStunt(participant, animation);
         } else {
             std::shared_ptr<Creature> participant;
             if (anim.participant == "owner") {
@@ -337,7 +419,7 @@ void DialogGUI::repositionMessage() {
 }
 
 void DialogGUI::onFinish() {
-    if (_dialog->isAnimatedCutscene()) {
+    if (hasStuntPresentation()) {
         releaseStuntParticipants();
     }
 
@@ -349,10 +431,18 @@ void DialogGUI::onFinish() {
 }
 
 void DialogGUI::releaseStuntParticipants() {
+    if (!_dialog->isAnimatedCutscene()) {
+        for (auto &participant : _participantByTag) {
+            leaveMixedStunt(participant.second);
+        }
+        _participantByTag.clear();
+        return;
+    }
     for (auto &participant : _participantByTag) {
         participant.second.creature->stopStuntMode();
         participant.second.creature->setIsInConversation(false);
     }
+    _participantByTag.clear();
 }
 
 void DialogGUI::onEntryEnded() {

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -367,7 +367,7 @@ bool Creature::playAnimation(const std::shared_ptr<Animation> &anim, AnimationPr
 }
 
 bool Creature::playExternalAnimation(const std::shared_ptr<Animation> &anim, AnimationProperties properties) {
-    return doPlayAnimation(false, [&]() {
+    return doPlayAnimation(true, [&]() {
         auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
         if (model) {
             model->playAnimation(*anim, nullptr, properties);

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -367,7 +367,7 @@ bool Creature::playAnimation(const std::shared_ptr<Animation> &anim, AnimationPr
 }
 
 bool Creature::playExternalAnimation(const std::shared_ptr<Animation> &anim, AnimationProperties properties) {
-    return doPlayAnimation(true, [&]() {
+    return doPlayAnimation(false, [&]() {
         auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
         if (model) {
             model->playAnimation(*anim, nullptr, properties);

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -342,26 +342,34 @@ void Creature::playAnimation(const std::string &name, AnimationProperties proper
     });
 }
 
-void Creature::doPlayAnimation(bool fireForget, const std::function<void()> &callback) {
-    if (!_sceneNode || _movementType != MovementType::None)
-        return;
+bool Creature::doPlayAnimation(bool fireForget, const std::function<void()> &callback) {
+    if (!_sceneNode || _movementType != MovementType::None) {
+        return false;
+    }
 
     callback();
 
     if (fireForget) {
         _animFireForget = true;
     }
+    return true;
 }
 
-void Creature::playAnimation(const std::shared_ptr<Animation> &anim, AnimationProperties properties) {
+bool Creature::playAnimation(const std::shared_ptr<Animation> &anim, AnimationProperties properties) {
     bool fireForget = !(properties.flags & AnimationFlags::loop);
 
-    doPlayAnimation(fireForget, [&]() {
+    return doPlayAnimation(fireForget, [&]() {
         auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
         if (model) {
             model->playAnimation(*anim, nullptr, properties);
         }
     });
+}
+
+void Creature::resumeStateDrivenAnimation() {
+    _animFireForget = false;
+    _animDirty = true;
+    updateModelAnimation();
 }
 
 void Creature::playAnimation(CombatAnimation anim, CreatureWieldType wield, int variant) {

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -366,6 +366,15 @@ bool Creature::playAnimation(const std::shared_ptr<Animation> &anim, AnimationPr
     });
 }
 
+bool Creature::playExternalAnimation(const std::shared_ptr<Animation> &anim, AnimationProperties properties) {
+    return doPlayAnimation(false, [&]() {
+        auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
+        if (model) {
+            model->playAnimation(*anim, nullptr, properties);
+        }
+    });
+}
+
 void Creature::resumeStateDrivenAnimation() {
     _animFireForget = false;
     _animDirty = true;

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -27,6 +27,7 @@
 #include "reone/game/game.h"
 #include "reone/game/gui/areatransition.h"
 #include "reone/game/gui/conversation.h"
+#include "reone/game/gui/dialog.h"
 #include "reone/game/gui/hud.h"
 #include "reone/game/gui/statussummary.h"
 #include "reone/game/object/area.h"
@@ -82,6 +83,44 @@ public:
 private:
     void setReplyLines(std::vector<std::string>) override {}
     void setMessage(std::string) override {}
+};
+
+class MixedStuntTestAccess {
+public:
+    static void loadParticipants(DialogGUI &gui, const std::shared_ptr<resource::Dialog> &dialog) {
+        gui._dialog = dialog;
+        gui.loadStuntParticipants();
+    }
+
+    static size_t participantCount(const DialogGUI &gui) {
+        return gui._participantByTag.size();
+    }
+
+    static std::shared_ptr<Creature> participantCreature(DialogGUI &gui, const std::string &tag) {
+        return gui._participantByTag.at(tag).creature;
+    }
+
+    static std::shared_ptr<graphics::Model> participantModel(DialogGUI &gui, const std::string &tag) {
+        return gui._participantByTag.at(tag).model;
+    }
+
+    static bool applyAnimation(DialogGUI &gui, const std::string &tag, int ordinal) {
+        auto animation = gui.getStuntParticipantAnimation(tag, ordinal);
+        return animation && gui.enterMixedStunt(gui._participantByTag.at(tag), animation);
+    }
+
+    static bool isActive(DialogGUI &gui, const std::string &tag) {
+        return gui._participantByTag.at(tag).mixedStuntActive;
+    }
+
+    static void restoreForEntry(DialogGUI &gui, const resource::Dialog::EntryReply &entry) {
+        gui._currentEntry = &entry;
+        gui.restoreInactiveStuntParticipants();
+    }
+
+    static void finish(DialogGUI &gui) {
+        gui.onFinish();
+    }
 };
 
 } // namespace reone::game
@@ -417,6 +456,25 @@ std::shared_ptr<graphics::Animation> makeAnimation(std::string name) {
         std::vector<graphics::Animation::Event>());
 }
 
+std::shared_ptr<graphics::Model> makeModel(
+    std::string name,
+    std::vector<std::shared_ptr<graphics::Animation>> animations) {
+    auto root = std::make_shared<graphics::ModelNode>(
+        0,
+        "root_node",
+        glm::vec3(0.0f),
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f),
+        true,
+        nullptr);
+    return std::make_shared<graphics::Model>(
+        std::move(name),
+        0,
+        std::move(root),
+        std::move(animations),
+        "",
+        1.0f);
+}
+
 std::shared_ptr<Dialog> makeRoutingDialog() {
     auto dialog = std::make_shared<Dialog>();
     dialog->startEntries.push_back(Dialog::EntryReplyLink {0});
@@ -558,6 +616,126 @@ TEST(Creature, should_hold_dialog_owned_external_animation_until_assignment_chan
 
     creature.resumeStateDrivenAnimation();
     EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+}
+
+TEST(DialogGUI, should_prepare_the_real_player_from_a_stunt_model_without_creating_a_duplicate) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    auto originalSceneNode = player->sceneNode();
+    auto stuntModel = makeModel("player_stunt", {});
+    EXPECT_CALL(engine.resourceModule().models(), get("player_stunt"))
+        .WillOnce(Return(stuntModel));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = false;
+    dialog->cameraModel.clear();
+    dialog->stunts.push_back({"PLAYER", "player_stunt"});
+    DialogGUI gui(game, engine.services());
+
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+    EXPECT_EQ(MixedStuntTestAccess::participantCreature(gui, "PLAYER"), player);
+    EXPECT_EQ(MixedStuntTestAccess::participantModel(gui, "PLAYER"), stuntModel);
+    EXPECT_EQ(player->sceneNode(), originalSceneNode);
+    EXPECT_FALSE(player->isStuntMode());
+}
+
+TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assignments) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto idle = makeAnimation("cpause1");
+    auto first = makeAnimation("cut001w");
+    auto second = makeAnimation("cut002w");
+    auto stuntModel = makeModel("player_stunt", {idle, first, second});
+    graphics::GraphicsOptions graphicsOptions;
+    scene::SceneGraph graph(
+        "test",
+        engine.sceneModule().renderPipelineFactory(),
+        graphicsOptions,
+        engine.services().graphics,
+        engine.services().audio,
+        engine.services().resource);
+    auto modelNode = graph.newModel(*stuntModel, scene::ModelUsage::Creature);
+    auto player = std::make_shared<TestCreature>(1, "player", game, engine.services());
+    player->setSceneNode(modelNode);
+    player->setPosition(glm::vec3(1.0f, 2.0f, 3.0f));
+    player->setFacing(0.75f);
+    modelNode->setCullingEnabled(false);
+    player->resumeStateDrivenAnimation();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    EXPECT_CALL(engine.resourceModule().models(), get("player_stunt"))
+        .WillOnce(Return(stuntModel));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->stunts.push_back({"PLAYER", "player_stunt"});
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    modelNode->update(0.4f);
+    ASSERT_EQ(modelNode->animationChannels().size(), 1);
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
+
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
+
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1201));
+    EXPECT_EQ(modelNode->activeAnimationName(), "cut002w");
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.0f);
+
+    Dialog::EntryReply droppedEntry;
+    MixedStuntTestAccess::restoreForEntry(gui, droppedEntry);
+    EXPECT_FALSE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
+    EXPECT_EQ(player->position(), glm::vec3(1.0f, 2.0f, 3.0f));
+    EXPECT_FLOAT_EQ(player->getFacing(), 0.75f);
+    EXPECT_FALSE(modelNode->isCullingEnabled());
+    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    MixedStuntTestAccess::finish(gui);
+    EXPECT_EQ(MixedStuntTestAccess::participantCount(gui), 0);
+    EXPECT_FALSE(player->isStuntMode());
+    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+}
+
+TEST(DialogGUI, should_leave_no_partial_mixed_stunt_state_when_inputs_are_missing) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto dialog = std::make_shared<Dialog>();
+    dialog->stunts.push_back({"PLAYER", "missing_stunt"});
+    DialogGUI gui(game, engine.services());
+
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    EXPECT_EQ(MixedStuntTestAccess::participantCount(gui), 0);
+
+    auto player = game.newCreature();
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    EXPECT_CALL(engine.resourceModule().models(), get("missing_stunt"))
+        .WillOnce(Return(nullptr));
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    EXPECT_EQ(MixedStuntTestAccess::participantCount(gui), 0);
+
+    auto sourceModel = makeModel("player_stunt", {makeAnimation("cut001w")});
+    dialog->stunts.front().stuntModel = "player_stunt";
+    EXPECT_CALL(engine.resourceModule().models(), get("player_stunt"))
+        .WillOnce(Return(sourceModel));
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+
+    EXPECT_FALSE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1201));
+    EXPECT_FALSE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
+    EXPECT_FALSE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    EXPECT_FALSE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
+    EXPECT_FALSE(player->isStuntMode());
 }
 
 TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -26,6 +26,7 @@
 #include "reone/game/action/unlockobject.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/areatransition.h"
+#include "reone/game/gui/conversation.h"
 #include "reone/game/gui/hud.h"
 #include "reone/game/object/area.h"
 #include "reone/game/object/creature.h"
@@ -61,6 +62,22 @@ class TestAreaTransition : public AreaTransition {
 public:
     using AreaTransition::AreaTransition;
     using AreaTransition::preload;
+};
+
+class TestConversation : public Conversation {
+public:
+    using Conversation::Conversation;
+
+    int startCount {0};
+    int finishCount {0};
+    int entryCount {0};
+
+private:
+    void loadEntry(int, bool) override { ++entryCount; }
+    void setReplyLines(std::vector<std::string>) override {}
+    void setMessage(std::string) override {}
+    void onStart() override { ++startCount; }
+    void onFinish() override { ++finishCount; }
 };
 
 // TestEngine initializes the Logger singleton, which only tolerates a single
@@ -281,6 +298,24 @@ std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int st
 }
 
 } // namespace
+
+TEST(Conversation, should_finish_active_presentation_before_starting_replacement) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    TestConversation conversation(game, engine.services());
+    auto first = std::make_shared<Dialog>();
+    auto second = std::make_shared<Dialog>();
+    first->startEntries.push_back(Dialog::EntryReplyLink {});
+    second->startEntries.push_back(Dialog::EntryReplyLink {});
+
+    conversation.start(first, nullptr);
+    conversation.start(second, nullptr);
+
+    EXPECT_EQ(conversation.startCount, 2);
+    EXPECT_EQ(conversation.entryCount, 2);
+    EXPECT_EQ(conversation.finishCount, 1);
+}
 
 TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {
     TestEngine &engine = testEngine();

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -34,10 +34,14 @@
 #include "reone/game/object/item.h"
 #include "reone/game/object/placeable.h"
 #include "reone/game/object/trigger.h"
+#include "reone/graphics/animation.h"
+#include "reone/graphics/model.h"
+#include "reone/graphics/modelnode.h"
 #include "reone/graphics/walkmesh.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/gff.h"
 #include "reone/scene/collision.h"
+#include "reone/scene/node/model.h"
 #include "reone/scene/node/trigger.h"
 #include "reone/script/program.h"
 
@@ -78,6 +82,28 @@ private:
     void setMessage(std::string) override {}
     void onStart() override { ++startCount; }
     void onFinish() override { ++finishCount; }
+};
+
+class RoutingConversation : public Conversation {
+public:
+    using Conversation::Conversation;
+
+    int presentedEntryCount {0};
+    std::vector<std::string> messages;
+
+private:
+    void setReplyLines(std::vector<std::string>) override {}
+    void setMessage(std::string message) override { messages.push_back(std::move(message)); }
+    void onLoadEntry() override { ++presentedEntryCount; }
+};
+
+class TestCreature : public Creature {
+public:
+    using Creature::Creature;
+
+    void setSceneNode(std::shared_ptr<scene::SceneNode> node) {
+        _sceneNode = std::move(node);
+    }
 };
 
 // TestEngine initializes the Logger singleton, which only tolerates a single
@@ -297,6 +323,46 @@ std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int st
     return item;
 }
 
+std::shared_ptr<graphics::Animation> makeAnimation(std::string name) {
+    auto root = std::make_shared<graphics::ModelNode>(
+        0,
+        "root_node",
+        glm::vec3(0.0f),
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f),
+        false,
+        nullptr);
+    root->vectorTracks()[graphics::ControllerTypes::position].add(0.0f, glm::vec3(0.0f));
+    root->vectorTracks()[graphics::ControllerTypes::position].add(1.0f, glm::vec3(1.0f));
+    return std::make_shared<graphics::Animation>(
+        std::move(name),
+        1.0f,
+        0.0f,
+        "root_node",
+        std::move(root),
+        std::vector<graphics::Animation::Event>());
+}
+
+std::shared_ptr<Dialog> makeRoutingDialog() {
+    auto dialog = std::make_shared<Dialog>();
+    dialog->startEntries.push_back(Dialog::EntryReplyLink {0});
+
+    Dialog::EntryReply routing;
+    routing.delay = -1;
+    routing.cameraId = 0;
+    routing.replies.push_back(Dialog::EntryReplyLink {0});
+    dialog->entries.push_back(std::move(routing));
+
+    Dialog::EntryReply visible;
+    visible.text = "visible";
+    visible.delay = 30;
+    dialog->entries.push_back(std::move(visible));
+
+    Dialog::EntryReply continuation;
+    continuation.entries.push_back(Dialog::EntryReplyLink {1});
+    dialog->replies.push_back(std::move(continuation));
+    return dialog;
+}
+
 } // namespace
 
 TEST(Conversation, should_finish_active_presentation_before_starting_replacement) {
@@ -315,6 +381,108 @@ TEST(Conversation, should_finish_active_presentation_before_starting_replacement
     EXPECT_EQ(conversation.startCount, 2);
     EXPECT_EQ(conversation.entryCount, 2);
     EXPECT_EQ(conversation.finishCount, 1);
+}
+
+TEST(Conversation, should_advance_script_only_auto_routing_entry_without_presenting_it) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    RoutingConversation conversation(game, engine.services());
+
+    conversation.start(makeRoutingDialog(), nullptr);
+
+    ASSERT_EQ(conversation.messages.size(), 2);
+    EXPECT_EQ(conversation.messages[0], "");
+    EXPECT_EQ(conversation.messages[1], "visible");
+    EXPECT_EQ(conversation.presentedEntryCount, 1);
+}
+
+TEST(Conversation, should_present_auto_routing_entry_with_authored_presentation_data) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    std::vector<std::function<void(Dialog::EntryReply &)>> addPresentation {
+        [](auto &entry) { entry.text = "text"; },
+        [](auto &entry) { entry.sound = "sound"; },
+        [](auto &entry) { entry.voResRef = "voice"; },
+        [](auto &entry) { entry.cameraAnimation = 1200; },
+        [](auto &entry) { entry.cameraId = 1; },
+        [](auto &entry) { entry.cameraAngle = 1; },
+        [](auto &entry) { entry.animations.push_back({"participant", 1200}); },
+        [](auto &entry) { entry.delay = 0; },
+    };
+
+    for (auto &mutate : addPresentation) {
+        auto dialog = makeRoutingDialog();
+        mutate(dialog->entries[0]);
+        RoutingConversation conversation(game, engine.services());
+
+        conversation.start(dialog, nullptr);
+
+        EXPECT_EQ(conversation.presentedEntryCount, 1);
+        ASSERT_EQ(conversation.messages.size(), 1);
+    }
+}
+
+TEST(Creature, should_hold_dialog_owned_external_animation_until_assignment_changes) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto modelRoot = std::make_shared<graphics::ModelNode>(
+        0,
+        "root_node",
+        glm::vec3(0.0f),
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f),
+        true,
+        nullptr);
+    auto idle = makeAnimation("cpause1");
+    auto first = makeAnimation("first");
+    auto second = makeAnimation("second");
+    std::vector<std::shared_ptr<graphics::Animation>> animations {idle, first, second};
+    graphics::Model model("creature", 0, modelRoot, std::move(animations), "", 1.0f);
+    graphics::GraphicsOptions graphicsOptions;
+    scene::SceneGraph graph(
+        "test",
+        engine.sceneModule().renderPipelineFactory(),
+        graphicsOptions,
+        engine.services().graphics,
+        engine.services().audio,
+        engine.services().resource);
+    auto modelNode = graph.newModel(model, scene::ModelUsage::Creature);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(modelNode);
+    creature.resumeStateDrivenAnimation();
+
+    scene::AnimationProperties properties;
+    properties.flags = scene::AnimationFlags::propagate;
+    properties.scale = 1.0f;
+
+    ASSERT_TRUE(creature.playExternalAnimation(first, properties));
+    modelNode->update(0.4f);
+    ASSERT_EQ(modelNode->animationChannels().size(), 1);
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
+
+    ASSERT_TRUE(creature.playExternalAnimation(first, properties));
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
+
+    modelNode->update(0.7f);
+    creature.update(0.0f);
+    EXPECT_EQ(modelNode->activeAnimationName(), "first");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+
+    ASSERT_TRUE(creature.playExternalAnimation(second, properties));
+    EXPECT_EQ(modelNode->activeAnimationName(), "second");
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.0f);
+
+    creature.update(0.0f);
+    modelNode->update(0.0f);
+    EXPECT_EQ(modelNode->activeAnimationName(), "second");
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.0f);
+
+    creature.resumeStateDrivenAnimation();
+    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
 }
 
 TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -558,7 +558,7 @@ TEST(Conversation, should_present_auto_routing_entry_with_authored_presentation_
     }
 }
 
-TEST(Creature, should_hold_dialog_owned_external_animation_until_assignment_changes) {
+TEST(Creature, should_release_completed_external_animation_without_truncating_or_restarting_it) {
     TestEngine &engine = testEngine();
     StubConsole console;
     Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
@@ -600,10 +600,15 @@ TEST(Creature, should_hold_dialog_owned_external_animation_until_assignment_chan
     ASSERT_TRUE(creature.playExternalAnimation(first, properties));
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
 
-    modelNode->update(0.7f);
+    modelNode->update(0.5f);
     creature.update(0.0f);
     EXPECT_EQ(modelNode->activeAnimationName(), "first");
+    EXPECT_FALSE(modelNode->isAnimationFinished());
+
+    modelNode->update(0.2f);
     EXPECT_TRUE(modelNode->isAnimationFinished());
+    creature.update(0.0f);
+    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
 
     ASSERT_TRUE(creature.playExternalAnimation(second, properties));
     EXPECT_EQ(modelNode->activeAnimationName(), "second");
@@ -685,6 +690,11 @@ TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assig
 
     ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
+
+    modelNode->update(0.7f);
+    player->update(0.0f);
+    EXPECT_TRUE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
+    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
 
     ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1201));
     EXPECT_EQ(modelNode->activeAnimationName(), "cut002w");

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -547,7 +547,7 @@ TEST(Conversation, should_present_auto_routing_entry_with_authored_presentation_
     }
 }
 
-TEST(Creature, should_release_completed_external_animation_without_truncating_or_restarting_it) {
+TEST(Creature, should_hold_completed_external_animation_until_assignment_is_released) {
     TestEngine &engine = testEngine();
     StubConsole console;
     Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
@@ -589,19 +589,33 @@ TEST(Creature, should_release_completed_external_animation_without_truncating_or
     ASSERT_TRUE(creature.playExternalAnimation(first, properties));
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
 
+    modelNode->update(0.7f);
+    creature.update(0.0f);
+    EXPECT_EQ(modelNode->activeAnimationName(), "first");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+    ASSERT_EQ(modelNode->animationChannels().size(), 1);
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
+
+    auto rootSceneNode = modelNode->getNodeByName("root_node");
+    ASSERT_TRUE(rootSceneNode);
+    EXPECT_NEAR(rootSceneNode->localTransform()[3].x, 1.0f, 1e-5);
+
     modelNode->update(0.5f);
     creature.update(0.0f);
     EXPECT_EQ(modelNode->activeAnimationName(), "first");
-    EXPECT_FALSE(modelNode->isAnimationFinished());
-
-    modelNode->update(0.2f);
     EXPECT_TRUE(modelNode->isAnimationFinished());
-    creature.update(0.0f);
-    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
+    EXPECT_NEAR(rootSceneNode->localTransform()[3].x, 1.0f, 1e-5);
+
+    ASSERT_TRUE(creature.playExternalAnimation(first, properties));
+    EXPECT_EQ(modelNode->activeAnimationName(), "first");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
 
     ASSERT_TRUE(creature.playExternalAnimation(second, properties));
     EXPECT_EQ(modelNode->activeAnimationName(), "second");
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.0f);
+    EXPECT_FALSE(modelNode->isAnimationFinished());
 
     creature.update(0.0f);
     modelNode->update(0.0f);
@@ -639,7 +653,7 @@ TEST(DialogGUI, should_prepare_the_real_player_from_a_stunt_model_without_creati
     EXPECT_FALSE(player->isStuntMode());
 }
 
-TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assignments) {
+TEST(DialogGUI, should_hold_mixed_stunt_assignment_and_restore_on_drop_or_teardown) {
     TestEngine &engine = testEngine();
     StubConsole console;
     Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
@@ -673,6 +687,15 @@ TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assig
     MixedStuntTestAccess::loadParticipants(gui, dialog);
 
     ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    EXPECT_TRUE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
+    EXPECT_TRUE(player->isStuntMode());
+    EXPECT_TRUE(modelNode->isEnabled());
+    EXPECT_FALSE(modelNode->isCulled());
+    EXPECT_FALSE(modelNode->isCullingEnabled());
+    EXPECT_NEAR(modelNode->localTransform()[3].x, 0.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].y, 0.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].z, 0.0f, 1e-5);
+
     modelNode->update(0.4f);
     ASSERT_EQ(modelNode->animationChannels().size(), 1);
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.4f);
@@ -683,11 +706,39 @@ TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assig
     modelNode->update(0.7f);
     player->update(0.0f);
     EXPECT_TRUE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
-    EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+    EXPECT_TRUE(player->isStuntMode());
+    EXPECT_TRUE(modelNode->isEnabled());
+    EXPECT_FALSE(modelNode->isCulled());
+    EXPECT_FALSE(modelNode->isCullingEnabled());
+    EXPECT_EQ(modelNode->activeAnimationName(), "cut001w");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
+
+    auto rootSceneNode = modelNode->getNodeByName("root_node");
+    ASSERT_TRUE(rootSceneNode);
+    EXPECT_NEAR(rootSceneNode->localTransform()[3].x, 1.0f, 1e-5);
+
+    modelNode->update(0.5f);
+    player->update(0.0f);
+    EXPECT_EQ(modelNode->activeAnimationName(), "cut001w");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
+    EXPECT_NEAR(rootSceneNode->localTransform()[3].x, 1.0f, 1e-5);
+
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
+    EXPECT_EQ(modelNode->activeAnimationName(), "cut001w");
+    EXPECT_TRUE(modelNode->isAnimationFinished());
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 1.0f);
 
     ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1201));
     EXPECT_EQ(modelNode->activeAnimationName(), "cut002w");
     EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.0f);
+    EXPECT_FALSE(modelNode->isAnimationFinished());
+
+    modelNode->update(0.25f);
+    ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1201));
+    EXPECT_EQ(modelNode->activeAnimationName(), "cut002w");
+    EXPECT_FLOAT_EQ(modelNode->animationChannels().front().time, 0.25f);
 
     Dialog::EntryReply droppedEntry;
     MixedStuntTestAccess::restoreForEntry(gui, droppedEntry);
@@ -696,12 +747,21 @@ TEST(DialogGUI, should_preserve_change_drop_and_release_mixed_player_stunt_assig
     EXPECT_FLOAT_EQ(player->getFacing(), 0.75f);
     EXPECT_FALSE(modelNode->isCullingEnabled());
     EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+    EXPECT_NEAR(modelNode->localTransform()[3].x, 1.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].y, 2.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].z, 3.0f, 1e-5);
 
     ASSERT_TRUE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
     MixedStuntTestAccess::finish(gui);
     EXPECT_EQ(MixedStuntTestAccess::participantCount(gui), 0);
     EXPECT_FALSE(player->isStuntMode());
+    EXPECT_EQ(player->position(), glm::vec3(1.0f, 2.0f, 3.0f));
+    EXPECT_FLOAT_EQ(player->getFacing(), 0.75f);
+    EXPECT_FALSE(modelNode->isCullingEnabled());
     EXPECT_EQ(modelNode->activeAnimationName(), "cpause1");
+    EXPECT_NEAR(modelNode->localTransform()[3].x, 1.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].y, 2.0f, 1e-5);
+    EXPECT_NEAR(modelNode->localTransform()[3].z, 3.0f, 1e-5);
 }
 
 TEST(DialogGUI, should_leave_no_partial_mixed_stunt_state_when_inputs_are_missing) {


### PR DESCRIPTION
## Problem

Some K1 dialogues use `CameraModel` and `StuntList` for individual participant animations without enabling whole-dialogue `AnimatedCut`. reone skipped that path, so the animated camera could film stunt-local space while the real player was absent or left in normal world presentation.

## Fix

- Load mixed-dialogue stunt resources independently of `AnimatedCut`.
- Resolve `PLAYER` to the real party player.
- Stage participants before the first visible stunt shot.
- Use stunt animations on the existing participant model without creating a duplicate.
- Preserve unchanged assignments, start changed clips once, and hold completed clips until the assignment changes.
- Restore normal presentation on drop, replacement, transition, or dialogue teardown.
- Safely handle missing participants, models, clips, and scene nodes.

## Validation

- Taris hideout cutscene and dialogue.  The real player is present from the opening bed shot.
- The player performs the authored `cut004w` and `cut002w` animations without duplication or disappearance.

## Known issues

- Remaining differences from K1 are camera-related and will be handled in a separate PR.
- During the short scripted transition after the wake-up animation, the camera briefly remains on the player’s terminal pose.
- The later switch to Carth, dialogue-camera framing, FoV, and participant/camera timing are not addressed by this PR.