### PR TITLE
[resource] Add Extract resources backend behind a DI switch

### DIFF
--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -65,6 +65,13 @@ class ScriptModule;
 
 namespace resource {
 
+/// Backend that serves resource lookups. Extract reads game data through the
+/// extract layer primitives, with lookup semantics identical to Legacy.
+enum class ResourcesBackend {
+    Legacy,
+    Extract,
+};
+
 class ResourceModule : boost::noncopyable {
 public:
     ResourceModule(GameID gameId,
@@ -73,14 +80,16 @@ public:
                    audio::AudioOptions &audioOpt,
                    graphics::GraphicsModule &graphics,
                    audio::AudioModule &audio,
-                   script::ScriptModule &script) :
+                   script::ScriptModule &script,
+                   ResourcesBackend resourcesBackend = ResourcesBackend::Legacy) :
         _gameId(gameId),
         _gamePath(std::move(gamePath)),
         _graphicsOpt(graphicsOpt),
         _audioOpt(audioOpt),
         _graphics(graphics),
         _audio(audio),
-        _script(script) {
+        _script(script),
+        _resourcesBackend(resourcesBackend) {
     }
 
     ~ResourceModule() { deinit(); }
@@ -123,9 +132,10 @@ private:
     graphics::GraphicsModule &_graphics;
     audio::AudioModule &_audio;
     script::ScriptModule &_script;
+    ResourcesBackend _resourcesBackend {ResourcesBackend::Legacy};
 
     std::unique_ptr<Gffs> _gffs;
-    std::unique_ptr<Resources> _resources;
+    std::unique_ptr<IResources> _resources;
     std::unique_ptr<Strings> _strings;
     std::unique_ptr<TwoDAs> _twoDas;
     std::unique_ptr<Scripts> _scripts;

--- a/include/reone/resource/extractresources.h
+++ b/include/reone/resource/extractresources.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "resources.h"
+
+namespace reone {
+
+namespace resource {
+
+/**
+ * IResources backend that reads game data through the extract layer
+ * primitives, while reproducing the exact lookup semantics of the legacy
+ * container-based Resources: sources are searched newest-first, and
+ * clearLocal/clearSave drop only sources mounted with the respective kind.
+ *
+ * This is a compatibility backend. Native extract::Installation search
+ * orders are deliberately not used here; adopting them is a separate,
+ * behavior-changing step.
+ */
+class ExtractResources : public IResources, boost::noncopyable {
+public:
+    void clear() override {
+        _sources.clear();
+    }
+
+    void clearLocal() override {
+        clearSome(ContainerKind::Local);
+    }
+
+    void clearSave() override {
+        clearSome(ContainerKind::Save);
+    }
+
+    void addEXE(const std::filesystem::path &path) override;
+    void addKEY(const std::filesystem::path &path) override;
+    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
+    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
+    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+
+    Resource get(const ResourceId &id) override;
+    std::optional<Resource> find(const ResourceId &id) override;
+
+    size_t sourceCount() const { return _sources.size(); }
+
+private:
+    struct Source {
+        ContainerKind kind;
+        std::function<std::optional<ByteBuffer>(const ResourceId &)> find;
+    };
+
+    std::list<Source> _sources;
+
+    void clearSome(ContainerKind kind) {
+        auto toErase = std::remove_if(_sources.begin(), _sources.end(), [kind](auto &source) {
+            return source.kind == kind;
+        });
+        _sources.erase(toErase, _sources.end());
+    }
+
+    void addSource(ContainerKind kind, std::function<std::optional<ByteBuffer>(const ResourceId &)> find) {
+        _sources.push_front(Source {kind, std::move(find)});
+    }
+
+    void addMemArchive(ByteBuffer buffer, ContainerKind kind, bool rim);
+};
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -37,6 +37,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/dialog.h
     ${RESOURCE_INCLUDE_DIR}/director.h
     ${RESOURCE_INCLUDE_DIR}/exception/notfound.h
+    ${RESOURCE_INCLUDE_DIR}/extractresources.h
     ${RESOURCE_INCLUDE_DIR}/format/2dareader.h
     ${RESOURCE_INCLUDE_DIR}/format/2dawriter.h
     ${RESOURCE_INCLUDE_DIR}/format/bifreader.h
@@ -108,6 +109,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/extract/fileresource.cpp
     ${RESOURCE_SOURCE_DIR}/extract/finder.cpp
     ${RESOURCE_SOURCE_DIR}/extract/installation.cpp
+    ${RESOURCE_SOURCE_DIR}/extractresources.cpp
     ${RESOURCE_SOURCE_DIR}/container/erf.cpp
     ${RESOURCE_SOURCE_DIR}/container/exe.cpp
     ${RESOURCE_SOURCE_DIR}/container/folder.cpp

--- a/src/libs/resource/di/module.cpp
+++ b/src/libs/resource/di/module.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/resource/di/module.h"
 
+#include "reone/resource/extractresources.h"
+
 #include "reone/audio/di/module.h"
 #include "reone/graphics/di/module.h"
 #include "reone/script/di/module.h"
@@ -26,7 +28,11 @@ namespace reone {
 namespace resource {
 
 void ResourceModule::init() {
-    _resources = std::make_unique<Resources>();
+    if (_resourcesBackend == ResourcesBackend::Extract) {
+        _resources = std::make_unique<ExtractResources>();
+    } else {
+        _resources = std::make_unique<Resources>();
+    }
     _strings = std::make_unique<Strings>();
     _twoDas = std::make_unique<TwoDAs>(*_resources);
     _gffs = std::make_unique<Gffs>(*_resources);

--- a/src/libs/resource/extractresources.cpp
+++ b/src/libs/resource/extractresources.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/extractresources.h"
+
+#include "reone/extract/capsule.h"
+#include "reone/extract/chitin.h"
+#include "reone/extract/fileresource.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/format/erfreader.h"
+#include "reone/resource/format/pereader.h"
+#include "reone/resource/format/rimreader.h"
+#include "reone/system/stream/gameinput.h"
+#include "reone/system/stream/memoryinput.h"
+
+namespace reone {
+
+namespace resource {
+
+void ExtractResources::addKEY(const std::filesystem::path &path) {
+    auto index = std::make_shared<std::unordered_map<ResourceId, extract::FileResource>>();
+    extract::Chitin chitin(path);
+    for (auto &res : chitin.resources()) {
+        index->emplace(res.id(), res);
+    }
+    addSource(ContainerKind::Global, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+        auto it = index->find(id);
+        if (it == index->end()) {
+            return std::nullopt;
+        }
+        return it->second.readData();
+    });
+}
+
+void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind kind) {
+    auto capsule = std::make_shared<extract::LazyCapsule>(path);
+    addSource(kind, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
+        auto res = capsule->find(id);
+        if (!res) {
+            return std::nullopt;
+        }
+        return res->readData();
+    });
+}
+
+void ExtractResources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
+    // LazyCapsule picks the reader by file extension; the director only mounts
+    // RIMs from *.rim paths.
+    addERF(path, kind);
+}
+
+void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, bool rim) {
+    auto bytes = std::make_shared<ByteBuffer>(std::move(buffer));
+    auto index = std::make_shared<std::unordered_map<ResourceId, std::pair<uint32_t, uint32_t>>>();
+
+    MemoryInputStream stream(*bytes);
+    if (rim) {
+        RimReader reader(stream);
+        reader.load();
+        for (auto &res : reader.resources()) {
+            index->emplace(res.resId, std::make_pair(res.offset, res.size));
+        }
+    } else {
+        ErfReader reader(stream);
+        reader.load();
+        auto &keys = reader.keys();
+        auto &resources = reader.resources();
+        for (size_t i = 0; i < keys.size() && i < resources.size(); ++i) {
+            index->emplace(keys[i].resId, std::make_pair(resources[i].offset, resources[i].size));
+        }
+    }
+
+    addSource(kind, [bytes, index](const ResourceId &id) -> std::optional<ByteBuffer> {
+        auto it = index->find(id);
+        if (it == index->end()) {
+            return std::nullopt;
+        }
+        auto [offset, size] = it->second;
+        if (offset + static_cast<size_t>(size) > bytes->size()) {
+            return std::nullopt;
+        }
+        return ByteBuffer(bytes->begin() + offset, bytes->begin() + offset + size);
+    });
+}
+
+void ExtractResources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
+    addMemArchive(std::move(buffer), kind, false);
+}
+
+void ExtractResources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
+    addMemArchive(std::move(buffer), kind, true);
+}
+
+void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
+    auto index = std::make_shared<std::unordered_map<ResourceId, std::filesystem::path>>();
+    if (std::filesystem::exists(path)) {
+        for (auto &entry : std::filesystem::recursive_directory_iterator(path)) {
+            if (!entry.is_regular_file()) {
+                continue;
+            }
+            auto id = extract::resourceIdFromPath(entry.path());
+            if (id) {
+                index->emplace(*id, entry.path());
+            }
+        }
+    }
+    addSource(kind, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+        auto it = index->find(id);
+        if (it == index->end()) {
+            return std::nullopt;
+        }
+        auto stream = openGameInputStream(it->second);
+        ByteBuffer buf;
+        buf.resize(static_cast<size_t>(std::filesystem::file_size(it->second)));
+        if (!buf.empty()) {
+            stream->read(buf.data(), buf.size());
+        }
+        return buf;
+    });
+}
+
+void ExtractResources::addEXE(const std::filesystem::path &path) {
+    static const std::unordered_map<PEResType, ResType> kPEResTypeToResType {
+        {PEResType::Cursor, ResType::Cursor},
+        {PEResType::CursorGroup, ResType::CursorGroup},
+    };
+
+    auto index = std::make_shared<std::unordered_map<ResourceId, extract::FileResource>>();
+    auto stream = openGameInputStream(path);
+    PeReader reader(*stream);
+    reader.load();
+    for (auto &peRes : reader.resources()) {
+        auto resType = kPEResTypeToResType.find(peRes.type);
+        if (resType == kPEResTypeToResType.end()) {
+            continue;
+        }
+        extract::FileResource res(
+            std::to_string(peRes.name),
+            resType->second,
+            peRes.size,
+            peRes.offset,
+            path);
+        index->emplace(res.id(), std::move(res));
+    }
+    addSource(ContainerKind::Global, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+        auto it = index->find(id);
+        if (it == index->end()) {
+            return std::nullopt;
+        }
+        return it->second.readData();
+    });
+}
+
+Resource ExtractResources::get(const ResourceId &id) {
+    auto data = find(id);
+    if (!data) {
+        throw ResourceNotFoundException(id.string());
+    }
+    return *data;
+}
+
+std::optional<Resource> ExtractResources::find(const ResourceId &id) {
+    for (auto &source : _sources) {
+        auto data = source.find(id);
+        if (data) {
+            return Resource {std::move(*data)};
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace resource
+
+} // namespace reone

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
+    ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dawriter.cpp
     ${TESTS_SOURCE_DIR}/resource/format/bifreader.cpp

--- a/test/resource/extractresources.cpp
+++ b/test/resource/extractresources.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The extract-backed IResources implementation must satisfy the same
+ * observable contract as the legacy container stack. These tests mirror the
+ * characterization suite in test/resource/lookup.cpp, run against
+ * ExtractResources - including the behaviors that suite documents as
+ * accidental, which a backend swap must not change.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/graphics/options.h"
+#include "reone/resource/director.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/extractresources.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/archive.h"
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::resource;
+using namespace reone::test;
+
+using testing::NiceMock;
+
+namespace {
+
+ByteBuffer erfBytes(ErfWriter::FileType fileType, const std::vector<ArchiveRes> &resources) {
+    ErfWriter writer;
+    for (const auto &res : resources) {
+        writer.add(ErfWriter::Resource {res.resRef, res.type, toBytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(fileType, stream);
+    return buffer;
+}
+
+ByteBuffer rimBytes(const std::vector<ArchiveRes> &resources) {
+    RimWriter writer;
+    for (const auto &res : resources) {
+        writer.add(RimWriter::Resource {res.resRef, res.type, toBytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    return buffer;
+}
+
+std::string dataOf(const std::optional<Resource> &res) {
+    if (!res) {
+        return "<not found>";
+    }
+    return std::string(res->data.begin(), res->data.end());
+}
+
+/// Temporarily change the working directory. ResourceDirector::init loads
+/// shaderpack.erf from the working directory.
+struct CwdGuard {
+    std::filesystem::path previous;
+
+    explicit CwdGuard(const std::filesystem::path &path) {
+        previous = std::filesystem::current_path();
+        std::filesystem::current_path(path);
+    }
+
+    ~CwdGuard() {
+        std::error_code ec;
+        std::filesystem::current_path(previous, ec);
+    }
+};
+
+} // namespace
+
+TEST(ExtractResourcesLookup, should_prefer_last_added_source_for_colliding_id) {
+    ExtractResources resources;
+    resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                 {{"shared", ResType::Txt, "first"},
+                                  {"first_only", ResType::Txt, "from first"}}),
+                        ContainerKind::Global);
+    resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                 {{"shared", ResType::Txt, "second"}}),
+                        ContainerKind::Global);
+
+    EXPECT_EQ("second", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
+    EXPECT_EQ("from first", dataOf(resources.find(ResourceId("first_only", ResType::Txt))));
+}
+
+TEST(ExtractResourcesLookup, should_clear_sources_by_kind_only) {
+    ExtractResources resources;
+    resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                 {{"shared", ResType::Txt, "global"},
+                                  {"global_only", ResType::Txt, "global"}}),
+                        ContainerKind::Global);
+    resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                 {{"shared", ResType::Txt, "save"},
+                                  {"save_only", ResType::Txt, "save"}}),
+                        ContainerKind::Save);
+    resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                 {{"shared", ResType::Txt, "local"},
+                                  {"local_only", ResType::Txt, "local"}}),
+                        ContainerKind::Local);
+
+    EXPECT_EQ("local", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
+
+    resources.clearLocal();
+    EXPECT_EQ("save", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
+    EXPECT_FALSE(resources.find(ResourceId("local_only", ResType::Txt)));
+    EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
+
+    resources.clearSave();
+    EXPECT_EQ("global", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
+    EXPECT_FALSE(resources.find(ResourceId("save_only", ResType::Txt)));
+    EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
+}
+
+TEST(ExtractResourcesLookup, should_serve_memory_rim_archives) {
+    ExtractResources resources;
+    resources.addMemRIM(rimBytes({{"entry", ResType::Txt, "rim payload"}}), ContainerKind::Local);
+
+    EXPECT_EQ("rim payload", dataOf(resources.find(ResourceId("entry", ResType::Txt))));
+    EXPECT_FALSE(resources.find(ResourceId("missing", ResType::Txt)));
+}
+
+TEST(ExtractResourcesLookup, should_report_missing_resources) {
+    ExtractResources resources;
+
+    EXPECT_FALSE(resources.find(ResourceId("missing", ResType::Txt)));
+    EXPECT_THROW(resources.get(ResourceId("missing", ResType::Txt)), ResourceNotFoundException);
+}
+
+// The production director drives the extract-backed implementation exactly
+// like the legacy one; observable precedence must be identical.
+
+class ExtractResourcesDirectorLookup : public testing::Test {
+protected:
+    void SetUp() override {
+        _graphics.init();
+        _script.init();
+    }
+
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+        return std::make_unique<ResourceDirector>(
+            GameID::KotOR,
+            gamePath,
+            _graphicsOpt,
+            _graphics.services(),
+            _script.services(),
+            _dialogs,
+            _gffs,
+            _lips,
+            _paths,
+            _resources,
+            _scripts);
+    }
+
+    std::string find(const std::string &resRef, ResType type = ResType::Txt) {
+        return dataOf(_resources.find(ResourceId(resRef, type)));
+    }
+
+    graphics::GraphicsOptions _graphicsOpt;
+    graphics::TestGraphicsModule _graphics;
+    script::TestScriptModule _script;
+
+    NiceMock<MockDialogs> _dialogs;
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockLips> _lips;
+    NiceMock<MockPaths> _paths;
+    NiceMock<MockScripts> _scripts;
+
+    ExtractResources _resources;
+};
+
+TEST_F(ExtractResourcesDirectorLookup, should_mount_global_locations_in_precedence_order) {
+    TmpDir game("reone_test_xres_global");
+    TmpDir cwd("reone_test_xres_global_cwd");
+    writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF,
+             {{"a", ResType::Txt, "shaderpack"}});
+
+    writeKeyBif(game.path, "sample.bif",
+                {{"a", ResType::Txt, "chitin"},
+                 {"b", ResType::Txt, "chitin"}});
+    auto texPacks = game.path / "texturepacks";
+    std::filesystem::create_directories(texPacks);
+    writeErf(texPacks / "swpc_tex_gui.erf", ErfWriter::FileType::ERF,
+             {{"b", ResType::Txt, "gui pack"},
+              {"c", ResType::Txt, "gui pack"}});
+    writeErf(texPacks / "swpc_tex_tpa.erf", ErfWriter::FileType::ERF,
+             {{"c", ResType::Txt, "texture pack"},
+              {"d", ResType::Txt, "texture pack"}});
+    writeErf(game.path / "patch.erf", ErfWriter::FileType::ERF,
+             {{"d", ResType::Txt, "patch"},
+              {"e", ResType::Txt, "patch"}});
+    auto override_ = game.path / "override";
+    std::filesystem::create_directories(override_);
+    detail::writeFile(override_ / "e.txt", "override");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("chitin", find("a")) << "chitin must beat shaderpack";
+    EXPECT_EQ("gui pack", find("b")) << "GUI texture pack must beat chitin";
+    EXPECT_EQ("texture pack", find("c")) << "quality texture pack must beat GUI pack";
+    EXPECT_EQ("patch", find("d")) << "patch.erf must beat texture packs";
+    EXPECT_EQ("override", find("e")) << "override must beat patch.erf";
+}
+
+TEST_F(ExtractResourcesDirectorLookup, should_mount_module_locations_over_global_and_clear_on_transition) {
+    TmpDir game("reone_test_xres_module");
+    TmpDir cwd("reone_test_xres_module_cwd");
+    writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+
+    auto override_ = game.path / "override";
+    std::filesystem::create_directories(override_);
+    detail::writeFile(override_ / "m.txt", "override");
+
+    auto modules = game.path / "modules";
+    std::filesystem::create_directories(modules);
+    writeRim(modules / "foo.rim",
+             {{"m", ResType::Txt, "main rim"},
+              {"rim_only", ResType::Txt, "main rim"}});
+    writeRim(modules / "foo_s.rim",
+             {{"m", ResType::Txt, "data rim"},
+              {"rims_only", ResType::Txt, "data rim"}});
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD,
+             {{"m", ResType::Txt, "mod"}});
+    writeRim(modules / "bar.rim",
+             {{"m", ResType::Txt, "bar rim"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("mod", find("m")) << ".mod must beat _s.rim, .rim and all global locations, including override";
+    EXPECT_EQ("main rim", find("rim_only"));
+    EXPECT_EQ("data rim", find("rims_only"));
+
+    director->onModuleLoad("bar");
+
+    EXPECT_EQ("bar rim", find("m")) << "previous module sources must be dropped on transition";
+    EXPECT_FALSE(_resources.find(ResourceId("rim_only", ResType::Txt)));
+}
+
+TEST_F(ExtractResourcesDirectorLookup, should_mount_save_scope_and_modules_nested_in_save_archive) {
+    TmpDir game("reone_test_xres_save");
+    TmpDir cwd("reone_test_xres_save_cwd");
+    writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+
+    auto modules = game.path / "modules";
+    std::filesystem::create_directories(modules);
+    writeRim(modules / "bar.rim",
+             {{"bar_res", ResType::Txt, "disk rim"}});
+    writeErf(modules / "bar.mod", ErfWriter::FileType::MOD,
+             {{"bar_res", ResType::Txt, "disk mod"}});
+
+    auto nestedModule = erfBytes(ErfWriter::FileType::MOD,
+                                 {{"bar_res", ResType::Txt, "save module"}});
+
+    auto slot = game.path / "saves" / "000001";
+    std::filesystem::create_directories(slot);
+    detail::writeFile(slot / "loose.txt", "save folder");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"loose", ResType::Txt, "save archive"},
+              {"first_only", ResType::Txt, "first save"},
+              {"bar", ResType::Mod, std::string(nestedModule.begin(), nestedModule.end())}});
+
+    auto secondSlot = game.path / "saves" / "000002";
+    std::filesystem::create_directories(secondSlot);
+    writeErf(secondSlot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"loose", ResType::Txt, "second save"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("000001");
+
+    EXPECT_EQ("save archive", find("loose")) << "savegame.sav must beat loose files in the save folder";
+
+    director->onModuleLoad("bar");
+
+    EXPECT_EQ("save module", find("bar_res")) << "module archive nested in savegame.sav must beat disk modules";
+
+    director->onGameLoad("000002");
+
+    EXPECT_EQ("second save", find("loose")) << "the save loaded last must win";
+
+    // Same known defect the legacy characterization pins: the director mounts
+    // save sources with the default Global kind, so clearSave is a no-op and
+    // sources of previously loaded saves leak. The backend must honor caller
+    // kinds, not paper over this; the fix belongs to the director.
+    EXPECT_EQ("first save", find("first_only")) << "previous save sources currently leak";
+}
+
+TEST_F(ExtractResourcesDirectorLookup, should_throw_when_save_slot_is_missing) {
+    TmpDir game("reone_test_xres_missing_save");
+    std::filesystem::create_directories(game.path / "saves");
+
+    auto director = makeDirector(game.path);
+
+    EXPECT_THROW(director->onGameLoad("nosuchslot"), ResourceNotFoundException);
+}


### PR DESCRIPTION
> **Resource-loader migration: D1 — compatibility backend**

## Summary

Adds an Extract-backed implementation of `IResources` behind an explicit DI selector.

Legacy remains the default, so this does not change production runtime or save behaviour.

The backend supports loose files, ERF/RIM archives, KEY/BIF resources, executable resources, and retained in-memory archives while preserving the current lookup ordering.