### PR TITLE
[graphics] Disable PBR renderer by default

### DIFF
--- a/include/reone/graphics/options.h
+++ b/include/reone/graphics/options.h
@@ -30,9 +30,9 @@ struct GraphicsOptions {
     bool fullscreen {false};
     bool vsync {true};
     bool grass {true};
-    bool pbr {true};
-    bool ssao {true};
-    bool ssr {true};
+    bool pbr {false};
+    bool ssao {false};
+    bool ssr {false};
     bool fxaa {true};
     bool sharpen {true};
     TextureQuality textureQuality {TextureQuality::High};

--- a/src/apps/launcher/frame.h
+++ b/src/apps/launcher/frame.h
@@ -47,9 +47,9 @@ private:
         bool fullscreen {false};
         bool vsync {false};
         bool grass {true};
-        bool pbr {true};
-        bool ssao {true};
-        bool ssr {true};
+        bool pbr {false};
+        bool ssao {false};
+        bool ssr {false};
         bool fxaa {true};
         bool sharpen {true};
         int texQuality {0};


### PR DESCRIPTION
PBR render pipeline is not complete, and it looks way worse the Retro
renderer. Switch default choice to Retro until we have bandwidth to
complete PBR.

SSAO and SSR are only implemented for PBR, so they are disabled as
well.