### PR TITLE
[engine] Add batch console command

### DIFF
--- a/src/apps/engine/console.cpp
+++ b/src/apps/engine/console.cpp
@@ -91,9 +91,17 @@ void Console::printLine(const std::string &text) {
 }
 
 bool Console::handle(const input::Event &event) {
-    if (event.type == input::EventType::KeyUp && (event.key.code == input::KeyCode::Backquote)) {
-        _open = !_open;
-        return true;
+    if (event.type == input::EventType::KeyUp) {
+        if (event.key.code == input::KeyCode::Backquote &&
+            event.key.mod & input::KeyModifiers::alt) {
+            executeNextBatch();
+            return true;
+        }
+
+        if (event.key.code == input::KeyCode::Backquote) {
+            _open = !_open;
+            return true;
+        }
     }
 
     if (!_open) {
@@ -217,6 +225,27 @@ void Console::execute(std::string_view command) {
         return;
     }
 
+    if (tokens[0] == "batch") {
+        if (tokens.size() != 2 && tokens[1] != "{") {
+            printLine("batch must be followed by {");
+            return;
+        }
+        _state = State::Batch;
+        _batches.emplace_back();
+        return;
+    }
+
+    if (tokens[0] == "}") {
+        _state = State::Execute;
+        return;
+    }
+
+    if (_state == State::Batch) {
+        assert(!_batches.empty() && "batch is not initialized");
+        _batches.back().push_back(std::string(command));
+        return;
+    }
+
     auto commandByName = _nameToCommand.find(tokens[0]);
     if (commandByName == _nameToCommand.end()) {
         printLine("Unrecognized command: " + tokens[0]);
@@ -228,6 +257,18 @@ void Console::execute(std::string_view command) {
     } catch (const std::exception &ex) {
         printLine("Command failed: " + std::string(ex.what()));
     }
+}
+
+void Console::executeNextBatch() {
+    if (_batches.empty()) {
+        return;
+    }
+
+    Batch &batch = _batches.front();
+    for (auto &command : batch) {
+        execute(command);
+    }
+    _batches.pop_front();
 }
 
 void Console::render() {

--- a/src/apps/engine/console.h
+++ b/src/apps/engine/console.h
@@ -65,6 +65,7 @@ public:
     void printLine(const std::string &text) override;
 
     void execute(std::string_view command);
+    void executeNextBatch();
 
 private:
     struct Command {
@@ -87,6 +88,15 @@ private:
     size_t _scrollOffset {0};
     std::vector<std::string> _history;
     size_t _historyIndex {0};
+
+    enum class State {
+        Execute,
+        Batch,
+    };
+    State _state {State::Execute};
+
+    using Batch = std::vector<std::string>;
+    std::deque<Batch> _batches;
 
     // Commands
 

--- a/src/apps/engine/engine.cpp
+++ b/src/apps/engine/engine.cpp
@@ -22,6 +22,7 @@
 #include "reone/graphics/window.h"
 #include "reone/resource/exception/notfound.h"
 #include "reone/resource/gameprobe.h"
+#include "reone/system/stringutil.h"
 
 using namespace reone::audio;
 using namespace reone::game;
@@ -142,11 +143,12 @@ void Engine::init() {
         for (std::string line; std::getline(file, line);) {
             // getline keeps the carriage return of a CRLF file, which would end
             // up inside the last argument of every command.
-            if (!line.empty() && line.back() == '\r') {
-                line.pop_back();
-            }
-            if (!line.empty()) {
-                _console->execute(line);
+            //
+            // Remove trailing and leading spaces as well.
+
+            std::string_view command = string_strip(line);
+            if (!command.empty()) {
+                _console->execute(command);
             }
         }
     }


### PR DESCRIPTION
The patch adds a special `batch` command that is followed by a block
of commands enclosed in `{ }`. All commands in a batch are
delayed. Keyboard shortcut `Alt ~` executes the next batch of delayed
commands:

    loadgame 16

    batch {
        setposition 355 197 8.25
    }

    batch {
        selectobjectbytag tar03_hiddenbek
        startconversation
    }

- In this example, we load a savegame 16 - the player appears near the elevator.
- `Alt ~` jumps to the Hidden Bek's base.
- Next `Alt ~` starts a conversation with the guard.