### PR TITLE
[game] Derive completion time of PlayAnimation from the animation

### DIFF
--- a/include/reone/game/action/playanimation.h
+++ b/include/reone/game/action/playanimation.h
@@ -20,6 +20,7 @@
 #include "../types.h"
 
 #include "../action.h"
+#include "reone/system/timer.h"
 
 namespace reone {
 
@@ -49,6 +50,7 @@ private:
     float _speed;
     float _durationSeconds;
 
+    Timer _timer;
     bool _playing {false};
 };
 

--- a/src/libs/game/action/playanimation.cpp
+++ b/src/libs/game/action/playanimation.cpp
@@ -20,6 +20,7 @@
 #include "reone/game/animationutil.h"
 #include "reone/game/object.h"
 #include "reone/scene/animproperties.h"
+#include "reone/graphics/animation.h"
 
 using namespace reone::scene;
 
@@ -28,26 +29,44 @@ namespace reone {
 namespace game {
 
 void PlayAnimationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    std::string animName = actor.getAnimationName(_animation);
     if (_playing) {
-        if (actor.getActiveAnimationName() != animName) {
+        _timer.update(dt);
+        if (_timer.elapsed()) {
             complete();
         }
         return;
     }
 
+    if (isAnimationLooping(_animation)) {
+        // Looping animations never finish. Complete the action immediately to
+        // avoid stalling the action queue.
+        if (_durationSeconds < 0.0f) {
+            complete();
+        } else {
+            _timer.reset(_durationSeconds);
+        }
+    } else {
+        // Set the timer to match duration of the animation.
+        auto node = actor.sceneNode();
+        if (node->type() != SceneNodeType::Model) {
+            complete();
+            return;
+        }
+
+        const graphics::Model &model = std::static_pointer_cast<ModelSceneNode>(node)->model();
+        std::shared_ptr<graphics::Animation> anim = model.getAnimation(actor.getAnimationName(_animation));
+        if (!anim) {
+            complete();
+            return;
+        }
+
+        _timer.reset(anim->length());
+    }
+
     AnimationProperties properties;
     properties.speed = _speed;
     properties.duration = _durationSeconds;
-
-    bool looping = isAnimationLooping(_animation) && properties.duration == -1.0f;
     actor.playAnimation(_animation, std::move(properties));
-    if (looping) {
-        // Looping animations never finish. Complete the action
-        // immediately to avoid stalling the action queue.
-        complete();
-    }
-
     _playing = true;
 }
 


### PR DESCRIPTION
PlayAnimation used to rely on `getActiveAnimationName() != animName`
condition, but if the animation is `pause1` (aka default idle
animation), the action is never going to complete.

With the patch we now set a timer for the duration of the animation.
If it is looping and duration is -1.0, the action completes
immediately. If it is looping but duration is non-negative, the action
is respects this duration.

This fixes Juhani scene on Dantooine, where scripts call PlayAnimation
for pause1 with 0.1s duration.