### PR TITLE
[scene] Honor isEnabled when refreshing the scene graph

### DIFF
--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -319,6 +319,13 @@ void SceneGraph::refresh() {
 }
 
 void SceneGraph::refreshFromNode(SceneNode &node) {
+    // A disabled node (and its subtree) is skipped from the render lists, so
+    // callers can suppress a specific mesh or emitter. The renderer otherwise
+    // ignores isEnabled on child nodes.
+    if (!node.isEnabled()) {
+        return;
+    }
+
     bool propagate = true;
 
     switch (node.type()) {


### PR DESCRIPTION
`SceneNode::isEnabled` was only consulted for the node a caller disabled
directly. `refreshFromNode` walked the whole tree and registered every mesh and
emitter it found, so disabling a child node had no visible effect — the renderer
drew it anyway.

Skip disabled nodes and their subtrees when rebuilding the render lists, so
`isEnabled` suppresses a mesh or emitter as callers already expect it to.

Test suite passes.
