### PR TITLE
[game] Fix use-after-free in Area::update

### DIFF
--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -790,8 +790,9 @@ void Area::update(float dt) {
     }
     Object::update(dt);
 
-    for (auto &object : _objects) {
-        object->update(dt);
+    // Update can create new objects, so iterate with indices.
+    for (size_t i = 0; i < _objects.size(); ++i) {
+        _objects[i]->update(dt);
     }
     updateLeaderTriggerOccupancy();
     updatePerception(dt);


### PR DESCRIPTION
Updates of objects can create new objects, which can lead to
reallocation of the vector. Iterate with indices to avoid hitting
deallocated memory.