### PR TITLE
[resource] Depend on the resources interface in providers

### DIFF
--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -89,7 +89,7 @@ public:
     void deinit();
 
     Gffs &gffs() { return *_gffs; }
-    Resources &resources() { return *_resources; }
+    IResources &resources() { return *_resources; }
     Strings &strings() { return *_strings; }
     TwoDAs &twoDas() { return *_twoDas; }
     Scripts &scripts() { return *_scripts; }

--- a/include/reone/resource/provider/2das.h
+++ b/include/reone/resource/provider/2das.h
@@ -25,7 +25,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class ITwoDAs {
 public:
@@ -38,7 +38,7 @@ public:
 
 class TwoDAs : public ITwoDAs, boost::noncopyable {
 public:
-    TwoDAs(Resources &resources) :
+    TwoDAs(IResources &resources) :
         _resources(resources) {
     }
 
@@ -49,7 +49,7 @@ public:
     std::shared_ptr<TwoDA> get(const std::string &key) override;
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     Cache<std::string, TwoDA> _cache;
 };

--- a/include/reone/resource/provider/audioclips.h
+++ b/include/reone/resource/provider/audioclips.h
@@ -27,7 +27,7 @@ class AudioClip;
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class IAudioClips {
 public:
@@ -40,7 +40,7 @@ public:
 
 class AudioClips : public IAudioClips {
 public:
-    AudioClips(Resources &resources) :
+    AudioClips(IResources &resources) :
         _resources(resources) {
     }
 
@@ -58,7 +58,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<audio::AudioClip>> _objects;
 

--- a/include/reone/resource/provider/cursors.h
+++ b/include/reone/resource/provider/cursors.h
@@ -36,7 +36,7 @@ class Uniforms;
 
 namespace resource {
 
-class Resources;
+class IResources;
 class Textures;
 
 class ICursors {
@@ -55,7 +55,7 @@ public:
         resource::Textures &textures,
         graphics::Uniforms &uniforms,
         graphics::IStatistic &statistic,
-        Resources &resources) :
+        IResources &resources) :
         _context(context),
         _meshRegistry(meshRegistry),
         _shaderRegistry(shaderRegistry),
@@ -82,7 +82,7 @@ private:
     resource::Textures &_textures;
     graphics::Uniforms &_uniforms;
     graphics::IStatistic &_statistic;
-    Resources &_resources;
+    IResources &_resources;
 
     // END Services
 

--- a/include/reone/resource/provider/gffs.h
+++ b/include/reone/resource/provider/gffs.h
@@ -27,7 +27,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class IGffs {
 public:
@@ -40,7 +40,7 @@ public:
 
 class Gffs : public IGffs, boost::noncopyable {
 public:
-    Gffs(Resources &resources) :
+    Gffs(IResources &resources) :
         _resources(resources) {
     }
 
@@ -51,7 +51,7 @@ public:
     std::shared_ptr<Gff> get(const std::string &resRef, ResType type) override;
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     Cache<ResourceId, Gff> _cache;
 };

--- a/include/reone/resource/provider/layouts.h
+++ b/include/reone/resource/provider/layouts.h
@@ -23,7 +23,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class ILayouts {
 public:
@@ -36,7 +36,7 @@ public:
 
 class Layouts : public ILayouts {
 public:
-    Layouts(Resources &resources) :
+    Layouts(IResources &resources) :
         _resources(resources) {
     }
 
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<Layout>> _objects;
 

--- a/include/reone/resource/provider/lips.h
+++ b/include/reone/resource/provider/lips.h
@@ -24,7 +24,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class ILips {
 public:
@@ -37,7 +37,7 @@ public:
 
 class Lips : public ILips {
 public:
-    Lips(Resources &resources) :
+    Lips(IResources &resources) :
         _resources(resources) {
     }
 
@@ -55,7 +55,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<graphics::LipAnimation>> _objects;
 

--- a/include/reone/resource/provider/ltrs.h
+++ b/include/reone/resource/provider/ltrs.h
@@ -38,7 +38,7 @@ public:
 
 class Ltrs : public ILtrs, boost::noncopyable {
 public:
-    Ltrs(Resources &resources) :
+    Ltrs(IResources &resources) :
         _resources(resources) {
     }
 
@@ -47,7 +47,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     Cache<ResRef, Ltr> _cache;
 

--- a/include/reone/resource/provider/models.h
+++ b/include/reone/resource/provider/models.h
@@ -30,7 +30,7 @@ class Model;
 
 namespace resource {
 
-class Resources;
+class IResources;
 class Textures;
 
 class IModels {
@@ -44,7 +44,7 @@ public:
 class Models : public IModels, boost::noncopyable {
 public:
     Models(Textures &textures,
-           Resources &resources,
+           IResources &resources,
            graphics::IStatistic &statistic) :
         _textures(textures),
         _resources(resources),
@@ -57,7 +57,7 @@ public:
 
 private:
     Textures &_textures;
-    Resources &_resources;
+    IResources &_resources;
     graphics::IStatistic &_statistic;
 
     std::unordered_map<std::string, std::shared_ptr<graphics::Model>> _cache;

--- a/include/reone/resource/provider/scripts.h
+++ b/include/reone/resource/provider/scripts.h
@@ -36,7 +36,7 @@ public:
 
 class Scripts : public IScripts {
 public:
-    Scripts(Resources &resources) :
+    Scripts(IResources &resources) :
         _resources(resources) {
     }
 
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<script::ScriptProgram>> _objects;
 

--- a/include/reone/resource/provider/shaders.h
+++ b/include/reone/resource/provider/shaders.h
@@ -34,7 +34,7 @@ class ShaderRegistry;
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class IShaders {
 public:
@@ -45,7 +45,7 @@ class Shaders : public IShaders, boost::noncopyable {
 public:
     Shaders(graphics::GraphicsOptions &graphicsOpt,
             graphics::ShaderRegistry &shaderRegistry,
-            Resources &resources) :
+            IResources &resources) :
         _graphicsOpt(graphicsOpt),
         _shaderRegistry(shaderRegistry),
         _resources(resources) {
@@ -61,7 +61,7 @@ public:
 private:
     graphics::GraphicsOptions &_graphicsOpt;
     graphics::ShaderRegistry &_shaderRegistry;
-    Resources &_resources;
+    IResources &_resources;
 
     bool _inited {false};
 

--- a/include/reone/resource/provider/soundsets.h
+++ b/include/reone/resource/provider/soundsets.h
@@ -23,7 +23,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 class Strings;
 class AudioClips;
 
@@ -40,7 +40,7 @@ class SoundSets : public ISoundSets {
 public:
     SoundSets(
         AudioClips &audioClips,
-        Resources &resources,
+        IResources &resources,
         Strings &strings) :
         _audioClips(audioClips),
         _resources(resources),
@@ -62,7 +62,7 @@ public:
 
 private:
     AudioClips &_audioClips;
-    Resources &_resources;
+    IResources &_resources;
     Strings &_strings;
 
     std::unordered_map<std::string, std::shared_ptr<SoundSet>> _objects;

--- a/include/reone/resource/provider/textures.h
+++ b/include/reone/resource/provider/textures.h
@@ -30,7 +30,7 @@ class Texture;
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class ITextures {
 public:
@@ -44,7 +44,7 @@ public:
 
 class Textures : public ITextures, boost::noncopyable {
 public:
-    Textures(graphics::GraphicsOptions &options, Resources &resources) :
+    Textures(graphics::GraphicsOptions &options, IResources &resources) :
         _options(options),
         _resources(resources) {
     }
@@ -59,7 +59,7 @@ private:
     int _activeUnit {0};
 
     graphics::GraphicsOptions &_options;
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<graphics::Texture>> _cache;
 

--- a/include/reone/resource/provider/visibilities.h
+++ b/include/reone/resource/provider/visibilities.h
@@ -23,7 +23,7 @@ namespace reone {
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class IVisibilities {
 public:
@@ -36,7 +36,7 @@ public:
 
 class Visibilities : public IVisibilities, boost::noncopyable {
 public:
-    Visibilities(Resources &resources) :
+    Visibilities(IResources &resources) :
         _resources(resources) {
     }
 
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    Resources &_resources;
+    IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<Visibility>> _objects;
 

--- a/include/reone/resource/provider/walkmeshes.h
+++ b/include/reone/resource/provider/walkmeshes.h
@@ -28,7 +28,7 @@ class Walkmesh;
 
 namespace resource {
 
-class Resources;
+class IResources;
 
 class IWalkmeshes {
 public:
@@ -41,14 +41,14 @@ public:
 
 class Walkmeshes : public IWalkmeshes, boost::noncopyable {
 public:
-    Walkmeshes(resource::Resources &resources);
+    Walkmeshes(resource::IResources &resources);
 
     void clear() override;
 
     std::shared_ptr<graphics::Walkmesh> get(const std::string &resRef, ResType type) override;
 
 private:
-    resource::Resources &_resources;
+    resource::IResources &_resources;
 
     std::unordered_map<std::string, std::shared_ptr<graphics::Walkmesh>> _cache;
 

--- a/src/libs/resource/provider/walkmeshes.cpp
+++ b/src/libs/resource/provider/walkmeshes.cpp
@@ -27,7 +27,7 @@ namespace reone {
 
 namespace resource {
 
-Walkmeshes::Walkmeshes(Resources &resources) :
+Walkmeshes::Walkmeshes(IResources &resources) :
     _resources(resources) {
 }
 


### PR DESCRIPTION
> **Resource-loader migration: D0 — provider interface seam**

## Summary

Moves resource providers from the concrete `Resources` class to `IResources`.

Production still constructs and injects the existing Legacy backend, so this does not change resource lookup or runtime behaviour.

This provides the interface seam needed for the Extract compatibility backend in the next slice.