### PR TITLE
Implementing smarter placement for companions

### DIFF
--- a/include/reone/game/object/area.h
+++ b/include/reone/game/object/area.h
@@ -171,6 +171,7 @@ public:
 
     // Party
 
+    void unloadPartyMember(const std::shared_ptr<Creature> &member);
     void loadParty(const glm::vec3 &position, float facing, bool fromSave = false);
     void unloadParty();
     void reloadParty();
@@ -321,6 +322,9 @@ private:
     void doDestroyObjects();
     void updateVisibility();
     void updateHeartbeat(float dt);
+
+    void loadPartyMember(const std::shared_ptr<Creature> &member, int index, bool fromSave);
+    glm::vec3 findPartyPosition(const Creature &member, const glm::vec3 &position) const;
 
     void doUpdatePerception();
     void updateObjectSelection();

--- a/src/apps/shaderpack/main.cpp
+++ b/src/apps/shaderpack/main.cpp
@@ -25,9 +25,9 @@ using namespace reone::resource;
 int main(int argc, char **argv) {
     try {
         boost::program_options::options_description description;
-        description.add_options()                                                            //
-            ("srcdir", boost::program_options::value<std::filesystem::path>()->required())   //
-            ("destdir", boost::program_options::value<std::filesystem::path>()->required()); //
+		description.add_options() //
+			("srcdir", boost::program_options::value<std::string>()->required()) //
+			("destdir", boost::program_options::value<std::string>()->required()); //
 
         boost::program_options::positional_options_description positionalDesc;
         positionalDesc.add("srcdir", 1);
@@ -42,12 +42,12 @@ int main(int argc, char **argv) {
         boost::program_options::store(options, vars);
         boost::program_options::notify(vars);
 
-        auto &srcdir = vars["srcdir"].as<std::filesystem::path>();
+        auto srcdir = std::filesystem::path(vars["srcdir"].as<std::string>());
         if (!std::filesystem::exists(srcdir) || !std::filesystem::is_directory(srcdir)) {
             throw std::runtime_error("Source directory does not exist: " + srcdir.string());
         }
 
-        auto &destdir = vars["destdir"].as<std::filesystem::path>();
+        auto destdir = std::filesystem::path(vars["destdir"].as<std::string>());
         if (!std::filesystem::exists(destdir) || !std::filesystem::is_directory(destdir)) {
             throw std::runtime_error("Destination directory does not exist: " + destdir.string());
         }

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -331,12 +331,14 @@ void PartySelection::changeParty() {
     }
 
     std::shared_ptr<Area> area(_game.module()->area());
-    area->unloadParty();
+    for (const auto &member : party.members()) {
+        if (member.npc != kNpcPlayer && !_added[member.npc]) {
+            area->unloadPartyMember(member.creature);
+        }
+    }
 
     party.clear();
     party.addMember(kNpcPlayer, party.player());
-
-    std::shared_ptr<Creature> player(_game.party().player());
 
     for (int i = 0; i < npcCount(); ++i) {
         if (!_added[i])

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/object/area.h"
 
+#include <array>
+
 #include "reone/game/minigame.h"
 
 #include "reone/game/camerastyles.h"
@@ -77,10 +79,10 @@ static constexpr float kLineOfSightHeight = 1.7f;        // TODO: make it appear
 static constexpr float kMaxCollisionDistance = 8.0f;
 static constexpr float kMaxCollisionDistance2 = kMaxCollisionDistance * kMaxCollisionDistance;
 
-static constexpr glm::vec3 kPartyFormationOffsets[] {
+static constexpr std::array<glm::vec3, 2> kPartyFormationOffsets {{
     glm::vec3(1.5f, -0.7f, 0.0f),
     glm::vec3(-1.5f, 0.8f, 0.0f),
-};
+}};
 static constexpr float kPartyPositionSearchRadius = 10.0f;
 static constexpr float kPartyPositionSearchStep = 1.0f;
 static constexpr int kPartyPositionSearchDirections = 16;
@@ -795,8 +797,12 @@ void Area::loadPartyMember(const std::shared_ptr<Creature> &member, int index, b
 
     if (!fromSave && index > 0) {
         auto leader = _game.party().getLeader();
-        glm::quat rotation(glm::angleAxis(leader->getFacing(), glm::vec3(0.0f, 0.0f, 1.0f)));
-        glm::vec3 position(leader->position() + rotation * kPartyFormationOffsets[index - 1]);
+        glm::vec3 position(leader->position());
+
+        if (index <= static_cast<int>(kPartyFormationOffsets.size())) {
+            glm::quat rotation(glm::angleAxis(leader->getFacing(), glm::vec3(0.0f, 0.0f, 1.0f)));
+            position += rotation * kPartyFormationOffsets[index - 1];
+        }
 
         member->setPosition(findPartyPosition(*member, position));
         member->setFacing(leader->getFacing());

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -77,6 +77,16 @@ static constexpr float kLineOfSightHeight = 1.7f;        // TODO: make it appear
 static constexpr float kMaxCollisionDistance = 8.0f;
 static constexpr float kMaxCollisionDistance2 = kMaxCollisionDistance * kMaxCollisionDistance;
 
+static constexpr glm::vec3 kPartyFormationOffsets[] {
+    glm::vec3(1.5f, -0.7f, 0.0f),
+    glm::vec3(-1.5f, 0.8f, 0.0f),
+};
+static constexpr float kPartyPositionSearchRadius = 10.0f;
+static constexpr float kPartyPositionSearchStep = 1.0f;
+static constexpr int kPartyPositionSearchDirections = 16;
+static constexpr float kPartyMemberSpacing = 1.5f;
+static constexpr float kPartyMemberSpacing2 = kPartyMemberSpacing * kPartyMemberSpacing;
+
 static glm::vec3 g_defaultAmbientColor {0.2f};
 static CameraStyle g_defaultCameraStyle {"", 3.2f, 83.0f, 0.45f, 55.0f};
 
@@ -741,30 +751,96 @@ void Area::landObject(Object &object) {
     }
 }
 
+glm::vec3 Area::findPartyPosition(const Creature &member, const glm::vec3 &position) const {
+    auto &sceneGraph = _services.scene.graphs.get(_sceneName);
+    const auto &creatures = _objectsByType.at(ObjectType::Creature);
+
+    auto tryPosition = [&](const glm::vec3 &candidate, glm::vec3 &result) {
+        Collision collision;
+        if (!sceneGraph.testElevation(candidate, collision)) {
+            return false;
+        }
+        for (const auto &object : creatures) {
+            if (object.get() == &member) {
+                continue;
+            }
+            if (glm::distance2(glm::vec2(collision.intersection), glm::vec2(object->position())) < kPartyMemberSpacing2) {
+                return false;
+            }
+        }
+        result = collision.intersection;
+        return true;
+    };
+
+    glm::vec3 result;
+    if (tryPosition(position, result)) {
+        return result;
+    }
+
+    for (float radius = kPartyPositionSearchStep; radius <= kPartyPositionSearchRadius; radius += kPartyPositionSearchStep) {
+        for (int i = 0; i < kPartyPositionSearchDirections; ++i) {
+            float angle = i * glm::two_pi<float>() / kPartyPositionSearchDirections;
+            glm::vec3 candidate(position.x + radius * glm::sin(angle), position.y + radius * glm::cos(angle), position.z);
+            if (tryPosition(candidate, result)) {
+                return result;
+            }
+        }
+    }
+
+    return position;
+}
+
+void Area::loadPartyMember(const std::shared_ptr<Creature> &member, int index, bool fromSave) {
+    bool loaded = std::find(_objects.begin(), _objects.end(), member) != _objects.end();
+
+    if (!fromSave && index > 0) {
+        auto leader = _game.party().getLeader();
+        glm::quat rotation(glm::angleAxis(leader->getFacing(), glm::vec3(0.0f, 0.0f, 1.0f)));
+        glm::vec3 position(leader->position() + rotation * kPartyFormationOffsets[index - 1]);
+
+        member->setPosition(findPartyPosition(*member, position));
+        member->setFacing(leader->getFacing());
+    }
+
+    landObject(*member);
+
+    if (loaded) {
+        determineObjectRoom(*member);
+        return;
+    }
+
+    add(member);
+    member->runSpawnScript();
+}
+
+void Area::unloadPartyMember(const std::shared_ptr<Creature> &member) {
+    doDestroyObject(member->id());
+}
+
 void Area::loadParty(const glm::vec3 &position, float facing, bool fromSave) {
     Party &party = _game.party();
+    auto leader = party.getLeader();
 
-    for (int i = 0; i < party.getSize(); ++i) {
-        auto member = party.getMember(i);
-        if (!fromSave) {
-            member->setPosition(position);
-            member->setFacing(facing);
-        }
-        landObject(*member);
-        add(member);
-        member->runSpawnScript();
+    if (!fromSave) {
+        leader->setPosition(position);
+        leader->setFacing(facing);
+    }
+    loadPartyMember(leader, 0, fromSave);
+
+    for (int i = 1; i < party.getSize(); ++i) {
+        loadPartyMember(party.getMember(i), i, fromSave);
     }
 }
 
 void Area::unloadParty() {
     for (auto &member : _game.party().members()) {
-        doDestroyObject(member.creature->id());
+        unloadPartyMember(member.creature);
     }
 }
 
 void Area::reloadParty() {
-    std::shared_ptr<Creature> player(_game.party().player());
-    loadParty(player->position(), player->getFacing());
+    auto leader = _game.party().getLeader();
+    loadParty(leader->position(), leader->getFacing());
 }
 
 bool Area::handle(const input::Event &event) {


### PR DESCRIPTION
## Summary

This changes party placement so that companions no longer spawn at the same position as the party leader to address #19 

The party leader is placed at the requested area entry point. Other active party members are placed in leader-relative formation slots and moved to a nearby valid position when the intended slot is unavailable.

The party-selection screen now unloads only members that were removed from the active party instead of unloading every party member before rebuilding the selection.

## Problem

`Area::loadParty()` currently assigns the same position and facing to every active party member:

```cpp
member->setPosition(position);
member->setFacing(facing);
```

This causes companions to overlap the player after:

- entering a module;
- warping to a module;
- reloading the active party;
- accepting a new selection in the party-selection GUI.

`PartySelection::changeParty()` also unloads the complete party before rebuilding it. Members that remain selected are unnecessarily removed from the area and added again.

## Changes

### Per-member area placement

`Area` now has a dedicated path for loading and unloading one party member.

For a normal area load:

1. The current party leader is placed at the requested entry position and facing.
2. Each companion's formation offset is rotated by the leader's facing.
3. The companion is placed at the first nearby position that has a valid elevation and sufficient spacing from another creature.
4. Existing area objects are repositioned without being added a second time or rerunning their spawn scripts.
5. Newly loaded members are added normally and run their spawn scripts.

Saved-game loads keep the stored member positions instead of applying the entry formation.

### Formation position search

The intended formation point is tested first. If it is unavailable, the search checks sixteen directions in one-unit rings up to ten units away.

A candidate is accepted when:

- an elevation can be resolved on the area walkmesh;
- it is at least 1.5 horizontal units from another loaded creature.

### Party reloads

`Area::reloadParty()` now uses the current party leader as the formation anchor rather than always using the original player character.

### Party-selection

`PartySelection::changeParty()` now unloads only companions that are no longer selected.

The active membership list is then rebuilt, and `Area::reloadParty()` places the selected party around the current leader. Members that remained selected are already loaded, so they are repositioned without being respawned.