### PR TITLE
[game] Push delayed actions to the front of the queue

### DIFF
--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -175,10 +175,11 @@ void Object::removeCompletedActions() {
 }
 
 void Object::updateDelayedActions(float dt) {
-    for (auto &delayed : _delayed) {
-        delayed.timer->update(dt);
-        if (delayed.timer->elapsed()) {
-            _actions.push_back(std::move(delayed.action));
+    // Iterate in reverse order, so addActionOnTop keeps the original order.
+    for (auto delayed = _delayed.rbegin(), end = _delayed.rend(); delayed != end; ++delayed) {
+        delayed->timer->update(dt);
+        if (delayed->timer->elapsed()) {
+            addActionOnTop(std::move(delayed->action));
         }
     }
     auto delayedToRemove = std::remove_if(


### PR DESCRIPTION
Delayed actions are supposed to execute at specific time.
Before the patch, reone added them to the back of the queue, meaning
that all preceding actions must execute before delayed actions.

This broke scripts that relied on DelayCommand *and* ActionWait:

    DelayCommand(7.0, AssignCommand(GetFirstPC(), ...));
    ActionWait(8.0);

Here, actions should complete in order:

- AssignCommand (at 7 seconds)
- ActionWait (at 8 seconds)

AssignCommand is delayed. Once the timer is 0, there is already
ActionWait in the queue. Before the patch, AssignCommand was
pushed *after* action wait, effectively extending DelayCommand to 8
seconds. Now AssignCommand is pushed in front of the queue, so it
executes before ActionWait.