### PR TITLE
[game] Handle AssuredHit effect in computeAttack

### DIFF
--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -135,6 +135,13 @@ public:
     void clearAllEffects();
     void applyEffect(const std::shared_ptr<Effect> &effect, DurationType durationType, float duration = 0.0f);
 
+    struct AppliedEffect {
+        std::shared_ptr<Effect> effect;
+        DurationType durationType {DurationType::Instant};
+        float duration {0.0f};
+    };
+
+    const std::deque<AppliedEffect> &effects() const { return _effects; }
     std::shared_ptr<Effect> getFirstEffect();
     std::shared_ptr<Effect> getNextEffect();
 
@@ -213,12 +220,6 @@ protected:
     struct DelayedAction {
         std::shared_ptr<Action> action;
         std::unique_ptr<Timer> timer;
-    };
-
-    struct AppliedEffect {
-        std::shared_ptr<Effect> effect;
-        DurationType durationType {DurationType::Instant};
-        float duration {0.0f};
     };
 
     uint32_t _id;

--- a/src/libs/game/attack.cpp
+++ b/src/libs/game/attack.cpp
@@ -116,7 +116,20 @@ static int getWeaponAttackBonus(const Creature &attacker, const Item &weapon) {
     return modifier + effects - penalty;
 }
 
+static bool hasAssuredHitEffect(const Creature &attacker) {
+    for (auto &effect : attacker.effects()) {
+        if (effect.effect->type() == EffectType::AssuredHit) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static AttackResultType computeAttack(const Creature &attacker, const Object &target, int rollBonus, int threatBonus) {
+    if (hasAssuredHitEffect(attacker)) {
+        return AttackResultType::AutomaticHit;
+    }
+
     // Determine defense of a target
     int defense;
     if (const auto *creature = dyn_cast<Creature>(&target)) {


### PR DESCRIPTION
`AssuredHit` is used in many cutscenes together with regular attacks instead of `CutsceneAttack`. Without an `AssuredHit`, these attacks are susceptible to random misses. Cutscenes can break or never finish if there was a `PauseConversation`, but Resume happens only when the attack hits.