### PR TITLE
[game] Dispatch from UseTalent to UseFeat or CastSpellAtObject

### DIFF
--- a/include/reone/game/action/usetalentonobject.h
+++ b/include/reone/game/action/usetalentonobject.h
@@ -30,17 +30,23 @@ public:
         Action(game, services, ActionType::UseTalentOnObject),
         _chosenTalent(std::move(chosenTalent)),
         _target(std::move(target)) {
+
+        dispatchToAction();
     }
 
     static bool classof(Action *from) {
         return from->type() == ActionType::UseTalentOnObject;
     }
 
+    void dispatchToAction();
     void execute(std::shared_ptr<Action> self, Object &actor, float dt) override;
+
+    const std::shared_ptr<Action> &subAction() const { return _action; }
 
 private:
     std::shared_ptr<Talent> _chosenTalent;
     std::shared_ptr<Object> _target;
+    std::shared_ptr<Action> _action;
 };
 
 } // namespace game

--- a/include/reone/game/attack.h
+++ b/include/reone/game/attack.h
@@ -197,6 +197,8 @@ public:
      */
     void reset();
 
+    bool empty() const { return _projectiles.empty(); }
+
 private:
     TimeEvents _events;
     SmallVector<Projectile, 16> _projectiles;

--- a/src/libs/game/action/castspellatobject.cpp
+++ b/src/libs/game/action/castspellatobject.cpp
@@ -41,6 +41,10 @@ CastSpellAtObjectAction::CastSpellAtObjectAction(
     _cheat(cheat) {}
 
 static void runScript(Game &game, const Spell &spell, const Object &target) {
+    if (spell.impactScript.empty()) {
+        return;
+    }
+
     auto location = std::make_shared<Location>(target.position(), target.getFacing());
     std::vector<script::Argument> args = {
         {script::ArgKind::Caller, script::Variable::ofObject(target.id())},

--- a/src/libs/game/action/usefeat.cpp
+++ b/src/libs/game/action/usefeat.cpp
@@ -210,16 +210,18 @@ void UseFeatAction::execute(std::shared_ptr<Action> self, Object &actor, float d
     }
 
     // Projectiles
-    switch (state) {
-    case AttackSchedule::Damage:
-    case AttackSchedule::WaitDamage:
-    case AttackSchedule::WaitFinish: {
-        auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
-        _projectiles.update(dt, attacker, *_target, sceneGraph);
-        break;
-    }
-    default:
-        break;
+    if (!_projectiles.empty()) {
+        switch (state) {
+        case AttackSchedule::Damage:
+        case AttackSchedule::WaitDamage:
+        case AttackSchedule::WaitFinish: {
+            auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+            _projectiles.update(dt, attacker, *_target, sceneGraph);
+            break;
+        }
+        default:
+            break;
+        }
     }
 }
 

--- a/src/libs/game/action/usetalentonobject.cpp
+++ b/src/libs/game/action/usetalentonobject.cpp
@@ -16,15 +16,48 @@
  */
 
 #include "reone/game/action/usetalentonobject.h"
+#include "reone/game/action/castspellatobject.h"
+#include "reone/game/action/usefeat.h"
+#include "reone/game/game.h"
 
 namespace reone {
 
 namespace game {
 
-void UseTalentOnObjectAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    // TODO: implement
+void UseTalentOnObjectAction::dispatchToAction() {
+    assert(!_action && "dispatchToAction is called twice");
+    switch (_chosenTalent->type()) {
+    case TalentType::Feat: {
+        _action = _game.newAction<UseFeatAction>(
+            static_cast<FeatType>(_chosenTalent->value()),
+            _target);
+        break;
+    }
+    case TalentType::Spell: {
+        auto spell = _services.game.spells.get(static_cast<SpellType>(_chosenTalent->value()));
+        if (!spell) {
+            return;
+        }
+        _action = _game.newAction<CastSpellAtObjectAction>(
+            std::move(spell), _target, /*item=*/std::nullopt, /*cheat=*/false);
+        break;
+    }
+    default:
+        break;
+    }
+}
 
-    complete();
+void UseTalentOnObjectAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
+    if (!_action) {
+        complete();
+        return;
+    }
+
+    _action->execute(_action, actor, dt);
+
+    if (_action->isCompleted()) {
+        complete();
+    }
 }
 
 } // namespace game

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(TESTS_HEADERS
 
 set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/audio/format/wavreader.cpp
+    ${TESTS_SOURCE_DIR}/fixtures/engine.cpp
+    ${TESTS_SOURCE_DIR}/game/action.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/journal.cpp

--- a/test/fixtures/engine.cpp
+++ b/test/fixtures/engine.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "engine.h"
+
+namespace reone {
+
+TestEngine &testEngine() {
+    static TestEngine engine;
+    static bool initialized = false;
+    if (!initialized) {
+        engine.init();
+        initialized = true;
+    }
+    return engine;
+}
+
+} // namespace reone

--- a/test/fixtures/engine.h
+++ b/test/fixtures/engine.h
@@ -131,4 +131,8 @@ private:
     std::unique_ptr<game::ServicesView> _services;
 };
 
+// TestEngine initializes the Logger singleton, which only tolerates a single
+// init per process.
+TestEngine &testEngine();
+
 } // namespace reone

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -38,6 +38,8 @@
 #include "reone/game/types.h"
 #include "reone/game/visualeffects.h"
 
+#include "reone/game/console.h"
+
 namespace reone {
 
 namespace game {
@@ -175,6 +177,8 @@ public:
         return *_services;
     }
 
+    MockSpells &spells() { return *_spells; }
+
 private:
     std::unique_ptr<MockCameraStyles> _cameraStyles;
     std::unique_ptr<MockClasses> _classes;
@@ -191,6 +195,12 @@ private:
     std::unique_ptr<MockVisualEffects> _visualEffects;
 
     std::unique_ptr<GameServices> _services;
+};
+
+class StubConsole : public IConsole, boost::noncopyable {
+public:
+    void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
+    void printLine(const std::string &text) override {}
 };
 
 } // namespace game

--- a/test/game/action.cpp
+++ b/test/game/action.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "reone/game/action/usetalentonobject.h"
+#include "reone/game/game.h"
+#include "reone/resource/types.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace testing;
+
+TEST(Action, use_talent_dispatch_to_use_feat) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto player = game.newCreature();
+    auto target = game.newCreature();
+    auto talent = game.newTalent(TalentType::Feat, static_cast<int>(FeatType::PowerAttack));
+    auto action = game.newAction<UseTalentOnObjectAction>(std::move(talent), target);
+    auto subAction = action->subAction();
+    ASSERT_TRUE(subAction);
+
+    EXPECT_FALSE(action->isCompleted());
+    EXPECT_FALSE(subAction->isCompleted());
+
+    // Cycle through combat states
+    for (int i = 0; i < 10; ++i) {
+        action->execute(action, *target, 1.0f);
+        game.combat().update(2.0f);
+    }
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_TRUE(subAction->isCompleted());
+}
+
+TEST(Action, use_talent_dispatch_to_cast_spell) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto spell = std::make_shared<Spell>();
+    spell->type = SpellType::LightSaberThrow;
+    spell->castTime = 1.0f;
+    spell->conjTime = 1.0f;
+
+    EXPECT_CALL(engine.gameModule().spells(), get(SpellType::LightSaberThrow))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(spell));
+
+    auto player = game.newCreature();
+    auto target = game.newCreature();
+    auto talent = game.newTalent(TalentType::Spell, static_cast<int>(SpellType::LightSaberThrow));
+    auto action = game.newAction<UseTalentOnObjectAction>(std::move(talent), target);
+    auto subAction = action->subAction();
+    ASSERT_TRUE(subAction);
+
+    EXPECT_FALSE(action->isCompleted());
+    EXPECT_FALSE(subAction->isCompleted());
+
+    // Cycle through combat states
+    for (int i = 0; i < 10; ++i) {
+        action->execute(action, *target, 1.0f);
+        game.combat().update(2.0f);
+    }
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_TRUE(subAction->isCompleted());
+}

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -51,29 +51,11 @@ std::pair<std::string, std::string> reone::game::TestGameModule::scheduledTransi
 
 namespace {
 
-class StubConsole : public IConsole, boost::noncopyable {
-public:
-    void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
-    void printLine(const std::string &text) override {}
-};
-
 class TestAreaTransition : public AreaTransition {
 public:
     using AreaTransition::AreaTransition;
     using AreaTransition::preload;
 };
-
-// TestEngine initializes the Logger singleton, which only tolerates a single
-// init per process.
-TestEngine &testEngine() {
-    static TestEngine engine;
-    static bool initialized = false;
-    if (!initialized) {
-        engine.init();
-        initialized = true;
-    }
-    return engine;
-}
 
 std::pair<std::string, std::string> scheduledTransition(TestEngine &engine, const Game &game) {
     return engine.gameModule().scheduledTransition(game);


### PR DESCRIPTION
Scripts call `UseTalent` and concrete `UseFeat`/`CastSpellAtObject`
interchangeably. It is unclear whether we actually need these distinct UseTalent
actions, or we can dispatch it to concrete actions in the routine itself without
creating an intermediate action object.

The patch keeps the current structure intact, but makes `UseTalent` a wrapper
around the corresponding action.