### PR TITLE
[script] Report the exception that halts a script

### DIFF
--- a/src/libs/script/virtualmachine.cpp
+++ b/src/libs/script/virtualmachine.cpp
@@ -239,6 +239,8 @@ int VirtualMachine::run() {
         try {
             handler->second(ins);
         } catch (const std::exception &ex) {
+            error(str(boost::format("Script '%s' halted at %04x: %s") % _program->name() % insOff % ex.what()),
+                  LogChannel::Script);
             halt = true;
         }
 


### PR DESCRIPTION
`VirtualMachine::run` caught the exception that stops a script and discarded its
message, leaving only a `Halt` line on a log channel that is off by default. A
routine that threw therefore made the script around it silently do nothing, with
no way to find out why — the failure was invisible even at maximum log severity.

Log the failing script, the instruction offset and the exception message instead.

This is what made the routine-argument bug in the companion PR diagnosable at
all: the symptom was a dialogue option that did nothing, and nothing anywhere
reported a reason.

Test suite passes.
