### PR TITLE
[resource] Support runtime resource replacements

### DIFF
--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -36,6 +36,7 @@
 #include "../provider/textures.h"
 #include "../provider/visibilities.h"
 #include "../provider/walkmeshes.h"
+#include "../replacements.h"
 #include "../resources.h"
 #include "../strings.h"
 
@@ -99,6 +100,7 @@ public:
 
     Gffs &gffs() { return *_gffs; }
     IResources &resources() { return *_resources; }
+    IResourceReplacements &replacements() { return *_replacements; }
     Strings &strings() { return *_strings; }
     TwoDAs &twoDas() { return *_twoDas; }
     Scripts &scripts() { return *_scripts; }
@@ -135,6 +137,7 @@ private:
     ResourcesBackend _resourcesBackend {ResourcesBackend::Legacy};
 
     std::unique_ptr<Gffs> _gffs;
+    std::unique_ptr<IResourceReplacements> _replacements;
     std::unique_ptr<IResources> _resources;
     std::unique_ptr<Strings> _strings;
     std::unique_ptr<TwoDAs> _twoDas;

--- a/include/reone/resource/di/services.h
+++ b/include/reone/resource/di/services.h
@@ -33,6 +33,7 @@ class IModels;
 class IMovies;
 class IPaths;
 class IResourceDirector;
+class IResourceReplacements;
 class IResources;
 class IScripts;
 class IShaders;
