### PR TITLE
[game] Treat dead objects as invalid for GetIsObjectValid

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -466,7 +466,7 @@ static Variable GetIsObjectValid(const std::vector<Variable> &args, const Routin
     bool valid;
     try {
         auto oObject = getObject(args, 0, ctx);
-        valid = static_cast<bool>(oObject);
+        valid = oObject && !oObject->isDead();
     } catch (const RoutineArgumentException &ignored) {
         valid = false;
     }


### PR DESCRIPTION
On tar_m08aa, the game expects that Calo Nord is not valid, even
though it just been killed by a script. The vanilla engine is not
consistent in how it handles dead/valid checks, but this
implementation allows k_ptar_tarisover script to work.