### PR TITLE
[game] Keep a screen a reply script opened

### DIFF
--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -189,7 +189,12 @@ void Conversation::finish() {
     _paused = false;
     onFinish();
 
-    _game.openInGame();
+    // A reply script can hand the screen to something else before the
+    // conversation ends -- PlayPazaak opens the pazaak board from a dialogue
+    // action -- so only return to the world if the conversation still owns it.
+    if (_game.currentScreen() == Game::Screen::Conversation) {
+        _game.openInGame();
+    }
 
     // Run EndConversation script
     if (!_dialog->endScript.empty()) {

--- a/test/game/conversation.cpp
+++ b/test/game/conversation.cpp
@@ -358,6 +358,18 @@ TEST_F(ConversationTest, finishing_a_paused_conversation_does_not_leak_pause_to_
     EXPECT_EQ(2, _conversation->entryEndCount());
 }
 
+TEST_F(ConversationTest, finishing_leaves_a_screen_opened_by_a_reply_script_alone) {
+    // A reply script can hand the screen to something else before the
+    // conversation ends -- PlayPazaak opens the pazaak board from a dialogue
+    // action -- so finishing must not pull the screen back to the world.
+    startSilent();
+    _conversation->update(1.0f);
+
+    _conversation->pickReplyForTest(0);
+
+    EXPECT_EQ(Game::Screen::None, _game->currentScreen());
+}
+
 TEST_F(ConversationTest, module_transition_cleanup_clears_pause_before_the_next_session) {
     startSilent();
     _conversation->pause();


### PR DESCRIPTION
A dialogue action can hand the screen to something else: `PlayPazaak` opens the
pazaak board from a reply script. `Conversation::finish` then restored the world
screen unconditionally, taking the screen back in the same frame — picking the
dialogue option looked like it did nothing at all.

Return to the world only when the conversation still owns the screen.
`Game::startDialog` sets `Screen::Conversation` on entry, so ordinary
conversation endings are unaffected.

Includes a regression test. Test suite passes.
