### PR TITLE
[game] Resolve optional object arguments leniently

### DIFF
--- a/src/libs/game/script/routine/argutil.cpp
+++ b/src/libs/game/script/routine/argutil.cpp
@@ -238,9 +238,20 @@ glm::vec3 getVectorOrElse(const std::vector<Variable> &args, int index, glm::vec
 std::shared_ptr<Object> getObjectOrNull(const std::vector<Variable> &args, int index, const RoutineContext &ctx) {
     if (index < 0 || index >= args.size()) {
         return nullptr;
-    } else {
-        return getObject(args, index, ctx);
     }
+    throwIfUnexpectedType(VariableType::Object, args[index].type);
+
+    uint32_t objectId = args[index].objectId;
+    if (objectId == kObjectSelf) {
+        const Variable *caller = ctx.execution.findArg(ArgKind::Caller);
+        objectId = caller ? caller->objectId : kObjectInvalid;
+    }
+
+    // An optional object parameter is declared as OBJECT_INVALID in nwscript,
+    // so scripts routinely pass an id that references nothing. That is what
+    // this overload exists to express -- yield null instead of failing the
+    // routine and halting the script around it.
+    return objectId == kObjectSelf ? nullptr : ctx.game.getObjectById(objectId);
 }
 
 std::shared_ptr<Object> getObjectOrCaller(const std::vector<Variable> &args, int index, const RoutineContext &ctx) {


### PR DESCRIPTION
`nwscript` declares optional object parameters as `OBJECT_INVALID`, and scripts
call them that way. `getObjectOrNull` only yielded null for an argument that was
absent entirely, so a present but invalid id fell through to the strict lookup
and threw — which halts the calling script.

Concretely: the Taris pazaak dialogues call `PlayPazaak` with `oOpponent` left at
its default, so the routine threw `Id 1 does not reference a valid object` and
the script stopped before doing anything. Picking the dialogue option looked like
it did nothing at all.

This is not specific to that routine — it affects any routine taking an optional
object argument, roughly 15 call sites across `main.cpp`, `action.cpp` and
`effect.cpp`.

Resolve the argument leniently and return null when it references no object,
which is what callers of this overload already expect. `Game::getObjectById`
already returns null for `OBJECT_INVALID` and for unknown ids, so the lookup
itself cannot throw.

Test suite passes.