@@ -46,6 +47,7 @@ class IWalkmeshes;
 struct ResourceServices {
     IGffs &gffs;
     IResources &resources;
+    IResourceReplacements &replacements;
     IStrings &strings;
     ITwoDAs &twoDas;
     IScripts &scripts;
@@ -69,6 +71,7 @@ struct ResourceServices {
     ResourceServices(
         IGffs &gffs,
         IResources &resources,
+        IResourceReplacements &replacements,
         IStrings &strings,
         ITwoDAs &twoDas,
         IScripts &scripts,
@@ -90,6 +93,7 @@ struct ResourceServices {
         IResourceDirector &director) :
         gffs(gffs),
         resources(resources),
+        replacements(replacements),
         strings(strings),
         twoDas(twoDas),
         scripts(scripts),

--- a/include/reone/resource/provider/scripts.h
+++ b/include/reone/resource/provider/scripts.h
@@ -19,6 +19,7 @@
 
 #include "reone/script/program.h"
 
+#include "../replacements.h"
 #include "../resources.h"
 
 namespace reone {
@@ -36,8 +37,10 @@ public:
 
 class Scripts : public IScripts {
 public:
-    Scripts(IResources &resources) :
-        _resources(resources) {
+    Scripts(IResources &resources,
+            IResourceReplacements &replacements) :
+        _resources(resources),
+        _replacements(replacements) {
     }
 
     void clear() override {
@@ -45,18 +48,28 @@ public:
     }
 
     std::shared_ptr<script::ScriptProgram> get(const std::string &key) override {
-        auto maybeObject = _objects.find(key);
-        if (maybeObject != _objects.end()) {
-            return maybeObject->second;
+        ResRef resRef(key);
+        ResourceId id(resRef, ResType::Ncs);
+        uint64_t revision = _replacements.revision(id);
+        auto maybeObject = _objects.find(resRef);
+        if (maybeObject != _objects.end() && maybeObject->second.revision == revision) {
+            return maybeObject->second.program;
         }
-        auto object = doGet(key);
-        return _objects.insert(make_pair(key, std::move(object))).first->second;
+        auto program = doGet(resRef.value());
+        _objects[resRef] = CachedProgram {std::move(program), revision};
+        return _objects.at(resRef).program;
     }
 
 private:
-    IResources &_resources;
+    struct CachedProgram {
+        std::shared_ptr<script::ScriptProgram> program;
+        uint64_t revision;
+    };
 
-    std::unordered_map<std::string, std::shared_ptr<script::ScriptProgram>> _objects;
+    IResources &_resources;
+    IResourceReplacements &_replacements;
+
+    std::unordered_map<ResRef, CachedProgram> _objects;
 
     std::shared_ptr<script::ScriptProgram> doGet(std::string resRef);
 };

--- a/include/reone/resource/replacementresources.h
+++ b/include/reone/resource/replacementresources.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "replacements.h"
+#include "resources.h"
+
+namespace reone {
+
+namespace resource {
+
+class ReplacementResources : public IResources, boost::noncopyable {
+public:
+    ReplacementResources(std::unique_ptr<IResources> backend,
+                         IResourceReplacements &replacements) :
+        _backend(std::move(backend)),
+        _replacements(replacements) {
+    }
+
+    void clear() override;
+    void clearLocal() override;
+    void clearSave() override;
+
+    void addEXE(const std::filesystem::path &path) override;
+    void addKEY(const std::filesystem::path &path) override;
+    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
+    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
+    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+
+    Resource get(const ResourceId &id) override;
+    std::optional<Resource> find(const ResourceId &id) override;
+
+private:
+    std::unique_ptr<IResources> _backend;
+    IResourceReplacements &_replacements;
+};
+
+} // namespace resource
+
+} // namespace reone

--- a/include/reone/resource/replacements.h
+++ b/include/reone/resource/replacements.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "id.h"
+#include "resource.h"
+
+namespace reone {
+
+namespace resource {
+
+class IResourceReplacements {
+public:
+    virtual ~IResourceReplacements() = default;
+
+    virtual void replaceResource(ResourceId id, ByteBuffer data) = 0;
+    virtual void removeResourceReplacement(const ResourceId &id) = 0;
+    virtual void clearResourceReplacements() = 0;
+
+    virtual std::optional<Resource> findResourceReplacement(const ResourceId &id) const = 0;
+    virtual uint64_t revision(const ResourceId &id) const = 0;
+};
+
+class ResourceReplacements : public IResourceReplacements, boost::noncopyable {
+public:
+    void replaceResource(ResourceId id, ByteBuffer data) override;
+    void removeResourceReplacement(const ResourceId &id) override;
+    void clearResourceReplacements() override;
+
+    std::optional<Resource> findResourceReplacement(const ResourceId &id) const override;
+    uint64_t revision(const ResourceId &id) const override;
+
+private:
+    std::unordered_map<ResourceId, std::shared_ptr<const ByteBuffer>> _resources;
+    std::unordered_map<ResourceId, uint64_t> _revisions;
+    uint64_t _nextRevision {0};
+
+    void advanceRevision(const ResourceId &id);
+};
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -38,6 +38,8 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/director.h
     ${RESOURCE_INCLUDE_DIR}/exception/notfound.h
     ${RESOURCE_INCLUDE_DIR}/extractresources.h
+    ${RESOURCE_INCLUDE_DIR}/replacementresources.h
+    ${RESOURCE_INCLUDE_DIR}/replacements.h
     ${RESOURCE_INCLUDE_DIR}/format/2dareader.h
     ${RESOURCE_INCLUDE_DIR}/format/2dawriter.h
     ${RESOURCE_INCLUDE_DIR}/format/bifreader.h
@@ -110,6 +112,8 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/extract/finder.cpp
     ${RESOURCE_SOURCE_DIR}/extract/installation.cpp
     ${RESOURCE_SOURCE_DIR}/extractresources.cpp
+    ${RESOURCE_SOURCE_DIR}/replacementresources.cpp
+    ${RESOURCE_SOURCE_DIR}/replacements.cpp
     ${RESOURCE_SOURCE_DIR}/container/erf.cpp
     ${RESOURCE_SOURCE_DIR}/container/exe.cpp
     ${RESOURCE_SOURCE_DIR}/container/folder.cpp

--- a/src/libs/resource/di/module.cpp
+++ b/src/libs/resource/di/module.cpp
@@ -18,6 +18,8 @@
 #include "reone/resource/di/module.h"
 
 #include "reone/resource/extractresources.h"
+#include "reone/resource/replacementresources.h"
+#include "reone/resource/replacements.h"
 
 #include "reone/audio/di/module.h"
 #include "reone/graphics/di/module.h"
@@ -28,11 +30,14 @@ namespace reone {
 namespace resource {
 
 void ResourceModule::init() {
+    std::unique_ptr<IResources> backend;
     if (_resourcesBackend == ResourcesBackend::Extract) {
-        _resources = std::make_unique<ExtractResources>();
+        backend = std::make_unique<ExtractResources>();
     } else {
-        _resources = std::make_unique<Resources>();
+        backend = std::make_unique<Resources>();
     }
+    _replacements = std::make_unique<ResourceReplacements>();
+    _resources = std::make_unique<ReplacementResources>(std::move(backend), *_replacements);
     _strings = std::make_unique<Strings>();
     _twoDas = std::make_unique<TwoDAs>(*_resources);
     _gffs = std::make_unique<Gffs>(*_resources);
@@ -86,6 +91,7 @@ void ResourceModule::init() {
     _services = std::make_unique<ResourceServices>(
         *_gffs,
         *_resources,
+        *_replacements,
         *_strings,
         *_twoDas,
         *_scripts,
@@ -131,6 +137,7 @@ void ResourceModule::deinit() {
     _twoDas.reset();
     _strings.reset();
     _resources.reset();
+    _replacements.reset();
 }
 
 } // namespace resource

--- a/src/libs/resource/di/module.cpp
+++ b/src/libs/resource/di/module.cpp
@@ -63,7 +63,7 @@ void ResourceModule::init() {
         *_resources);
     _audioClips = std::make_unique<AudioClips>(*_resources);
     _movies = std::make_unique<Movies>(_gamePath, _graphics.services(), _audio.mixer());
-    _scripts = std::make_unique<Scripts>(*_resources);
+    _scripts = std::make_unique<Scripts>(*_resources, *_replacements);
     _dialogs = std::make_unique<Dialogs>(*_gffs, *_strings);
     _layouts = std::make_unique<Layouts>(*_resources);
     _paths = std::make_unique<Paths>(*_gffs);

--- a/src/libs/resource/replacementresources.cpp
+++ b/src/libs/resource/replacementresources.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/replacementresources.h"
+
+#include "reone/resource/exception/notfound.h"
+
+namespace reone {
+
+namespace resource {
+
+void ReplacementResources::clear() {
+    _backend->clear();
+}
+
+void ReplacementResources::clearLocal() {
+    _backend->clearLocal();
+}
+
+void ReplacementResources::clearSave() {
+    _backend->clearSave();
+}
+
+void ReplacementResources::addEXE(const std::filesystem::path &path) {
+    _backend->addEXE(path);
+}
+
+void ReplacementResources::addKEY(const std::filesystem::path &path) {
+    _backend->addKEY(path);
+}
+
+void ReplacementResources::addERF(const std::filesystem::path &path, ContainerKind kind) {
+    _backend->addERF(path, kind);
+}
+
+void ReplacementResources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
+    _backend->addMemERF(std::move(buffer), kind);
+}
+
+void ReplacementResources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
+    _backend->addRIM(path, kind);
+}
+
+void ReplacementResources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
+    _backend->addMemRIM(std::move(buffer), kind);
+}
+
+void ReplacementResources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
+    _backend->addFolder(path, kind);
+}
+
+Resource ReplacementResources::get(const ResourceId &id) {
+    auto data = find(id);
+    if (!data) {
+        throw ResourceNotFoundException(id.string());
+    }
+    return *data;
+}
+
+std::optional<Resource> ReplacementResources::find(const ResourceId &id) {
+    auto replacement = _replacements.findResourceReplacement(id);
+    return replacement ? replacement : _backend->find(id);
+}
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/resource/replacements.cpp
+++ b/src/libs/resource/replacements.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/replacements.h"
+
+namespace reone {
+
+namespace resource {
+
+void ResourceReplacements::replaceResource(ResourceId id, ByteBuffer data) {
+    _resources[id] = std::make_shared<const ByteBuffer>(std::move(data));
+    advanceRevision(id);
+}
+
+void ResourceReplacements::removeResourceReplacement(const ResourceId &id) {
+    if (_resources.erase(id) != 0) {
+        advanceRevision(id);
+    }
+}
+
+void ResourceReplacements::clearResourceReplacements() {
+    for (const auto &[id, _] : _resources) {
+        advanceRevision(id);
+    }
+    _resources.clear();
+}
+
+std::optional<Resource> ResourceReplacements::findResourceReplacement(const ResourceId &id) const {
+    auto it = _resources.find(id);
+    if (it == _resources.end()) {
+        return std::nullopt;
+    }
+    return Resource {*it->second};
+}
+
+uint64_t ResourceReplacements::revision(const ResourceId &id) const {
+    auto it = _revisions.find(id);
+    return it == _revisions.end() ? 0 : it->second;
+}
+
+void ResourceReplacements::advanceRevision(const ResourceId &id) {
+    _revisions[id] = ++_nextRevision;
+}
+
+} // namespace resource
+
+} // namespace reone

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/provider/2das.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/dialogs.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/gffs.cpp
+    ${TESTS_SOURCE_DIR}/resource/provider/scripts.cpp
     ${TESTS_SOURCE_DIR}/resource/resources.cpp
     ${TESTS_SOURCE_DIR}/resource/resref.cpp
     ${TESTS_SOURCE_DIR}/resource/strings.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
+    ${TESTS_SOURCE_DIR}/resource/replacements.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dawriter.cpp
     ${TESTS_SOURCE_DIR}/resource/format/bifreader.cpp

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -39,6 +39,7 @@
 #include "reone/resource/provider/textures.h"
 #include "reone/resource/provider/visibilities.h"
 #include "reone/resource/provider/walkmeshes.h"
+#include "reone/resource/replacements.h"
 #include "reone/resource/resources.h"
 #include "reone/resource/strings.h"
 
@@ -67,6 +68,15 @@ public:
 
     MOCK_METHOD(Resource, get, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, find, (const ResourceId &id), (override));
+};
+
+class MockResourceReplacements : public IResourceReplacements, boost::noncopyable {
+public:
+    MOCK_METHOD(void, replaceResource, (ResourceId id, ByteBuffer data), (override));
+    MOCK_METHOD(void, removeResourceReplacement, (const ResourceId &id), (override));
+    MOCK_METHOD(void, clearResourceReplacements, (), (override));
+    MOCK_METHOD(std::optional<Resource>, findResourceReplacement, (const ResourceId &id), (const override));
+    MOCK_METHOD(uint64_t, revision, (const ResourceId &id), (const override));
 };
 
 class MockStrings : public IStrings, boost::noncopyable {
@@ -186,6 +196,7 @@ public:
     void init() {
         _gffs = std::make_unique<MockGffs>();
         _resources = std::make_unique<MockResources>();
+        _replacements = std::make_unique<MockResourceReplacements>();
         _strings = std::make_unique<MockStrings>();
         _twoDas = std::make_unique<MockTwoDAs>();
         _scripts = std::make_unique<MockScripts>();
@@ -209,6 +220,7 @@ public:
         _services = std::make_unique<ResourceServices>(
             *_gffs,
             *_resources,
+            *_replacements,
             *_strings,
             *_twoDas,
             *_scripts,
@@ -281,6 +293,7 @@ public:
 private:
     std::unique_ptr<MockGffs> _gffs;
     std::unique_ptr<MockResources> _resources;
+    std::unique_ptr<MockResourceReplacements> _replacements;
     std::unique_ptr<MockStrings> _strings;
     std::unique_ptr<MockTwoDAs> _twoDas;
     std::unique_ptr<MockScripts> _scripts;

--- a/test/resource/provider/scripts.cpp
+++ b/test/resource/provider/scripts.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/script/runner.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/provider/scripts.h"
+#include "reone/resource/replacementresources.h"
+#include "reone/resource/replacements.h"
+#include "reone/resource/resources.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/executionstate.h"
+#include "reone/script/format/ncswriter.h"
+#include "reone/script/program.h"
+#include "reone/script/virtualmachine.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace reone::script;
+
+namespace {
+
+ByteBuffer ncsBytes(int value) {
+    ScriptProgram program("replacement_test");
+    program.add(Instruction::newCONSTI(value));
+    program.add(Instruction(InstructionType::RETN));
+
+    ByteBuffer bytes;
+    auto stream = std::make_shared<MemoryOutputStream>(bytes);
+    NcsWriter(program).save(stream);
+    return bytes;
+}
+
+ByteBuffer erfBytes(std::string resRef, ByteBuffer data) {
+    ErfWriter writer;
+    writer.add(ErfWriter::Resource {std::move(resRef), ResType::Ncs, std::move(data)});
+    ByteBuffer bytes;
+    MemoryOutputStream stream(bytes);
+    writer.save(ErfWriter::FileType::ERF, stream);
+    return bytes;
+}
+
+class ScriptsReplacementTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _resources.addMemERF(erfBytes("script", ncsBytes(1)), ContainerKind::Global);
+    }
+
+    ResourceId id() const {
+        return ResourceId("script", ResType::Ncs);
+    }
+
+    int run(const std::string &resRef = "script") {
+        return ScriptRunner(_routines, _scripts).run(resRef, std::vector<Argument> {});
+    }
+
+    int runProgram(std::shared_ptr<ScriptProgram> program,
+                   std::shared_ptr<ExecutionState> savedState = nullptr) {
+        auto context = std::make_unique<ExecutionContext>();
+        context->routines = &_routines;
+        context->savedState = std::move(savedState);
+        return VirtualMachine(std::move(program), std::move(context)).run();
+    }
+
+    ResourceReplacements _replacements;
+    ReplacementResources _resources {std::make_unique<Resources>(), _replacements};
+    Scripts _scripts {_resources, _replacements};
+    MockRoutines _routines;
+};
+
+TEST_F(ScriptsReplacementTest, replacement_refreshes_an_already_cached_program) {
+    EXPECT_EQ(1, run());
+    auto original = _scripts.get("script");
+
+    _replacements.replaceResource(id(), ncsBytes(2));
+
+    auto replacement = _scripts.get("SCRIPT");
+    EXPECT_NE(original, replacement);
+    EXPECT_EQ(2, run());
+    EXPECT_EQ(1, runProgram(original));
+}
+
+TEST_F(ScriptsReplacementTest, repeated_replacement_uses_the_newest_program) {
+    _replacements.replaceResource(id(), ncsBytes(2));
+    EXPECT_EQ(2, run());
+
+    _replacements.replaceResource(id(), ncsBytes(3));
+
+    EXPECT_EQ(3, run());
+}
+
+TEST_F(ScriptsReplacementTest, removing_a_replacement_reloads_the_underlying_program) {
+    _replacements.replaceResource(id(), ncsBytes(2));
+    EXPECT_EQ(2, run());
+
+    _replacements.removeResourceReplacement(id());
+
+    EXPECT_EQ(1, run());
+}
+
+TEST_F(ScriptsReplacementTest, clearing_replacements_reloads_the_underlying_program) {
+    _replacements.replaceResource(id(), ncsBytes(2));
+    EXPECT_EQ(2, run());
+
+    _replacements.clearResourceReplacements();
+
+    EXPECT_EQ(1, run());
+}
+
+TEST_F(ScriptsReplacementTest, clear_followed_by_replacement_does_not_alias_an_old_revision) {
+    _replacements.replaceResource(id(), ncsBytes(2));
+    EXPECT_EQ(2, run());
+    _replacements.clearResourceReplacements();
+
+    _replacements.replaceResource(id(), ncsBytes(3));
+
+    EXPECT_EQ(3, run());
+}
+
+TEST_F(ScriptsReplacementTest, replacement_makes_a_cached_missing_script_available) {
+    EXPECT_FALSE(_scripts.get("missing"));
+    ResourceId missing("missing", ResType::Ncs);
+
+    _replacements.replaceResource(missing, ncsBytes(4));
+
+    EXPECT_EQ(4, run("missing"));
+}
+
+TEST_F(ScriptsReplacementTest, case_variants_share_one_canonical_cache_entry) {
+    auto lower = _scripts.get("script");
+    auto upper = _scripts.get("SCRIPT");
+
+    EXPECT_EQ(lower, upper);
+}
+
+TEST_F(ScriptsReplacementTest, deferred_execution_state_keeps_its_original_program) {
+    auto original = _scripts.get("script");
+    auto savedState = std::make_shared<ExecutionState>();
+    savedState->program = original;
+    savedState->insOffset = 13;
+
+    _replacements.replaceResource(id(), ncsBytes(2));
+
+    EXPECT_EQ(2, run());
+    EXPECT_EQ(1, runProgram(savedState->program, savedState));
+}
+
+} // namespace

--- a/test/resource/replacements.cpp
+++ b/test/resource/replacements.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/replacementresources.h"
+#include "reone/resource/replacements.h"
+#include "reone/resource/resources.h"
+#include "reone/system/stream/memoryinput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+namespace {
+
+enum class Backend {
+    Legacy,
+    Extract,
+};
+
+std::string backendName(const testing::TestParamInfo<Backend> &info) {
+    return info.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+ByteBuffer erfBytes(const std::vector<ErfWriter::Resource> &resources) {
+    ErfWriter writer;
+    for (auto resource : resources) {
+        writer.add(std::move(resource));
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(ErfWriter::FileType::ERF, stream);
+    return buffer;
+}
+
+std::string dataOf(const std::optional<Resource> &resource) {
+    if (!resource) {
+        return "<not found>";
+    }
+    return std::string(resource->data.begin(), resource->data.end());
+}
+
+class ReplacementResourcesTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        std::unique_ptr<IResources> backend;
+        if (GetParam() == Backend::Legacy) {
+            backend = std::make_unique<Resources>();
+        } else {
+            backend = std::make_unique<ExtractResources>();
+        }
+        _resources = std::make_unique<ReplacementResources>(std::move(backend), _replacements);
+    }
+
+    ResourceId id(std::string resRef) const {
+        return ResourceId(std::move(resRef), ResType::Txt);
+    }
+
+    void addMounted(std::string resRef, std::string data, ContainerKind kind = ContainerKind::Global) {
+        _resources->addMemERF(erfBytes({ErfWriter::Resource {std::move(resRef), ResType::Txt, bytes(data)}}), kind);
+    }
+
+    ResourceReplacements _replacements;
+    std::unique_ptr<ReplacementResources> _resources;
+};
+
+TEST_P(ReplacementResourcesTest, replacement_beats_a_mounted_resource) {
+    addMounted("shared", "mounted");
+
+    _replacements.replaceResource(id("shared"), bytes("replacement"));
+
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("shared"))));
+}
+
+TEST_P(ReplacementResourcesTest, replacement_supplies_a_missing_resource) {
+    _replacements.replaceResource(id("missing"), bytes("replacement"));
+
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("missing"))));
+}
+
+TEST_P(ReplacementResourcesTest, repeated_replacement_uses_the_newest_bytes) {
+    _replacements.replaceResource(id("shared"), bytes("first"));
+    _replacements.replaceResource(id("shared"), bytes("second"));
+
+    EXPECT_EQ("second", dataOf(_resources->find(id("shared"))));
+}
+
+TEST_P(ReplacementResourcesTest, removal_restores_the_mounted_resource) {
+    addMounted("shared", "mounted");
+    _replacements.replaceResource(id("shared"), bytes("replacement"));
+
+    _replacements.removeResourceReplacement(id("shared"));
+
+    EXPECT_EQ("mounted", dataOf(_resources->find(id("shared"))));
+}
+
+TEST_P(ReplacementResourcesTest, clear_restores_all_mounted_resources) {
+    addMounted("first", "first mounted");
+    addMounted("second", "second mounted");
+    _replacements.replaceResource(id("first"), bytes("first replacement"));
+    _replacements.replaceResource(id("second"), bytes("second replacement"));
+
+    _replacements.clearResourceReplacements();
+
+    EXPECT_EQ("first mounted", dataOf(_resources->find(id("first"))));
+    EXPECT_EQ("second mounted", dataOf(_resources->find(id("second"))));
+}
+
+TEST_P(ReplacementResourcesTest, empty_replacement_is_present) {
+    _replacements.replaceResource(id("empty"), {});
+
+    auto resource = _resources->find(id("empty"));
+
+    ASSERT_TRUE(resource);
+    EXPECT_TRUE(resource->data.empty());
+}
+
+TEST_P(ReplacementResourcesTest, resource_ids_are_case_normalized) {
+    _replacements.replaceResource(id("MiXeD"), bytes("replacement"));
+
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("mixed"))));
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("MIXED"))));
+}
+
+TEST_P(ReplacementResourcesTest, preserves_fallback_behavior_without_replacements) {
+    addMounted("mounted", "mounted");
+
+    EXPECT_EQ("mounted", dataOf(_resources->find(id("mounted"))));
+    EXPECT_FALSE(_resources->find(id("missing")));
+}
+
+TEST_P(ReplacementResourcesTest, returned_data_remains_valid_after_replacement_changes) {
+    _replacements.replaceResource(id("shared"), bytes("first"));
+    auto first = _resources->get(id("shared"));
+    MemoryInputStream stream(first.data);
+
+    _replacements.replaceResource(id("shared"), bytes("second"));
+    _replacements.removeResourceReplacement(id("shared"));
+
+    ByteBuffer read(first.data.size());
+    stream.read(read.data(), read.size());
+    EXPECT_EQ("first", std::string(read.begin(), read.end()));
+}
+
+TEST_P(ReplacementResourcesTest, replacements_survive_local_and_save_scope_changes) {
+    addMounted("shared", "global", ContainerKind::Global);
+    addMounted("shared", "save", ContainerKind::Save);
+    addMounted("shared", "local", ContainerKind::Local);
+    _replacements.replaceResource(id("shared"), bytes("replacement"));
+
+    _resources->clearLocal();
+    _resources->clearSave();
+
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("shared"))));
+}
+
+TEST(ResourceReplacementsRevision, advances_on_every_meaningful_state_transition) {
+    ResourceReplacements replacements;
+    ResourceId id("script", ResType::Ncs);
+
+    EXPECT_EQ(0u, replacements.revision(id));
+
+    replacements.replaceResource(id, bytes("first"));
+    auto first = replacements.revision(id);
+    replacements.removeResourceReplacement(id);
+    auto removed = replacements.revision(id);
+    replacements.replaceResource(id, bytes("second"));
+    auto second = replacements.revision(id);
+    replacements.clearResourceReplacements();
+    auto cleared = replacements.revision(id);
+    replacements.replaceResource(id, bytes("third"));
+    auto third = replacements.revision(id);
+
+    EXPECT_LT(first, removed);
+    EXPECT_LT(removed, second);
+    EXPECT_LT(second, cleared);
+    EXPECT_LT(cleared, third);
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         ReplacementResourcesTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+} // namespace


### PR DESCRIPTION
> **Resource-loader migration: D2 — runtime replacements**

## Summary

Adds a backend-independent in-memory resource overlay that can replace resources while the game is running.

Replacements take priority over every mounted source and work with both Legacy and Extract backends. Removing or clearing a replacement falls back to the normal resource.

The Scripts provider tracks replacement revisions, so subsequent NCS invocations use updated bytecode while active and deferred script executions safely retain their existing program.

This provides the loader hooks needed for a future script-editing workflow without adding filesystem watching, timestamp polling, compilation, or editor integration.