### PR TITLE
[game] Avoid a potential race in Conversation::endCurrentEntry

### DIFF
--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -366,7 +366,7 @@ bool Conversation::handle(const input::Event &event) {
 
 bool Conversation::handleMouseButtonDown(const input::MouseButtonEvent &event) {
     if (event.button == input::MouseButton::Left && !_entryEnded && isSkippableEntry()) {
-        endCurrentEntry();
+        _endEntryTimer.reset(0);
         return true;
     }
     return false;


### PR DESCRIPTION
Before the patch, when player skipped an entry with a mouse click, it
used to execute endCurrentEntry directly. This function is part of the
update() routine, and executing it in handle() may lead to "random"
bugs due to out of order execution of scripts and actions.

For example, when a dialogue script pushes ActionPauseConversation, we
must execute it *before* the next entry, but this can only happen in
the update() cycle. Moving to the next entry in handle() can bypass
this order.