### PR TITLE
[game] Set IsInConversation for dialogue owners

### DIFF
--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -81,6 +81,10 @@ void Conversation::start(const std::shared_ptr<Dialog> &dialog, const std::share
     _dialog = dialog;
     _owner = owner;
 
+    if (_owner) {
+        _owner->setIsInConversation(true);
+    }
+
     loadConversationBackground();
     loadCameraModel();
     onStart();
@@ -188,6 +192,10 @@ void Conversation::finish() {
     // Run EndConversation script
     if (!_dialog->endScript.empty()) {
         _game.scriptRunner().run(_dialog->endScript, _owner->id());
+    }
+
+    if (_owner) {
+        _owner->setIsInConversation(false);
     }
 }
 


### PR DESCRIPTION
Dialogue scripts execute with the owner object as the Caller, and all
dialogue actions are added to the Caller action queue.

When the owner is a regular character, it also executes heartbeat
scripts. These scripts check that a character is not in a
conversation, and may clear actions, add new ones, etc.

Before the patch, only stunt (animated cutscene) participants had
IsInConversation set to true. This caused issues on tar_m11aa, where
k_ai_master script executes "ambient" actions for characters in a
regular (non-stunt) conversation.