### PR TITLE
[game] Pure Pazaak

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -42,6 +42,7 @@
 #include "gui/mainmenu.h"
 #include "gui/map.h"
 #include "gui/partyselect.h"
+#include "gui/pazaak.h"
 #include "gui/saveload.h"
 #include "journal.h"
 #include "location.h"
@@ -62,6 +63,7 @@
 #include "object/waypoint.h"
 #include "options.h"
 #include "party.h"
+#include "pazaaksession.h"
 #include "script/runner.h"
 #include "swooprace.h"
 #include "statussummary.h"
@@ -99,7 +101,10 @@ public:
         Container,
         PartySelection,
         SaveLoad,
-        SwoopRace
+        SwoopRace,
+        PazaakWager,
+        PazaakSetup,
+        PazaakBoard
     };
 
     Game(
@@ -173,6 +178,27 @@ public:
     void openContainer(const std::shared_ptr<Object> &container);
     void openPartySelection(const PartySelectionContext &ctx);
     void openSaveLoad(SaveLoadMode mode);
+
+    // KotOR I Pazaak lifecycle
+
+    bool playPazaak(
+        int opponentDeck,
+        std::string continuationScript,
+        int maximumWager,
+        bool tutorialRequested,
+        const std::shared_ptr<Object> &opponent);
+
+    PazaakSession *pazaakSession() { return _pazaakSession.get(); }
+    const PazaakSession *pazaakSession() const { return _pazaakSession.get(); }
+    const std::optional<PazaakCompletedResult> &lastPazaakResult() const { return _lastPazaakResult; }
+
+    void showPazaakSetup();
+    void showPazaakBoard();
+    void cancelPazaak();
+    void abortPazaak();
+    void completePazaakIfReady();
+
+    // END KotOR I Pazaak lifecycle
 
     void startCharacterGeneration();
     void startDialog(const std::shared_ptr<Object> &owner, const std::string &resRef);
@@ -375,6 +401,7 @@ public:
     void deserializeGlobalVariables(resource::Gff &gvtGff);
     void deserializeParty(resource::Gff &ifoGff);
     void deserializePartyTable(resource::Gff &ptGff);
+    void serializePazaakPartyTable(resource::Gff &ptGff) const;
     void deserializePartyMembers(resource::Gff &ptGff);
     void deserializeJournal(const resource::Gff &ptGff);
     void deserializeInventory(resource::Gff &inventoryGff);
@@ -455,6 +482,31 @@ private:
     std::unique_ptr<ContainerGUI> _container;
     std::unique_ptr<PartySelection> _partySelect;
     std::unique_ptr<SaveLoad> _saveLoad;
+    std::unique_ptr<PazaakWagerGUI> _pazaakWager;
+    std::unique_ptr<PazaakSetupGUI> _pazaakSetup;
+    std::unique_ptr<PazaakBoardGUI> _pazaakBoard;
+
+    std::unique_ptr<PazaakSession> _pazaakSession;
+    std::optional<PazaakCompletedResult> _lastPazaakResult;
+    std::weak_ptr<Object> _pazaakContinuationCaller;
+    Screen _pazaakOriginScreen {Screen::None};
+    bool _pazaakGUIsReady {false};
+    bool _pazaakDevelopmentLaunch {false};
+    bool _pazaakSelectionPersisted {false};
+    bool _pazaakSettlementApplied {false};
+    bool _pazaakShowcaseHands {false};
+    float _pazaakOpponentEventElapsed {0.0f};
+
+    // Narrow injectable seams used by focused lifecycle tests.
+    PazaakSession::HandSelector _pazaakPlayerHandSelector;
+    PazaakSession::HandSelector _pazaakOpponentHandSelector;
+    PazaakSession::MainDeckFactory _pazaakMainDeckFactory;
+    PazaakSession::FirstParticipantSelector _pazaakFirstParticipantSelector;
+    bool _pazaakPaceAutomaticDraws {true};
+    std::function<bool()> _pazaakGuiLoadOverride;
+    std::function<void(const std::string &, uint32_t)> _pazaakContinuationOverride;
+    std::weak_ptr<Object> _pazaakDevelopmentSelectedObjectOverride;
+    std::optional<pazaak::SideDeck> _pazaakOpponentDeckOverride;
 
     std::unique_ptr<Map> _map;
     std::unique_ptr<LoadingScreen> _loadScreen;
@@ -558,6 +610,15 @@ private:
     // GUI
 
     void loadInGameMenus();
+    bool loadPazaakGUIs();
+    bool startPazaakFlow(
+        PazaakSessionParams params,
+        const std::shared_ptr<Object> &continuationCaller,
+        bool developmentLaunch);
+    bool startDevelopmentPazaak(std::string opponentName);
+    void finishPazaak(PazaakCompletedResult result);
+    void releasePazaakFlow(bool restoreOrigin);
+    Screen safePazaakOriginScreen() const;
 
     void changeScreen(Screen screen);
 
@@ -642,6 +703,7 @@ private:
     void consoleOpenCloseDoor(const ConsoleArgs &tokens);
     void consoleListGames(const ConsoleArgs &tokens);
     void consoleLoadGame(const ConsoleArgs &tokens);
+    void consoleStartPazaak(const ConsoleArgs &tokens);
     void consoleMiniGameInfo(const ConsoleArgs &tokens);
     void consoleStartSwoop(const ConsoleArgs &tokens);
     void consoleStopSwoop(const ConsoleArgs &tokens);

--- a/include/reone/game/gui/pazaak.h
+++ b/include/reone/game/gui/pazaak.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "../gui.h"
+#include "../pazaaksession.h"
+
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/label.h"
+
+#include <array>
+
+namespace reone {
+
+namespace game {
+
+const char *pazaakAudioResRef(PazaakPresentationEventType event);
+
+class PazaakWagerGUI : public GameGUI {
+public:
+    PazaakWagerGUI(Game &game, ServicesView &services);
+
+    void refresh();
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Button> less;
+        std::shared_ptr<gui::Button> more;
+        std::shared_ptr<gui::Button> quit;
+        std::shared_ptr<gui::Button> wager;
+        std::shared_ptr<gui::Label> maximum;
+        std::shared_ptr<gui::Label> title;
+        std::shared_ptr<gui::Label> wagerValue;
+    };
+
+    Controls _controls;
+
+    void onGUILoaded() override;
+};
+
+class PazaakSetupGUI : public GameGUI {
+public:
+    PazaakSetupGUI(Game &game, ServicesView &services);
+
+    bool handle(const input::Event &event) override;
+    void refresh();
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Button> accept;
+        std::shared_ptr<gui::Button> cancel;
+        std::shared_ptr<gui::Button> clear;
+        std::shared_ptr<gui::Label> help;
+        std::shared_ptr<gui::Label> leftTitle;
+        std::shared_ptr<gui::Label> rightTitle;
+        std::shared_ptr<gui::Label> title;
+        std::array<std::shared_ptr<gui::Button>, 24> availableButtons;
+        std::array<std::shared_ptr<gui::Label>, 24> availableLabels;
+        std::array<std::shared_ptr<gui::Label>, 24> availableCounts;
+        std::array<std::shared_ptr<gui::Button>, pazaak::kSideDeckSize> chosenButtons;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kSideDeckSize> chosenLabels;
+    };
+
+    Controls _controls;
+    std::optional<size_t> _selectedAvailable;
+
+    void onGUILoaded() override;
+};
+
+class PazaakBoardGUI : public GameGUI {
+public:
+    PazaakBoardGUI(Game &game, ServicesView &services);
+
+    bool handle(const input::Event &event) override;
+    void refresh();
+
+private:
+    struct Controls {
+        std::shared_ptr<gui::Button> endTurn;
+        std::shared_ptr<gui::Button> stand;
+        std::shared_ptr<gui::Button> forfeit;
+        // Per-hand-slot sign switch, and its authored legend/icon.
+        std::array<std::shared_ptr<gui::Button>, pazaak::kHandSize> flip;
+        std::shared_ptr<gui::Label> flipLegend;
+        std::shared_ptr<gui::Label> flipIcon;
+        // Per-hand-slot KotOR II Value Change switch (optional; absent in KotOR I).
+        std::array<std::shared_ptr<gui::Button>, pazaak::kHandSize> change;
+        std::shared_ptr<gui::Label> changeLegend;
+        std::shared_ptr<gui::Label> changeIcon;
+        std::array<std::shared_ptr<gui::Button>, pazaak::kBoardSize> opponentBoardButtons;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kBoardSize> opponentBoardLabels;
+        std::array<std::shared_ptr<gui::Button>, pazaak::kHandSize> opponentHandButtons;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kHandSize> opponentHandLabels;
+        std::array<std::shared_ptr<gui::Button>, pazaak::kBoardSize> playerBoardButtons;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kBoardSize> playerBoardLabels;
+        std::array<std::shared_ptr<gui::Button>, pazaak::kHandSize> playerHandButtons;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kHandSize> playerHandLabels;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kSetWinsForMatch> opponentScores;
+        std::array<std::shared_ptr<gui::Label>, pazaak::kSetWinsForMatch> playerScores;
+        std::shared_ptr<gui::Label> opponentName;
+        std::shared_ptr<gui::Label> opponentTotal;
+        std::shared_ptr<gui::Label> opponentTurn;
+        std::shared_ptr<gui::Label> playerName;
+        std::shared_ptr<gui::Label> playerTotal;
+        std::shared_ptr<gui::Label> playerTurn;
+    };
+
+    Controls _controls;
+
+    void onGUILoaded() override;
+    void refreshAfterCommand(pazaak::ActionError error);
+    void playPendingAudio();
+    void playAudio(const std::string &resRef);
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/gui/pazaak.h
+++ b/include/reone/game/gui/pazaak.h
@@ -5,6 +5,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -19,6 +19,8 @@
 
 #include "reone/input/event.h"
 
+#include <array>
+
 namespace reone {
 
 namespace game {
@@ -36,6 +38,14 @@ enum class XPSource {
 
 class Party {
 public:
+    // PARTYTABLE.res stores one ownership count per card type plus one spare
+    // entry: KotOR I ships eighteen card types, KotOR II twenty-three.
+    static constexpr size_t kK1PazaakCardCount = 19;
+    static constexpr size_t kK2PazaakCardCount = 24;
+    static constexpr size_t kMaxPazaakCardCount = kK2PazaakCardCount;
+    static constexpr size_t kK1PazaakSideDeckSize = 10;
+    using PazaakCardCounts = std::array<int, kMaxPazaakCardCount>;
+    using PazaakSideDeck = std::array<int, kK1PazaakSideDeckSize>;
     struct Member {
         int npc {0};
         std::shared_ptr<Creature> creature;
@@ -116,6 +126,21 @@ public:
 
     // END Credits
 
+    // Pazaak state stored in PARTYTABLE.res. The final ownership slot is retained
+    // verbatim even though side decks only use the card-type IDs before it.
+    bool hasValidPazaakData() const { return _pazaakDataValid; }
+    const PazaakCardCounts &pazaakCardCounts() const { return _pazaakCardCounts; }
+    /// Number of ownership entries the loaded table actually carries.
+    size_t pazaakCardCount() const { return _pazaakCardCount; }
+    const PazaakSideDeck &pazaakSideDeck() const { return _pazaakSideDeck; }
+    void setPazaakData(
+        PazaakCardCounts counts,
+        PazaakSideDeck sideDeck,
+        size_t cardCount = kK1PazaakCardCount);
+    void setPazaakSideDeck(PazaakSideDeck sideDeck);
+    /// Authored starting collection: two copies each of +1 through +5.
+    void setDefaultPazaakData(size_t cardCount = kK1PazaakCardCount);
+
     // Experience
     //
     // KOTOR stores experience as a single party-shared pool. XP awarded to a
@@ -152,6 +177,10 @@ private:
     bool _solo {false};
     int _gold {0};
     int _xp {0};
+    bool _pazaakDataValid {false};
+    size_t _pazaakCardCount {kK1PazaakCardCount};
+    PazaakCardCounts _pazaakCardCounts {};
+    PazaakSideDeck _pazaakSideDeck {};
 
     bool handleKeyDown(const input::KeyEvent &event);
 

--- a/include/reone/game/pazaak.h
+++ b/include/reone/game/pazaak.h
@@ -46,6 +46,12 @@ enum class CardBehavior {
     FixedPositive,
     FixedNegative,
     SignSelectable,
+    // KotOR II special side-deck cards.
+    Double,        // doubles the value of the immediately preceding board card
+    FlipTwoFour,   // flips the owner's positive 2s and 4s in play to negative
+    FlipThreeSix,  // flips the owner's positive 3s and 6s in play to negative
+    Tiebreaker,    // a selectable +/-1 that also wins an otherwise-tied set
+    ValueChange,   // selectable among +1, +2, -1, -2
 };
 
 enum class CardSign {
@@ -60,9 +66,31 @@ public:
     static CardDefinition fixedPositive(int magnitude);
     static CardDefinition fixedNegative(int magnitude);
     static CardDefinition signSelectable(int magnitude);
+    // KotOR II special cards.
+    static CardDefinition doubleCard();
+    static CardDefinition flipTwoFour();
+    static CardDefinition flipThreeSix();
+    static CardDefinition tiebreaker();
+    static CardDefinition valueChange();
 
     CardBehavior behavior() const { return _behavior; }
     int magnitude() const { return _magnitude; }
+
+    /// True for cards whose committed sign is chosen at play time.
+    bool isSignSelectable() const {
+        return _behavior == CardBehavior::SignSelectable ||
+               _behavior == CardBehavior::Tiebreaker;
+    }
+    /// True for cards whose committed value (magnitude and sign) is chosen at play time.
+    bool isValueSelectable() const { return _behavior == CardBehavior::ValueChange; }
+    /// True for KotOR II special cards that are not present in KotOR I.
+    bool isSpecial() const {
+        return _behavior == CardBehavior::Double ||
+               _behavior == CardBehavior::FlipTwoFour ||
+               _behavior == CardBehavior::FlipThreeSix ||
+               _behavior == CardBehavior::Tiebreaker ||
+               _behavior == CardBehavior::ValueChange;
+    }
 
     bool operator==(const CardDefinition &other) const;
 
@@ -148,6 +176,7 @@ public:
     bool stood() const { return _stood; }
     bool busted() const { return _busted; }
     bool hasNineCardPriority() const { return _nineCardPriority; }
+    bool hasTiebreaker() const { return _hasTiebreaker; }
     bool finished() const { return _stood || _busted || _nineCardPriority; }
     int total() const;
 
@@ -160,6 +189,7 @@ private:
     bool _stood {false};
     bool _busted {false};
     bool _nineCardPriority {false};
+    bool _hasTiebreaker {false};
 };
 
 enum class TurnStage {
@@ -213,6 +243,8 @@ struct PlayHandCardCommand {
     Participant actor;
     size_t handIndex;
     std::optional<CardSign> sign;
+    // Signed selection for ValueChange cards: +1, +2, -1 or -2.
+    std::optional<int> value;
 };
 
 struct EndTurnCommand {
@@ -242,6 +274,10 @@ enum class ActionError {
     SignRequired,
     SignNotAllowed,
     InvalidSign,
+    ValueRequired,
+    ValueNotAllowed,
+    InvalidValue,
+    NoPrecedingCard,
     SetInProgress,
     SetUnresolved,
 };
@@ -289,6 +325,8 @@ private:
     ActionError validateEndTurn(const EndTurnCommand &command) const;
     ActionError validateStand(const StandCommand &command) const;
     void applyValidated(const Command &command);
+    void playHandCard(const PlayHandCardCommand &command);
+    void resolveAutomaticStand(Participant actor);
     void resolveTurn(Participant actor, bool stand);
     void completeSet(SetResult result);
 

--- a/include/reone/game/pazaak.h
+++ b/include/reone/game/pazaak.h
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace reone {
+
+namespace game {
+
+namespace pazaak {
+
+constexpr int kTargetTotal = 20;
+constexpr size_t kMainDeckSize = 40;
+constexpr size_t kSideDeckSize = 10;
+constexpr size_t kHandSize = 4;
+constexpr size_t kBoardSize = 9;
+constexpr uint8_t kSetWinsForMatch = 3;
+
+enum class Participant {
+    One,
+    Two,
+};
+
+enum class CardBehavior {
+    FixedPositive,
+    FixedNegative,
+    SignSelectable,
+};
+
+enum class CardSign {
+    Positive,
+    Negative,
+};
+
+class CardDefinition {
+public:
+    CardDefinition(CardBehavior behavior, int magnitude);
+
+    static CardDefinition fixedPositive(int magnitude);
+    static CardDefinition fixedNegative(int magnitude);
+    static CardDefinition signSelectable(int magnitude);
+
+    CardBehavior behavior() const { return _behavior; }
+    int magnitude() const { return _magnitude; }
+
+    bool operator==(const CardDefinition &other) const;
+
+private:
+    CardBehavior _behavior;
+    int _magnitude;
+};
+
+using SideDeck = std::array<CardDefinition, kSideDeckSize>;
+using HandSelection = std::array<size_t, kHandSize>;
+
+class MainDeck {
+public:
+    explicit MainDeck(std::vector<int> cards);
+
+    static MainDeck standardOrdered();
+
+    const std::vector<int> &cards() const { return _cards; }
+
+    bool operator==(const MainDeck &other) const;
+
+private:
+    friend class MatchState;
+
+    int draw();
+
+    std::vector<int> _cards;
+    size_t _next {0};
+};
+
+struct HandCard {
+    CardDefinition definition;
+    bool used {false};
+
+    bool operator==(const HandCard &other) const;
+};
+
+class ParticipantMatchState {
+public:
+    ParticipantMatchState(const SideDeck &sideDeck, const HandSelection &selection);
+
+    const std::vector<HandCard> &hand() const { return _hand; }
+    uint8_t setWins() const { return _setWins; }
+
+    bool operator==(const ParticipantMatchState &other) const;
+
+private:
+    friend class MatchState;
+
+    std::vector<HandCard> _hand;
+    uint8_t _setWins {0};
+};
+
+enum class PlayedCardSource {
+    MainDeck,
+    Hand,
+};
+
+class PlayedCard {
+public:
+    PlayedCardSource source() const { return _source; }
+    int value() const { return _value; }
+    const std::optional<size_t> &handIndex() const { return _handIndex; }
+
+    bool operator==(const PlayedCard &other) const;
+
+private:
+    friend class MatchState;
+
+    static PlayedCard mainDeck(int value);
+    static PlayedCard hand(size_t handIndex, int value);
+
+    PlayedCard(PlayedCardSource source, int value, std::optional<size_t> handIndex);
+
+    PlayedCardSource _source;
+    int _value;
+    std::optional<size_t> _handIndex;
+};
+
+class ParticipantSetState {
+public:
+    const std::vector<PlayedCard> &board() const { return _board; }
+    bool stood() const { return _stood; }
+    bool busted() const { return _busted; }
+    bool hasNineCardPriority() const { return _nineCardPriority; }
+    bool finished() const { return _stood || _busted || _nineCardPriority; }
+    int total() const;
+
+    bool operator==(const ParticipantSetState &other) const;
+
+private:
+    friend class MatchState;
+
+    std::vector<PlayedCard> _board;
+    bool _stood {false};
+    bool _busted {false};
+    bool _nineCardPriority {false};
+};
+
+enum class TurnStage {
+    AwaitingDraw,
+    AwaitingAction,
+    Complete,
+};
+
+enum class SetResult {
+    InProgress,
+    Tie,
+    UnresolvedBothNine,
+    ParticipantOneWon,
+    ParticipantTwoWon,
+};
+
+class SetState {
+public:
+    /// Invalid participant values are programmer misuse and throw std::invalid_argument.
+    const ParticipantSetState &participant(Participant participant) const;
+    Participant activeParticipant() const { return _activeParticipant; }
+    TurnStage turnStage() const { return _turnStage; }
+    bool handCardPlayedThisTurn() const { return _handCardPlayedThisTurn; }
+    SetResult result() const { return _result; }
+
+    bool operator==(const SetState &other) const;
+
+private:
+    friend class MatchState;
+
+    explicit SetState(Participant firstParticipant);
+
+    std::array<ParticipantSetState, 2> _participants;
+    Participant _activeParticipant;
+    TurnStage _turnStage {TurnStage::AwaitingDraw};
+    bool _handCardPlayedThisTurn {false};
+    SetResult _result {SetResult::InProgress};
+};
+
+enum class MatchResult {
+    InProgress,
+    ParticipantOneWon,
+    ParticipantTwoWon,
+};
+
+struct DrawCommand {
+    Participant actor;
+};
+
+struct PlayHandCardCommand {
+    Participant actor;
+    size_t handIndex;
+    std::optional<CardSign> sign;
+};
+
+struct EndTurnCommand {
+    Participant actor;
+};
+
+struct StandCommand {
+    Participant actor;
+};
+
+using Command = std::variant<DrawCommand, PlayHandCardCommand, EndTurnCommand, StandCommand>;
+
+enum class ActionError {
+    None,
+    InvalidParticipant,
+    MatchComplete,
+    SetComplete,
+    ParticipantFinished,
+    ParticipantStanding,
+    NotActiveParticipant,
+    MustDrawFirst,
+    DrawAlreadyPerformed,
+    BoardFull,
+    InvalidHandIndex,
+    HandCardUsed,
+    HandCardAlreadyPlayedThisTurn,
+    SignRequired,
+    SignNotAllowed,
+    InvalidSign,
+    SetInProgress,
+    SetUnresolved,
+};
+
+struct LegalActions {
+    bool canDraw {false};
+    bool canEndTurn {false};
+    bool canStand {false};
+    std::vector<size_t> playableHandCards;
+};
+
+class MatchState {
+public:
+    MatchState(MainDeck mainDeck,
+               ParticipantMatchState participantOne,
+               ParticipantMatchState participantTwo,
+               Participant firstParticipant);
+
+    const MainDeck &mainDeck() const { return _mainDeck; }
+    /// Invalid participant values are programmer misuse and throw std::invalid_argument.
+    const ParticipantMatchState &participant(Participant participant) const;
+    const SetState &set() const { return _set; }
+    MatchResult result() const { return _result; }
+
+    ActionError validate(const Command &command) const;
+    LegalActions legalActions(Participant participant) const;
+    ActionError apply(const Command &command);
+
+    ActionError startNextSet(MainDeck mainDeck, Participant firstParticipant);
+
+    bool operator==(const MatchState &other) const;
+
+private:
+    friend class SetState;
+
+    static bool isValidParticipant(Participant participant);
+    static size_t participantIndex(Participant participant);
+    static Participant otherParticipant(Participant participant);
+
+    ParticipantSetState &setParticipant(Participant participant);
+    ParticipantMatchState &matchParticipant(Participant participant);
+    ActionError validateActor(Participant actor) const;
+    ActionError validateDraw(const DrawCommand &command) const;
+    ActionError validatePlayHandCard(const PlayHandCardCommand &command) const;
+    ActionError validateEndTurn(const EndTurnCommand &command) const;
+    ActionError validateStand(const StandCommand &command) const;
+    void applyValidated(const Command &command);
+    void resolveTurn(Participant actor, bool stand);
+    void completeSet(SetResult result);
+
+    MainDeck _mainDeck;
+    std::array<ParticipantMatchState, 2> _participants;
+    SetState _set;
+    MatchResult _result {MatchResult::InProgress};
+};
+
+} // namespace pazaak
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/pazaaksession.h
+++ b/include/reone/game/pazaaksession.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "pazaak.h"
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace reone {
+
+namespace game {
+
+enum class PazaakFlowScreen {
+    Wager,
+    Setup,
+    Board,
+};
+
+enum class PazaakCompletedResult {
+    PlayerWon,
+    OpponentWon,
+    PlayerForfeited,
+};
+
+enum class PazaakBoardState {
+    PlayerTurn,
+    AwaitingOpponentPolicy,
+    SetComplete,
+    MatchComplete,
+    UnresolvedBothNine,
+};
+
+enum class PazaakOpponentEvent {
+    None,
+    Draw,
+    PlayerDraw,
+    PlayHandCard,
+    EndTurn,
+    Stand,
+};
+
+enum class PazaakPresentationEventType {
+    TurnStarted,
+    MainDeckDrawn,
+    HandCardPlayed,
+    PlayerSetWon,
+    PlayerSetLost,
+    SetTied,
+    PlayerMatchWon,
+    PlayerMatchLost,
+};
+
+struct PazaakPresentationEvent {
+    PazaakPresentationEventType type;
+    std::optional<pazaak::Participant> participant;
+};
+
+struct PazaakCollectionCard {
+    pazaak::CardDefinition definition;
+    size_t copies {0};
+    int persistentId {-1};
+};
+
+struct PazaakBoardSlot {
+    bool occupied {false};
+    int value {0};
+    pazaak::PlayedCardSource source {pazaak::PlayedCardSource::MainDeck};
+    std::optional<pazaak::CardBehavior> behavior;
+};
+
+struct PazaakHandSlot {
+    bool occupied {false};
+    bool hidden {false};
+    bool used {false};
+    bool playable {false};
+    std::optional<pazaak::CardDefinition> definition;
+    pazaak::CardSign selectedSign {pazaak::CardSign::Positive};
+    // Signed committed value for a ValueChange card: one of +1, +2, -1, -2.
+    int selectedValue {1};
+};
+
+struct PazaakBoardProjection {
+    std::array<PazaakBoardSlot, pazaak::kBoardSize> playerBoard;
+    std::array<PazaakBoardSlot, pazaak::kBoardSize> opponentBoard;
+    std::array<PazaakHandSlot, pazaak::kHandSize> playerHand;
+    std::array<PazaakHandSlot, pazaak::kHandSize> opponentHand;
+    std::string playerName;
+    std::string opponentName;
+    int playerTotal {0};
+    int opponentTotal {0};
+    uint8_t playerSetWins {0};
+    uint8_t opponentSetWins {0};
+    bool playerActive {false};
+    bool opponentActive {false};
+    bool playerStood {false};
+    bool opponentStood {false};
+    bool canEndTurn {false};
+    bool canStand {false};
+    bool forfeitRequested {false};
+    PazaakBoardState state {PazaakBoardState::PlayerTurn};
+    pazaak::SetResult setResult {pazaak::SetResult::InProgress};
+
+    bool operator==(const PazaakBoardProjection &other) const;
+};
+
+struct PazaakSessionParams {
+    int opponentDeck {0};
+    std::string continuationScript;
+    int maximumWager {0};
+    bool tutorialRequested {false};
+    uint32_t opponentId {0};
+    std::string playerName;
+    std::string opponentName;
+    int availableCredits {0};
+    std::vector<PazaakCollectionCard> collection;
+    std::vector<size_t> initialChosenCards;
+    std::optional<pazaak::SideDeck> opponentSideDeck;
+    float resultPresentationDuration {1.5f};
+    bool paceAutomaticDraws {false};
+};
+
+class PazaakSession {
+public:
+    using HandSelector = std::function<pazaak::HandSelection(const pazaak::SideDeck &)>;
+    using MainDeckFactory = std::function<pazaak::MainDeck()>;
+    using FirstParticipantSelector = std::function<pazaak::Participant(size_t setIndex)>;
+
+    PazaakSession(
+        PazaakSessionParams params,
+        HandSelector playerHandSelector,
+        HandSelector opponentHandSelector,
+        MainDeckFactory mainDeckFactory,
+        FirstParticipantSelector firstParticipantSelector = {});
+
+    /// Development-only K1 card pool; it does not read or mutate inventory.
+    static std::vector<PazaakCollectionCard> temporaryK1TestCollection();
+    /// Development-only opponent deck used by the startpazaak console route.
+    static pazaak::SideDeck temporaryK1OpponentSideDeck();
+    /// KotOR II title-default card pool (all 23 card types). Used where the
+    /// clean save does not yet persist owned KotOR II cards; never mutates a save.
+    static std::vector<PazaakCollectionCard> k2DefaultCollection();
+    /// Development-only KotOR II opponent deck (mixes numbered and special cards).
+    static pazaak::SideDeck temporaryK2OpponentSideDeck();
+    /// Development-only deterministic KotOR II showcase selection: indices into
+    /// k2DefaultCollection covering every supported card family.
+    static std::vector<size_t> k2ShowcaseChosenCards();
+
+    PazaakFlowScreen screen() const { return _screen; }
+    int opponentDeck() const { return _params.opponentDeck; }
+    const std::string &continuationScript() const { return _params.continuationScript; }
+    bool tutorialRequested() const { return _params.tutorialRequested; }
+    uint32_t opponentId() const { return _params.opponentId; }
+    const pazaak::SideDeck &opponentSideDeck() const { return *_params.opponentSideDeck; }
+
+    int wager() const { return _wager; }
+    int wagerLimit() const { return _wagerLimit; }
+    void increaseWager();
+    void decreaseWager();
+    bool confirmWager();
+
+    const std::vector<PazaakCollectionCard> &collection() const { return _params.collection; }
+    const std::vector<size_t> &chosenCards() const { return _chosenCards; }
+    size_t remainingCopies(size_t collectionIndex) const;
+    bool selectCard(size_t collectionIndex);
+    bool removeChosenCard(size_t chosenIndex);
+    void clearChosenCards();
+    bool canConfirmSetup() const;
+    bool confirmSetup();
+
+    const pazaak::MatchState *match() const { return _match.get(); }
+    PazaakBoardProjection boardProjection() const;
+    bool selectPlayerCardSign(size_t handIndex, pazaak::CardSign sign);
+    /// Sets the committed value of a ValueChange card; value must be +/-1 or +/-2.
+    bool selectPlayerCardValue(size_t handIndex, int value);
+    /// The four legal ValueChange states, in change-control order (+1, +2, -1, -2).
+    static const std::array<int, 4> &valueChangeStates();
+    pazaak::ActionError playPlayerHandCard(size_t handIndex);
+    pazaak::ActionError endPlayerTurn();
+    pazaak::ActionError standPlayer();
+    bool requestForfeit();
+    bool cancelForfeitRequest();
+    bool confirmForfeit();
+
+    // Explicit development seam for deterministic integration tests.
+    pazaak::ActionError applyOpponentCommand(const pazaak::Command &command);
+    PazaakOpponentEvent advanceOpponentEvent();
+    bool advanceResultPresentation(float dt);
+    std::vector<PazaakPresentationEvent> takePresentationEvents();
+
+    const std::optional<PazaakCompletedResult> &completedResult() const { return _completedResult; }
+    bool terminal() const;
+    bool presentationPending() const { return _resultPresentationPending; }
+
+private:
+    PazaakSessionParams _params;
+    HandSelector _playerHandSelector;
+    HandSelector _opponentHandSelector;
+    MainDeckFactory _mainDeckFactory;
+    FirstParticipantSelector _firstParticipantSelector;
+    PazaakFlowScreen _screen {PazaakFlowScreen::Setup};
+    int _wager {0};
+    int _wagerLimit {0};
+    std::vector<size_t> _chosenCards;
+    std::unique_ptr<pazaak::MatchState> _match;
+    std::array<pazaak::CardSign, pazaak::kHandSize> _selectedSigns;
+    std::array<int, pazaak::kHandSize> _selectedValues;
+    size_t _setIndex {0};
+    bool _forfeitRequested {false};
+    bool _resultPresentationPending {false};
+    float _resultPresentationElapsed {0.0f};
+    std::vector<PazaakPresentationEvent> _presentationEvents;
+    std::optional<PazaakCompletedResult> _completedResult;
+
+    static pazaak::HandSelection defaultHandSelection();
+
+    pazaak::SideDeck chosenSideDeck() const;
+    pazaak::ActionError applyPlayerCommand(const pazaak::Command &command);
+    pazaak::ActionError applyAcceptedCommand(const pazaak::Command &command);
+    void beginResultPresentation();
+    void queueTurnStarted(pazaak::Participant participant);
+    std::optional<pazaak::PlayHandCardCommand> chooseOpponentHandCard() const;
+    pazaak::Command chooseOpponentAction() const;
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/gui/control.h
+++ b/include/reone/gui/control.h
@@ -130,12 +130,15 @@ public:
     bool isSelectable() const { return _selectable; }
     bool isSelected() const { return _selected; }
     bool isDisabled() const { return _disabled; }
+    bool isHilightOverBorder() const { return _hilightOverBorder; }
 
     int id() const { return _id; }
     int padding() const { return _padding; }
     Border &border() const { return *_border; }
     const Extent &extent() const { return _extent; }
     const Border &hilight() const { return *_hilight; }
+    const std::string &borderFillResRef() const { return _borderFillResRef; }
+    const std::string &hilightFillResRef() const { return _hilightFillResRef; }
     const std::string &tag() const { return _tag; }
     const Text &text() const { return _text; }
     const std::vector<std::string> &textLines() const { return _textLines; }
@@ -161,6 +164,7 @@ public:
     void setHilightFill(std::string resRef);
     void setHilightFill(std::shared_ptr<graphics::Texture> texture);
     void setHilightFillTransform(Border::FillTransform transform);
+    void setHilightOverBorder(bool enabled) { _hilightOverBorder = enabled; }
     void setPadding(int padding);
     void setSceneName(std::string name);
     void setText(Text text);
@@ -213,6 +217,8 @@ protected:
 
     int _id {-1};
     std::string _tag;
+    std::string _borderFillResRef;
+    std::string _hilightFillResRef;
     Extent _extent;
     std::shared_ptr<Border> _border;
     std::shared_ptr<Border> _hilight;
@@ -223,6 +229,7 @@ protected:
     bool _visible {true};
     bool _disabled {false};
     bool _selected {false};
+    bool _hilightOverBorder {false};
     bool _selectable {false};
     bool _tintBorderFill {false};
     glm::vec3 _borderColorOverride {1.0f};

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -286,6 +286,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/mainmenu.h
     ${GAME_INCLUDE_DIR}/gui/map.h
     ${GAME_INCLUDE_DIR}/gui/partyselect.h
+    ${GAME_INCLUDE_DIR}/gui/pazaak.h
     ${GAME_INCLUDE_DIR}/gui/saveload.h
     ${GAME_INCLUDE_DIR}/gui/selectoverlay.h
     ${GAME_INCLUDE_DIR}/gui/sounds.h
@@ -502,6 +503,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/mainmenu.cpp
     ${GAME_SOURCE_DIR}/gui/map.cpp
     ${GAME_SOURCE_DIR}/gui/partyselect.cpp
+    ${GAME_SOURCE_DIR}/gui/pazaak.cpp
     ${GAME_SOURCE_DIR}/gui/saveload.cpp
     ${GAME_SOURCE_DIR}/gui/selectoverlay.cpp
     ${GAME_SOURCE_DIR}/gui/sounds.cpp

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -316,6 +316,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/options.h
     ${GAME_INCLUDE_DIR}/party.h
     ${GAME_INCLUDE_DIR}/pazaak.h
+    ${GAME_INCLUDE_DIR}/pazaaksession.h
     ${GAME_INCLUDE_DIR}/pathfinder.h
     ${GAME_INCLUDE_DIR}/player.h
     ${GAME_INCLUDE_DIR}/portrait.h
@@ -527,6 +528,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/object/waypoint.cpp
     ${GAME_SOURCE_DIR}/party.cpp
     ${GAME_SOURCE_DIR}/pazaak.cpp
+    ${GAME_SOURCE_DIR}/pazaaksession.cpp
     ${GAME_SOURCE_DIR}/pathfinder.cpp
     ${GAME_SOURCE_DIR}/player.cpp
     ${GAME_SOURCE_DIR}/portraits.cpp

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -315,6 +315,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/object/waypoint.h
     ${GAME_INCLUDE_DIR}/options.h
     ${GAME_INCLUDE_DIR}/party.h
+    ${GAME_INCLUDE_DIR}/pazaak.h
     ${GAME_INCLUDE_DIR}/pathfinder.h
     ${GAME_INCLUDE_DIR}/player.h
     ${GAME_INCLUDE_DIR}/portrait.h
@@ -525,6 +526,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/object/trigger.cpp
     ${GAME_SOURCE_DIR}/object/waypoint.cpp
     ${GAME_SOURCE_DIR}/party.cpp
+    ${GAME_SOURCE_DIR}/pazaak.cpp
     ${GAME_SOURCE_DIR}/pathfinder.cpp
     ${GAME_SOURCE_DIR}/player.cpp
     ${GAME_SOURCE_DIR}/portraits.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -19,6 +19,7 @@
 
 #include <cctype>
 #include <exception>
+#include <numeric>
 
 #include "reone/game/minigame.h"
 
@@ -87,6 +88,7 @@
 #include "reone/system/exception/validation.h"
 #include "reone/system/fileutil.h"
 #include "reone/system/logutil.h"
+#include "reone/system/randomutil.h"
 #include "reone/system/smallset.h"
 #include "reone/system/threadutil.h"
 
@@ -131,9 +133,182 @@ static const char *screenName(Game::Screen screen) {
         return "PartySelection";
     case Game::Screen::SaveLoad:
         return "SaveLoad";
+    case Game::Screen::SwoopRace:
+        return "SwoopRace";
+    case Game::Screen::PazaakWager:
+        return "PazaakWager";
+    case Game::Screen::PazaakSetup:
+        return "PazaakSetup";
+    case Game::Screen::PazaakBoard:
+        return "PazaakBoard";
     default:
         return "Unknown";
     }
+}
+
+static pazaak::HandSelection randomPazaakHandSelection(const pazaak::SideDeck &) {
+    std::array<size_t, pazaak::kSideDeckSize> indices;
+    std::iota(indices.begin(), indices.end(), 0);
+    for (size_t i = indices.size() - 1; i > 0; --i) {
+        size_t swapIndex = static_cast<size_t>(randomInt(0, static_cast<int>(i)));
+        std::swap(indices[i], indices[swapIndex]);
+    }
+    return {indices[0], indices[1], indices[2], indices[3]};
+}
+
+// Developer-only KotOR II showcase hand selection. The showcase side deck is
+// built in a fixed order, so rotating the four-card window across sets exposes
+// every supported card family during a single match while still obeying the
+// ordinary ten-card side deck and four-card hand rules.
+static PazaakSession::HandSelector showcasePazaakHandSelector() {
+    auto set = std::make_shared<size_t>(0);
+    return [set](const pazaak::SideDeck &) {
+        static const std::array<pazaak::HandSelection, 3> windows {
+            pazaak::HandSelection {0, 1, 2, 3},
+            pazaak::HandSelection {4, 5, 6, 7},
+            pazaak::HandSelection {8, 9, 0, 1},
+        };
+        pazaak::HandSelection selection = windows[*set % windows.size()];
+        ++*set;
+        return selection;
+    };
+}
+
+static pazaak::MainDeck randomPazaakMainDeck() {
+    std::vector<int> cards(pazaak::MainDeck::standardOrdered().cards());
+    for (size_t i = cards.size() - 1; i > 0; --i) {
+        size_t swapIndex = static_cast<size_t>(randomInt(0, static_cast<int>(i)));
+        std::swap(cards[i], cards[swapIndex]);
+    }
+    return pazaak::MainDeck(std::move(cards));
+}
+
+static std::optional<pazaak::CardDefinition> k1PazaakCardDefinition(int cardId) {
+    if (cardId < 0 || cardId >= 18) {
+        return std::nullopt;
+    }
+    int magnitude = cardId % 6 + 1;
+    if (cardId < 6) {
+        return pazaak::CardDefinition::fixedPositive(magnitude);
+    }
+    if (cardId < 12) {
+        return pazaak::CardDefinition::fixedNegative(magnitude);
+    }
+    return pazaak::CardDefinition::signSelectable(magnitude);
+}
+
+// KotOR II owns five extra card types after the numbered ones. Their order
+// follows the authored side-deck screen: Tiebreaker, Double, Flip 2&4, Flip 3&6
+// and Value Change.
+static std::optional<pazaak::CardDefinition> k2PazaakCardDefinition(int cardId) {
+    if (cardId < 0 || cardId >= 23) {
+        return std::nullopt;
+    }
+    if (cardId < 18) {
+        return k1PazaakCardDefinition(cardId);
+    }
+    switch (cardId) {
+    case 18:
+        return pazaak::CardDefinition::tiebreaker();
+    case 19:
+        return pazaak::CardDefinition::doubleCard();
+    case 20:
+        return pazaak::CardDefinition::flipTwoFour();
+    case 21:
+        return pazaak::CardDefinition::flipThreeSix();
+    default:
+        return pazaak::CardDefinition::valueChange();
+    }
+}
+
+static std::optional<pazaak::CardDefinition> parseK1PazaakDeckCard(
+    const std::string &token) {
+
+    if (token.size() != 2 ||
+        (token[0] != '+' && token[0] != '-' && token[0] != '*') ||
+        token[1] < '1' || token[1] > '6') {
+        return std::nullopt;
+    }
+    int magnitude = token[1] - '0';
+    switch (token[0]) {
+    case '+':
+        return pazaak::CardDefinition::fixedPositive(magnitude);
+    case '-':
+        return pazaak::CardDefinition::fixedNegative(magnitude);
+    case '*':
+        return pazaak::CardDefinition::signSelectable(magnitude);
+    default:
+        return std::nullopt;
+    }
+}
+
+static std::optional<pazaak::SideDeck> loadK1PazaakOpponentDeck(
+    const resource::TwoDA &decks,
+    int row) {
+
+    if (row < 0 || row >= decks.getRowCount()) {
+        return std::nullopt;
+    }
+    std::vector<pazaak::CardDefinition> cards;
+    cards.reserve(pazaak::kSideDeckSize);
+    for (size_t i = 0; i < pazaak::kSideDeckSize; ++i) {
+        auto card = parseK1PazaakDeckCard(
+            decks.getString(row, "card" + std::to_string(i)));
+        if (!card) {
+            return std::nullopt;
+        }
+        cards.push_back(*card);
+    }
+    return pazaak::SideDeck {
+        cards[0], cards[1], cards[2], cards[3], cards[4],
+        cards[5], cards[6], cards[7], cards[8], cards[9],
+    };
+}
+
+static std::optional<pazaak::CardDefinition> parseK2PazaakDeckCard(
+    const std::string &token) {
+
+    // KotOR II special-card tokens, verified from shipped card descriptions.
+    if (token == "$$") {
+        return pazaak::CardDefinition::doubleCard();
+    }
+    if (token == "F1") {
+        return pazaak::CardDefinition::flipTwoFour();
+    }
+    if (token == "F2") {
+        return pazaak::CardDefinition::flipThreeSix();
+    }
+    if (token == "TT") {
+        return pazaak::CardDefinition::tiebreaker();
+    }
+    if (token == "VV") {
+        return pazaak::CardDefinition::valueChange();
+    }
+    // Otherwise the KotOR I grammar (+N / -N / *N) applies unchanged.
+    return parseK1PazaakDeckCard(token);
+}
+
+static std::optional<pazaak::SideDeck> loadK2PazaakOpponentDeck(
+    const resource::TwoDA &decks,
+    int row) {
+
+    if (row < 0 || row >= decks.getRowCount()) {
+        return std::nullopt;
+    }
+    std::vector<pazaak::CardDefinition> cards;
+    cards.reserve(pazaak::kSideDeckSize);
+    for (size_t i = 0; i < pazaak::kSideDeckSize; ++i) {
+        auto card = parseK2PazaakDeckCard(
+            decks.getString(row, "card" + std::to_string(i)));
+        if (!card) {
+            return std::nullopt;
+        }
+        cards.push_back(*card);
+    }
+    return pazaak::SideDeck {
+        cards[0], cards[1], cards[2], cards[3], cards[4],
+        cards[5], cards[6], cards[7], cards[8], cards[9],
+    };
 }
 
 static const char *cameraTypeName(CameraType type) {
@@ -285,6 +460,7 @@ void Game::initConsole() {
     registerConsoleCommand("closedoor", "close a selected door object", &Game::consoleOpenCloseDoor);
     registerConsoleCommand("listgames", "list savegames", &Game::consoleListGames);
     registerConsoleCommand("loadgame", "load a savegame", &Game::consoleLoadGame);
+    registerConsoleCommand("startpazaak", "start a development Pazaak match", &Game::consoleStartPazaak);
     if (_options.game.developer) {
         registerConsoleCommand("minigameinfo", "print minigame metadata for current area", &Game::consoleMiniGameInfo);
         registerConsoleCommand("startswoop", "enter the developer swoop race mode for the current area", &Game::consoleStartSwoop);
@@ -382,6 +558,28 @@ void Game::update(float frameTime) {
         return;
     }
     updateMusic();
+
+    if (_screen == Screen::PazaakBoard && _pazaakSession) {
+        static constexpr float kPazaakOpponentEventDelay = 0.45f;
+        if (_pazaakSession->advanceResultPresentation(dt)) {
+            if (_pazaakBoard) {
+                _pazaakBoard->refresh();
+            }
+            completePazaakIfReady();
+        } else if (_pazaakSession && !_pazaakSession->presentationPending()) {
+            _pazaakOpponentEventElapsed += dt;
+            if (_pazaakOpponentEventElapsed >= kPazaakOpponentEventDelay) {
+                _pazaakOpponentEventElapsed = 0.0f;
+                PazaakOpponentEvent event = _pazaakSession->advanceOpponentEvent();
+                if (event != PazaakOpponentEvent::None) {
+                    if (_pazaakBoard) {
+                        _pazaakBoard->refresh();
+                    }
+                    completePazaakIfReady();
+                }
+            }
+        }
+    }
 
     if (!_nextModule.empty()) {
         loadNextModule();
@@ -546,6 +744,10 @@ bool Game::handleMouseButtonUp(const input::MouseButtonEvent &event) {
 void Game::loadModule(const std::string &name, std::string entry, bool fromSave) {
     info("Loading module '" + name + "'");
 
+    // A module transition is a technical Pazaak abort. It must not manufacture
+    // a result or invoke the pending continuation.
+    abortPazaak();
+
     // Tear down an active race before the current area (and its camera/scene)
     // is unloaded, so no dangling references survive the transition.
     if (_swoopRace.isActive()) {
@@ -635,6 +837,7 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
 }
 
 void Game::resetGame() {
+    abortPazaak();
     if (_swoopRace.isActive()) {
         _swoopRace.stop();
     }
@@ -779,6 +982,49 @@ void Game::deserializeParty(resource::Gff &ifoGff) {
 }
 
 void Game::deserializePartyTable(resource::Gff &ptGff) {
+    const auto &pazaakCards = ptGff.getList("PT_PAZAAKCARDS");
+    const auto &pazaakSide = ptGff.getList("PT_PAZSIDELIST");
+    // Each title stores its own number of ownership entries, so the saved table
+    // is accepted at either authored length and the card-type ID range follows
+    // from it.
+    size_t expectedCards = isTSL() ? Party::kK2PazaakCardCount : Party::kK1PazaakCardCount;
+    size_t cardTypes = expectedCards - 1;
+    if (pazaakCards.size() == expectedCards &&
+        pazaakSide.size() == Party::kK1PazaakSideDeckSize) {
+        Party::PazaakCardCounts counts {};
+        Party::PazaakSideDeck sideDeck;
+        bool valid = true;
+        for (size_t i = 0; i < expectedCards; ++i) {
+            counts[i] = pazaakCards[i]->getInt("PT_PAZAAKCOUNT", -1);
+            valid = valid && counts[i] >= 0 && counts[i] <= 255;
+        }
+        bool allEmpty = true;
+        bool allSelected = true;
+        Party::PazaakCardCounts selectedCounts {};
+        for (size_t i = 0; i < sideDeck.size(); ++i) {
+            sideDeck[i] = pazaakSide[i]->getInt("PT_PAZSIDECARD", -2);
+            allEmpty = allEmpty && sideDeck[i] == -1;
+            bool owned = sideDeck[i] >= 0 && static_cast<size_t>(sideDeck[i]) < cardTypes;
+            allSelected = allSelected && owned;
+            if (owned) {
+                ++selectedCounts[sideDeck[i]];
+            }
+        }
+        valid = valid && (allEmpty || allSelected);
+        if (allSelected) {
+            for (size_t i = 0; i < cardTypes; ++i) {
+                valid = valid && selectedCounts[i] <= counts[i];
+            }
+        }
+        if (valid) {
+            _party.setPazaakData(std::move(counts), std::move(sideDeck), expectedCards);
+        } else {
+            warn("Game: invalid Pazaak state in PARTYTABLE.res");
+        }
+    } else if (!pazaakCards.empty() || !pazaakSide.empty()) {
+        warn("Game: invalid Pazaak list sizes in PARTYTABLE.res");
+    }
+
     int nextNpc = 0;
     for (const auto &npcState : ptGff.getList("PT_AVAIL_NPCS")) {
         int npc = nextNpc++;
@@ -873,6 +1119,9 @@ bool Game::loadParty() {
 }
 
 void Game::loadDefaultParty() {
+    // A new game starts with the authored basic collection for the running title.
+    _party.setDefaultPazaakData(
+        isTSL() ? Party::kK2PazaakCardCount : Party::kK1PazaakCardCount);
     std::string member1, member2, member3;
     _party.defaultMembers(member1, member2, member3);
 
@@ -2151,6 +2400,426 @@ void Game::openSaveLoad(SaveLoadMode mode) {
     changeScreen(Screen::SaveLoad);
 }
 
+void Game::serializePazaakPartyTable(resource::Gff &ptGff) const {
+    auto replaceField = [&ptGff](resource::Gff::Field replacement) {
+        auto &fields = ptGff.fields();
+        auto found = std::find_if(fields.begin(), fields.end(), [&replacement](const auto &field) {
+            return field.label == replacement.label;
+        });
+        if (found == fields.end()) {
+            fields.push_back(std::move(replacement));
+        } else {
+            *found = std::move(replacement);
+        }
+    };
+
+    replaceField(resource::Gff::Field::newDword(
+        "PT_GOLD",
+        static_cast<uint32_t>(std::max(0, _party.gold()))));
+    if (!_party.hasValidPazaakData()) {
+        return;
+    }
+
+    // Only the entries the running title actually stores are written back.
+    std::vector<std::shared_ptr<resource::Gff>> cardEntries;
+    const auto &savedCounts = _party.pazaakCardCounts();
+    for (size_t i = 0; i < _party.pazaakCardCount(); ++i) {
+        int count = savedCounts[i];
+        cardEntries.push_back(
+            resource::Gff::Builder()
+                .field(resource::Gff::Field::newByte(
+                    "PT_PAZAAKCOUNT",
+                    static_cast<uint32_t>(count)))
+                .build());
+    }
+    replaceField(resource::Gff::Field::newList(
+        "PT_PAZAAKCARDS",
+        std::move(cardEntries)));
+
+    std::vector<std::shared_ptr<resource::Gff>> sideEntries;
+    for (int cardId : _party.pazaakSideDeck()) {
+        sideEntries.push_back(
+            resource::Gff::Builder()
+                .field(resource::Gff::Field::newInt(
+                    "PT_PAZSIDECARD",
+                    cardId))
+                .build());
+    }
+    replaceField(resource::Gff::Field::newList(
+        "PT_PAZSIDELIST",
+        std::move(sideEntries)));
+}
+
+bool Game::playPazaak(
+    int opponentDeck,
+    std::string continuationScript,
+    int maximumWager,
+    bool tutorialRequested,
+    const std::shared_ptr<Object> &opponent) {
+
+    if (!opponent) {
+        return false;
+    }
+
+    PazaakSessionParams params;
+    params.opponentDeck = opponentDeck;
+    params.continuationScript = std::move(continuationScript);
+    params.maximumWager = maximumWager;
+    params.tutorialRequested = tutorialRequested;
+    params.opponentId = opponent->id();
+    params.opponentName = opponent->name().empty() ? opponent->tag() : opponent->name();
+
+    // A native match always plays with the cards the player actually owns, read
+    // from PARTYTABLE.res. Only the developer command uses temporary cards.
+    if (!_party.hasValidPazaakData()) {
+        error("Unable to start Pazaak: PARTYTABLE.res has no valid Pazaak data");
+        return false;
+    }
+    int cardTypes = static_cast<int>(
+        (isTSL() ? Party::kK2PazaakCardCount : Party::kK1PazaakCardCount) - 1);
+    std::array<std::optional<size_t>, Party::kMaxPazaakCardCount> collectionIndex;
+    const auto &counts = _party.pazaakCardCounts();
+    size_t ownedCards = 0;
+    for (int cardId = 0; cardId < cardTypes; ++cardId) {
+        if (counts[cardId] == 0) {
+            continue;
+        }
+        auto definition = isTSL() ? k2PazaakCardDefinition(cardId)
+                                  : k1PazaakCardDefinition(cardId);
+        if (!definition) {
+            error("Unable to start Pazaak: invalid player collection card ID");
+            return false;
+        }
+        collectionIndex[cardId] = params.collection.size();
+        params.collection.push_back(
+            {*definition, static_cast<size_t>(counts[cardId]), cardId});
+        ownedCards += static_cast<size_t>(counts[cardId]);
+    }
+    if (ownedCards < pazaak::kSideDeckSize) {
+        error("Unable to start Pazaak: player owns fewer than ten side-deck cards");
+        return false;
+    }
+
+    const auto &savedSideDeck = _party.pazaakSideDeck();
+    if (std::all_of(savedSideDeck.begin(), savedSideDeck.end(), [](int id) {
+            return id >= 0;
+        })) {
+        for (int cardId : savedSideDeck) {
+            if (cardId >= cardTypes || !collectionIndex[cardId]) {
+                error("Unable to start Pazaak: saved side deck is not owned");
+                return false;
+            }
+            params.initialChosenCards.push_back(*collectionIndex[cardId]);
+        }
+    }
+
+    if (_pazaakOpponentDeckOverride) {
+        params.opponentSideDeck = _pazaakOpponentDeckOverride;
+    } else {
+        try {
+            auto decks = _services.resource.twoDas.get("pazaakdecks");
+            if (!decks) {
+                error("Unable to start Pazaak: pazaakdecks.2da is missing");
+                return false;
+            }
+            params.opponentSideDeck = isTSL()
+                                          ? loadK2PazaakOpponentDeck(*decks, opponentDeck)
+                                          : loadK1PazaakOpponentDeck(*decks, opponentDeck);
+        } catch (const std::exception &e) {
+            error("Unable to read pazaakdecks.2da: " + std::string(e.what()));
+            return false;
+        }
+        if (!params.opponentSideDeck) {
+            error("Unable to start Pazaak: invalid opponent deck row in pazaakdecks.2da");
+            return false;
+        }
+    }
+    return startPazaakFlow(std::move(params), opponent, false);
+}
+
+bool Game::startDevelopmentPazaak(std::string opponentName) {
+    PazaakSessionParams params;
+    params.opponentDeck = 0;
+    params.maximumWager = 0;
+    params.opponentName = opponentName.empty() ? "Pazaak Opponent" : std::move(opponentName);
+    // The developer route never touches save-owned cards or credits: it uses a
+    // temporary, title-appropriate collection and opponent deck only.
+    if (isTSL()) {
+        params.collection = PazaakSession::k2DefaultCollection();
+        params.opponentSideDeck = PazaakSession::temporaryK2OpponentSideDeck();
+        // Deterministic showcase deck covering every KotOR II family. The first
+        // four entries become the opening hand: a Value Change card, a
+        // sign-selectable card, a fixed card and a non-switchable special.
+        params.initialChosenCards = PazaakSession::k2ShowcaseChosenCards();
+        _pazaakShowcaseHands = true;
+    } else {
+        params.collection = PazaakSession::temporaryK1TestCollection();
+        params.opponentSideDeck = PazaakSession::temporaryK1OpponentSideDeck();
+    }
+    return startPazaakFlow(std::move(params), nullptr, true);
+}
+
+bool Game::startPazaakFlow(
+    PazaakSessionParams params,
+    const std::shared_ptr<Object> &continuationCaller,
+    bool developmentLaunch) {
+
+    if (_pazaakSession) {
+        return false;
+    }
+
+    _pazaakOriginScreen = _screen;
+    _pazaakContinuationCaller = continuationCaller;
+    _pazaakDevelopmentLaunch = developmentLaunch;
+    _pazaakSelectionPersisted = false;
+    _pazaakSettlementApplied = false;
+    _pazaakOpponentEventElapsed = 0.0f;
+    params.availableCredits = _party.gold();
+    params.paceAutomaticDraws = _pazaakPaceAutomaticDraws;
+    if (auto player = _party.player()) {
+        params.playerName = player->name();
+    }
+
+    auto playerSelector = _pazaakPlayerHandSelector
+                              ? _pazaakPlayerHandSelector
+                              : (_pazaakShowcaseHands
+                                     ? showcasePazaakHandSelector()
+                                     : PazaakSession::HandSelector(randomPazaakHandSelection));
+    auto opponentSelector = _pazaakOpponentHandSelector
+                                ? _pazaakOpponentHandSelector
+                                : PazaakSession::HandSelector(randomPazaakHandSelection);
+    auto mainDeckFactory = _pazaakMainDeckFactory
+                               ? _pazaakMainDeckFactory
+                               : PazaakSession::MainDeckFactory(randomPazaakMainDeck);
+    pazaak::Participant firstParticipant =
+        randomInt(0, 1) == 0 ? pazaak::Participant::One : pazaak::Participant::Two;
+    auto firstParticipantSelector = _pazaakFirstParticipantSelector
+                                        ? _pazaakFirstParticipantSelector
+                                        : PazaakSession::FirstParticipantSelector(
+                                              [firstParticipant](size_t setIndex) {
+                                                  bool useInitial = setIndex % 2 == 0;
+                                                  if (useInitial) {
+                                                      return firstParticipant;
+                                                  }
+                                                  return firstParticipant == pazaak::Participant::One
+                                                             ? pazaak::Participant::Two
+                                                             : pazaak::Participant::One;
+                                              });
+
+    try {
+        _pazaakSession = std::make_unique<PazaakSession>(
+            std::move(params),
+            std::move(playerSelector),
+            std::move(opponentSelector),
+            std::move(mainDeckFactory),
+            std::move(firstParticipantSelector));
+    } catch (const std::exception &e) {
+        error("Unable to create Pazaak session: " + std::string(e.what()));
+        releasePazaakFlow(true);
+        return false;
+    }
+
+    if (!loadPazaakGUIs()) {
+        releasePazaakFlow(true);
+        return false;
+    }
+
+    if (_module && _module->area()) {
+        stopMovement();
+    }
+    setRelativeMouseMode(false);
+    setCursorType(CursorType::Default);
+    if (_pazaakSession->screen() == PazaakFlowScreen::Wager) {
+        if (_pazaakWager) {
+            _pazaakWager->refresh();
+        }
+        changeScreen(Screen::PazaakWager);
+    } else {
+        showPazaakSetup();
+    }
+    return true;
+}
+
+bool Game::loadPazaakGUIs() {
+    if (_pazaakGuiLoadOverride) {
+        _pazaakGUIsReady = _pazaakGuiLoadOverride();
+        return _pazaakGUIsReady;
+    }
+
+    _pazaakWager = tryLoadGUI<PazaakWagerGUI>();
+    _pazaakSetup = tryLoadGUI<PazaakSetupGUI>();
+    _pazaakBoard = tryLoadGUI<PazaakBoardGUI>();
+    _pazaakGUIsReady = _pazaakWager && _pazaakSetup && _pazaakBoard;
+    if (!_pazaakGUIsReady) {
+        _pazaakWager.reset();
+        _pazaakSetup.reset();
+        _pazaakBoard.reset();
+    }
+    return _pazaakGUIsReady;
+}
+
+void Game::showPazaakSetup() {
+    if (!_pazaakSession ||
+        !_pazaakGUIsReady ||
+        _pazaakSession->screen() != PazaakFlowScreen::Setup) {
+        return;
+    }
+    if (_pazaakSetup) {
+        _pazaakSetup->refresh();
+    }
+    changeScreen(Screen::PazaakSetup);
+}
+
+void Game::showPazaakBoard() {
+    if (!_pazaakSession ||
+        !_pazaakGUIsReady ||
+        _pazaakSession->screen() != PazaakFlowScreen::Board ||
+        !_pazaakSession->match()) {
+        return;
+    }
+    if (!_pazaakDevelopmentLaunch && !_pazaakSelectionPersisted) {
+        Party::PazaakSideDeck selected;
+        const auto &collection = _pazaakSession->collection();
+        const auto &chosen = _pazaakSession->chosenCards();
+        if (chosen.size() != selected.size()) {
+            error("Unable to persist Pazaak side deck: selection is incomplete");
+            return;
+        }
+        for (size_t i = 0; i < chosen.size(); ++i) {
+            if (chosen[i] >= collection.size() ||
+                collection[chosen[i]].persistentId < 0) {
+                error("Unable to persist Pazaak side deck: invalid collection mapping");
+                return;
+            }
+            selected[i] = collection[chosen[i]].persistentId;
+        }
+        _party.setPazaakSideDeck(std::move(selected));
+        _pazaakSelectionPersisted = true;
+    }
+    if (_pazaakBoard) {
+        _pazaakBoard->refresh();
+    }
+    changeScreen(Screen::PazaakBoard);
+    completePazaakIfReady();
+}
+
+void Game::cancelPazaak() {
+    if (!_pazaakSession || _pazaakSession->screen() == PazaakFlowScreen::Board) {
+        return;
+    }
+    bool developmentLaunch = _pazaakDevelopmentLaunch;
+    releasePazaakFlow(true);
+    if (developmentLaunch) {
+        _console.printLine("pazaak: development match cancelled");
+    }
+}
+
+void Game::abortPazaak() {
+    if (!_pazaakSession) {
+        return;
+    }
+    releasePazaakFlow(true);
+}
+
+void Game::completePazaakIfReady() {
+    if (!_pazaakSession ||
+        !_pazaakSession->completedResult() ||
+        _pazaakSession->presentationPending()) {
+        return;
+    }
+    finishPazaak(*_pazaakSession->completedResult());
+}
+
+void Game::finishPazaak(PazaakCompletedResult result) {
+    if (!_pazaakSession) {
+        return;
+    }
+
+    std::string continuation(_pazaakSession->continuationScript());
+    uint32_t opponentId = _pazaakSession->opponentId();
+    std::shared_ptr<Object> continuationCaller(_pazaakContinuationCaller.lock());
+    bool developmentLaunch = _pazaakDevelopmentLaunch;
+    int wager = _pazaakSession->wager();
+    bool callerValid = continuationCaller &&
+                       continuationCaller->id() == opponentId &&
+                       getObjectById(opponentId) == continuationCaller;
+    _lastPazaakResult = result;
+
+    if (!developmentLaunch && !_pazaakSettlementApplied) {
+        if (result == PazaakCompletedResult::PlayerWon) {
+            _party.giveGold(wager);
+        } else {
+            _party.takeGold(wager);
+        }
+        _pazaakSettlementApplied = true;
+    }
+
+    // Release ownership before external script execution so re-entrant or
+    // repeated completion cannot invoke the continuation twice.
+    releasePazaakFlow(true);
+
+    if (developmentLaunch) {
+        switch (result) {
+        case PazaakCompletedResult::PlayerWon:
+            _console.printLine("pazaak: development match completed - player won");
+            break;
+        case PazaakCompletedResult::OpponentWon:
+            _console.printLine("pazaak: development match completed - opponent won");
+            break;
+        case PazaakCompletedResult::PlayerForfeited:
+            _console.printLine("pazaak: development match completed - player forfeited");
+            break;
+        }
+    }
+
+    if (continuation.empty()) {
+        return;
+    }
+    if (!callerValid) {
+        error("Pazaak continuation skipped because its caller is no longer valid");
+        return;
+    }
+    if (_pazaakContinuationOverride) {
+        _pazaakContinuationOverride(continuation, opponentId);
+    } else if (_scriptRunner) {
+        _scriptRunner->run(continuation, opponentId);
+    }
+}
+
+Game::Screen Game::safePazaakOriginScreen() const {
+    switch (_pazaakOriginScreen) {
+    case Screen::PazaakWager:
+    case Screen::PazaakSetup:
+    case Screen::PazaakBoard:
+        return _module ? Screen::InGame : Screen::None;
+    case Screen::Conversation:
+        // The dialogue may finish after its action script opens Pazaak.
+        // Returning to the world cannot strand an ended conversation GUI.
+        return _module ? Screen::InGame : Screen::None;
+    default:
+        return _pazaakOriginScreen;
+    }
+}
+
+void Game::releasePazaakFlow(bool restoreOrigin) {
+    Screen restore = safePazaakOriginScreen();
+    _pazaakSession.reset();
+    _pazaakWager.reset();
+    _pazaakSetup.reset();
+    _pazaakBoard.reset();
+    _pazaakGUIsReady = false;
+    _pazaakContinuationCaller.reset();
+    _pazaakDevelopmentLaunch = false;
+    _pazaakSelectionPersisted = false;
+    _pazaakSettlementApplied = false;
+    _pazaakShowcaseHands = false;
+    _pazaakOpponentEventElapsed = 0.0f;
+    if (restoreOrigin) {
+        changeScreen(restore);
+    }
+    _pazaakOriginScreen = Screen::None;
+}
+
 void Game::openLevelUp() {
     if (!_charGen) {
         _charGen = tryLoadGUI<CharacterGeneration>();
@@ -2265,6 +2934,12 @@ GameGUI *Game::getScreenGUI() const {
         return _saveLoad.get();
     case Screen::SwoopRace:
         return nullptr; // race skeleton has no HUD yet
+    case Screen::PazaakWager:
+        return _pazaakWager.get();
+    case Screen::PazaakSetup:
+        return _pazaakSetup.get();
+    case Screen::PazaakBoard:
+        return _pazaakBoard.get();
     default:
         return nullptr;
     }
@@ -2993,6 +3668,44 @@ void Game::consoleLoadGame(const ConsoleArgs &args) {
     auto name = _saveNames.begin();
     std::advance(name, id);
     loadGame(*name);
+}
+
+void Game::consoleStartPazaak(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 0, 0, "");
+    if (!_options.game.developer) {
+        _console.printLine("pazaak: developer mode required");
+        return;
+    }
+    if (_pazaakSession) {
+        _console.printLine("pazaak: already active");
+        return;
+    }
+    if (!_module || _screen != Screen::InGame) {
+        _console.printLine("pazaak: no active in-game module");
+        return;
+    }
+
+    std::shared_ptr<Object> selected(_pazaakDevelopmentSelectedObjectOverride.lock());
+    if (!selected) {
+        if (auto area = _module->area()) {
+            selected = area->selectedObject();
+        }
+    }
+
+    std::string opponentName("Pazaak Opponent");
+    if (selected && selected->type() == ObjectType::Creature) {
+        if (!selected->name().empty()) {
+            opponentName = selected->name();
+        } else if (!selected->tag().empty()) {
+            opponentName = selected->tag();
+        }
+    }
+
+    if (!startDevelopmentPazaak(opponentName)) {
+        _console.printLine("pazaak: development launch failed");
+        return;
+    }
+    _console.printLine("pazaak: development match started against " + opponentName);
 }
 
 void Game::consoleMiniGameInfo(const ConsoleArgs &args) {

--- a/src/libs/game/gui/pazaak.cpp
+++ b/src/libs/game/gui/pazaak.cpp
@@ -1,0 +1,863 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "reone/game/gui/pazaak.h"
+
+#include "reone/game/game.h"
+#include "reone/game/pazaaksession.h"
+
+#include "reone/audio/di/services.h"
+#include "reone/audio/mixer.h"
+#include "reone/resource/di/services.h"
+#include "reone/resource/provider/audioclips.h"
+#include "reone/system/logutil.h"
+
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+namespace reone {
+
+namespace game {
+
+using namespace gui;
+using namespace pazaak;
+
+const char *pazaakAudioResRef(PazaakPresentationEventType event) {
+    switch (event) {
+    case PazaakPresentationEventType::TurnStarted:
+        return "mgs_startturn";
+    case PazaakPresentationEventType::MainDeckDrawn:
+        return "mgs_drawmain";
+    case PazaakPresentationEventType::HandCardPlayed:
+        return "mgs_playside";
+    case PazaakPresentationEventType::PlayerSetWon:
+        return "mgs_winset";
+    case PazaakPresentationEventType::PlayerSetLost:
+        return "mgs_loseset";
+    case PazaakPresentationEventType::PlayerMatchWon:
+        return "mgs_winmatch";
+    case PazaakPresentationEventType::PlayerMatchLost:
+        return "mgs_losematch";
+    case PazaakPresentationEventType::SetTied:
+        return nullptr;
+    default:
+        return nullptr;
+    }
+}
+
+namespace {
+
+std::string signedText(int value) {
+    return std::string(value >= 0 ? "+" : "") + std::to_string(value);
+}
+
+std::string cardText(const CardDefinition &card,
+                     CardSign selectedSign = CardSign::Positive,
+                     int selectedValue = 1) {
+    switch (card.behavior()) {
+    case CardBehavior::FixedPositive:
+        return "+" + std::to_string(card.magnitude());
+    case CardBehavior::FixedNegative:
+        return "-" + std::to_string(card.magnitude());
+    case CardBehavior::SignSelectable:
+        return std::string(selectedSign == CardSign::Positive ? "+" : "-") +
+               std::to_string(card.magnitude());
+    // Every special card shares one artwork face, so its identifying label is
+    // drawn in the card's value window using the authored symbols.
+    case CardBehavior::Tiebreaker:
+        return "\xB1" "1T";
+    case CardBehavior::ValueChange:
+        return signedText(selectedValue);
+    case CardBehavior::Double:
+        return "D";
+    case CardBehavior::FlipTwoFour:
+        return "2&4";
+    case CardBehavior::FlipThreeSix:
+        return "3&6";
+    default:
+        return "";
+    }
+}
+
+// One coherent title policy for card art: KotOR I uses the lbl_card* family;
+// KotOR II uses the PC (_p) pcards_* family that accompanies the *_p GUI
+// layouts. Colour derives from explicit provenance, never signed value.
+std::string kotorTwoCardTexture(const char *family) {
+    return std::string(family) + "_p";
+}
+
+// Family assignment follows the shipped artwork: pcards_generic is the green
+// mandatory main-deck card, pcards_gold is the special card, pcards_pos/neg are
+// the blue/red numbered side cards, and pcards_dblpos/dblneg are the split
+// blue/red states of a sign-selectable card.
+std::string mainDeckTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_generic") : "lbl_cardstand";
+}
+std::string specialCardTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_gold") : "lbl_cardrarem";
+}
+std::string positiveCardTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_pos") : "lbl_cardmpos";
+}
+std::string negativeCardTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_neg") : "lbl_cardmneg";
+}
+std::string cardBackTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_back") : "lbl_cardback";
+}
+std::string cardHiliteTexture(bool tsl) {
+    return tsl ? kotorTwoCardTexture("pcards_hilite") : "lbl_cardhilite";
+}
+std::string pipTexture(bool won, bool tsl) {
+    if (tsl) {
+        return won ? "pz_playerliteon" : "pz_playerliteoff";
+    }
+    return won ? "lbl_winmark02" : "lbl_winmark01";
+}
+std::string turnLightTexture(bool tsl) { return tsl ? "pz_playerliteon" : "lbl_pazaakturn"; }
+
+std::string signedSideTexture(bool positive, bool tsl) {
+    if (tsl) {
+        return kotorTwoCardTexture(positive ? "pcards_dblpos" : "pcards_dblneg");
+    }
+    return positive ? "lbl_cardrarem" : "lbl_cardraref";
+}
+
+std::string handCardTexture(const CardDefinition &card, CardSign sign, bool tsl) {
+    switch (card.behavior()) {
+    case CardBehavior::FixedPositive:
+        return positiveCardTexture(tsl);
+    case CardBehavior::FixedNegative:
+        return negativeCardTexture(tsl);
+    case CardBehavior::SignSelectable:
+        return signedSideTexture(sign == CardSign::Positive, tsl);
+    default:
+        // Special cards: Double, both flips, Tiebreaker and Value Change.
+        return specialCardTexture(tsl);
+    }
+}
+
+std::string collectionCardText(const CardDefinition &card) {
+    // The engine draws one glyph per byte, so the plus-minus sign is emitted as a
+    // single authored code point rather than a multi-byte sequence.
+    if (card.behavior() == CardBehavior::SignSelectable) {
+        return "\xB1" + std::to_string(card.magnitude());
+    }
+    if (card.behavior() == CardBehavior::ValueChange) {
+        // Uncommitted, the card advertises the range it can take.
+        return "1\xB1" "2";
+    }
+    return cardText(card);
+}
+
+// A board card's appearance comes from where it came from, never from its final
+// numeric value: a mandatory main-deck draw keeps the main-deck face, and a side
+// card keeps its own family's face once played.
+std::string boardCardTexture(const PazaakBoardSlot &slot, bool tsl) {
+    if (slot.source == PlayedCardSource::MainDeck) {
+        return mainDeckTexture(tsl);
+    }
+    switch (slot.behavior.value_or(CardBehavior::FixedPositive)) {
+    case CardBehavior::FixedNegative:
+        return negativeCardTexture(tsl);
+    case CardBehavior::SignSelectable:
+        return signedSideTexture(slot.value >= 0, tsl);
+    case CardBehavior::Double:
+    case CardBehavior::FlipTwoFour:
+    case CardBehavior::FlipThreeSix:
+    case CardBehavior::Tiebreaker:
+    case CardBehavior::ValueChange:
+        return specialCardTexture(tsl);
+    default:
+        return positiveCardTexture(tsl);
+    }
+}
+
+std::string boardCardText(const PazaakBoardSlot &slot) {
+    if (slot.source == PlayedCardSource::MainDeck) {
+        return std::to_string(slot.value);
+    }
+    if (slot.behavior == CardBehavior::FlipTwoFour) {
+        return "2&4";
+    }
+    if (slot.behavior == CardBehavior::FlipThreeSix) {
+        return "3&6";
+    }
+    return signedText(slot.value);
+}
+
+std::string twoDigitIndex(size_t index) {
+    std::ostringstream stream;
+    stream << (index / 6) << (index % 6);
+    return stream.str();
+}
+
+void clearCard(Control &button, Control &label) {
+    button.setBorderFill("");
+    button.setHilightFill("");
+    button.setHilightOverBorder(false);
+    button.setSelected(false);
+    button.setTextMessage("");
+    button.setDisabled(true);
+    label.setTextMessage("");
+    label.setVisible(false);
+}
+
+void setCardFace(
+    Control &button,
+    Control &label,
+    const std::string &texture,
+    const std::string &text,
+    bool interactive,
+    bool tsl) {
+
+    button.setBorderFill(texture);
+    button.setTextMessage("");
+    button.setDisabled(!interactive);
+    button.setHilightOverBorder(true);
+    button.setHilightFill(cardHiliteTexture(tsl));
+    button.setSelected(false);
+    label.setTextMessage(text);
+    label.setVisible(true);
+}
+
+void setBoardSlot(
+    Control &button,
+    Control &label,
+    const PazaakBoardSlot &slot,
+    bool tsl) {
+
+    if (!slot.occupied) {
+        clearCard(button, label);
+        return;
+    }
+    setCardFace(
+        button,
+        label,
+        boardCardTexture(slot, tsl),
+        boardCardText(slot),
+        false,
+        tsl);
+}
+
+} // namespace
+
+PazaakWagerGUI::PazaakWagerGUI(Game &game, ServicesView &services) :
+    GameGUI(game, services) {
+    _resRef = guiResRef("pazaakwager");
+}
+
+void PazaakWagerGUI::onGUILoaded() {
+    auto button = [this](const std::string &tag) {
+        auto control = findControl<Button>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak button: " + tag);
+        }
+        return control;
+    };
+    auto label = [this](const std::string &tag) {
+        auto control = findControl<Label>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak label: " + tag);
+        }
+        return control;
+    };
+    _controls.less = button("BTN_LESS");
+    _controls.more = button("BTN_MORE");
+    _controls.quit = button("BTN_QUIT");
+    _controls.wager = button("BTN_WAGER");
+    _controls.maximum = label("LBL_MAXIMUM");
+    _controls.title = label("LBL_TITLE");
+    _controls.wagerValue = label("LBL_WAGERVAL");
+
+    _controls.less->setOnClick([this]() {
+        if (auto session = _game.pazaakSession()) {
+            session->decreaseWager();
+            refresh();
+        }
+    });
+    _controls.more->setOnClick([this]() {
+        if (auto session = _game.pazaakSession()) {
+            session->increaseWager();
+            refresh();
+        }
+    });
+    _controls.wager->setOnClick([this]() {
+        if (auto session = _game.pazaakSession(); session && session->confirmWager()) {
+            _game.showPazaakSetup();
+        }
+    });
+    _controls.quit->setOnClick([this]() {
+        _game.cancelPazaak();
+    });
+    _controls.title->setTextMessage("Pazaak");
+    refresh();
+}
+
+void PazaakWagerGUI::refresh() {
+    auto session = _game.pazaakSession();
+    if (!session) {
+        return;
+    }
+    _controls.wagerValue->setTextMessage(std::to_string(session->wager()));
+    _controls.maximum->setTextMessage(
+        "Maximum wager " + std::to_string(session->wagerLimit()));
+    _controls.less->setDisabled(session->wager() <= 0);
+    _controls.more->setDisabled(session->wager() >= session->wagerLimit());
+}
+
+PazaakSetupGUI::PazaakSetupGUI(Game &game, ServicesView &services) :
+    GameGUI(game, services) {
+    _resRef = guiResRef("pazaaksetup");
+}
+
+bool PazaakSetupGUI::handle(const input::Event &event) {
+    if (event.type == input::EventType::KeyDown &&
+        event.key.code == input::KeyCode::Escape &&
+        !event.key.repeat) {
+        _game.cancelPazaak();
+        return true;
+    }
+    return GameGUI::handle(event);
+}
+
+void PazaakSetupGUI::onGUILoaded() {
+    auto button = [this](const std::string &tag) {
+        auto control = findControl<Button>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak button: " + tag);
+        }
+        return control;
+    };
+    auto label = [this](const std::string &tag) {
+        auto control = findControl<Label>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak label: " + tag);
+        }
+        return control;
+    };
+    _controls.accept = button("BTN_ATEXT");
+    // K1's setup has an "Add card" button (BTN_YTEXT); K2's setup omits it (a
+    // card is added by clicking it in the available grid), so it is optional.
+    _controls.cancel = findControl<Button>("BTN_YTEXT");
+    _controls.clear = findControl<Button>("BTN_CLEARCARDS");
+    _controls.help = findControl<Label>("LBL_HELP");
+    _controls.leftTitle = label("LBL_LTEXT");
+    _controls.rightTitle = label("LBL_RTEXT");
+    _controls.title = label("LBL_TITLE");
+    auto session = _game.pazaakSession();
+    size_t requiredAvailableSlots = session ? session->collection().size() : 0;
+    for (size_t i = 0; i < _controls.availableButtons.size(); ++i) {
+        std::string suffix(twoDigitIndex(i));
+        _controls.availableButtons[i] = findControl<Button>("BTN_AVAIL" + suffix);
+        _controls.availableLabels[i] = findControl<Label>("LBL_AVAIL" + suffix);
+        _controls.availableCounts[i] = findControl<Label>("LBL_AVAILNUM" + suffix);
+        if (!_controls.availableButtons[i] ||
+            !_controls.availableLabels[i] ||
+            !_controls.availableCounts[i]) {
+            if (i < requiredAvailableSlots) {
+                throw std::runtime_error(
+                    "Missing Pazaak collection slot: " + suffix);
+            }
+            break;
+        }
+        _controls.availableButtons[i]->setOnClick([this, i]() {
+            _selectedAvailable = i;
+            if (auto session = _game.pazaakSession()) {
+                session->selectCard(i);
+            }
+            refresh();
+        });
+    }
+    for (size_t i = 0; i < _controls.chosenButtons.size(); ++i) {
+        std::string suffix(std::to_string(i));
+        _controls.chosenButtons[i] = button("BTN_CHOSEN" + suffix);
+        _controls.chosenLabels[i] = label("LBL_CHOSEN" + suffix);
+        _controls.chosenButtons[i]->setOnClick([this, i]() {
+            if (auto session = _game.pazaakSession()) {
+                session->removeChosenCard(i);
+                refresh();
+            }
+        });
+    }
+    if (_controls.clear) {
+        _controls.clear->setOnClick([this]() {
+            if (auto session = _game.pazaakSession()) {
+                session->clearChosenCards();
+                refresh();
+            }
+        });
+    }
+    _controls.accept->setOnClick([this]() {
+        if (auto session = _game.pazaakSession(); session && session->confirmSetup()) {
+            _game.showPazaakBoard();
+        }
+    });
+    if (_controls.cancel) {
+        _controls.cancel->setOnClick([this]() {
+            if (auto session = _game.pazaakSession(); session && _selectedAvailable) {
+                session->selectCard(*_selectedAvailable);
+                refresh();
+            }
+        });
+    }
+    _controls.title->setTextMessage("Choose Sidedeck");
+    _controls.leftTitle->setTextMessage("Available cards");
+    _controls.rightTitle->setTextMessage("Chosen cards");
+    _controls.accept->setTextMessage("Play");
+    if (_controls.cancel) {
+        _controls.cancel->setTextMessage("Add card");
+    }
+    if (_controls.help) {
+        _controls.help->setTextMessage("");
+    }
+    refresh();
+}
+
+void PazaakSetupGUI::refresh() {
+    auto session = _game.pazaakSession();
+    if (!session) {
+        return;
+    }
+
+    const auto &collection = session->collection();
+    for (size_t i = 0; i < _controls.availableButtons.size(); ++i) {
+        if (!_controls.availableButtons[i]) {
+            continue;
+        }
+        bool present = i < collection.size();
+        _controls.availableButtons[i]->setVisible(present);
+        _controls.availableLabels[i]->setVisible(present);
+        _controls.availableCounts[i]->setVisible(present);
+        if (!present) {
+            clearCard(
+                *_controls.availableButtons[i],
+                *_controls.availableLabels[i]);
+            _controls.availableCounts[i]->setVisible(false);
+            continue;
+        }
+        size_t remaining = session->remainingCopies(i);
+        std::string text(collectionCardText(collection[i].definition));
+        setCardFace(
+            *_controls.availableButtons[i],
+            *_controls.availableLabels[i],
+            handCardTexture(collection[i].definition, CardSign::Positive, _game.isTSL()),
+            text,
+            remaining > 0 && session->chosenCards().size() < kSideDeckSize,
+            _game.isTSL());
+        _controls.availableButtons[i]->setSelected(
+            _selectedAvailable && *_selectedAvailable == i);
+        _controls.availableCounts[i]->setTextMessage(std::to_string(remaining));
+        _controls.availableCounts[i]->setVisible(true);
+    }
+
+    const auto &chosen = session->chosenCards();
+    for (size_t i = 0; i < _controls.chosenButtons.size(); ++i) {
+        bool present = i < chosen.size();
+        if (!present) {
+            clearCard(*_controls.chosenButtons[i], *_controls.chosenLabels[i]);
+            continue;
+        }
+        const CardDefinition &definition = collection[chosen[i]].definition;
+        setCardFace(
+            *_controls.chosenButtons[i],
+            *_controls.chosenLabels[i],
+            handCardTexture(definition, CardSign::Positive, _game.isTSL()),
+            collectionCardText(definition),
+            true,
+            _game.isTSL());
+    }
+    _controls.accept->setDisabled(!session->canConfirmSetup());
+    if (_controls.cancel) {
+        _controls.cancel->setDisabled(
+            !_selectedAvailable ||
+            session->remainingCopies(*_selectedAvailable) == 0 ||
+            session->chosenCards().size() >= kSideDeckSize);
+    }
+    if (_controls.clear) {
+        _controls.clear->setDisabled(chosen.empty());
+    }
+}
+
+PazaakBoardGUI::PazaakBoardGUI(Game &game, ServicesView &services) :
+    GameGUI(game, services) {
+    _resRef = guiResRef("pazaakgame");
+}
+
+bool PazaakBoardGUI::handle(const input::Event &event) {
+    if (event.type == input::EventType::KeyDown &&
+        event.key.code == input::KeyCode::Escape &&
+        !event.key.repeat) {
+        auto session = _game.pazaakSession();
+        if (!session) {
+            return true;
+        }
+        if (session->boardProjection().forfeitRequested) {
+            if (session->confirmForfeit()) {
+                refresh();
+                _game.completePazaakIfReady();
+            }
+        } else if (session->requestForfeit()) {
+            refresh();
+        }
+        return true;
+    }
+    return GameGUI::handle(event);
+}
+
+void PazaakBoardGUI::onGUILoaded() {
+    auto button = [this](const std::string &tag) {
+        auto control = findControl<Button>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak button: " + tag);
+        }
+        return control;
+    };
+    auto label = [this](const std::string &tag) {
+        auto control = findControl<Label>(tag);
+        if (!control) {
+            throw std::runtime_error("Missing Pazaak label: " + tag);
+        }
+        return control;
+    };
+    _controls.endTurn = button("BTN_XTEXT");
+    _controls.stand = button("BTN_YTEXT");
+    _controls.opponentName = label("LBL_NPCNAME");
+    _controls.opponentTotal = label("LBL_NPCTOTAL");
+    _controls.opponentTurn = label("LBL_NPCTURN");
+    _controls.playerName = label("LBL_PLRNAME");
+    _controls.playerTotal = label("LBL_PLRTOTAL");
+    _controls.playerTurn = label("LBL_PLRTURN");
+
+    for (size_t i = 0; i < kHandSize; ++i) {
+        std::string suffix(std::to_string(i));
+        _controls.flip[i] = findControl<Button>("BTN_FLIP" + suffix);
+        _controls.opponentHandButtons[i] = button("BTN_NPCSIDE" + suffix);
+        _controls.opponentHandLabels[i] = label("LBL_NPCSIDE" + suffix);
+        _controls.playerHandButtons[i] = button("BTN_PLRSIDE" + suffix);
+        _controls.playerHandLabels[i] = label("LBL_PLRSIDE" + suffix);
+
+        if (_controls.flip[i]) {
+            _controls.flip[i]->setOnClick([this, i]() {
+                auto session = _game.pazaakSession();
+                if (!session) {
+                    return;
+                }
+                auto projection = session->boardProjection();
+                CardSign next = projection.playerHand[i].selectedSign == CardSign::Positive
+                                    ? CardSign::Negative
+                                    : CardSign::Positive;
+                session->selectPlayerCardSign(i, next);
+                refresh();
+            });
+        }
+        _controls.playerHandButtons[i]->setOnClick([this, i]() {
+            if (auto session = _game.pazaakSession()) {
+                refreshAfterCommand(session->playPlayerHandCard(i));
+            }
+        });
+        _controls.opponentHandButtons[i]->setDisabled(true);
+    }
+    _controls.forfeit = findControl<Button>("BTN_FORFEITGAME");
+    // The KotOR II Value Change switch is per hand slot, like the sign switch.
+    // It is optional and absent in KotOR I, so a missing control stays unwired.
+    for (size_t i = 0; i < _controls.change.size(); ++i) {
+        _controls.change[i] = findControl<Button>("BTN_CHANGE" + std::to_string(i));
+        if (!_controls.change[i]) {
+            continue;
+        }
+        _controls.change[i]->setOnClick([this, i]() {
+            auto session = _game.pazaakSession();
+            if (!session) {
+                return;
+            }
+            // Advance that slot's card through its legal values.
+            const auto &states = PazaakSession::valueChangeStates();
+            int current = session->boardProjection().playerHand[i].selectedValue;
+            size_t next = 0;
+            for (size_t s = 0; s < states.size(); ++s) {
+                if (states[s] == current) {
+                    next = (s + 1) % states.size();
+                    break;
+                }
+            }
+            session->selectPlayerCardValue(i, states[next]);
+            refresh();
+        });
+    }
+    _controls.flipLegend = findControl<Label>("LBL_FLIPLEGEND");
+    _controls.flipIcon = findControl<Label>("LBL_FLIPICON");
+    _controls.changeLegend = findControl<Label>("LBL_CHANGELEGEND");
+    _controls.changeIcon = findControl<Label>("LBL_CHANGEICON");
+    for (size_t i = 0; i < kBoardSize; ++i) {
+        std::string suffix(std::to_string(i));
+        _controls.opponentBoardButtons[i] = button("BTN_NPC" + suffix);
+        _controls.opponentBoardLabels[i] = label("LBL_NPC" + suffix);
+        _controls.playerBoardButtons[i] = button("BTN_PLR" + suffix);
+        _controls.playerBoardLabels[i] = label("LBL_PLR" + suffix);
+    }
+    for (size_t i = 0; i < kSetWinsForMatch; ++i) {
+        std::string suffix(std::to_string(i));
+        _controls.opponentScores[i] = label("LBL_NPCSCORE" + suffix);
+        _controls.playerScores[i] = label("LBL_PLRSCORE" + suffix);
+    }
+
+    _controls.endTurn->setOnClick([this]() {
+        if (auto session = _game.pazaakSession()) {
+            refreshAfterCommand(session->endPlayerTurn());
+        }
+    });
+    _controls.stand->setOnClick([this]() {
+        if (auto session = _game.pazaakSession()) {
+            refreshAfterCommand(session->standPlayer());
+        }
+    });
+    if (_controls.forfeit) {
+        _controls.forfeit->setOnClick([this]() {
+            auto session = _game.pazaakSession();
+            if (!session) {
+                return;
+            }
+            PazaakBoardProjection projection(session->boardProjection());
+            if (projection.state == PazaakBoardState::UnresolvedBothNine) {
+                _game.abortPazaak();
+            } else if (projection.forfeitRequested) {
+                if (session->confirmForfeit()) {
+                    refresh();
+                    _game.completePazaakIfReady();
+                }
+            } else {
+                session->requestForfeit();
+                refresh();
+            }
+        });
+    }
+    _controls.endTurn->setTextMessage("End Turn");
+    _controls.stand->setTextMessage("Stand");
+    refresh();
+}
+
+void PazaakBoardGUI::refreshAfterCommand(ActionError error) {
+    // MatchState::apply is atomic. Refreshing from the model for both accepted
+    // and rejected commands guarantees the GUI never maintains shadow rules.
+    refresh();
+    if (error == ActionError::None) {
+        _game.completePazaakIfReady();
+    }
+}
+
+void PazaakBoardGUI::refresh() {
+    auto session = _game.pazaakSession();
+    if (!session) {
+        return;
+    }
+    PazaakBoardProjection projection(session->boardProjection());
+    bool tsl = _game.isTSL();
+
+    _controls.playerName->setTextMessage(projection.playerName);
+    _controls.opponentName->setTextMessage(projection.opponentName);
+    _controls.playerTotal->setTextMessage(std::to_string(projection.playerTotal));
+    _controls.opponentTotal->setTextMessage(std::to_string(projection.opponentTotal));
+
+    _controls.playerTurn->setBorderFill("");
+    _controls.opponentTurn->setBorderFill("");
+    _controls.playerTurn->setTextMessage("");
+    _controls.opponentTurn->setTextMessage("");
+    _controls.playerTurn->setVisible(false);
+    _controls.opponentTurn->setVisible(false);
+
+    // Set and match results are never announced with text. They are conveyed
+    // only through the score markers, the resolved board, the authored set and
+    // match audio, and the automatic set transition / final board close. The
+    // turn light marks the active participant while a set is in progress.
+    if (projection.playerActive) {
+        _controls.playerTurn->setVisible(true);
+        _controls.playerTurn->setBorderFill(turnLightTexture(tsl));
+    } else if (projection.opponentActive) {
+        _controls.opponentTurn->setVisible(true);
+        _controls.opponentTurn->setBorderFill(turnLightTexture(tsl));
+    }
+
+    for (size_t i = 0; i < kBoardSize; ++i) {
+        setBoardSlot(
+            *_controls.playerBoardButtons[i],
+            *_controls.playerBoardLabels[i],
+            projection.playerBoard[i],
+            tsl);
+        setBoardSlot(
+            *_controls.opponentBoardButtons[i],
+            *_controls.opponentBoardLabels[i],
+            projection.opponentBoard[i],
+            tsl);
+    }
+    // Every switch control is hidden and cleared first, then only the controls
+    // belonging to the cards actually holding them are turned back on. Because
+    // this runs on every refresh, no control can survive a card being played, a
+    // turn ending, a stand, a set or match transition, or a screen reopen, and a
+    // control can never leak from one hand slot onto another.
+    bool anyFlipShown = false;
+    bool anyChangeShown = false;
+    for (size_t i = 0; i < kHandSize; ++i) {
+        if (_controls.flip[i]) {
+            _controls.flip[i]->setVisible(false);
+            _controls.flip[i]->setDisabled(true);
+            _controls.flip[i]->setSelected(false);
+            _controls.flip[i]->setBorderFill("");
+            _controls.flip[i]->setTextMessage("");
+        }
+        if (_controls.change[i]) {
+            _controls.change[i]->setVisible(false);
+            _controls.change[i]->setDisabled(true);
+            _controls.change[i]->setSelected(false);
+            _controls.change[i]->setBorderFill("");
+            _controls.change[i]->setTextMessage("");
+        }
+    }
+
+    for (size_t i = 0; i < kHandSize; ++i) {
+        const PazaakHandSlot &player = projection.playerHand[i];
+        std::string playerText = player.definition
+                                     ? cardText(*player.definition, player.selectedSign, player.selectedValue)
+                                     : "";
+        if (player.occupied && !player.used && player.definition) {
+            setCardFace(
+                *_controls.playerHandButtons[i],
+                *_controls.playerHandLabels[i],
+                handCardTexture(*player.definition, player.selectedSign, tsl),
+                playerText,
+                player.playable,
+                tsl);
+        } else {
+            clearCard(
+                *_controls.playerHandButtons[i],
+                *_controls.playerHandLabels[i]);
+        }
+
+        bool live = player.occupied && !player.used && player.playable && player.definition;
+        // Only a sign-selectable card carries a sign switch; fixed cards and the
+        // non-switchable specials (Double, both flips, Tiebreaker) carry none.
+        if (live &&
+            player.definition->behavior() == CardBehavior::SignSelectable &&
+            _controls.flip[i]) {
+            _controls.flip[i]->setVisible(true);
+            _controls.flip[i]->setDisabled(false);
+            _controls.flip[i]->setBorderFill(
+                player.selectedSign == CardSign::Positive ? "pazflip" : "pazflip2");
+            anyFlipShown = true;
+        }
+        // Only a Value Change card carries a value switch.
+        if (live && player.definition->isValueSelectable() && _controls.change[i]) {
+            _controls.change[i]->setVisible(true);
+            _controls.change[i]->setDisabled(false);
+            anyChangeShown = true;
+        }
+
+        const PazaakHandSlot &opponent = projection.opponentHand[i];
+        if (opponent.occupied && !opponent.used && opponent.hidden) {
+            _controls.opponentHandButtons[i]->setBorderFill(cardBackTexture(tsl));
+            _controls.opponentHandButtons[i]->setHilightFill("");
+            _controls.opponentHandButtons[i]->setSelected(false);
+            _controls.opponentHandButtons[i]->setTextMessage("");
+            _controls.opponentHandButtons[i]->setDisabled(true);
+            _controls.opponentHandLabels[i]->setTextMessage("");
+            _controls.opponentHandLabels[i]->setVisible(false);
+        } else {
+            clearCard(
+                *_controls.opponentHandButtons[i],
+                *_controls.opponentHandLabels[i]);
+        }
+    }
+
+    // The switch legends and icons are authored artwork, so they are only shown
+    // or hidden alongside their controls and never have text written into them.
+    if (_controls.flipLegend) {
+        _controls.flipLegend->setVisible(anyFlipShown);
+    }
+    if (_controls.flipIcon) {
+        _controls.flipIcon->setVisible(anyFlipShown);
+    }
+    if (_controls.changeLegend) {
+        _controls.changeLegend->setVisible(anyChangeShown);
+    }
+    if (_controls.changeIcon) {
+        _controls.changeIcon->setVisible(anyChangeShown);
+    }
+
+    // All six markers are assigned deterministically on every refresh: the lit
+    // texture for a won set, the unlit texture otherwise. This never relies on
+    // an authored default, so unearned markers can never go missing and a stale
+    // win from a previous match cannot persist into a new one.
+    for (size_t i = 0; i < kSetWinsForMatch; ++i) {
+        bool playerWon = i < projection.playerSetWins;
+        bool opponentWon = i < projection.opponentSetWins;
+        _controls.playerScores[i]->setBorderFill(pipTexture(playerWon, tsl));
+        _controls.opponentScores[i]->setBorderFill(pipTexture(opponentWon, tsl));
+        _controls.playerScores[i]->setTextMessage("");
+        _controls.opponentScores[i]->setTextMessage("");
+        _controls.playerScores[i]->setVisible(true);
+        _controls.opponentScores[i]->setVisible(true);
+    }
+
+    _controls.endTurn->setTextMessage("End Turn");
+    _controls.endTurn->setDisabled(!projection.canEndTurn);
+    _controls.stand->setDisabled(!projection.canStand);
+    _controls.stand->setTextMessage("Stand");
+    if (_controls.forfeit) {
+        _controls.forfeit->setDisabled(
+            !projection.playerActive &&
+            projection.state != PazaakBoardState::UnresolvedBothNine);
+        _controls.forfeit->setTextMessage(
+            projection.state == PazaakBoardState::UnresolvedBothNine
+                ? "Exit"
+                : (projection.forfeitRequested ? "Confirm Forfeit" : "Forfeit"));
+    }
+    playPendingAudio();
+}
+
+void PazaakBoardGUI::playPendingAudio() {
+    auto session = _game.pazaakSession();
+    if (!session) {
+        return;
+    }
+    for (const PazaakPresentationEvent &event : session->takePresentationEvents()) {
+        if (const char *resRef = pazaakAudioResRef(event.type)) {
+            playAudio(resRef);
+        }
+    }
+}
+
+void PazaakBoardGUI::playAudio(const std::string &resRef) {
+    try {
+        auto clip = _services.resource.audioClips.get(resRef);
+        if (!clip) {
+            warn("Pazaak audio cue is unavailable: " + resRef);
+            return;
+        }
+        auto source = _services.audio.mixer.play(
+            std::move(clip),
+            audio::AudioType::Sound);
+        if (!source) {
+            warn("Pazaak audio cue failed to start: " + resRef);
+            return;
+        }
+        _audioSource = std::move(source);
+    } catch (const std::exception &e) {
+        warn(
+            "Pazaak audio cue failed to load: " +
+            resRef +
+            " (" +
+            e.what() +
+            ")");
+    }
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -31,6 +31,29 @@ static constexpr char kBlueprintResRefBastila[] = "p_bastilla";
 static constexpr char kBlueprintResRefAtton[] = "p_atton";
 static constexpr char kBlueprintResRefKreia[] = "p_kreia";
 
+void Party::setPazaakData(
+    PazaakCardCounts counts,
+    PazaakSideDeck sideDeck,
+    size_t cardCount) {
+
+    _pazaakCardCounts = std::move(counts);
+    _pazaakSideDeck = std::move(sideDeck);
+    _pazaakCardCount = std::min(cardCount, kMaxPazaakCardCount);
+    _pazaakDataValid = true;
+}
+
+void Party::setPazaakSideDeck(PazaakSideDeck sideDeck) {
+    _pazaakSideDeck = std::move(sideDeck);
+}
+
+void Party::setDefaultPazaakData(size_t cardCount) {
+    PazaakCardCounts counts {};
+    counts[0] = counts[1] = counts[2] = counts[3] = counts[4] = 2;
+    PazaakSideDeck sideDeck;
+    sideDeck.fill(-1);
+    setPazaakData(std::move(counts), std::move(sideDeck), cardCount);
+}
+
 bool Party::handle(const input::Event &event) {
     if (event.type == input::EventType::KeyDown) {
         return handleKeyDown(event.key);
@@ -107,6 +130,9 @@ void Party::reset() {
     _solo = false;
     _gold = 0;
     _xp = 0;
+    _pazaakDataValid = false;
+    _pazaakCardCounts.fill(0);
+    _pazaakSideDeck.fill(-1);
 }
 
 void Party::clear() {

--- a/src/libs/game/pazaak.cpp
+++ b/src/libs/game/pazaak.cpp
@@ -32,13 +32,31 @@ namespace pazaak {
 CardDefinition::CardDefinition(CardBehavior behavior, int magnitude)
     : _behavior(behavior),
       _magnitude(magnitude) {
-    if (behavior != CardBehavior::FixedPositive &&
-        behavior != CardBehavior::FixedNegative &&
-        behavior != CardBehavior::SignSelectable) {
-        throw std::invalid_argument("Unsupported KotOR I Pazaak card behavior");
-    }
-    if (magnitude < 1 || magnitude > 6) {
-        throw std::invalid_argument("KotOR I Pazaak card magnitude must be between 1 and 6");
+    switch (behavior) {
+    case CardBehavior::FixedPositive:
+    case CardBehavior::FixedNegative:
+    case CardBehavior::SignSelectable:
+        if (magnitude < 1 || magnitude > 6) {
+            throw std::invalid_argument("Pazaak numbered card magnitude must be between 1 and 6");
+        }
+        break;
+    case CardBehavior::Tiebreaker:
+        // The Tiebreaker contributes a selectable +/-1 in addition to winning ties.
+        if (magnitude != 1) {
+            throw std::invalid_argument("Pazaak Tiebreaker card magnitude must be 1");
+        }
+        break;
+    case CardBehavior::Double:
+    case CardBehavior::FlipTwoFour:
+    case CardBehavior::FlipThreeSix:
+    case CardBehavior::ValueChange:
+        // These cards carry no fixed magnitude of their own.
+        if (magnitude != 0) {
+            throw std::invalid_argument("Pazaak special card must not declare a magnitude");
+        }
+        break;
+    default:
+        throw std::invalid_argument("Unsupported Pazaak card behavior");
     }
 }
 
@@ -52,6 +70,26 @@ CardDefinition CardDefinition::fixedNegative(int magnitude) {
 
 CardDefinition CardDefinition::signSelectable(int magnitude) {
     return CardDefinition(CardBehavior::SignSelectable, magnitude);
+}
+
+CardDefinition CardDefinition::doubleCard() {
+    return CardDefinition(CardBehavior::Double, 0);
+}
+
+CardDefinition CardDefinition::flipTwoFour() {
+    return CardDefinition(CardBehavior::FlipTwoFour, 0);
+}
+
+CardDefinition CardDefinition::flipThreeSix() {
+    return CardDefinition(CardBehavior::FlipThreeSix, 0);
+}
+
+CardDefinition CardDefinition::tiebreaker() {
+    return CardDefinition(CardBehavior::Tiebreaker, 1);
+}
+
+CardDefinition CardDefinition::valueChange() {
+    return CardDefinition(CardBehavior::ValueChange, 0);
 }
 
 bool CardDefinition::operator==(const CardDefinition &other) const {
@@ -148,7 +186,8 @@ bool ParticipantSetState::operator==(const ParticipantSetState &other) const {
     return _board == other._board &&
            _stood == other._stood &&
            _busted == other._busted &&
-           _nineCardPriority == other._nineCardPriority;
+           _nineCardPriority == other._nineCardPriority &&
+           _hasTiebreaker == other._hasTiebreaker;
 }
 
 SetState::SetState(Participant firstParticipant)
@@ -274,16 +313,43 @@ ActionError MatchState::validatePlayHandCard(const PlayHandCardCommand &command)
     switch (handCard.definition.behavior()) {
     case CardBehavior::FixedPositive:
     case CardBehavior::FixedNegative:
+    case CardBehavior::Double:
+    case CardBehavior::FlipTwoFour:
+    case CardBehavior::FlipThreeSix:
         if (command.sign) {
             return ActionError::SignNotAllowed;
         }
+        if (command.value) {
+            return ActionError::ValueNotAllowed;
+        }
+        if (handCard.definition.behavior() == CardBehavior::Double &&
+            setParticipantState._board.empty()) {
+            // Double has nothing to double with no preceding board card.
+            return ActionError::NoPrecedingCard;
+        }
         break;
     case CardBehavior::SignSelectable:
+    case CardBehavior::Tiebreaker:
+        if (command.value) {
+            return ActionError::ValueNotAllowed;
+        }
         if (!command.sign) {
             return ActionError::SignRequired;
         }
         if (*command.sign != CardSign::Positive && *command.sign != CardSign::Negative) {
             return ActionError::InvalidSign;
+        }
+        break;
+    case CardBehavior::ValueChange:
+        if (command.sign) {
+            return ActionError::SignNotAllowed;
+        }
+        if (!command.value) {
+            return ActionError::ValueRequired;
+        }
+        if (*command.value != 1 && *command.value != 2 &&
+            *command.value != -1 && *command.value != -2) {
+            return ActionError::InvalidValue;
         }
         break;
     default:
@@ -337,7 +403,10 @@ LegalActions MatchState::legalActions(Participant participant) const {
     for (size_t index = 0; index < hand.size(); ++index) {
         const CardDefinition &definition = hand[index].definition;
         bool playable = false;
-        if (definition.behavior() == CardBehavior::SignSelectable) {
+        if (definition.isValueSelectable()) {
+            // Any of the four legal values would validate the same way.
+            playable = validate(PlayHandCardCommand {participant, index, std::nullopt, 1}) == ActionError::None;
+        } else if (definition.isSignSelectable()) {
             playable = validate(PlayHandCardCommand {participant, index, CardSign::Positive}) == ActionError::None ||
                        validate(PlayHandCardCommand {participant, index, CardSign::Negative}) == ActionError::None;
         } else {
@@ -368,16 +437,9 @@ void MatchState::applyValidated(const Command &command) {
         if constexpr (std::is_same_v<CommandType, DrawCommand>) {
             setParticipant(typedCommand.actor)._board.push_back(PlayedCard::mainDeck(_mainDeck.draw()));
             _set._turnStage = TurnStage::AwaitingAction;
+            resolveAutomaticStand(typedCommand.actor);
         } else if constexpr (std::is_same_v<CommandType, PlayHandCardCommand>) {
-            HandCard &handCard = matchParticipant(typedCommand.actor)._hand[typedCommand.handIndex];
-            int value = handCard.definition.magnitude();
-            if (handCard.definition.behavior() == CardBehavior::FixedNegative ||
-                (handCard.definition.behavior() == CardBehavior::SignSelectable && *typedCommand.sign == CardSign::Negative)) {
-                value = -value;
-            }
-            setParticipant(typedCommand.actor)._board.push_back(PlayedCard::hand(typedCommand.handIndex, value));
-            handCard.used = true;
-            _set._handCardPlayedThisTurn = true;
+            playHandCard(typedCommand);
         } else if constexpr (std::is_same_v<CommandType, EndTurnCommand>) {
             resolveTurn(typedCommand.actor, false);
         } else {
@@ -385,6 +447,77 @@ void MatchState::applyValidated(const Command &command) {
         }
     },
                command);
+}
+
+void MatchState::playHandCard(const PlayHandCardCommand &command) {
+    HandCard &handCard = matchParticipant(command.actor)._hand[command.handIndex];
+    ParticipantSetState &actorState = setParticipant(command.actor);
+    const CardDefinition &definition = handCard.definition;
+
+    int playedValue = 0;
+    switch (definition.behavior()) {
+    case CardBehavior::FixedPositive:
+        playedValue = definition.magnitude();
+        break;
+    case CardBehavior::FixedNegative:
+        playedValue = -definition.magnitude();
+        break;
+    case CardBehavior::SignSelectable:
+        playedValue = *command.sign == CardSign::Negative
+                          ? -definition.magnitude()
+                          : definition.magnitude();
+        break;
+    case CardBehavior::Tiebreaker:
+        // Contributes a selectable +/-1 and marks the set for tie resolution.
+        playedValue = *command.sign == CardSign::Negative ? -1 : 1;
+        actorState._hasTiebreaker = true;
+        break;
+    case CardBehavior::ValueChange:
+        // The signed value was validated to be one of +1, +2, -1, -2.
+        playedValue = *command.value;
+        break;
+    case CardBehavior::Double:
+        // Doubles the immediately preceding board card by contributing its
+        // value again as a distinct card. The board is non-empty (validated).
+        playedValue = actorState._board.back().value();
+        break;
+    case CardBehavior::FlipTwoFour:
+        // Flip only the owner's positive 2s and 4s to negative.
+        for (PlayedCard &card : actorState._board) {
+            if (card._value == 2) {
+                card._value = -2;
+            } else if (card._value == 4) {
+                card._value = -4;
+            }
+        }
+        playedValue = 0;
+        break;
+    case CardBehavior::FlipThreeSix:
+        for (PlayedCard &card : actorState._board) {
+            if (card._value == 3) {
+                card._value = -3;
+            } else if (card._value == 6) {
+                card._value = -6;
+            }
+        }
+        playedValue = 0;
+        break;
+    }
+
+    actorState._board.push_back(PlayedCard::hand(command.handIndex, playedValue));
+    handCard.used = true;
+    _set._handCardPlayedThisTurn = true;
+    resolveAutomaticStand(command.actor);
+}
+
+void MatchState::resolveAutomaticStand(Participant actor) {
+    if (_set._result == SetResult::InProgress &&
+        setParticipant(actor).total() == kTargetTotal) {
+        // resolveTurn owns bust and nine-card precedence. In particular, a
+        // legal ninth card at 20 becomes nine-card priority, not an ordinary
+        // stand.
+        resolveTurn(actor, true);
+    }
 }
 
 void MatchState::resolveTurn(Participant actor, bool stand) {
@@ -422,7 +555,17 @@ void MatchState::resolveTurn(Participant actor, bool stand) {
     }
     if (actorState._stood && otherState._stood) {
         if (actorState.total() == otherState.total()) {
-            completeSet(SetResult::Tie);
+            // Tiebreaker precedence applies only to an otherwise-legal tie
+            // (bust and nine-card priority are resolved earlier). A single
+            // committed Tiebreaker wins; if neither or both hold one it stays
+            // a tie.
+            if (actorState._hasTiebreaker && !otherState._hasTiebreaker) {
+                completeSet(actor == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);
+            } else if (otherState._hasTiebreaker && !actorState._hasTiebreaker) {
+                completeSet(other == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);
+            } else {
+                completeSet(SetResult::Tie);
+            }
         } else {
             Participant winner = actorState.total() > otherState.total() ? actor : other;
             completeSet(winner == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);

--- a/src/libs/game/pazaak.cpp
+++ b/src/libs/game/pazaak.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/pazaak.h"
+
+#include <algorithm>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace reone {
+
+namespace game {
+
+namespace pazaak {
+
+CardDefinition::CardDefinition(CardBehavior behavior, int magnitude)
+    : _behavior(behavior),
+      _magnitude(magnitude) {
+    if (behavior != CardBehavior::FixedPositive &&
+        behavior != CardBehavior::FixedNegative &&
+        behavior != CardBehavior::SignSelectable) {
+        throw std::invalid_argument("Unsupported KotOR I Pazaak card behavior");
+    }
+    if (magnitude < 1 || magnitude > 6) {
+        throw std::invalid_argument("KotOR I Pazaak card magnitude must be between 1 and 6");
+    }
+}
+
+CardDefinition CardDefinition::fixedPositive(int magnitude) {
+    return CardDefinition(CardBehavior::FixedPositive, magnitude);
+}
+
+CardDefinition CardDefinition::fixedNegative(int magnitude) {
+    return CardDefinition(CardBehavior::FixedNegative, magnitude);
+}
+
+CardDefinition CardDefinition::signSelectable(int magnitude) {
+    return CardDefinition(CardBehavior::SignSelectable, magnitude);
+}
+
+bool CardDefinition::operator==(const CardDefinition &other) const {
+    return _behavior == other._behavior && _magnitude == other._magnitude;
+}
+
+MainDeck::MainDeck(std::vector<int> cards)
+    : _cards(std::move(cards)) {
+    if (_cards.size() != kMainDeckSize) {
+        throw std::invalid_argument("A Pazaak main deck must contain exactly 40 cards");
+    }
+
+    std::array<size_t, 11> counts {};
+    for (int value : _cards) {
+        if (value < 1 || value > 10) {
+            throw std::invalid_argument("Pazaak main-deck values must be between 1 and 10");
+        }
+        ++counts[value];
+    }
+    for (int value = 1; value <= 10; ++value) {
+        if (counts[value] != 4) {
+            throw std::invalid_argument("A Pazaak main deck must contain four copies of every value from 1 to 10");
+        }
+    }
+}
+
+MainDeck MainDeck::standardOrdered() {
+    std::vector<int> cards;
+    cards.reserve(kMainDeckSize);
+    for (int value = 1; value <= 10; ++value) {
+        for (int copy = 0; copy < 4; ++copy) {
+            cards.push_back(value);
+        }
+    }
+    return MainDeck(std::move(cards));
+}
+
+int MainDeck::draw() {
+    return _cards[_next++];
+}
+
+bool MainDeck::operator==(const MainDeck &other) const {
+    return _cards == other._cards && _next == other._next;
+}
+
+bool HandCard::operator==(const HandCard &other) const {
+    return definition == other.definition && used == other.used;
+}
+
+ParticipantMatchState::ParticipantMatchState(const SideDeck &sideDeck, const HandSelection &selection) {
+    std::array<bool, kSideDeckSize> selected {};
+    _hand.reserve(kHandSize);
+    for (size_t index : selection) {
+        if (index >= sideDeck.size()) {
+            throw std::invalid_argument("Pazaak hand selection index is outside the ten-card side deck");
+        }
+        if (selected[index]) {
+            throw std::invalid_argument("Pazaak hand selection indices must be unique");
+        }
+        selected[index] = true;
+        _hand.push_back({sideDeck[index], false});
+    }
+}
+
+bool ParticipantMatchState::operator==(const ParticipantMatchState &other) const {
+    return _hand == other._hand && _setWins == other._setWins;
+}
+
+PlayedCard::PlayedCard(PlayedCardSource source, int value, std::optional<size_t> handIndex)
+    : _source(source),
+      _value(value),
+      _handIndex(handIndex) {
+}
+
+PlayedCard PlayedCard::mainDeck(int value) {
+    return PlayedCard(PlayedCardSource::MainDeck, value, std::nullopt);
+}
+
+PlayedCard PlayedCard::hand(size_t handIndex, int value) {
+    return PlayedCard(PlayedCardSource::Hand, value, handIndex);
+}
+
+bool PlayedCard::operator==(const PlayedCard &other) const {
+    return _source == other._source && _value == other._value && _handIndex == other._handIndex;
+}
+
+int ParticipantSetState::total() const {
+    return std::accumulate(_board.begin(), _board.end(), 0, [](int total, const PlayedCard &card) {
+        return total + card.value();
+    });
+}
+
+bool ParticipantSetState::operator==(const ParticipantSetState &other) const {
+    return _board == other._board &&
+           _stood == other._stood &&
+           _busted == other._busted &&
+           _nineCardPriority == other._nineCardPriority;
+}
+
+SetState::SetState(Participant firstParticipant)
+    : _activeParticipant(firstParticipant) {
+}
+
+const ParticipantSetState &SetState::participant(Participant participant) const {
+    if (!MatchState::isValidParticipant(participant)) {
+        throw std::invalid_argument("Invalid Pazaak participant");
+    }
+    return _participants[MatchState::participantIndex(participant)];
+}
+
+bool SetState::operator==(const SetState &other) const {
+    return _participants == other._participants &&
+           _activeParticipant == other._activeParticipant &&
+           _turnStage == other._turnStage &&
+           _handCardPlayedThisTurn == other._handCardPlayedThisTurn &&
+           _result == other._result;
+}
+
+MatchState::MatchState(MainDeck mainDeck,
+                       ParticipantMatchState participantOne,
+                       ParticipantMatchState participantTwo,
+                       Participant firstParticipant)
+    : _mainDeck(std::move(mainDeck)),
+      _participants({std::move(participantOne), std::move(participantTwo)}),
+      _set(firstParticipant) {
+    if (!isValidParticipant(firstParticipant)) {
+        throw std::invalid_argument("Invalid first Pazaak participant");
+    }
+}
+
+const ParticipantMatchState &MatchState::participant(Participant participant) const {
+    if (!isValidParticipant(participant)) {
+        throw std::invalid_argument("Invalid Pazaak participant");
+    }
+    return _participants[participantIndex(participant)];
+}
+
+bool MatchState::isValidParticipant(Participant participant) {
+    return participant == Participant::One || participant == Participant::Two;
+}
+
+size_t MatchState::participantIndex(Participant participant) {
+    return participant == Participant::One ? 0 : 1;
+}
+
+Participant MatchState::otherParticipant(Participant participant) {
+    return participant == Participant::One ? Participant::Two : Participant::One;
+}
+
+ParticipantSetState &MatchState::setParticipant(Participant participant) {
+    return _set._participants[participantIndex(participant)];
+}
+
+ParticipantMatchState &MatchState::matchParticipant(Participant participant) {
+    return _participants[participantIndex(participant)];
+}
+
+ActionError MatchState::validateActor(Participant actor) const {
+    if (!isValidParticipant(actor)) {
+        return ActionError::InvalidParticipant;
+    }
+    if (_result != MatchResult::InProgress) {
+        return ActionError::MatchComplete;
+    }
+    if (_set._result != SetResult::InProgress) {
+        return ActionError::SetComplete;
+    }
+    if (_set._participants[participantIndex(actor)]._nineCardPriority) {
+        return ActionError::ParticipantFinished;
+    }
+    if (_set._participants[participantIndex(actor)]._stood) {
+        return ActionError::ParticipantStanding;
+    }
+    if (_set._activeParticipant != actor) {
+        return ActionError::NotActiveParticipant;
+    }
+    return ActionError::None;
+}
+
+ActionError MatchState::validateDraw(const DrawCommand &command) const {
+    ActionError error = validateActor(command.actor);
+    if (error != ActionError::None) {
+        return error;
+    }
+    if (_set._turnStage != TurnStage::AwaitingDraw) {
+        return ActionError::DrawAlreadyPerformed;
+    }
+    if (_set._participants[participantIndex(command.actor)]._board.size() >= kBoardSize) {
+        return ActionError::BoardFull;
+    }
+    return ActionError::None;
+}
+
+ActionError MatchState::validatePlayHandCard(const PlayHandCardCommand &command) const {
+    ActionError error = validateActor(command.actor);
+    if (error != ActionError::None) {
+        return error;
+    }
+    if (_set._turnStage != TurnStage::AwaitingAction) {
+        return ActionError::MustDrawFirst;
+    }
+    if (_set._handCardPlayedThisTurn) {
+        return ActionError::HandCardAlreadyPlayedThisTurn;
+    }
+
+    const ParticipantSetState &setParticipantState = _set._participants[participantIndex(command.actor)];
+    if (setParticipantState._board.size() >= kBoardSize) {
+        return ActionError::BoardFull;
+    }
+
+    const ParticipantMatchState &matchParticipantState = _participants[participantIndex(command.actor)];
+    if (command.handIndex >= matchParticipantState._hand.size()) {
+        return ActionError::InvalidHandIndex;
+    }
+    const HandCard &handCard = matchParticipantState._hand[command.handIndex];
+    if (handCard.used) {
+        return ActionError::HandCardUsed;
+    }
+
+    switch (handCard.definition.behavior()) {
+    case CardBehavior::FixedPositive:
+    case CardBehavior::FixedNegative:
+        if (command.sign) {
+            return ActionError::SignNotAllowed;
+        }
+        break;
+    case CardBehavior::SignSelectable:
+        if (!command.sign) {
+            return ActionError::SignRequired;
+        }
+        if (*command.sign != CardSign::Positive && *command.sign != CardSign::Negative) {
+            return ActionError::InvalidSign;
+        }
+        break;
+    default:
+        return ActionError::InvalidSign;
+    }
+    return ActionError::None;
+}
+
+ActionError MatchState::validateEndTurn(const EndTurnCommand &command) const {
+    ActionError error = validateActor(command.actor);
+    if (error != ActionError::None) {
+        return error;
+    }
+    return _set._turnStage == TurnStage::AwaitingAction ? ActionError::None : ActionError::MustDrawFirst;
+}
+
+ActionError MatchState::validateStand(const StandCommand &command) const {
+    ActionError error = validateActor(command.actor);
+    if (error != ActionError::None) {
+        return error;
+    }
+    return _set._turnStage == TurnStage::AwaitingAction ? ActionError::None : ActionError::MustDrawFirst;
+}
+
+ActionError MatchState::validate(const Command &command) const {
+    return std::visit([this](const auto &typedCommand) {
+        using CommandType = std::decay_t<decltype(typedCommand)>;
+        if constexpr (std::is_same_v<CommandType, DrawCommand>) {
+            return validateDraw(typedCommand);
+        } else if constexpr (std::is_same_v<CommandType, PlayHandCardCommand>) {
+            return validatePlayHandCard(typedCommand);
+        } else if constexpr (std::is_same_v<CommandType, EndTurnCommand>) {
+            return validateEndTurn(typedCommand);
+        } else {
+            return validateStand(typedCommand);
+        }
+    },
+                      command);
+}
+
+LegalActions MatchState::legalActions(Participant participant) const {
+    LegalActions actions;
+    actions.canDraw = validate(DrawCommand {participant}) == ActionError::None;
+    actions.canEndTurn = validate(EndTurnCommand {participant}) == ActionError::None;
+    actions.canStand = validate(StandCommand {participant}) == ActionError::None;
+
+    if (!isValidParticipant(participant)) {
+        return actions;
+    }
+    const auto &hand = _participants[participantIndex(participant)]._hand;
+    for (size_t index = 0; index < hand.size(); ++index) {
+        const CardDefinition &definition = hand[index].definition;
+        bool playable = false;
+        if (definition.behavior() == CardBehavior::SignSelectable) {
+            playable = validate(PlayHandCardCommand {participant, index, CardSign::Positive}) == ActionError::None ||
+                       validate(PlayHandCardCommand {participant, index, CardSign::Negative}) == ActionError::None;
+        } else {
+            playable = validate(PlayHandCardCommand {participant, index, std::nullopt}) == ActionError::None;
+        }
+        if (playable) {
+            actions.playableHandCards.push_back(index);
+        }
+    }
+    return actions;
+}
+
+ActionError MatchState::apply(const Command &command) {
+    ActionError error = validate(command);
+    if (error != ActionError::None) {
+        return error;
+    }
+
+    MatchState next(*this);
+    next.applyValidated(command);
+    *this = std::move(next);
+    return ActionError::None;
+}
+
+void MatchState::applyValidated(const Command &command) {
+    std::visit([this](const auto &typedCommand) {
+        using CommandType = std::decay_t<decltype(typedCommand)>;
+        if constexpr (std::is_same_v<CommandType, DrawCommand>) {
+            setParticipant(typedCommand.actor)._board.push_back(PlayedCard::mainDeck(_mainDeck.draw()));
+            _set._turnStage = TurnStage::AwaitingAction;
+        } else if constexpr (std::is_same_v<CommandType, PlayHandCardCommand>) {
+            HandCard &handCard = matchParticipant(typedCommand.actor)._hand[typedCommand.handIndex];
+            int value = handCard.definition.magnitude();
+            if (handCard.definition.behavior() == CardBehavior::FixedNegative ||
+                (handCard.definition.behavior() == CardBehavior::SignSelectable && *typedCommand.sign == CardSign::Negative)) {
+                value = -value;
+            }
+            setParticipant(typedCommand.actor)._board.push_back(PlayedCard::hand(typedCommand.handIndex, value));
+            handCard.used = true;
+            _set._handCardPlayedThisTurn = true;
+        } else if constexpr (std::is_same_v<CommandType, EndTurnCommand>) {
+            resolveTurn(typedCommand.actor, false);
+        } else {
+            resolveTurn(typedCommand.actor, true);
+        }
+    },
+               command);
+}
+
+void MatchState::resolveTurn(Participant actor, bool stand) {
+    ParticipantSetState &actorState = setParticipant(actor);
+    Participant other = otherParticipant(actor);
+    ParticipantSetState &otherState = setParticipant(other);
+
+    if (actorState.total() > kTargetTotal) {
+        actorState._busted = true;
+        completeSet(actor == Participant::One ? SetResult::ParticipantTwoWon : SetResult::ParticipantOneWon);
+        return;
+    }
+
+    if (actorState._board.size() == kBoardSize) {
+        actorState._nineCardPriority = true;
+        if (otherState._nineCardPriority) {
+            completeSet(SetResult::UnresolvedBothNine);
+        } else if (otherState.finished()) {
+            completeSet(actor == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);
+        } else {
+            _set._activeParticipant = other;
+            _set._turnStage = TurnStage::AwaitingDraw;
+            _set._handCardPlayedThisTurn = false;
+        }
+        return;
+    }
+
+    if (stand) {
+        actorState._stood = true;
+    }
+
+    if (actorState._stood && otherState._nineCardPriority) {
+        completeSet(other == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);
+        return;
+    }
+    if (actorState._stood && otherState._stood) {
+        if (actorState.total() == otherState.total()) {
+            completeSet(SetResult::Tie);
+        } else {
+            Participant winner = actorState.total() > otherState.total() ? actor : other;
+            completeSet(winner == Participant::One ? SetResult::ParticipantOneWon : SetResult::ParticipantTwoWon);
+        }
+        return;
+    }
+
+    _set._activeParticipant = otherState.finished() ? actor : other;
+    _set._turnStage = TurnStage::AwaitingDraw;
+    _set._handCardPlayedThisTurn = false;
+}
+
+void MatchState::completeSet(SetResult result) {
+    if (_set._result != SetResult::InProgress) {
+        return;
+    }
+    _set._result = result;
+    _set._turnStage = TurnStage::Complete;
+    if (result == SetResult::Tie || result == SetResult::UnresolvedBothNine) {
+        return;
+    }
+
+    Participant winner = result == SetResult::ParticipantOneWon ? Participant::One : Participant::Two;
+    ParticipantMatchState &winnerState = matchParticipant(winner);
+    if (winnerState._setWins < kSetWinsForMatch) {
+        ++winnerState._setWins;
+    }
+    if (winnerState._setWins == kSetWinsForMatch) {
+        _result = winner == Participant::One ? MatchResult::ParticipantOneWon : MatchResult::ParticipantTwoWon;
+    }
+}
+
+ActionError MatchState::startNextSet(MainDeck mainDeck, Participant firstParticipant) {
+    if (!isValidParticipant(firstParticipant)) {
+        return ActionError::InvalidParticipant;
+    }
+    if (_result != MatchResult::InProgress) {
+        return ActionError::MatchComplete;
+    }
+    if (_set._result == SetResult::UnresolvedBothNine) {
+        return ActionError::SetUnresolved;
+    }
+    if (_set._result == SetResult::InProgress) {
+        return ActionError::SetInProgress;
+    }
+
+    MatchState next(*this);
+    next._mainDeck = std::move(mainDeck);
+    next._set = SetState(firstParticipant);
+    *this = std::move(next);
+    return ActionError::None;
+}
+
+bool MatchState::operator==(const MatchState &other) const {
+    return _mainDeck == other._mainDeck &&
+           _participants == other._participants &&
+           _set == other._set &&
+           _result == other._result;
+}
+
+} // namespace pazaak
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/pazaaksession.cpp
+++ b/src/libs/game/pazaaksession.cpp
@@ -1,0 +1,828 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "reone/game/pazaaksession.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace reone {
+
+namespace game {
+
+using namespace pazaak;
+
+namespace {
+
+bool boardSlotsEqual(
+    const std::array<PazaakBoardSlot, kBoardSize> &left,
+    const std::array<PazaakBoardSlot, kBoardSize> &right) {
+
+    for (size_t i = 0; i < left.size(); ++i) {
+        if (left[i].occupied != right[i].occupied ||
+            left[i].value != right[i].value ||
+            left[i].source != right[i].source ||
+            left[i].behavior != right[i].behavior) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool handSlotsEqual(
+    const std::array<PazaakHandSlot, kHandSize> &left,
+    const std::array<PazaakHandSlot, kHandSize> &right) {
+
+    for (size_t i = 0; i < left.size(); ++i) {
+        if (left[i].occupied != right[i].occupied ||
+            left[i].hidden != right[i].hidden ||
+            left[i].used != right[i].used ||
+            left[i].playable != right[i].playable ||
+            !(left[i].definition == right[i].definition) ||
+            left[i].selectedSign != right[i].selectedSign) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+bool PazaakBoardProjection::operator==(const PazaakBoardProjection &other) const {
+    return boardSlotsEqual(playerBoard, other.playerBoard) &&
+           boardSlotsEqual(opponentBoard, other.opponentBoard) &&
+           handSlotsEqual(playerHand, other.playerHand) &&
+           handSlotsEqual(opponentHand, other.opponentHand) &&
+           playerName == other.playerName &&
+           opponentName == other.opponentName &&
+           playerTotal == other.playerTotal &&
+           opponentTotal == other.opponentTotal &&
+           playerSetWins == other.playerSetWins &&
+           opponentSetWins == other.opponentSetWins &&
+           playerActive == other.playerActive &&
+           opponentActive == other.opponentActive &&
+           playerStood == other.playerStood &&
+           opponentStood == other.opponentStood &&
+           canEndTurn == other.canEndTurn &&
+           canStand == other.canStand &&
+           forfeitRequested == other.forfeitRequested &&
+           state == other.state &&
+           setResult == other.setResult;
+}
+
+PazaakSession::PazaakSession(
+    PazaakSessionParams params,
+    HandSelector playerHandSelector,
+    HandSelector opponentHandSelector,
+    MainDeckFactory mainDeckFactory,
+    FirstParticipantSelector firstParticipantSelector) :
+    _params(std::move(params)),
+    _playerHandSelector(std::move(playerHandSelector)),
+    _opponentHandSelector(std::move(opponentHandSelector)),
+    _mainDeckFactory(std::move(mainDeckFactory)),
+    _firstParticipantSelector(std::move(firstParticipantSelector)) {
+
+    if (_params.collection.empty()) {
+        throw std::invalid_argument("Pazaak collection must not be empty");
+    }
+    if (!_params.opponentSideDeck) {
+        throw std::invalid_argument("Pazaak opponent side deck must be supplied");
+    }
+    if (!_playerHandSelector) {
+        _playerHandSelector = [](const SideDeck &) { return defaultHandSelection(); };
+    }
+    if (!_opponentHandSelector) {
+        _opponentHandSelector = [](const SideDeck &) { return defaultHandSelection(); };
+    }
+    if (!_mainDeckFactory) {
+        _mainDeckFactory = []() { return MainDeck::standardOrdered(); };
+    }
+    if (!_firstParticipantSelector) {
+        _firstParticipantSelector = [](size_t) { return Participant::One; };
+    }
+
+    _wagerLimit = std::min(
+        std::max(0, _params.maximumWager),
+        std::max(0, _params.availableCredits));
+    _params.resultPresentationDuration =
+        std::max(0.0f, _params.resultPresentationDuration);
+    _screen = _wagerLimit > 0 ? PazaakFlowScreen::Wager : PazaakFlowScreen::Setup;
+    _wager = _wagerLimit;
+    _chosenCards = _params.initialChosenCards;
+    if (_chosenCards.size() > kSideDeckSize ||
+        std::any_of(_chosenCards.begin(), _chosenCards.end(), [this](size_t index) {
+            return index >= _params.collection.size();
+        })) {
+        throw std::invalid_argument("Invalid saved Pazaak side deck selection");
+    }
+    for (size_t index = 0; index < _params.collection.size(); ++index) {
+        if (std::count(_chosenCards.begin(), _chosenCards.end(), index) >
+            static_cast<ptrdiff_t>(_params.collection[index].copies)) {
+            throw std::invalid_argument("Saved Pazaak side deck exceeds owned copies");
+        }
+    }
+    _selectedSigns.fill(CardSign::Positive);
+    _selectedValues.fill(1);
+}
+
+const std::array<int, 4> &PazaakSession::valueChangeStates() {
+    static const std::array<int, 4> states {1, 2, -1, -2};
+    return states;
+}
+
+std::vector<PazaakCollectionCard> PazaakSession::temporaryK1TestCollection() {
+    std::vector<PazaakCollectionCard> cards;
+    cards.reserve(18);
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::fixedPositive(magnitude), 2, magnitude - 1});
+    }
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::fixedNegative(magnitude), 2, 6 + magnitude - 1});
+    }
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::signSelectable(magnitude), 2, 12 + magnitude - 1});
+    }
+    return cards;
+}
+
+void PazaakSession::increaseWager() {
+    if (_screen == PazaakFlowScreen::Wager && _wager < _wagerLimit) {
+        _wager = std::min(_wagerLimit, _wager + 5);
+    }
+}
+
+void PazaakSession::decreaseWager() {
+    if (_screen == PazaakFlowScreen::Wager && _wager > 1) {
+        _wager = std::max(1, _wager - 5);
+    }
+}
+
+bool PazaakSession::confirmWager() {
+    if (_screen != PazaakFlowScreen::Wager || _wager < 1) {
+        return false;
+    }
+    _screen = PazaakFlowScreen::Setup;
+    return true;
+}
+
+size_t PazaakSession::remainingCopies(size_t collectionIndex) const {
+    if (collectionIndex >= _params.collection.size()) {
+        return 0;
+    }
+    size_t selected = static_cast<size_t>(std::count(
+        _chosenCards.begin(), _chosenCards.end(), collectionIndex));
+    size_t copies = _params.collection[collectionIndex].copies;
+    return selected < copies ? copies - selected : 0;
+}
+
+bool PazaakSession::selectCard(size_t collectionIndex) {
+    if (_screen != PazaakFlowScreen::Setup ||
+        _chosenCards.size() >= kSideDeckSize ||
+        remainingCopies(collectionIndex) == 0) {
+        return false;
+    }
+    _chosenCards.push_back(collectionIndex);
+    return true;
+}
+
+bool PazaakSession::removeChosenCard(size_t chosenIndex) {
+    if (_screen != PazaakFlowScreen::Setup || chosenIndex >= _chosenCards.size()) {
+        return false;
+    }
+    _chosenCards.erase(_chosenCards.begin() + static_cast<ptrdiff_t>(chosenIndex));
+    return true;
+}
+
+void PazaakSession::clearChosenCards() {
+    if (_screen == PazaakFlowScreen::Setup) {
+        _chosenCards.clear();
+    }
+}
+
+bool PazaakSession::canConfirmSetup() const {
+    return _screen == PazaakFlowScreen::Setup && _chosenCards.size() == kSideDeckSize;
+}
+
+SideDeck PazaakSession::chosenSideDeck() const {
+    if (_chosenCards.size() != kSideDeckSize) {
+        throw std::logic_error("Pazaak setup does not contain ten cards");
+    }
+    return {
+        _params.collection[_chosenCards[0]].definition,
+        _params.collection[_chosenCards[1]].definition,
+        _params.collection[_chosenCards[2]].definition,
+        _params.collection[_chosenCards[3]].definition,
+        _params.collection[_chosenCards[4]].definition,
+        _params.collection[_chosenCards[5]].definition,
+        _params.collection[_chosenCards[6]].definition,
+        _params.collection[_chosenCards[7]].definition,
+        _params.collection[_chosenCards[8]].definition,
+        _params.collection[_chosenCards[9]].definition,
+    };
+}
+
+SideDeck PazaakSession::temporaryK1OpponentSideDeck() {
+    return {
+        CardDefinition::fixedPositive(1),
+        CardDefinition::fixedPositive(2),
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::fixedPositive(6),
+        CardDefinition::fixedNegative(1),
+        CardDefinition::fixedNegative(2),
+        CardDefinition::signSelectable(3),
+        CardDefinition::signSelectable(4),
+    };
+}
+
+std::vector<PazaakCollectionCard> PazaakSession::k2DefaultCollection() {
+    std::vector<PazaakCollectionCard> cards;
+    cards.reserve(23);
+    int id = 0;
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::fixedPositive(magnitude), 2, id++});
+    }
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::fixedNegative(magnitude), 2, id++});
+    }
+    for (int magnitude = 1; magnitude <= 6; ++magnitude) {
+        cards.push_back({CardDefinition::signSelectable(magnitude), 2, id++});
+    }
+    // Specials follow the authored side-deck screen order.
+    cards.push_back({CardDefinition::tiebreaker(), 2, id++});
+    cards.push_back({CardDefinition::doubleCard(), 2, id++});
+    cards.push_back({CardDefinition::flipTwoFour(), 2, id++});
+    cards.push_back({CardDefinition::flipThreeSix(), 2, id++});
+    cards.push_back({CardDefinition::valueChange(), 2, id++});
+    return cards;
+}
+
+SideDeck PazaakSession::temporaryK2OpponentSideDeck() {
+    return {
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::signSelectable(1),
+        CardDefinition::signSelectable(2),
+        CardDefinition::fixedNegative(6),
+        CardDefinition::doubleCard(),
+        CardDefinition::valueChange(),
+        CardDefinition::tiebreaker(),
+        CardDefinition::flipTwoFour(),
+    };
+}
+
+std::vector<size_t> PazaakSession::k2ShowcaseChosenCards() {
+    // Indices into k2DefaultCollection, which is ordered +1..+6, -1..-6,
+    // +/-1..+/-6, then Tiebreaker, Double, Flip 2&4, Flip 3&6, Value Change.
+    // The first four become the opening hand and deliberately cover a Value
+    // Change card, a sign-selectable card, a fixed card and a non-switchable
+    // special; the remaining six expose the other specials in later sets.
+    return {
+        22, // Value Change
+        12, // +/-1
+        0,  // +1
+        19, // Double
+        20, // Flip 2&4
+        21, // Flip 3&6
+        18, // Tiebreaker
+        6,  // -1
+        4,  // +5
+        13, // +/-2
+    };
+}
+
+HandSelection PazaakSession::defaultHandSelection() {
+    return {0, 1, 2, 3};
+}
+
+bool PazaakSession::confirmSetup() {
+    if (!canConfirmSetup()) {
+        return false;
+    }
+
+    try {
+        SideDeck playerDeck(chosenSideDeck());
+        SideDeck opponentDeck(*_params.opponentSideDeck);
+        ParticipantMatchState player(playerDeck, _playerHandSelector(playerDeck));
+        ParticipantMatchState opponent(opponentDeck, _opponentHandSelector(opponentDeck));
+        _match = std::make_unique<MatchState>(
+            _mainDeckFactory(),
+            std::move(player),
+            std::move(opponent),
+            _firstParticipantSelector(0));
+    } catch (const std::exception &) {
+        _match.reset();
+        return false;
+    }
+
+    _screen = PazaakFlowScreen::Board;
+    _setIndex = 0;
+    queueTurnStarted(_match->set().activeParticipant());
+    if (!_params.paceAutomaticDraws &&
+        _match->set().activeParticipant() == Participant::One) {
+        applyAcceptedCommand(DrawCommand {Participant::One});
+    }
+    return true;
+}
+
+PazaakBoardProjection PazaakSession::boardProjection() const {
+    PazaakBoardProjection projection;
+    projection.playerName = _params.playerName;
+    projection.opponentName = _params.opponentName;
+    projection.forfeitRequested = _forfeitRequested;
+    if (!_match) {
+        return projection;
+    }
+
+    const SetState &set = _match->set();
+    const ParticipantSetState &playerSet = set.participant(Participant::One);
+    const ParticipantSetState &opponentSet = set.participant(Participant::Two);
+    const ParticipantMatchState &playerMatch = _match->participant(Participant::One);
+    const ParticipantMatchState &opponentMatch = _match->participant(Participant::Two);
+
+    for (size_t i = 0; i < playerSet.board().size() && i < projection.playerBoard.size(); ++i) {
+        const PlayedCard &card = playerSet.board()[i];
+        std::optional<CardBehavior> behavior;
+        if (card.source() == PlayedCardSource::Hand && card.handIndex()) {
+            behavior = playerMatch.hand()[*card.handIndex()].definition.behavior();
+        }
+        projection.playerBoard[i] = {true, card.value(), card.source(), behavior};
+    }
+    for (size_t i = 0; i < opponentSet.board().size() && i < projection.opponentBoard.size(); ++i) {
+        const PlayedCard &card = opponentSet.board()[i];
+        std::optional<CardBehavior> behavior;
+        if (card.source() == PlayedCardSource::Hand && card.handIndex()) {
+            behavior = opponentMatch.hand()[*card.handIndex()].definition.behavior();
+        }
+        projection.opponentBoard[i] = {true, card.value(), card.source(), behavior};
+    }
+
+    LegalActions legal(_match->legalActions(Participant::One));
+    for (size_t i = 0; i < playerMatch.hand().size() && i < projection.playerHand.size(); ++i) {
+        const HandCard &card = playerMatch.hand()[i];
+        bool playable = std::find(
+                            legal.playableHandCards.begin(),
+                            legal.playableHandCards.end(),
+                            i) != legal.playableHandCards.end();
+        projection.playerHand[i] = {
+            true,
+            false,
+            card.used,
+            playable,
+            card.definition,
+            _selectedSigns[i],
+            _selectedValues[i],
+        };
+    }
+    for (size_t i = 0; i < opponentMatch.hand().size() && i < projection.opponentHand.size(); ++i) {
+        const HandCard &card = opponentMatch.hand()[i];
+        projection.opponentHand[i] = {
+            true,
+            !card.used,
+            card.used,
+            false,
+            card.used ? std::optional<CardDefinition>(card.definition) : std::nullopt,
+            CardSign::Positive,
+        };
+    }
+
+    projection.playerTotal = playerSet.total();
+    projection.opponentTotal = opponentSet.total();
+    projection.setResult = set.result();
+    projection.playerSetWins = playerMatch.setWins();
+    projection.opponentSetWins = opponentMatch.setWins();
+    projection.playerActive = set.result() == SetResult::InProgress &&
+                              set.activeParticipant() == Participant::One;
+    projection.opponentActive = set.result() == SetResult::InProgress &&
+                                set.activeParticipant() == Participant::Two;
+    projection.playerStood = playerSet.stood();
+    projection.opponentStood = opponentSet.stood();
+    projection.canEndTurn = legal.canEndTurn;
+    projection.canStand = legal.canStand;
+
+    if (_match->result() != MatchResult::InProgress || _completedResult) {
+        projection.state = PazaakBoardState::MatchComplete;
+    } else if (set.result() == SetResult::UnresolvedBothNine) {
+        projection.state = PazaakBoardState::UnresolvedBothNine;
+    } else if (set.result() != SetResult::InProgress) {
+        projection.state = PazaakBoardState::SetComplete;
+    } else if (set.activeParticipant() == Participant::Two) {
+        projection.state = PazaakBoardState::AwaitingOpponentPolicy;
+    } else {
+        projection.state = PazaakBoardState::PlayerTurn;
+    }
+    return projection;
+}
+
+bool PazaakSession::selectPlayerCardSign(size_t handIndex, CardSign sign) {
+    if (_screen != PazaakFlowScreen::Board ||
+        !_match ||
+        terminal() ||
+        handIndex >= kHandSize) {
+        return false;
+    }
+    if (sign != CardSign::Positive && sign != CardSign::Negative) {
+        return false;
+    }
+    const auto &hand = _match->participant(Participant::One).hand();
+    LegalActions legal(_match->legalActions(Participant::One));
+    bool playable = std::find(
+                        legal.playableHandCards.begin(),
+                        legal.playableHandCards.end(),
+                        handIndex) != legal.playableHandCards.end();
+    if (handIndex >= hand.size() ||
+        !hand[handIndex].definition.isSignSelectable() ||
+        hand[handIndex].used ||
+        !playable) {
+        return false;
+    }
+    _selectedSigns[handIndex] = sign;
+    return true;
+}
+
+bool PazaakSession::selectPlayerCardValue(size_t handIndex, int value) {
+    if (_screen != PazaakFlowScreen::Board ||
+        !_match ||
+        terminal() ||
+        handIndex >= kHandSize) {
+        return false;
+    }
+    const auto &states = valueChangeStates();
+    if (std::find(states.begin(), states.end(), value) == states.end()) {
+        return false;
+    }
+    const auto &hand = _match->participant(Participant::One).hand();
+    LegalActions legal(_match->legalActions(Participant::One));
+    bool playable = std::find(
+                        legal.playableHandCards.begin(),
+                        legal.playableHandCards.end(),
+                        handIndex) != legal.playableHandCards.end();
+    if (handIndex >= hand.size() ||
+        !hand[handIndex].definition.isValueSelectable() ||
+        hand[handIndex].used ||
+        !playable) {
+        return false;
+    }
+    _selectedValues[handIndex] = value;
+    return true;
+}
+
+ActionError PazaakSession::playPlayerHandCard(size_t handIndex) {
+    if (!_match || handIndex >= kHandSize) {
+        return ActionError::InvalidHandIndex;
+    }
+    const auto &hand = _match->participant(Participant::One).hand();
+    if (handIndex >= hand.size()) {
+        return ActionError::InvalidHandIndex;
+    }
+    const CardDefinition &definition = hand[handIndex].definition;
+    std::optional<CardSign> sign;
+    std::optional<int> value;
+    if (definition.isValueSelectable()) {
+        value = _selectedValues[handIndex];
+    } else if (definition.isSignSelectable()) {
+        sign = _selectedSigns[handIndex];
+    }
+    return applyPlayerCommand(PlayHandCardCommand {Participant::One, handIndex, sign, value});
+}
+
+ActionError PazaakSession::endPlayerTurn() {
+    return applyPlayerCommand(EndTurnCommand {Participant::One});
+}
+
+ActionError PazaakSession::standPlayer() {
+    return applyPlayerCommand(StandCommand {Participant::One});
+}
+
+ActionError PazaakSession::applyPlayerCommand(const Command &command) {
+    if (_screen != PazaakFlowScreen::Board || !_match || terminal()) {
+        return ActionError::MatchComplete;
+    }
+    return applyAcceptedCommand(command);
+}
+
+ActionError PazaakSession::applyAcceptedCommand(const Command &command) {
+    Participant actor = std::visit([](const auto &typed) {
+        return typed.actor;
+    },
+                                   command);
+    bool setWasInProgress = _match->set().result() == SetResult::InProgress;
+    Participant previousActive = _match->set().activeParticipant();
+    TurnStage previousStage = _match->set().turnStage();
+    ActionError error = _match->apply(command);
+    if (error != ActionError::None) {
+        return error;
+    }
+
+    if (std::holds_alternative<DrawCommand>(command)) {
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::MainDeckDrawn, actor});
+    } else if (std::holds_alternative<PlayHandCardCommand>(command)) {
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::HandCardPlayed, actor});
+    }
+
+    if (setWasInProgress && _match->set().result() != SetResult::InProgress) {
+        beginResultPresentation();
+    } else if (_match->set().result() == SetResult::InProgress &&
+               _match->set().turnStage() == TurnStage::AwaitingDraw &&
+               (_match->set().activeParticipant() != previousActive ||
+                previousStage != TurnStage::AwaitingDraw)) {
+        queueTurnStarted(_match->set().activeParticipant());
+    }
+    return ActionError::None;
+}
+
+ActionError PazaakSession::applyOpponentCommand(const Command &command) {
+    bool opponentCommand = std::visit([](const auto &typed) {
+        return typed.actor == Participant::Two;
+    },
+                                      command);
+    if (!opponentCommand) {
+        return ActionError::InvalidParticipant;
+    }
+    if (_screen != PazaakFlowScreen::Board || !_match || terminal()) {
+        return ActionError::MatchComplete;
+    }
+    return applyAcceptedCommand(command);
+}
+
+void PazaakSession::beginResultPresentation() {
+    if (_resultPresentationPending ||
+        !_match ||
+        _match->set().result() == SetResult::InProgress ||
+        _match->set().result() == SetResult::UnresolvedBothNine) {
+        return;
+    }
+
+    _resultPresentationPending = true;
+    _resultPresentationElapsed = 0.0f;
+
+    if (_match->result() == MatchResult::ParticipantOneWon) {
+        _completedResult = PazaakCompletedResult::PlayerWon;
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::PlayerMatchWon, std::nullopt});
+        return;
+    }
+    if (_match->result() == MatchResult::ParticipantTwoWon) {
+        _completedResult = PazaakCompletedResult::OpponentWon;
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::PlayerMatchLost, std::nullopt});
+        return;
+    }
+
+    switch (_match->set().result()) {
+    case SetResult::ParticipantOneWon:
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::PlayerSetWon, std::nullopt});
+        break;
+    case SetResult::ParticipantTwoWon:
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::PlayerSetLost, std::nullopt});
+        break;
+    case SetResult::Tie:
+        _presentationEvents.push_back(
+            {PazaakPresentationEventType::SetTied, std::nullopt});
+        break;
+    default:
+        break;
+    }
+}
+
+void PazaakSession::queueTurnStarted(Participant participant) {
+    _presentationEvents.push_back(
+        {PazaakPresentationEventType::TurnStarted, participant});
+}
+
+bool PazaakSession::requestForfeit() {
+    if (_screen != PazaakFlowScreen::Board ||
+        !_match ||
+        terminal() ||
+        _match->set().result() != SetResult::InProgress ||
+        _match->set().activeParticipant() != Participant::One ||
+        _match->set().turnStage() != TurnStage::AwaitingAction) {
+        return false;
+    }
+    _forfeitRequested = true;
+    return true;
+}
+
+bool PazaakSession::cancelForfeitRequest() {
+    if (!_forfeitRequested || terminal()) {
+        return false;
+    }
+    _forfeitRequested = false;
+    return true;
+}
+
+bool PazaakSession::confirmForfeit() {
+    if (!_forfeitRequested || terminal()) {
+        return false;
+    }
+    _completedResult = PazaakCompletedResult::PlayerForfeited;
+    _forfeitRequested = false;
+    _resultPresentationPending = true;
+    _resultPresentationElapsed = 0.0f;
+    _presentationEvents.push_back(
+        {PazaakPresentationEventType::PlayerMatchLost, std::nullopt});
+    return true;
+}
+
+bool PazaakSession::terminal() const {
+    if (_completedResult) {
+        return true;
+    }
+    if (!_match) {
+        return false;
+    }
+    return _match->result() != MatchResult::InProgress ||
+           _match->set().result() == SetResult::UnresolvedBothNine;
+}
+
+bool PazaakSession::advanceResultPresentation(float dt) {
+    if (!_resultPresentationPending || !_match) {
+        return false;
+    }
+    _resultPresentationElapsed += std::max(0.0f, dt);
+    if (_resultPresentationElapsed < _params.resultPresentationDuration) {
+        return false;
+    }
+
+    _resultPresentationPending = false;
+    _resultPresentationElapsed = 0.0f;
+    if (_completedResult) {
+        return true;
+    }
+
+    Participant first = _firstParticipantSelector(_setIndex + 1);
+    ActionError error = _match->startNextSet(_mainDeckFactory(), first);
+    if (error != ActionError::None) {
+        return false;
+    }
+
+    ++_setIndex;
+    _forfeitRequested = false;
+    queueTurnStarted(first);
+    if (!_params.paceAutomaticDraws && first == Participant::One) {
+        applyAcceptedCommand(DrawCommand {Participant::One});
+    }
+    return true;
+}
+
+std::vector<PazaakPresentationEvent> PazaakSession::takePresentationEvents() {
+    std::vector<PazaakPresentationEvent> events(std::move(_presentationEvents));
+    _presentationEvents.clear();
+    return events;
+}
+
+std::optional<PlayHandCardCommand> PazaakSession::chooseOpponentHandCard() const {
+    if (!_match ||
+        _match->set().result() != SetResult::InProgress ||
+        _match->set().activeParticipant() != Participant::Two ||
+        _match->set().turnStage() != TurnStage::AwaitingAction) {
+        return std::nullopt;
+    }
+
+    const ParticipantSetState &opponent = _match->set().participant(Participant::Two);
+    const ParticipantSetState &player = _match->set().participant(Participant::One);
+    const auto &hand = _match->participant(Participant::Two).hand();
+    LegalActions legal(_match->legalActions(Participant::Two));
+    int currentTotal = opponent.total();
+    bool playerLocked = player.finished() && !player.hasNineCardPriority();
+
+    // Every legal committed play, including each K2 selection, is enumerated and
+    // scored by simulating the real rules on a copy of the match. This lets the
+    // opponent use special cards (Double, the flips, Value Change, Tiebreaker)
+    // coherently: their board effects are evaluated exactly as they will resolve,
+    // and an option that would bust is never chosen.
+    auto enumerate = [&](size_t handIndex) {
+        std::vector<PlayHandCardCommand> commands;
+        const CardDefinition &definition = hand[handIndex].definition;
+        if (definition.isValueSelectable()) {
+            for (int value : {1, 2, -1, -2}) {
+                commands.push_back({Participant::Two, handIndex, std::nullopt, value});
+            }
+        } else if (definition.isSignSelectable()) {
+            commands.push_back({Participant::Two, handIndex, CardSign::Positive});
+            commands.push_back({Participant::Two, handIndex, CardSign::Negative});
+        } else {
+            commands.push_back({Participant::Two, handIndex, std::nullopt});
+        }
+        return commands;
+    };
+
+    struct Candidate {
+        PlayHandCardCommand command;
+        int total;
+    };
+    std::optional<Candidate> best;
+    auto consider = [&](const PlayHandCardCommand &command) {
+        MatchState sim(*_match);
+        if (sim.apply(command) != ActionError::None) {
+            return;
+        }
+        int total = sim.set().participant(Participant::Two).total();
+        if (total > kTargetTotal) {
+            return;
+        }
+        bool useful = currentTotal > kTargetTotal;
+        if (!useful && playerLocked) {
+            useful = total >= player.total() && total > currentTotal;
+        }
+        if (!useful) {
+            return;
+        }
+        // Deterministic: keep the first play (in enumeration order) that reaches
+        // the highest legal total.
+        if (!best || total > best->total) {
+            best = Candidate {command, total};
+        }
+    };
+
+    for (size_t handIndex : legal.playableHandCards) {
+        for (const PlayHandCardCommand &command : enumerate(handIndex)) {
+            consider(command);
+        }
+    }
+
+    if (!best) {
+        return std::nullopt;
+    }
+    return best->command;
+}
+
+Command PazaakSession::chooseOpponentAction() const {
+    const ParticipantSetState &opponent = _match->set().participant(Participant::Two);
+    const ParticipantSetState &player = _match->set().participant(Participant::One);
+
+    if (opponent.total() <= kTargetTotal &&
+        !player.hasNineCardPriority() &&
+        (opponent.total() == kTargetTotal ||
+         (player.finished() && opponent.total() >= player.total()) ||
+         opponent.board().size() + 1 >= kBoardSize)) {
+        return StandCommand {Participant::Two};
+    }
+    return EndTurnCommand {Participant::Two};
+}
+
+PazaakOpponentEvent PazaakSession::advanceOpponentEvent() {
+    if (_screen != PazaakFlowScreen::Board || !_match) {
+        return PazaakOpponentEvent::None;
+    }
+    if (_resultPresentationPending) {
+        return PazaakOpponentEvent::None;
+    }
+    if (terminal()) {
+        return PazaakOpponentEvent::None;
+    }
+
+    const SetState &set = _match->set();
+    if (set.result() != SetResult::InProgress) {
+        return PazaakOpponentEvent::None;
+    }
+    if (set.activeParticipant() == Participant::One) {
+        if (set.turnStage() != TurnStage::AwaitingDraw) {
+            return PazaakOpponentEvent::None;
+        }
+        ActionError error = applyAcceptedCommand(DrawCommand {Participant::One});
+        return error == ActionError::None
+                   ? PazaakOpponentEvent::PlayerDraw
+                   : PazaakOpponentEvent::None;
+    }
+
+    PazaakOpponentEvent event = PazaakOpponentEvent::None;
+    ActionError error = ActionError::None;
+    if (set.turnStage() == TurnStage::AwaitingDraw) {
+        event = PazaakOpponentEvent::Draw;
+        error = applyAcceptedCommand(DrawCommand {Participant::Two});
+    } else if (set.turnStage() == TurnStage::AwaitingAction) {
+        if (auto card = chooseOpponentHandCard()) {
+            event = PazaakOpponentEvent::PlayHandCard;
+            error = applyAcceptedCommand(*card);
+        } else {
+            Command command(chooseOpponentAction());
+            event = std::holds_alternative<StandCommand>(command)
+                        ? PazaakOpponentEvent::Stand
+                        : PazaakOpponentEvent::EndTurn;
+            error = applyAcceptedCommand(command);
+        }
+    }
+
+    if (error != ActionError::None) {
+        return PazaakOpponentEvent::None;
+    }
+    return event;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3502,16 +3502,34 @@ static Variable PlayPazaak(const std::vector<Variable> &args, const RoutineConte
     auto nMaxWager = getInt(args, 2);
     auto bShowTutorial = getIntOrElse(args, 3, 0);
     auto oOpponent = getObjectOrNull(args, 4, ctx);
+    if (!oOpponent) {
+        // K1's authored k_act_mispaz call omits the optional opponent. In
+        // NWScript that argument defaults to OBJECT_INVALID; the script caller
+        // is the only authored identity/continuation context available.
+        oOpponent = getCaller(ctx);
+    }
 
-    // Transform
+    auto endScript = boost::to_lower_copy(sEndScript);
 
     // Execute
-    throw RoutineNotImplementedException("PlayPazaak");
+    ctx.game.playPazaak(
+        nOpponentPazaakDeck,
+        std::move(endScript),
+        nMaxWager,
+        bShowTutorial != 0,
+        oOpponent);
+    return Variable::ofNull();
 }
 
 static Variable GetLastPazaakResult(const std::vector<Variable> &args, const RoutineContext &ctx) {
-    // Execute
-    throw RoutineNotImplementedException("GetLastPazaakResult");
+    const auto &result = ctx.game.lastPazaakResult();
+    if (!result) {
+        return Variable::ofInt(0);
+    }
+    // Shipped K1 scripts consume 1 as a player win and 0 as a player loss.
+    // Forfeit follows the loss path.
+    return Variable::ofInt(
+        *result == PazaakCompletedResult::PlayerWon ? 1 : 0);
 }
 
 static Variable DisplayFeedBackText(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/gui/control.cpp
+++ b/src/libs/gui/control.cpp
@@ -207,10 +207,11 @@ void Control::render(const glm::ivec2 &screenSize,
         return;
     }
     glm::ivec2 size(_extent.width, _extent.height);
+    if (_border && (!_selected || _hilightOverBorder || !_hilight)) {
+        renderBorder(*_border, offset, size, pass);
+    }
     if (_selected && _hilight) {
         renderBorder(*_hilight, offset, size, pass);
-    } else if (_border) {
-        renderBorder(*_border, offset, size, pass);
     }
     if (!_textLines.empty()) {
         renderText(_textLines, offset, size, pass);
@@ -532,9 +533,11 @@ void Control::setBorderFill(std::string resRef) {
         texture = _resourceSvc.textures.get(resRef, TextureUsage::GUI);
     }
     setBorderFill(std::move(texture));
+    _borderFillResRef = std::move(resRef);
 }
 
 void Control::setBorderFill(std::shared_ptr<Texture> texture) {
+    _borderFillResRef.clear();
     if (!texture && _border) {
         _border->fill.reset();
         return;
@@ -582,9 +585,11 @@ void Control::setHilightFill(std::string resRef) {
         texture = _resourceSvc.textures.get(resRef, TextureUsage::GUI);
     }
     setHilightFill(texture);
+    _hilightFillResRef = std::move(resRef);
 }
 
 void Control::setHilightFill(std::shared_ptr<Texture> texture) {
+    _hilightFillResRef.clear();
     if (!texture && _hilight) {
         _hilight->fill.reset();
         return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pazaak.cpp
+    ${TESTS_SOURCE_DIR}/game/pazaaksession.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/journal.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
+    ${TESTS_SOURCE_DIR}/game/pazaak.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pazaak.cpp
+    ${TESTS_SOURCE_DIR}/game/pazaakintegration.cpp
     ${TESTS_SOURCE_DIR}/game/pazaaksession.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp

--- a/test/fixtures/audio.h
+++ b/test/fixtures/audio.h
@@ -64,6 +64,10 @@ public:
         return *_services;
     }
 
+    MockAudioMixer &mixer() {
+        return *_mixer;
+    }
+
 private:
     std::unique_ptr<MockContext> _context;
     std::unique_ptr<MockAudioMixer> _mixer;

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -31,6 +31,7 @@
 #include "reone/game/footstepsounds.h"
 #include "reone/game/gui/sounds.h"
 #include "reone/game/options.h"
+#include "reone/game/pazaaksession.h"
 #include "reone/game/portraits.h"
 #include "reone/game/projectiles.h"
 #include "reone/game/reputes.h"
@@ -42,9 +43,16 @@
 
 namespace reone {
 
+namespace resource {
+
+class Gff;
+
+}
+
 namespace game {
 
 class Game;
+class Object;
 
 class MockCameraStyles : public ICameraStyles, boost::noncopyable {
 public:
@@ -141,6 +149,25 @@ public:
 class TestGameModule : boost::noncopyable {
 public:
     static std::pair<std::string, std::string> scheduledTransition(const Game &game);
+    static void configurePazaak(
+        Game &game,
+        bool guiLoadSucceeds,
+        PazaakSession::HandSelector playerSelector,
+        PazaakSession::HandSelector opponentSelector,
+        PazaakSession::MainDeckFactory mainDeckFactory,
+        std::function<void(const std::string &, uint32_t)> continuation);
+    static void setCurrentScreen(Game &game, int screen);
+    static void initConsole(Game &game);
+    static void setActiveModule(Game &game, bool active);
+    static void setPazaakDevelopmentSelectedObject(
+        Game &game,
+        std::shared_ptr<Object> object);
+    static void removeObject(Game &game, uint32_t objectId);
+    static void useRuntimePazaakGUIs(Game &game);
+    static void useAuthoredPazaakDecks(Game &game);
+    static void finishPazaak(Game &game, PazaakCompletedResult result);
+    static void serializePazaakPartyTable(const Game &game, resource::Gff &gff);
+    static void deserializePartyTable(Game &game, resource::Gff &gff);
 
     void init() {
         _cameraStyles = std::make_unique<MockCameraStyles>();
@@ -199,8 +226,47 @@ private:
 
 class StubConsole : public IConsole, boost::noncopyable {
 public:
-    void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
-    void printLine(const std::string &text) override {}
+    struct RegisteredCommand {
+        std::string description;
+        CommandHandler handler;
+    };
+
+    void registerCommand(
+        std::string name,
+        std::string description,
+        CommandHandler handler) override {
+
+        commands.emplace(
+            std::move(name),
+            RegisteredCommand {std::move(description), std::move(handler)});
+    }
+
+    void printLine(const std::string &text) override {
+        lines.push_back(text);
+    }
+
+    bool hasCommand(const std::string &name) const {
+        return commands.find(name) != commands.end();
+    }
+
+    void execute(
+        const std::string &name,
+        std::vector<std::string> arguments = {}) {
+
+        auto found = commands.find(name);
+        if (found == commands.end()) {
+            throw std::runtime_error("Command is not registered: " + name);
+        }
+        ConsoleArgs::TokenList tokens {name};
+        tokens.insert(
+            tokens.end(),
+            arguments.begin(),
+            arguments.end());
+        found->second.handler(ConsoleArgs(std::move(tokens)));
+    }
+
+    std::map<std::string, RegisteredCommand> commands;
+    std::vector<std::string> lines;
 };
 
 } // namespace game

--- a/test/game/pazaak.cpp
+++ b/test/game/pazaak.cpp
@@ -131,7 +131,9 @@ static MatchState reachParticipantOneNineCardPriority(std::initializer_list<int>
         if (turn == 0) {
             EXPECT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
         }
-        EXPECT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+        if (!match.set().participant(Participant::One).finished()) {
+            EXPECT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+        }
         if (turn < 7) {
             EXPECT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
             EXPECT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
@@ -332,6 +334,84 @@ TEST(PazaakTurn, UnresolvedOverTwentyBustsWhenStanding) {
     EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
 }
 
+TEST(PazaakAutoStand, PlayerMainDeckDrawAtTwentyFinishesExactlyOnce) {
+    MatchState match = makeMatch(makeMainDeck({10, 1, 10}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    EXPECT_EQ(20, match.set().participant(Participant::One).total());
+    EXPECT_TRUE(match.set().participant(Participant::One).stood());
+    EXPECT_EQ(Participant::Two, match.set().activeParticipant());
+    EXPECT_EQ(TurnStage::AwaitingDraw, match.set().turnStage());
+    expectRejectedUnchanged(
+        match,
+        EndTurnCommand {Participant::One},
+        ActionError::ParticipantStanding);
+    expectRejectedUnchanged(
+        match,
+        StandCommand {Participant::One},
+        ActionError::ParticipantStanding);
+}
+
+TEST(PazaakAutoStand, PlayerHandCardAtTwentyCommitsBeforeStanding) {
+    MatchState match = makeMatch(
+        makeMainDeck({10, 1, 6}),
+        makeParticipant(makeSideDeck(), {3, 0, 6, 8}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+
+    ASSERT_EQ(
+        ActionError::None,
+        match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    const ParticipantSetState &player = match.set().participant(Participant::One);
+    ASSERT_EQ(3, player.board().size());
+    EXPECT_EQ(20, player.total());
+    EXPECT_EQ(PlayedCardSource::Hand, player.board().back().source());
+    EXPECT_TRUE(player.stood());
+    EXPECT_TRUE(match.participant(Participant::One).hand()[0].used);
+}
+
+TEST(PazaakAutoStand, OpponentMainDeckDrawAtTwentyAppliesSymmetrically) {
+    MatchState match = makeMatch(makeMainDeck({1, 10, 10}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+
+    EXPECT_EQ(20, match.set().participant(Participant::Two).total());
+    EXPECT_TRUE(match.set().participant(Participant::Two).stood());
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
+TEST(PazaakAutoStand, OpponentHandCardAtTwentyAppliesSymmetrically) {
+    MatchState match = makeMatch(
+        makeMainDeck({1, 10, 6}),
+        makeParticipant(),
+        makeParticipant(makeSideDeck(), {3, 0, 6, 8}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(
+        ActionError::None,
+        match.apply(PlayHandCardCommand {Participant::Two, 0, std::nullopt}));
+
+    const ParticipantSetState &opponent = match.set().participant(Participant::Two);
+    EXPECT_EQ(20, opponent.total());
+    EXPECT_TRUE(opponent.stood());
+    EXPECT_TRUE(match.participant(Participant::Two).hand()[0].used);
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
 TEST(PazaakResults, TieDoesNotIncrementWinsAndHigherTotalWins) {
     MatchState tie = makeMatch(makeMainDeck({10, 10}));
     finishSet(tie, 10, 10);
@@ -459,6 +539,28 @@ TEST(PazaakNineCard, PriorityFinishesParticipantAndLetsOpponentContinue) {
     EXPECT_EQ(8, match.set().participant(Participant::Two).board().size());
 }
 
+TEST(PazaakNineCard, NinthCardAtExactlyTwentyKeepsNineCardPriorityPrecedence) {
+    MatchState match = reachParticipantOneNineCardPriority({
+        2, 1,
+        2, 1,
+        3, 1,
+        3, 1,
+        4, 2,
+        4, 2,
+        4, 3,
+        4,
+    });
+
+    const ParticipantSetState &player =
+        match.set().participant(Participant::One);
+    EXPECT_EQ(20, player.total());
+    EXPECT_TRUE(player.hasNineCardPriority());
+    EXPECT_TRUE(player.finished());
+    EXPECT_FALSE(player.stood());
+    EXPECT_EQ(Participant::Two, match.set().activeParticipant());
+    EXPECT_EQ(TurnStage::AwaitingDraw, match.set().turnStage());
+}
+
 TEST(PazaakNineCard, PriorityDefeatsOpponentStandingOnHigherLegalTotal) {
     MatchState match = reachParticipantOneNineCardPriority({
         1, 1,
@@ -475,7 +577,7 @@ TEST(PazaakNineCard, PriorityDefeatsOpponentStandingOnHigherLegalTotal) {
 
     ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
     ASSERT_EQ(20, match.set().participant(Participant::Two).total());
-    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+    EXPECT_TRUE(match.set().participant(Participant::Two).stood());
 
     EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
     EXPECT_EQ(1, match.participant(Participant::One).setWins());
@@ -523,7 +625,7 @@ TEST(PazaakNineCard, PriorityWinsWhenOpponentHadAlreadyFinished) {
 }
 
 TEST(PazaakNineCard, NineCardsOverTwentyBustWithoutPriority) {
-    MatchState match = makeMatch(makeMainDeck({1, 10, 1, 1, 1, 4, 4, 4, 4, 5}));
+    MatchState match = makeMatch(makeMainDeck({1, 10, 1, 1, 1, 3, 3, 3, 3, 5}));
     ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
     ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
     ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
@@ -537,7 +639,7 @@ TEST(PazaakNineCard, NineCardsOverTwentyBustWithoutPriority) {
         }
     }
 
-    ASSERT_EQ(25, match.set().participant(Participant::One).total());
+    ASSERT_EQ(21, match.set().participant(Participant::One).total());
     ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
     EXPECT_TRUE(match.set().participant(Participant::One).busted());
     EXPECT_FALSE(match.set().participant(Participant::One).hasNineCardPriority());
@@ -592,4 +694,190 @@ TEST(PazaakNineCard, BothNineIsExplicitlyUnresolvedAndCannotResolveTwice) {
     EXPECT_EQ(unresolved, match);
     EXPECT_EQ(0, match.participant(Participant::One).setWins());
     EXPECT_EQ(0, match.participant(Participant::Two).setWins());
+}
+
+// ---------------------------------------------------------------------------
+// KotOR II special side-deck cards.
+// ---------------------------------------------------------------------------
+
+// A ten-card side deck whose first card is the supplied special card, so a
+// {0,1,2,3} hand selection always surfaces it as hand slot 0.
+static SideDeck specialLeadDeck(CardDefinition lead) {
+    return {
+        lead,
+        CardDefinition::fixedPositive(1),
+        CardDefinition::fixedPositive(2),
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::fixedPositive(6),
+        CardDefinition::fixedNegative(1),
+        CardDefinition::fixedNegative(2),
+        CardDefinition::fixedNegative(3),
+    };
+}
+
+TEST(PazaakSpecialCards, DefinitionsValidateMagnitudeByBehavior) {
+    EXPECT_EQ(CardBehavior::Double, CardDefinition::doubleCard().behavior());
+    EXPECT_TRUE(CardDefinition::doubleCard().isSpecial());
+    EXPECT_TRUE(CardDefinition::tiebreaker().isSignSelectable());
+    EXPECT_TRUE(CardDefinition::valueChange().isValueSelectable());
+    EXPECT_EQ(1, CardDefinition::tiebreaker().magnitude());
+    // A special card must not declare a magnitude, and the Tiebreaker must be 1.
+    EXPECT_THROW(CardDefinition(CardBehavior::Double, 3), std::invalid_argument);
+    EXPECT_THROW(CardDefinition(CardBehavior::Tiebreaker, 2), std::invalid_argument);
+    EXPECT_THROW(CardDefinition(CardBehavior::ValueChange, 1), std::invalid_argument);
+}
+
+TEST(PazaakSpecialCards, DoubleAddsTheValueOfThePrecedingBoardCard) {
+    MatchState match = makeMatch(
+        makeMainDeck({5}),
+        makeParticipant(specialLeadDeck(CardDefinition::doubleCard()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(5, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    // The Double is placed as a distinct board card that repeats the preceding
+    // value, so the total updates once from 5 to 10.
+    EXPECT_EQ(10, match.set().participant(Participant::One).total());
+    ASSERT_EQ(2u, match.set().participant(Participant::One).board().size());
+    EXPECT_EQ(5, match.set().participant(Participant::One).board()[1].value());
+}
+
+TEST(PazaakSpecialCards, DoubleCanPushAParticipantIntoABust) {
+    MatchState match = makeMatch(
+        makeMainDeck({6, 5, 8}),
+        makeParticipant(specialLeadDeck(CardDefinition::doubleCard()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 6
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 5
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 6+8=14
+    ASSERT_EQ(14, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    EXPECT_EQ(22, match.set().participant(Participant::One).total());           // doubles the 8
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
+TEST(PazaakSpecialCards, DoubleRejectedBeforeTheMandatoryDraw) {
+    MatchState match = makeMatch(
+        makeMainDeck({5}),
+        makeParticipant(specialLeadDeck(CardDefinition::doubleCard()), {0, 1, 2, 3}),
+        makeParticipant());
+    // No card has been drawn yet, so there is nothing to double.
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::MustDrawFirst);
+}
+
+TEST(PazaakSpecialCards, FlipTwoFourNegatesOwnPositiveTwosAndFours) {
+    MatchState match = makeMatch(
+        makeMainDeck({2, 1, 4}),
+        makeParticipant(specialLeadDeck(CardDefinition::flipTwoFour()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 2
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 1
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 2+4=6
+    ASSERT_EQ(6, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    const auto &board = match.set().participant(Participant::One).board();
+    EXPECT_EQ(-2, board[0].value());
+    EXPECT_EQ(-4, board[1].value());
+    EXPECT_EQ(0, board[2].value());   // the flip card contributes nothing itself
+    EXPECT_EQ(-6, match.set().participant(Participant::One).total());
+}
+
+TEST(PazaakSpecialCards, FlipThreeSixNegatesOwnPositiveThreesAndSixes) {
+    MatchState match = makeMatch(
+        makeMainDeck({3, 1, 6}),
+        makeParticipant(specialLeadDeck(CardDefinition::flipThreeSix()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 3
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 1
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 3+6=9
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    const auto &board = match.set().participant(Participant::One).board();
+    EXPECT_EQ(-3, board[0].value());
+    EXPECT_EQ(-6, board[1].value());
+    EXPECT_EQ(-9, match.set().participant(Participant::One).total());
+}
+
+TEST(PazaakSpecialCards, ValueChangeSelectsAmongTheFourSignedValues) {
+    MatchState match = makeMatch(
+        makeMainDeck({5}),
+        makeParticipant(specialLeadDeck(CardDefinition::valueChange()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    // A value is required, a sign is not permitted, and only +/-1 and +/-2 are legal.
+    EXPECT_EQ(ActionError::ValueRequired, match.validate(PlayHandCardCommand {Participant::One, 0, std::nullopt, std::nullopt}));
+    EXPECT_EQ(ActionError::SignNotAllowed, match.validate(PlayHandCardCommand {Participant::One, 0, CardSign::Positive, 1}));
+    EXPECT_EQ(ActionError::InvalidValue, match.validate(PlayHandCardCommand {Participant::One, 0, std::nullopt, 3}));
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt, -2}));
+    EXPECT_EQ(3, match.set().participant(Participant::One).total());
+    EXPECT_EQ(-2, match.set().participant(Participant::One).board()[1].value());
+}
+
+TEST(PazaakSpecialCards, ValueChangeAtExactlyTwentyAutomaticallyStands) {
+    MatchState match = makeMatch(
+        makeMainDeck({10, 5, 8}),
+        makeParticipant(specialLeadDeck(CardDefinition::valueChange()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 10
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 5
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 18
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt, 2}));  // 20
+    EXPECT_EQ(20, match.set().participant(Participant::One).total());
+    EXPECT_TRUE(match.set().participant(Participant::One).stood());
+}
+
+TEST(PazaakSpecialCards, TiebreakerWinsAnOtherwiseTiedSet) {
+    MatchState match = makeMatch(
+        makeMainDeck({9, 10}),
+        makeParticipant(specialLeadDeck(CardDefinition::tiebreaker()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 9
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, CardSign::Positive}));  // +1 -> 10
+    EXPECT_TRUE(match.set().participant(Participant::One).hasTiebreaker());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 10
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+    // Totals are tied at 10, but the Tiebreaker holder takes the set.
+    EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
+}
+
+TEST(PazaakSpecialCards, TiebreakerDoesNotOverrideABust) {
+    MatchState match = makeMatch(
+        makeMainDeck({10, 5, 10}),
+        makeParticipant(specialLeadDeck(CardDefinition::tiebreaker()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 10
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, CardSign::Positive}));  // 11
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));   // 5
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 21, busting
+    ASSERT_EQ(21, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    // The bust is resolved before any tie logic, so the Tiebreaker holder loses.
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
+TEST(PazaakSpecialCards, UsedSpecialCardCannotBePlayedAgain) {
+    MatchState match = makeMatch(
+        makeMainDeck({3, 5, 3}),
+        makeParticipant(specialLeadDeck(CardDefinition::valueChange()), {0, 1, 2, 3}),
+        makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));   // 3
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt, 1}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, std::nullopt, 1}, ActionError::HandCardUsed);
 }

--- a/test/game/pazaak.cpp
+++ b/test/game/pazaak.cpp
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <initializer_list>
+#include <stdexcept>
+#include <utility>
+
+#include "reone/game/pazaak.h"
+
+using namespace reone::game::pazaak;
+
+static SideDeck makeSideDeck() {
+    return {
+        CardDefinition::fixedPositive(1),
+        CardDefinition::fixedPositive(2),
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::fixedPositive(6),
+        CardDefinition::fixedNegative(1),
+        CardDefinition::fixedNegative(2),
+        CardDefinition::fixedNegative(3),
+        CardDefinition::fixedNegative(4),
+    };
+}
+
+static SideDeck makeSelectableSideDeck() {
+    return {
+        CardDefinition::signSelectable(1),
+        CardDefinition::signSelectable(2),
+        CardDefinition::fixedPositive(2),
+        CardDefinition::fixedNegative(3),
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::fixedPositive(6),
+        CardDefinition::fixedNegative(1),
+        CardDefinition::fixedNegative(2),
+    };
+}
+
+static SideDeck makeNegativeSixSideDeck() {
+    return {
+        CardDefinition::fixedNegative(6),
+        CardDefinition::fixedPositive(1),
+        CardDefinition::fixedPositive(2),
+        CardDefinition::fixedPositive(3),
+        CardDefinition::fixedPositive(4),
+        CardDefinition::fixedPositive(5),
+        CardDefinition::fixedPositive(6),
+        CardDefinition::fixedNegative(1),
+        CardDefinition::fixedNegative(2),
+        CardDefinition::fixedNegative(3),
+    };
+}
+
+static MainDeck makeMainDeck(std::initializer_list<int> prefix) {
+    std::array<int, 11> remaining {};
+    remaining.fill(4);
+
+    std::vector<int> cards;
+    cards.reserve(kMainDeckSize);
+    for (int value : prefix) {
+        if (value < 1 || value > 10 || remaining[value] == 0) {
+            throw std::invalid_argument("Invalid deterministic main-deck prefix");
+        }
+        cards.push_back(value);
+        --remaining[value];
+    }
+    for (int value = 1; value <= 10; ++value) {
+        for (int count = 0; count < remaining[value]; ++count) {
+            cards.push_back(value);
+        }
+    }
+    return MainDeck(std::move(cards));
+}
+
+static ParticipantMatchState makeParticipant(const SideDeck &sideDeck = makeSideDeck(),
+                                             HandSelection selection = {0, 1, 6, 8}) {
+    return ParticipantMatchState(sideDeck, selection);
+}
+
+static MatchState makeMatch(MainDeck mainDeck = MainDeck::standardOrdered(),
+                            ParticipantMatchState one = makeParticipant(),
+                            ParticipantMatchState two = makeParticipant(),
+                            Participant first = Participant::One) {
+    return MatchState(std::move(mainDeck), std::move(one), std::move(two), first);
+}
+
+static void expectRejectedUnchanged(MatchState &match, const Command &command, ActionError expected) {
+    MatchState before(match);
+    EXPECT_EQ(expected, match.validate(command));
+    EXPECT_EQ(expected, match.apply(command));
+    EXPECT_EQ(before, match);
+}
+
+static void finishSet(MatchState &match, int expectedOne, int expectedTwo) {
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(expectedOne, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(expectedTwo, match.set().participant(Participant::Two).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+}
+
+static MatchState reachParticipantOneNineCardPriority(std::initializer_list<int> deckPrefix) {
+    MatchState match = makeMatch(
+        makeMainDeck(deckPrefix),
+        makeParticipant(makeNegativeSixSideDeck(), {0, 1, 2, 3}),
+        makeParticipant());
+
+    for (int turn = 0; turn < 8; ++turn) {
+        EXPECT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+        if (turn == 0) {
+            EXPECT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+        }
+        EXPECT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+        if (turn < 7) {
+            EXPECT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+            EXPECT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+        }
+    }
+    return match;
+}
+
+TEST(PazaakCards, MainDeckCompositionAndDeterministicOrder) {
+    MainDeck deck = MainDeck::standardOrdered();
+    ASSERT_EQ(kMainDeckSize, deck.cards().size());
+    for (int value = 1; value <= 10; ++value) {
+        EXPECT_EQ(4, std::count(deck.cards().begin(), deck.cards().end(), value));
+    }
+
+    MatchState match = makeMatch(makeMainDeck({7, 3}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    EXPECT_EQ(7, match.set().participant(Participant::One).board().back().value());
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    EXPECT_EQ(3, match.set().participant(Participant::Two).board().back().value());
+}
+
+TEST(PazaakCards, ExplicitHandSelectionHasExactlyFourCards) {
+    SideDeck sideDeck = makeSideDeck();
+    ParticipantMatchState participant(sideDeck, {9, 0, 5, 7});
+
+    ASSERT_EQ(kHandSize, participant.hand().size());
+    EXPECT_EQ(CardDefinition::fixedNegative(4), participant.hand()[0].definition);
+    EXPECT_EQ(CardDefinition::fixedPositive(1), participant.hand()[1].definition);
+    EXPECT_EQ(CardDefinition::fixedPositive(6), participant.hand()[2].definition);
+    EXPECT_EQ(CardDefinition::fixedNegative(2), participant.hand()[3].definition);
+
+    EXPECT_THROW(ParticipantMatchState(sideDeck, {0, 0, 1, 2}), std::invalid_argument);
+    EXPECT_THROW(ParticipantMatchState(sideDeck, {0, 1, 2, 10}), std::invalid_argument);
+
+    SideDeck duplicateDefinitions = makeSideDeck();
+    duplicateDefinitions[1] = duplicateDefinitions[0];
+    ParticipantMatchState duplicateHand(duplicateDefinitions, {0, 1, 2, 3});
+    EXPECT_EQ(duplicateHand.hand()[0].definition, duplicateHand.hand()[1].definition);
+}
+
+TEST(PazaakCards, RejectsInvalidMainAndKotorOneCardDefinitions) {
+    std::vector<int> shortDeck(39, 1);
+    EXPECT_THROW((void)MainDeck(shortDeck), std::invalid_argument);
+
+    std::vector<int> wrongComposition(kMainDeckSize, 1);
+    EXPECT_THROW((void)MainDeck(wrongComposition), std::invalid_argument);
+
+    std::vector<int> invalidValue = MainDeck::standardOrdered().cards();
+    invalidValue[0] = 0;
+    EXPECT_THROW((void)MainDeck(invalidValue), std::invalid_argument);
+
+    EXPECT_THROW(CardDefinition(CardBehavior::FixedPositive, 0), std::invalid_argument);
+    EXPECT_THROW(CardDefinition(CardBehavior::FixedNegative, 7), std::invalid_argument);
+    EXPECT_THROW(CardDefinition(static_cast<CardBehavior>(99), 1), std::invalid_argument);
+}
+
+TEST(PazaakTurn, MandatoryDrawAndLegalActionQuery) {
+    MatchState match = makeMatch(makeMainDeck({6}));
+
+    LegalActions beforeDraw = match.legalActions(Participant::One);
+    EXPECT_TRUE(beforeDraw.canDraw);
+    EXPECT_FALSE(beforeDraw.canEndTurn);
+    EXPECT_FALSE(beforeDraw.canStand);
+    EXPECT_TRUE(beforeDraw.playableHandCards.empty());
+    expectRejectedUnchanged(match, EndTurnCommand {Participant::One}, ActionError::MustDrawFirst);
+    expectRejectedUnchanged(match, StandCommand {Participant::One}, ActionError::MustDrawFirst);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::MustDrawFirst);
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    EXPECT_EQ(6, match.set().participant(Participant::One).total());
+    EXPECT_EQ(TurnStage::AwaitingAction, match.set().turnStage());
+
+    LegalActions afterDraw = match.legalActions(Participant::One);
+    EXPECT_FALSE(afterDraw.canDraw);
+    EXPECT_TRUE(afterDraw.canEndTurn);
+    EXPECT_TRUE(afterDraw.canStand);
+    EXPECT_EQ(std::vector<size_t>({0, 1, 2, 3}), afterDraw.playableHandCards);
+}
+
+TEST(PazaakTurn, ParticipantTwoCanStartASet) {
+    MatchState match = makeMatch(makeMainDeck({7}), makeParticipant(), makeParticipant(), Participant::Two);
+
+    EXPECT_EQ(Participant::Two, match.set().activeParticipant());
+    EXPECT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    EXPECT_EQ(7, match.set().participant(Participant::Two).total());
+    expectRejectedUnchanged(match, DrawCommand {Participant::One}, ActionError::NotActiveParticipant);
+}
+
+TEST(PazaakTurn, EndTurnAndStandHaveDistinctEffects) {
+    MatchState endTurnMatch = makeMatch(makeMainDeck({5}));
+    ASSERT_EQ(ActionError::None, endTurnMatch.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, endTurnMatch.apply(EndTurnCommand {Participant::One}));
+    EXPECT_FALSE(endTurnMatch.set().participant(Participant::One).stood());
+    EXPECT_EQ(Participant::Two, endTurnMatch.set().activeParticipant());
+    EXPECT_EQ(TurnStage::AwaitingDraw, endTurnMatch.set().turnStage());
+
+    MatchState standMatch = makeMatch(makeMainDeck({5}));
+    ASSERT_EQ(ActionError::None, standMatch.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, standMatch.apply(StandCommand {Participant::One}));
+    EXPECT_TRUE(standMatch.set().participant(Participant::One).stood());
+    EXPECT_EQ(Participant::Two, standMatch.set().activeParticipant());
+    expectRejectedUnchanged(standMatch, DrawCommand {Participant::One}, ActionError::ParticipantStanding);
+    expectRejectedUnchanged(standMatch, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::ParticipantStanding);
+    expectRejectedUnchanged(standMatch, EndTurnCommand {Participant::One}, ActionError::ParticipantStanding);
+    expectRejectedUnchanged(standMatch, StandCommand {Participant::One}, ActionError::ParticipantStanding);
+}
+
+TEST(PazaakTurn, FixedAndSelectableHandCardsResolveToImmutableBoardValues) {
+    MatchState fixed = makeMatch(makeMainDeck({10}), makeParticipant(), makeParticipant());
+    ASSERT_EQ(ActionError::None, fixed.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, fixed.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    EXPECT_EQ(1, fixed.set().participant(Participant::One).board().back().value());
+    EXPECT_EQ(PlayedCardSource::Hand, fixed.set().participant(Participant::One).board().back().source());
+    EXPECT_EQ(std::optional<size_t>(0), fixed.set().participant(Participant::One).board().back().handIndex());
+
+    MatchState negative = makeMatch(makeMainDeck({10}), makeParticipant(), makeParticipant());
+    ASSERT_EQ(ActionError::None, negative.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, negative.apply(PlayHandCardCommand {Participant::One, 2, std::nullopt}));
+    EXPECT_EQ(-1, negative.set().participant(Participant::One).board().back().value());
+
+    ParticipantMatchState selectableParticipant(makeSelectableSideDeck(), {0, 1, 2, 3});
+    MatchState selectablePositive = makeMatch(makeMainDeck({10}), selectableParticipant, makeParticipant());
+    ASSERT_EQ(ActionError::None, selectablePositive.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, selectablePositive.apply(PlayHandCardCommand {Participant::One, 0, CardSign::Positive}));
+    EXPECT_EQ(1, selectablePositive.set().participant(Participant::One).board().back().value());
+
+    MatchState selectableNegative = makeMatch(makeMainDeck({10}), selectableParticipant, makeParticipant());
+    ASSERT_EQ(ActionError::None, selectableNegative.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, selectableNegative.apply(PlayHandCardCommand {Participant::One, 1, CardSign::Negative}));
+    EXPECT_EQ(-2, selectableNegative.set().participant(Participant::One).board().back().value());
+}
+
+TEST(PazaakTurn, AllowsOnlyOneHandCardPerTurnAndUsesEachOnlyOncePerMatch) {
+    MatchState match = makeMatch(makeMainDeck({10, 9}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 0, std::nullopt}));
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 1, std::nullopt}, ActionError::HandCardAlreadyPlayedThisTurn);
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+    ASSERT_EQ(SetResult::ParticipantOneWon, match.set().result());
+
+    ASSERT_EQ(ActionError::None, match.startNextSet(makeMainDeck({5}), Participant::One));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::HandCardUsed);
+    EXPECT_TRUE(match.participant(Participant::One).hand()[0].used);
+}
+
+TEST(PazaakTurn, CanRecoverAfterMandatoryDrawExceedsTwenty) {
+    MatchState match = makeMatch(makeMainDeck({10, 1, 10}), makeParticipant(), makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 1, std::nullopt}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    EXPECT_EQ(22, match.set().participant(Participant::One).total());
+    EXPECT_FALSE(match.set().participant(Participant::One).busted());
+    EXPECT_EQ(SetResult::InProgress, match.set().result());
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 3, std::nullopt}));
+    EXPECT_EQ(19, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
+}
+
+TEST(PazaakTurn, UnresolvedOverTwentyBustsWhenTurnEnds) {
+    MatchState match = makeMatch(makeMainDeck({10, 1, 10}), makeParticipant(), makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 1, std::nullopt}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(22, match.set().participant(Participant::One).total());
+
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    EXPECT_TRUE(match.set().participant(Participant::One).busted());
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+    EXPECT_EQ(1, match.participant(Participant::Two).setWins());
+}
+
+TEST(PazaakTurn, UnresolvedOverTwentyBustsWhenStanding) {
+    MatchState match = makeMatch(makeMainDeck({10, 1, 10}), makeParticipant(), makeParticipant());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(PlayHandCardCommand {Participant::One, 1, std::nullopt}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(22, match.set().participant(Participant::One).total());
+
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    EXPECT_TRUE(match.set().participant(Participant::One).busted());
+    EXPECT_FALSE(match.set().participant(Participant::One).hasNineCardPriority());
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
+TEST(PazaakResults, TieDoesNotIncrementWinsAndHigherTotalWins) {
+    MatchState tie = makeMatch(makeMainDeck({10, 10}));
+    finishSet(tie, 10, 10);
+    EXPECT_EQ(SetResult::Tie, tie.set().result());
+    EXPECT_EQ(0, tie.participant(Participant::One).setWins());
+    EXPECT_EQ(0, tie.participant(Participant::Two).setWins());
+
+    MatchState ordinary = makeMatch(makeMainDeck({10, 9}));
+    finishSet(ordinary, 10, 9);
+    EXPECT_EQ(SetResult::ParticipantOneWon, ordinary.set().result());
+    EXPECT_EQ(1, ordinary.participant(Participant::One).setWins());
+    EXPECT_EQ(0, ordinary.participant(Participant::Two).setWins());
+
+    expectRejectedUnchanged(ordinary, DrawCommand {Participant::One}, ActionError::SetComplete);
+    expectRejectedUnchanged(ordinary, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::SetComplete);
+    expectRejectedUnchanged(ordinary, EndTurnCommand {Participant::One}, ActionError::SetComplete);
+    expectRejectedUnchanged(ordinary, StandCommand {Participant::One}, ActionError::SetComplete);
+    EXPECT_EQ(1, ordinary.participant(Participant::One).setWins());
+}
+
+TEST(PazaakResults, FirstParticipantToThreeSetsWinsMatch) {
+    MatchState match = makeMatch(makeMainDeck({10, 9}));
+    for (int setNumber = 1; setNumber <= 3; ++setNumber) {
+        finishSet(match, 10, 9);
+        EXPECT_EQ(setNumber, match.participant(Participant::One).setWins());
+        EXPECT_LE(match.participant(Participant::One).setWins(), kSetWinsForMatch);
+        if (setNumber < 3) {
+            EXPECT_EQ(MatchResult::InProgress, match.result());
+            ASSERT_EQ(ActionError::None, match.startNextSet(makeMainDeck({10, 9}), Participant::One));
+        }
+    }
+
+    EXPECT_EQ(MatchResult::ParticipantOneWon, match.result());
+    expectRejectedUnchanged(match, DrawCommand {Participant::One}, ActionError::MatchComplete);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::MatchComplete);
+    expectRejectedUnchanged(match, EndTurnCommand {Participant::One}, ActionError::MatchComplete);
+    expectRejectedUnchanged(match, StandCommand {Participant::One}, ActionError::MatchComplete);
+    MatchState before(match);
+    EXPECT_EQ(ActionError::MatchComplete, match.startNextSet(makeMainDeck({10, 9}), Participant::One));
+    EXPECT_EQ(before, match);
+}
+
+TEST(PazaakResults, ParticipantTwoCanWinThreeSetsAndTheMatch) {
+    MatchState match = makeMatch(makeMainDeck({9, 10}));
+    for (int setNumber = 1; setNumber <= 3; ++setNumber) {
+        finishSet(match, 9, 10);
+        EXPECT_EQ(setNumber, match.participant(Participant::Two).setWins());
+        EXPECT_LE(match.participant(Participant::Two).setWins(), kSetWinsForMatch);
+        if (setNumber < 3) {
+            EXPECT_EQ(MatchResult::InProgress, match.result());
+            ASSERT_EQ(ActionError::None, match.startNextSet(makeMainDeck({9, 10}), Participant::One));
+        }
+    }
+    EXPECT_EQ(MatchResult::ParticipantTwoWon, match.result());
+    EXPECT_EQ(3, match.participant(Participant::Two).setWins());
+}
+
+TEST(PazaakValidation, InvalidActorStageIndexAndSignDoNotMutateState) {
+    MatchState match = makeMatch(makeMainDeck({5}));
+    Participant invalidParticipant = static_cast<Participant>(99);
+
+    MatchState beforeSetStart(match);
+    EXPECT_EQ(ActionError::SetInProgress, match.startNextSet(makeMainDeck({6}), Participant::One));
+    EXPECT_EQ(beforeSetStart, match);
+    EXPECT_EQ(ActionError::InvalidParticipant, match.startNextSet(makeMainDeck({6}), invalidParticipant));
+    EXPECT_EQ(beforeSetStart, match);
+
+    expectRejectedUnchanged(match, DrawCommand {invalidParticipant}, ActionError::InvalidParticipant);
+    expectRejectedUnchanged(match, DrawCommand {Participant::Two}, ActionError::NotActiveParticipant);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::Two, 0, std::nullopt}, ActionError::NotActiveParticipant);
+    expectRejectedUnchanged(match, EndTurnCommand {Participant::Two}, ActionError::NotActiveParticipant);
+    expectRejectedUnchanged(match, StandCommand {Participant::Two}, ActionError::NotActiveParticipant);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 9, std::nullopt}, ActionError::MustDrawFirst);
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    expectRejectedUnchanged(match, DrawCommand {Participant::One}, ActionError::DrawAlreadyPerformed);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 9, std::nullopt}, ActionError::InvalidHandIndex);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 0, CardSign::Positive}, ActionError::SignNotAllowed);
+
+    MatchState selectable = makeMatch(makeMainDeck({5}), makeParticipant(makeSelectableSideDeck(), {0, 1, 2, 3}), makeParticipant());
+    ASSERT_EQ(ActionError::None, selectable.apply(DrawCommand {Participant::One}));
+    expectRejectedUnchanged(selectable, PlayHandCardCommand {Participant::One, 0, std::nullopt}, ActionError::SignRequired);
+    expectRejectedUnchanged(selectable, PlayHandCardCommand {Participant::One, 0, static_cast<CardSign>(99)}, ActionError::InvalidSign);
+
+    EXPECT_THROW((void)MatchState(makeMainDeck({5}), makeParticipant(), makeParticipant(), invalidParticipant), std::invalid_argument);
+}
+
+TEST(PazaakNineCard, PriorityFinishesParticipantAndLetsOpponentContinue) {
+    MatchState match = reachParticipantOneNineCardPriority({
+        1, 1,
+        1, 1,
+        2, 2,
+        2, 2,
+        3, 3,
+        3, 3,
+        4, 4,
+        4,
+        4,
+    });
+
+    const ParticipantSetState &one = match.set().participant(Participant::One);
+    ASSERT_EQ(kBoardSize, one.board().size());
+    EXPECT_EQ(14, one.total());
+    EXPECT_TRUE(one.hasNineCardPriority());
+    EXPECT_TRUE(one.finished());
+    EXPECT_FALSE(one.stood());
+    EXPECT_FALSE(one.busted());
+    EXPECT_EQ(SetResult::InProgress, match.set().result());
+    EXPECT_EQ(Participant::Two, match.set().activeParticipant());
+    EXPECT_EQ(TurnStage::AwaitingDraw, match.set().turnStage());
+
+    expectRejectedUnchanged(match, DrawCommand {Participant::One}, ActionError::ParticipantFinished);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::One, 1, std::nullopt}, ActionError::ParticipantFinished);
+    expectRejectedUnchanged(match, EndTurnCommand {Participant::One}, ActionError::ParticipantFinished);
+    expectRejectedUnchanged(match, StandCommand {Participant::One}, ActionError::ParticipantFinished);
+
+    LegalActions priorityActions = match.legalActions(Participant::One);
+    EXPECT_FALSE(priorityActions.canDraw);
+    EXPECT_FALSE(priorityActions.canEndTurn);
+    EXPECT_FALSE(priorityActions.canStand);
+    EXPECT_TRUE(priorityActions.playableHandCards.empty());
+
+    EXPECT_TRUE(match.legalActions(Participant::Two).canDraw);
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    EXPECT_EQ(8, match.set().participant(Participant::Two).board().size());
+}
+
+TEST(PazaakNineCard, PriorityDefeatsOpponentStandingOnHigherLegalTotal) {
+    MatchState match = reachParticipantOneNineCardPriority({
+        1, 1,
+        1, 1,
+        2, 2,
+        2, 2,
+        3, 3,
+        3, 3,
+        4, 4,
+        4,
+        4,
+    });
+    ASSERT_EQ(14, match.set().participant(Participant::One).total());
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(20, match.set().participant(Participant::Two).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+
+    EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
+    EXPECT_EQ(1, match.participant(Participant::One).setWins());
+    EXPECT_EQ(0, match.participant(Participant::Two).setWins());
+}
+
+TEST(PazaakNineCard, PriorityDefeatsOpponentWhoLaterBusts) {
+    MatchState match = reachParticipantOneNineCardPriority({
+        1, 1,
+        1, 1,
+        2, 2,
+        2, 2,
+        3, 3,
+        3, 3,
+        4, 4,
+        4,
+        5,
+    });
+
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(21, match.set().participant(Participant::Two).total());
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+
+    EXPECT_TRUE(match.set().participant(Participant::Two).busted());
+    EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
+    EXPECT_EQ(1, match.participant(Participant::One).setWins());
+}
+
+TEST(PazaakNineCard, PriorityWinsWhenOpponentHadAlreadyFinished) {
+    MatchState match = makeMatch(makeMainDeck({1, 10, 1, 1, 1, 2, 2, 2, 2, 3}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+
+    for (size_t boardSize = 2; boardSize <= kBoardSize; ++boardSize) {
+        ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+        ASSERT_EQ(boardSize, match.set().participant(Participant::One).board().size());
+        ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    }
+
+    EXPECT_TRUE(match.set().participant(Participant::One).hasNineCardPriority());
+    EXPECT_EQ(SetResult::ParticipantOneWon, match.set().result());
+    EXPECT_EQ(1, match.participant(Participant::One).setWins());
+}
+
+TEST(PazaakNineCard, NineCardsOverTwentyBustWithoutPriority) {
+    MatchState match = makeMatch(makeMainDeck({1, 10, 1, 1, 1, 4, 4, 4, 4, 5}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::Two}));
+
+    for (size_t boardSize = 2; boardSize <= kBoardSize; ++boardSize) {
+        ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::One}));
+        ASSERT_EQ(boardSize, match.set().participant(Participant::One).board().size());
+        if (boardSize < kBoardSize) {
+            ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::One}));
+        }
+    }
+
+    ASSERT_EQ(25, match.set().participant(Participant::One).total());
+    ASSERT_EQ(ActionError::None, match.apply(StandCommand {Participant::One}));
+    EXPECT_TRUE(match.set().participant(Participant::One).busted());
+    EXPECT_FALSE(match.set().participant(Participant::One).hasNineCardPriority());
+    EXPECT_EQ(SetResult::ParticipantTwoWon, match.set().result());
+}
+
+TEST(PazaakNineCard, BothNineIsExplicitlyUnresolvedAndCannotResolveTwice) {
+    MatchState match = reachParticipantOneNineCardPriority({
+        2, 1,
+        2, 1,
+        3, 1,
+        3, 1,
+        4, 2,
+        4, 2,
+        4, 3,
+        4,
+        3, 5,
+    });
+    ASSERT_TRUE(match.set().participant(Participant::One).hasNineCardPriority());
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, match.apply(DrawCommand {Participant::Two}));
+    ASSERT_EQ(9, match.set().participant(Participant::Two).board().size());
+    ASSERT_EQ(19, match.set().participant(Participant::Two).total());
+    ASSERT_EQ(ActionError::None, match.apply(EndTurnCommand {Participant::Two}));
+
+    ASSERT_EQ(SetResult::UnresolvedBothNine, match.set().result());
+    EXPECT_EQ(TurnStage::Complete, match.set().turnStage());
+    EXPECT_TRUE(match.set().participant(Participant::Two).hasNineCardPriority());
+    EXPECT_EQ(0, match.participant(Participant::One).setWins());
+    EXPECT_EQ(0, match.participant(Participant::Two).setWins());
+    EXPECT_EQ(MatchResult::InProgress, match.result());
+
+    LegalActions oneActions = match.legalActions(Participant::One);
+    LegalActions twoActions = match.legalActions(Participant::Two);
+    EXPECT_FALSE(oneActions.canDraw);
+    EXPECT_FALSE(oneActions.canEndTurn);
+    EXPECT_FALSE(oneActions.canStand);
+    EXPECT_TRUE(oneActions.playableHandCards.empty());
+    EXPECT_FALSE(twoActions.canDraw);
+    EXPECT_FALSE(twoActions.canEndTurn);
+    EXPECT_FALSE(twoActions.canStand);
+    EXPECT_TRUE(twoActions.playableHandCards.empty());
+
+    expectRejectedUnchanged(match, DrawCommand {Participant::One}, ActionError::SetComplete);
+    expectRejectedUnchanged(match, PlayHandCardCommand {Participant::Two, 0, std::nullopt}, ActionError::SetComplete);
+    expectRejectedUnchanged(match, EndTurnCommand {Participant::One}, ActionError::SetComplete);
+    expectRejectedUnchanged(match, StandCommand {Participant::Two}, ActionError::SetComplete);
+
+    MatchState unresolved(match);
+    EXPECT_EQ(ActionError::SetUnresolved, match.startNextSet(makeMainDeck({10, 9}), Participant::One));
+    EXPECT_EQ(unresolved, match);
+    EXPECT_EQ(0, match.participant(Participant::One).setWins());
+    EXPECT_EQ(0, match.participant(Participant::Two).setWins());
+}

--- a/test/game/pazaakintegration.cpp
+++ b/test/game/pazaakintegration.cpp
@@ -1,0 +1,2338 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+
+#include "reone/audio/clip.h"
+#include "reone/game/game.h"
+#include "reone/game/script/routines.h"
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/label.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/variable.h"
+
+#include <map>
+#include <set>
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::game::pazaak;
+using namespace reone::resource;
+
+void reone::game::TestGameModule::configurePazaak(
+    Game &game,
+    bool guiLoadSucceeds,
+    PazaakSession::HandSelector playerSelector,
+    PazaakSession::HandSelector opponentSelector,
+    PazaakSession::MainDeckFactory mainDeckFactory,
+    std::function<void(const std::string &, uint32_t)> continuation) {
+
+    game._pazaakGuiLoadOverride = [guiLoadSucceeds]() { return guiLoadSucceeds; };
+    game._pazaakPlayerHandSelector = std::move(playerSelector);
+    game._pazaakOpponentHandSelector = std::move(opponentSelector);
+    game._pazaakMainDeckFactory = std::move(mainDeckFactory);
+    game._pazaakFirstParticipantSelector = [](size_t) { return Participant::One; };
+    game._pazaakPaceAutomaticDraws = false;
+    game._pazaakContinuationOverride = std::move(continuation);
+    game._pazaakOpponentDeckOverride = PazaakSession::temporaryK1OpponentSideDeck();
+    // Own two of every card type the running title stores; entries beyond the
+    // title's table stay zero so a save round trip is byte-for-byte stable.
+    size_t cardCount = game.isTSL() ? Party::kK2PazaakCardCount : Party::kK1PazaakCardCount;
+    Party::PazaakCardCounts counts {};
+    for (size_t i = 0; i < cardCount; ++i) {
+        counts[i] = 2;
+    }
+    Party::PazaakSideDeck sideDeck;
+    sideDeck.fill(-1);
+    game._party.setPazaakData(std::move(counts), std::move(sideDeck), cardCount);
+}
+
+void reone::game::TestGameModule::setCurrentScreen(Game &game, int screen) {
+    game.changeScreen(static_cast<Game::Screen>(screen));
+}
+
+void reone::game::TestGameModule::initConsole(Game &game) {
+    game.initConsole();
+}
+
+void reone::game::TestGameModule::setActiveModule(Game &game, bool active) {
+    game._module = active ? game.newModule() : nullptr;
+}
+
+void reone::game::TestGameModule::setPazaakDevelopmentSelectedObject(
+    Game &game,
+    std::shared_ptr<Object> object) {
+
+    game._pazaakDevelopmentSelectedObjectOverride = std::move(object);
+}
+
+void reone::game::TestGameModule::removeObject(Game &game, uint32_t objectId) {
+    game._objectById.erase(objectId);
+}
+
+void reone::game::TestGameModule::useRuntimePazaakGUIs(Game &game) {
+    game._pazaakGuiLoadOverride = {};
+    game._pazaakPaceAutomaticDraws = true;
+}
+
+void reone::game::TestGameModule::useAuthoredPazaakDecks(Game &game) {
+    game._pazaakOpponentDeckOverride.reset();
+}
+
+void reone::game::TestGameModule::finishPazaak(
+    Game &game,
+    PazaakCompletedResult result) {
+
+    game.finishPazaak(result);
+}
+
+void reone::game::TestGameModule::serializePazaakPartyTable(
+    const Game &game,
+    resource::Gff &gff) {
+
+    game.serializePazaakPartyTable(gff);
+}
+
+void reone::game::TestGameModule::deserializePartyTable(
+    Game &game,
+    resource::Gff &gff) {
+
+    game.deserializePartyTable(gff);
+}
+
+namespace {
+
+HandSelection firstFour(const SideDeck &) {
+    return {0, 1, 2, 3};
+}
+
+void configure(
+    Game &game,
+    bool guiLoadSucceeds = true,
+    std::function<void(const std::string &, uint32_t)> continuation = {}) {
+
+    TestGameModule::configurePazaak(
+        game,
+        guiLoadSucceeds,
+        firstFour,
+        firstFour,
+        []() { return MainDeck::standardOrdered(); },
+        std::move(continuation));
+}
+
+void chooseTen(PazaakSession &session) {
+    if (session.chosenCards().size() == kSideDeckSize) {
+        return;
+    }
+    for (size_t index = 0; index < kSideDeckSize; ++index) {
+        ASSERT_TRUE(session.selectCard(index));
+    }
+}
+
+MainDeck makeMainDeck(std::initializer_list<int> prefix) {
+    std::vector<int> cards(MainDeck::standardOrdered().cards());
+    size_t position = 0;
+    for (int value : prefix) {
+        auto found = std::find(
+            cards.begin() + static_cast<ptrdiff_t>(position),
+            cards.end(),
+            value);
+        std::iter_swap(
+            cards.begin() + static_cast<ptrdiff_t>(position),
+            found);
+        ++position;
+    }
+    return MainDeck(std::move(cards));
+}
+
+std::shared_ptr<TwoDA> pazaakDeckTable(
+    std::initializer_list<std::array<std::string, 10>> rows) {
+
+    TwoDA::Builder builder;
+    builder.columns({
+        "card0", "card1", "card2", "card3", "card4",
+        "card5", "card6", "card7", "card8", "card9",
+    });
+    for (const auto &row : rows) {
+        builder.row(std::vector<std::string>(row.begin(), row.end()));
+    }
+    return std::shared_ptr<TwoDA>(builder.build().release());
+}
+
+struct GameFixture {
+    TestEngine &engine {testEngine()};
+    bool developerWasEnabled {engine.options().game.developer};
+    StubConsole console;
+    Game game {GameID::KotOR, "", engine.options(), engine.services(), console};
+    std::shared_ptr<Creature> opponent {game.newCreature()};
+
+    ~GameFixture() {
+        engine.options().game.developer = developerWasEnabled;
+    }
+};
+
+struct LoadedPazaakGUIs {
+    std::map<std::string, std::map<std::string, std::shared_ptr<gui::Control>>> controls;
+    std::vector<std::shared_ptr<gui::MockGUI>> guis;
+};
+
+void installPazaakGUIResources(
+    TestEngine &engine,
+    LoadedPazaakGUIs &loaded,
+    std::set<std::string> missingControls = {},
+    bool mockMissingAudio = true,
+    int flows = 1) {
+    using testing::_;
+    using testing::AnyNumber;
+    using testing::Invoke;
+    using testing::NiceMock;
+    using testing::Return;
+
+    EXPECT_CALL(engine.resourceModule().textures(), get(_, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::shared_ptr<graphics::Texture> {}));
+    if (mockMissingAudio) {
+        EXPECT_CALL(engine.resourceModule().audioClips(), get(_))
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(std::shared_ptr<audio::AudioClip> {}));
+    }
+
+    EXPECT_CALL(engine.guiModule().guis(), get(_, _))
+        .Times(3 * flows)
+        .WillRepeatedly(Invoke(
+            [&, missingControls](const std::string &resRef, std::function<void(gui::IGUI &)> preload)
+                -> std::shared_ptr<gui::IGUI> {
+                auto mock = std::make_shared<NiceMock<gui::MockGUI>>();
+                gui::MockGUI *rawGUI = mock.get();
+                auto &controls = loaded.controls[resRef];
+                auto *controlsPtr = &controls;
+                ON_CALL(*mock, findControl(_))
+                    .WillByDefault(Invoke([&, rawGUI, controlsPtr, resRef, missingControls](const std::string &tag) {
+                        if (missingControls.find(resRef + ":" + tag) !=
+                            missingControls.end()) {
+                            return std::shared_ptr<gui::Control> {};
+                        }
+                        auto found = controlsPtr->find(tag);
+                        if (found != controlsPtr->end()) {
+                            return found->second;
+                        }
+
+                        std::shared_ptr<gui::Control> control;
+                        if (tag.rfind("BTN_", 0) == 0) {
+                            control = std::make_shared<gui::Button>(
+                                *rawGUI,
+                                engine.services().scene.graphs,
+                                engine.services().graphics,
+                                engine.services().resource);
+                        } else {
+                            control = std::make_shared<gui::Label>(
+                                *rawGUI,
+                                engine.services().scene.graphs,
+                                engine.services().graphics,
+                                engine.services().resource);
+                        }
+                        control->setTag(tag);
+                        if (tag.rfind("LBL_PLRSCORE", 0) == 0 ||
+                            tag.rfind("LBL_NPCSCORE", 0) == 0) {
+                            control->setBorderFill("lbl_winmark01");
+                        }
+                        controlsPtr->emplace(tag, control);
+                        return control;
+                    }));
+                preload(*mock);
+                loaded.guis.push_back(mock);
+                return mock;
+            }));
+}
+
+void click(
+    LoadedPazaakGUIs &loaded,
+    const std::string &resRef,
+    const std::string &tag) {
+
+    std::static_pointer_cast<gui::Button>(loaded.controls.at(resRef).at(tag))
+        ->handleClick(0, 0);
+}
+
+void prepareDevelopmentCommand(
+    GameFixture &fixture,
+    bool developer = true,
+    bool activeModule = true,
+    bool inGameScreen = true) {
+
+    configure(fixture.game);
+    fixture.engine.options().game.developer = developer;
+    TestGameModule::initConsole(fixture.game);
+    TestGameModule::setActiveModule(fixture.game, activeModule);
+    TestGameModule::setCurrentScreen(
+        fixture.game,
+        static_cast<int>(
+            inGameScreen ? Game::Screen::InGame : Game::Screen::MainMenu));
+}
+
+} // namespace
+
+TEST(PazaakGameLifecycle, NiklosAuthoredArgumentsCreateFlowAndOpenWager) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(25);
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+
+    routines.get(364).invoke(
+        {
+            script::Variable::ofInt(1),
+            script::Variable::ofString("K_PTAR_NIKPAZEND"),
+            script::Variable::ofInt(40),
+            script::Variable::ofInt(0),
+            script::Variable::ofObject(fixture.opponent->id()),
+        },
+        execution);
+
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::PazaakWager, fixture.game.currentScreen());
+    EXPECT_EQ(1, fixture.game.pazaakSession()->opponentDeck());
+    EXPECT_EQ("k_ptar_nikpazend", fixture.game.pazaakSession()->continuationScript());
+    EXPECT_FALSE(fixture.game.pazaakSession()->tutorialRequested());
+    EXPECT_EQ(25, fixture.game.pazaakSession()->wagerLimit());
+    EXPECT_EQ(25, fixture.game.pazaakSession()->wager());
+}
+
+TEST(PazaakGameLifecycle, TslBuildStartsKotorTwoPazaakFromOwnedCards) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+
+    EXPECT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    ASSERT_NE(nullptr, game.pazaakSession());
+    // This party owns every KotOR II card type, so all 23 are offered, including
+    // the special cards, and KotOR II can be played end to end.
+    const auto &collection = game.pazaakSession()->collection();
+    EXPECT_EQ(23u, collection.size());
+    bool hasSpecial = false;
+    for (const auto &card : collection) {
+        if (card.definition.isSpecial()) {
+            hasSpecial = true;
+        }
+    }
+    EXPECT_TRUE(hasSpecial);
+    game.abortPazaak();
+}
+
+TEST(PazaakGameLifecycle, NativeKotorTwoMatchOffersOnlyTheCardsTheSaveOwns) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+    TestGameModule::useAuthoredPazaakDecks(game);
+    auto table = pazaakDeckTable({
+        {"+3", "-3", "+4", "-4", "+5", "-5", "+5", "-3", "+4", "-5"},
+    });
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return(table));
+
+    // A save carrying only the authored basic collection: two each of +1..+5.
+    Party::PazaakCardCounts counts {};
+    for (size_t i = 0; i < 5; ++i) {
+        counts[i] = 2;
+    }
+    Party::PazaakSideDeck saved;
+    saved.fill(-1);
+    game.party().setPazaakData(counts, saved, Party::kK2PazaakCardCount);
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    const auto *session = game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    // Exactly the owned cards are offered: no loaded developer collection and no
+    // special cards the save does not own.
+    const auto &collection = session->collection();
+    ASSERT_EQ(5u, collection.size());
+    for (size_t i = 0; i < collection.size(); ++i) {
+        EXPECT_EQ(CardDefinition::fixedPositive(static_cast<int>(i) + 1), collection[i].definition);
+        EXPECT_EQ(2u, collection[i].copies);
+        EXPECT_FALSE(collection[i].definition.isSpecial());
+    }
+    game.abortPazaak();
+}
+
+TEST(PazaakGameLifecycle, NativeKotorTwoMatchUsesTheSavedSideDeckIncludingSpecials) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+
+    // A save that owns one Tiebreaker (KotOR II card ID 18) and nine numbered
+    // cards, with all ten already chosen as the side deck.
+    Party::PazaakCardCounts counts {};
+    counts[0] = counts[1] = counts[2] = counts[3] = 2;
+    counts[4] = 1;
+    counts[18] = 1;
+    Party::PazaakSideDeck saved {0, 0, 1, 1, 2, 2, 3, 3, 4, 18};
+    game.party().setPazaakData(counts, saved, Party::kK2PazaakCardCount);
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    const auto *session = game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    ASSERT_EQ(6u, session->collection().size());
+    EXPECT_EQ(CardDefinition::tiebreaker(), session->collection()[5].definition);
+    EXPECT_EQ(18, session->collection()[5].persistentId);
+    // The saved ten-card selection is restored, so the player keeps their deck.
+    EXPECT_EQ(kSideDeckSize, session->chosenCards().size());
+    EXPECT_EQ(5u, session->chosenCards().back());
+    game.abortPazaak();
+}
+
+TEST(PazaakGameLifecycle, MissingOpponentDoesNotStartFlow) {
+    GameFixture fixture;
+    configure(fixture.game);
+
+    EXPECT_FALSE(fixture.game.playPazaak(0, "", 0, false, nullptr));
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::None, fixture.game.currentScreen());
+}
+
+TEST(PazaakRetailData, AuthoredSelectorsProduceDistinctSemanticDecks) {
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useAuthoredPazaakDecks(fixture.game);
+    auto table = pazaakDeckTable({
+        {"+1", "+2", "+3", "+4", "+5", "+6", "-1", "-2", "*3", "*4"},
+        {"+3", "-3", "+4", "-4", "+5", "-5", "+5", "-3", "+4", "-5"},
+    });
+    EXPECT_CALL(fixture.engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(2)
+        .WillRepeatedly(testing::Return(table));
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    EXPECT_EQ(
+        CardDefinition::fixedPositive(1),
+        fixture.game.pazaakSession()->opponentSideDeck()[0]);
+    fixture.game.cancelPazaak();
+
+    ASSERT_TRUE(fixture.game.playPazaak(1, "", 0, false, fixture.opponent));
+    EXPECT_EQ(
+        CardDefinition::fixedNegative(3),
+        fixture.game.pazaakSession()->opponentSideDeck()[1]);
+    EXPECT_EQ(
+        CardDefinition::fixedNegative(5),
+        fixture.game.pazaakSession()->opponentSideDeck()[9]);
+}
+
+TEST(PazaakRetailData, InvalidOrMalformedAuthoredSelectorFailsSafely) {
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useAuthoredPazaakDecks(fixture.game);
+    auto table = pazaakDeckTable({
+        {"+1", "+2", "+3", "+4", "+5", "+6", "-1", "-2", "*3", "bogus"},
+    });
+    EXPECT_CALL(fixture.engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(2)
+        .WillRepeatedly(testing::Return(table));
+
+    EXPECT_FALSE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_FALSE(fixture.game.playPazaak(2, "", 0, false, fixture.opponent));
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+}
+
+TEST(PazaakRetailData, UsesOnlyOwnedQuantitiesAndPreloadsSavedTen) {
+    GameFixture fixture;
+    configure(fixture.game);
+    Party::PazaakCardCounts counts {};
+    counts[8] = 10;
+    Party::PazaakSideDeck saved;
+    saved.fill(8);
+    fixture.game.party().setPazaakData(counts, saved);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    const auto *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    ASSERT_EQ(1u, session->collection().size());
+    EXPECT_EQ(10u, session->collection()[0].copies);
+    EXPECT_EQ(8, session->collection()[0].persistentId);
+    EXPECT_EQ(CardDefinition::fixedNegative(3), session->collection()[0].definition);
+    EXPECT_EQ(10u, session->chosenCards().size());
+    EXPECT_TRUE(std::all_of(
+        session->chosenCards().begin(),
+        session->chosenCards().end(),
+        [](size_t index) { return index == 0; }));
+}
+
+TEST(PazaakScriptBoundary, OmittedOpponentUsesAuthoredScriptCaller) {
+    GameFixture fixture;
+    configure(fixture.game);
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(
+        script::ArgKind::Caller,
+        script::Variable::ofObject(fixture.opponent->id()));
+
+    routines.get(364).invoke(
+        {
+            script::Variable::ofInt(0),
+            script::Variable::ofString(""),
+            script::Variable::ofInt(0),
+        },
+        execution);
+
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(fixture.opponent->id(), fixture.game.pazaakSession()->opponentId());
+}
+
+TEST(PazaakConsoleCommand, RegistersExactNameAndRequiresDeveloperMode) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture, false);
+
+    ASSERT_TRUE(fixture.console.hasCommand("startpazaak"));
+    EXPECT_EQ(1, fixture.console.commands.count("startpazaak"));
+
+    fixture.console.execute("startpazaak");
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: developer mode required",
+        fixture.console.lines.back());
+}
+
+TEST(PazaakConsoleCommand, RequiresAnActiveInGameModule) {
+    GameFixture noModule;
+    prepareDevelopmentCommand(noModule, true, false, true);
+    noModule.console.execute("startpazaak");
+    EXPECT_EQ(nullptr, noModule.game.pazaakSession());
+    ASSERT_FALSE(noModule.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: no active in-game module",
+        noModule.console.lines.back());
+
+    GameFixture notInGame;
+    prepareDevelopmentCommand(notInGame, true, true, false);
+    notInGame.console.execute("startpazaak");
+    EXPECT_EQ(nullptr, notInGame.game.pazaakSession());
+    ASSERT_FALSE(notInGame.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: no active in-game module",
+        notInGame.console.lines.back());
+}
+
+TEST(PazaakConsoleCommand, StartsExactlyOnceWithoutSelectionAndPreservesGameData) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    auto player = fixture.game.newCreature();
+    fixture.game.party().addMember(kNpcPlayer, player);
+    fixture.game.party().setPlayer(player);
+    fixture.game.party().giveGold(37);
+
+    const int creditsBefore = fixture.game.party().gold();
+    const size_t inventorySizeBefore = player->items().size();
+    const auto transitionBefore =
+        TestGameModule::scheduledTransition(fixture.game);
+    std::shared_ptr<Module> moduleBefore = fixture.game.module();
+
+    fixture.console.execute("startpazaak");
+
+    PazaakSession *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    PazaakSession *firstSession = session;
+    EXPECT_EQ(Game::Screen::PazaakSetup, fixture.game.currentScreen());
+    EXPECT_EQ(0, session->wager());
+    EXPECT_EQ(0, session->wagerLimit());
+    EXPECT_EQ(0, session->opponentDeck());
+    EXPECT_EQ(0u, session->opponentId());
+    EXPECT_TRUE(session->continuationScript().empty());
+    EXPECT_EQ(
+        PazaakSession::temporaryK1TestCollection().size(),
+        session->collection().size());
+    EXPECT_EQ(creditsBefore, fixture.game.party().gold());
+    EXPECT_EQ(inventorySizeBefore, player->items().size());
+    EXPECT_EQ(transitionBefore, TestGameModule::scheduledTransition(fixture.game));
+    EXPECT_EQ(moduleBefore, fixture.game.module());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: development match started against Pazaak Opponent",
+        fixture.console.lines.back());
+
+    fixture.console.execute("startpazaak");
+    EXPECT_EQ(firstSession, fixture.game.pazaakSession());
+    EXPECT_EQ(
+        "pazaak: already active",
+        fixture.console.lines.back());
+
+    chooseTen(*session);
+    ASSERT_TRUE(session->confirmSetup());
+    EXPECT_EQ(
+        "Pazaak Opponent",
+        session->boardProjection().opponentName);
+}
+
+TEST(PazaakConsoleCommand, SelectedCreatureOnlyChangesVisibleDevelopmentIdentity) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    fixture.opponent->setTag("Selected Test Creature");
+    TestGameModule::setPazaakDevelopmentSelectedObject(
+        fixture.game,
+        fixture.opponent);
+
+    fixture.console.execute("startpazaak");
+
+    PazaakSession *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    EXPECT_EQ(0u, session->opponentId());
+    EXPECT_EQ(0, session->opponentDeck());
+    EXPECT_TRUE(session->continuationScript().empty());
+    chooseTen(*session);
+    ASSERT_TRUE(session->confirmSetup());
+    EXPECT_EQ(
+        "Selected Test Creature",
+        session->boardProjection().opponentName);
+    EXPECT_EQ(
+        "pazaak: development match started against Selected Test Creature",
+        fixture.console.lines.back());
+}
+
+TEST(PazaakConsoleCommand, ReportsDevelopmentLaunchFailure) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    TestGameModule::configurePazaak(
+        fixture.game,
+        false,
+        firstFour,
+        firstFour,
+        []() { return MainDeck::standardOrdered(); },
+        {});
+
+    fixture.console.execute("startpazaak");
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: development launch failed",
+        fixture.console.lines.back());
+}
+
+TEST(PazaakConsoleCommand, CancellationReturnsToGameplayAndCleanupIsIdempotent) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    fixture.game.party().giveGold(23);
+
+    fixture.console.execute("startpazaak");
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    fixture.game.cancelPazaak();
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+    EXPECT_EQ(23, fixture.game.party().gold());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: development match cancelled",
+        fixture.console.lines.back());
+
+    fixture.game.cancelPazaak();
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+    EXPECT_EQ(23, fixture.game.party().gold());
+}
+
+TEST(PazaakConsoleCommand, MatchCompletionReturnsToGameplay) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        firstFour,
+        firstFour,
+        []() { return makeMainDeck({10, 9}); },
+        {});
+    fixture.game.party().giveGold(19);
+
+    fixture.console.execute("startpazaak");
+    PazaakSession *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    chooseTen(*session);
+    ASSERT_TRUE(session->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    for (int commandCount = 0;
+        commandCount < 40 && !session->completedResult();
+         ++commandCount) {
+
+        if (session->match()->set().result() != SetResult::InProgress) {
+            ASSERT_TRUE(session->advanceResultPresentation(1.5f));
+        } else if (session->match()->set().activeParticipant() == Participant::One) {
+            if (session->match()->set().turnStage() == TurnStage::AwaitingDraw) {
+                ASSERT_EQ(
+                    PazaakOpponentEvent::PlayerDraw,
+                    session->advanceOpponentEvent());
+            } else {
+                ASSERT_EQ(ActionError::None, session->standPlayer());
+            }
+        } else if (session->match()->set().turnStage() == TurnStage::AwaitingDraw) {
+            ASSERT_EQ(
+                ActionError::None,
+                session->applyOpponentCommand(DrawCommand {Participant::Two}));
+        } else {
+            ASSERT_EQ(
+                ActionError::None,
+                session->applyOpponentCommand(StandCommand {Participant::Two}));
+        }
+    }
+
+    ASSERT_TRUE(session->completedResult().has_value());
+    ASSERT_TRUE(session->presentationPending());
+    ASSERT_TRUE(session->advanceResultPresentation(1.5f));
+    fixture.game.completePazaakIfReady();
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+    EXPECT_EQ(19, fixture.game.party().gold());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: development match completed - player won",
+        fixture.console.lines.back());
+}
+
+TEST(PazaakConsoleCommand, ForfeitReturnsToGameplay) {
+    GameFixture fixture;
+    prepareDevelopmentCommand(fixture);
+    fixture.game.party().giveGold(11);
+
+    fixture.console.execute("startpazaak");
+    PazaakSession *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    chooseTen(*session);
+    ASSERT_TRUE(session->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(session->requestForfeit());
+    ASSERT_TRUE(session->confirmForfeit());
+    ASSERT_TRUE(session->advanceResultPresentation(1.5f));
+    fixture.game.completePazaakIfReady();
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+    EXPECT_EQ(11, fixture.game.party().gold());
+    ASSERT_FALSE(fixture.console.lines.empty());
+    EXPECT_EQ(
+        "pazaak: development match completed - player forfeited",
+        fixture.console.lines.back());
+
+    fixture.game.completePazaakIfReady();
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::InGame, fixture.game.currentScreen());
+}
+
+TEST(PazaakGameLifecycle, ZeroWagerBypassesWagerAndDialogueDoesNotReclaimScreen) {
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::setCurrentScreen(
+        fixture.game,
+        static_cast<int>(Game::Screen::Conversation));
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    EXPECT_EQ(Game::Screen::PazaakSetup, fixture.game.currentScreen());
+}
+
+TEST(PazaakGameLifecycle, WagerCancellationPreservesCreditsAndLastResult) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(8);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 20, false, fixture.opponent));
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    for (int i = 0; i < 20; ++i) {
+        fixture.game.pazaakSession()->increaseWager();
+    }
+    EXPECT_EQ(8, fixture.game.pazaakSession()->wager());
+
+    fixture.game.cancelPazaak();
+    EXPECT_EQ(8, fixture.game.party().gold());
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+
+    fixture.game.cancelPazaak();
+    EXPECT_EQ(8, fixture.game.party().gold());
+}
+
+TEST(PazaakGameLifecycle, SelectedWagerSettlesForfeitExactlyOnce) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(10);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 10, false, fixture.opponent));
+    fixture.game.pazaakSession()->decreaseWager();
+    ASSERT_EQ(5, fixture.game.pazaakSession()->wager());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+    fixture.game.update(1.5f);
+
+    EXPECT_EQ(5, fixture.game.party().gold());
+    fixture.game.completePazaakIfReady();
+    EXPECT_EQ(5, fixture.game.party().gold());
+}
+
+TEST(PazaakGameLifecycle, MatchLossSubtractsWagerExactlyOnce) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(10);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 10, false, fixture.opponent));
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::OpponentWon);
+    EXPECT_EQ(0, fixture.game.party().gold());
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::OpponentWon);
+    EXPECT_EQ(0, fixture.game.party().gold());
+}
+
+TEST(PazaakGameLifecycle, MatchWinAddsWagerExactlyOnce) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(10);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 10, false, fixture.opponent));
+    ASSERT_EQ(10, fixture.game.pazaakSession()->wager());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::PlayerWon);
+    EXPECT_EQ(20, fixture.game.party().gold());
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::PlayerWon);
+    EXPECT_EQ(20, fixture.game.party().gold());
+}
+
+TEST(PazaakGameLifecycle, TechnicalAbortAfterCommitmentDoesNotSettle) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(10);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 10, false, fixture.opponent));
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    fixture.game.abortPazaak();
+    EXPECT_EQ(10, fixture.game.party().gold());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+}
+
+TEST(PazaakRetailData, CompletedSettlementAndChosenDeckRoundTripPartyTable) {
+    GameFixture fixture;
+    configure(fixture.game);
+    fixture.game.party().giveGold(10);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 10, false, fixture.opponent));
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::PlayerWon);
+
+    auto partyTable = Gff::Builder().build();
+    TestGameModule::serializePazaakPartyTable(fixture.game, *partyTable);
+    uint32_t savedGold = 0;
+    ASSERT_TRUE(partyTable->readDword(savedGold, "PT_GOLD"));
+    EXPECT_EQ(20u, savedGold);
+
+    GameFixture loaded;
+    TestGameModule::deserializePartyTable(loaded.game, *partyTable);
+    EXPECT_TRUE(loaded.game.party().hasValidPazaakData());
+    EXPECT_EQ(
+        fixture.game.party().pazaakCardCounts(),
+        loaded.game.party().pazaakCardCounts());
+    EXPECT_EQ(
+        fixture.game.party().pazaakSideDeck(),
+        loaded.game.party().pazaakSideDeck());
+}
+
+TEST(PazaakGameLifecycle, ConfirmedForfeitClearsBeforeOneShotContinuation) {
+    GameFixture fixture;
+    int continuationCount = 0;
+    std::string continuedScript;
+    uint32_t continuedOpponent = 0;
+    configure(
+        fixture.game,
+        true,
+        [&](const std::string &script, uint32_t opponentId) {
+            EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+            ++continuationCount;
+            continuedScript = script;
+            continuedOpponent = opponentId;
+        });
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        2,
+        "after_pazaak",
+        0,
+        false,
+        fixture.opponent));
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+
+    fixture.game.update(1.5f);
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.lastPazaakResult().has_value());
+    EXPECT_EQ(PazaakCompletedResult::PlayerForfeited, *fixture.game.lastPazaakResult());
+    EXPECT_EQ(1, continuationCount);
+    EXPECT_EQ("after_pazaak", continuedScript);
+    EXPECT_EQ(fixture.opponent->id(), continuedOpponent);
+
+    fixture.game.update(1.5f);
+    fixture.game.abortPazaak();
+    EXPECT_EQ(1, continuationCount);
+}
+
+TEST(PazaakGameLifecycle, DeletedContinuationCallerFailsSafely) {
+    GameFixture fixture;
+    int continuationCount = 0;
+    configure(
+        fixture.game,
+        true,
+        [&](const std::string &, uint32_t) {
+            ++continuationCount;
+        });
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        0,
+        "after_pazaak",
+        0,
+        false,
+        fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+    TestGameModule::removeObject(fixture.game, fixture.opponent->id());
+
+    fixture.game.update(1.5f);
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(0, continuationCount);
+    ASSERT_TRUE(fixture.game.lastPazaakResult().has_value());
+    EXPECT_EQ(
+        PazaakCompletedResult::PlayerForfeited,
+        *fixture.game.lastPazaakResult());
+}
+
+TEST(PazaakGameLifecycle, ContinuationCanReenterWithoutCompletingOldFlowTwice) {
+    GameFixture fixture;
+    int continuationCount = 0;
+    fixture.game.party().giveGold(10);
+    configure(
+        fixture.game,
+        true,
+        [&](const std::string &, uint32_t) {
+            ++continuationCount;
+            ASSERT_TRUE(fixture.game.playPazaak(
+                0,
+                "",
+                0,
+                false,
+                fixture.opponent));
+        });
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        0,
+        "after_pazaak",
+        5,
+        false,
+        fixture.opponent));
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmWager());
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+
+    fixture.game.update(1.5f);
+    EXPECT_EQ(1, continuationCount);
+    EXPECT_EQ(5, fixture.game.party().gold());
+    ASSERT_NE(nullptr, fixture.game.pazaakSession());
+    fixture.game.completePazaakIfReady();
+    EXPECT_EQ(1, continuationCount);
+    EXPECT_EQ(5, fixture.game.party().gold());
+    fixture.game.abortPazaak();
+}
+
+TEST(PazaakGameLifecycle, UpdatePacesOneOpponentEventPerInterval) {
+    GameFixture fixture;
+    configure(fixture.game);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->endPlayerTurn());
+
+    fixture.game.update(0.44f);
+    EXPECT_TRUE(
+        fixture.game.pazaakSession()
+            ->match()
+            ->set()
+            .participant(Participant::Two)
+            .board()
+            .empty());
+
+    fixture.game.update(0.02f);
+    EXPECT_EQ(
+        1,
+        fixture.game.pazaakSession()
+            ->match()
+            ->set()
+            .participant(Participant::Two)
+            .board()
+            .size());
+    EXPECT_EQ(TurnStage::AwaitingAction, fixture.game.pazaakSession()->match()->set().turnStage());
+
+    fixture.game.update(0.44f);
+    EXPECT_EQ(TurnStage::AwaitingAction, fixture.game.pazaakSession()->match()->set().turnStage());
+    fixture.game.update(0.02f);
+    EXPECT_EQ(Participant::One, fixture.game.pazaakSession()->match()->set().activeParticipant());
+    EXPECT_EQ(TurnStage::AwaitingDraw, fixture.game.pazaakSession()->match()->set().turnStage());
+}
+
+TEST(PazaakGUIResources, RuntimeResourcesBindControlsAndDriveSetupToBoard) {
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    ASSERT_EQ(3, loaded.controls.size());
+    EXPECT_TRUE(loaded.controls.count("pazaakwager"));
+    EXPECT_TRUE(loaded.controls.count("pazaaksetup"));
+    EXPECT_TRUE(loaded.controls.count("pazaakgame"));
+    EXPECT_EQ(Game::Screen::PazaakSetup, fixture.game.currentScreen());
+    EXPECT_TRUE(
+        loaded.controls.at("pazaaksetup").at("BTN_ATEXT")->isDisabled());
+    EXPECT_EQ(
+        "Choose Sidedeck",
+        loaded.controls.at("pazaaksetup").at("LBL_TITLE")->text().text);
+    EXPECT_EQ(
+        "Available cards",
+        loaded.controls.at("pazaaksetup").at("LBL_LTEXT")->text().text);
+    EXPECT_EQ(
+        "Chosen cards",
+        loaded.controls.at("pazaaksetup").at("LBL_RTEXT")->text().text);
+    EXPECT_EQ(
+        "Play",
+        loaded.controls.at("pazaaksetup").at("BTN_ATEXT")->text().text);
+    EXPECT_EQ(
+        "Add card",
+        loaded.controls.at("pazaaksetup").at("BTN_YTEXT")->text().text);
+    EXPECT_EQ(
+        "lbl_cardmpos",
+        loaded.controls.at("pazaaksetup").at("BTN_AVAIL00")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_cardmneg",
+        loaded.controls.at("pazaaksetup").at("BTN_AVAIL10")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_cardrarem",
+        loaded.controls.at("pazaaksetup").at("BTN_AVAIL20")->borderFillResRef());
+    // The plus-minus sign is a single code point: the engine draws one glyph per
+    // byte, so a multi-byte sequence would render a stray leading character.
+    EXPECT_EQ(
+        "\xB1" "1",
+        loaded.controls.at("pazaaksetup").at("LBL_AVAIL20")->text().text);
+
+    click(loaded, "pazaaksetup", "BTN_AVAIL00");
+    ASSERT_EQ(1, fixture.game.pazaakSession()->chosenCards().size());
+    click(loaded, "pazaaksetup", "BTN_YTEXT");
+    ASSERT_EQ(2, fixture.game.pazaakSession()->chosenCards().size());
+    click(loaded, "pazaaksetup", "BTN_CHOSEN1");
+    ASSERT_EQ(1, fixture.game.pazaakSession()->chosenCards().size());
+    for (const std::string &tag : {
+             "BTN_AVAIL10",
+             "BTN_AVAIL20",
+             "BTN_AVAIL01",
+             "BTN_AVAIL11",
+             "BTN_AVAIL21",
+             "BTN_AVAIL02",
+             "BTN_AVAIL12",
+             "BTN_AVAIL22",
+             "BTN_AVAIL03",
+         }) {
+        click(loaded, "pazaaksetup", tag);
+    }
+    ASSERT_EQ(kSideDeckSize, fixture.game.pazaakSession()->chosenCards().size());
+    EXPECT_FALSE(
+        loaded.controls.at("pazaaksetup").at("BTN_ATEXT")->isDisabled());
+    click(loaded, "pazaaksetup", "BTN_ATEXT");
+
+    ASSERT_EQ(Game::Screen::PazaakBoard, fixture.game.currentScreen());
+    ASSERT_NE(nullptr, fixture.game.pazaakSession()->match());
+    fixture.game.update(0.46f);
+    // The mandatory main-deck draw renders as the gold/olive card, distinct from
+    // a blue positive side card (lbl_cardmpos), and shows only its numeric value.
+    EXPECT_EQ(
+        "lbl_cardstand",
+        loaded.controls.at("pazaakgame").at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ(
+        "1",
+        loaded.controls.at("pazaakgame").at("LBL_PLR0")->text().text);
+    EXPECT_EQ(
+        "",
+        loaded.controls.at("pazaakgame").at("BTN_PLR1")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_cardback",
+        loaded.controls.at("pazaakgame").at("BTN_NPCSIDE0")->borderFillResRef());
+    EXPECT_EQ(
+        "",
+        loaded.controls.at("pazaakgame").at("LBL_NPCSIDE0")->text().text);
+    EXPECT_EQ(
+        "lbl_cardmpos",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_cardmneg",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE1")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_cardrarem",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE2")->borderFillResRef());
+    EXPECT_EQ(
+        "+1",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE0")->text().text);
+    EXPECT_EQ(
+        "-1",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE1")->text().text);
+    EXPECT_EQ(
+        "+1",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE2")->text().text);
+    EXPECT_TRUE(
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->isHilightOverBorder());
+    EXPECT_EQ(
+        "lbl_cardhilite",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->hilightFillResRef());
+    EXPECT_FALSE(
+        loaded.controls.at("pazaakgame").at("BTN_FLIP0")->isVisible());
+    EXPECT_TRUE(
+        loaded.controls.at("pazaakgame").at("BTN_FLIP2")->isVisible());
+    EXPECT_EQ(
+        "pazflip",
+        loaded.controls.at("pazaakgame").at("BTN_FLIP2")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_pazaakturn",
+        loaded.controls.at("pazaakgame").at("LBL_PLRTURN")->borderFillResRef());
+    EXPECT_EQ(
+        "End Turn",
+        loaded.controls.at("pazaakgame").at("BTN_XTEXT")->text().text);
+    EXPECT_EQ(
+        "Stand",
+        loaded.controls.at("pazaakgame").at("BTN_YTEXT")->text().text);
+    EXPECT_FALSE(
+        loaded.controls.at("pazaakgame").at("BTN_XTEXT")->isDisabled());
+    click(loaded, "pazaakgame", "BTN_FLIP2");
+    EXPECT_EQ(
+        "pazflip2",
+        loaded.controls.at("pazaakgame").at("BTN_FLIP2")->borderFillResRef());
+    EXPECT_EQ(
+        "-1",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE2")->text().text);
+
+    click(loaded, "pazaakgame", "BTN_PLRSIDE0");
+    EXPECT_EQ(
+        "",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_FALSE(
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE0")->isVisible());
+    EXPECT_EQ(
+        "lbl_cardmpos",
+        loaded.controls.at("pazaakgame").at("BTN_PLR1")->borderFillResRef());
+    EXPECT_EQ(
+        "+1",
+        loaded.controls.at("pazaakgame").at("LBL_PLR1")->text().text);
+    click(loaded, "pazaakgame", "BTN_XTEXT");
+    EXPECT_EQ(
+        PazaakBoardState::AwaitingOpponentPolicy,
+        fixture.game.pazaakSession()->boardProjection().state);
+    EXPECT_TRUE(
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->isDisabled());
+
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, StandingScoreAndResolvedSetUseAuthoredAutomaticPresentation) {
+    GameFixture fixture;
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        firstFour,
+        firstFour,
+        []() { return makeMainDeck({10, 9}); },
+        {});
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded);
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        0,
+        "",
+        0,
+        false,
+        fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    fixture.game.update(0.46f);
+
+    click(loaded, "pazaakgame", "BTN_YTEXT");
+    EXPECT_TRUE(
+        fixture.game.pazaakSession()
+            ->match()
+            ->set()
+            .participant(Participant::One)
+            .stood());
+    // Standing does not overlay a gold hilight: the main-deck card keeps its gold
+    // provenance face (lbl_cardstand) and side cards keep their own colour, so no
+    // played card changes appearance just because its owner has stood.
+    EXPECT_FALSE(
+        loaded.controls.at("pazaakgame").at("BTN_PLR0")->isSelected());
+    EXPECT_EQ(
+        "lbl_cardstand",
+        loaded.controls.at("pazaakgame").at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ(
+        "lbl_pazaakturn",
+        loaded.controls.at("pazaakgame").at("LBL_NPCTURN")->borderFillResRef());
+
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            DrawCommand {Participant::Two}));
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            StandCommand {Participant::Two}));
+    fixture.game.showPazaakBoard();
+
+    ASSERT_EQ(
+        PazaakBoardState::SetComplete,
+        fixture.game.pazaakSession()->boardProjection().state);
+    EXPECT_EQ(
+        "lbl_winmark02",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSCORE0")->borderFillResRef());
+    for (const std::string &tag : {
+             "LBL_PLRSCORE1",
+             "LBL_PLRSCORE2",
+             "LBL_NPCSCORE0",
+             "LBL_NPCSCORE1",
+             "LBL_NPCSCORE2",
+         }) {
+        EXPECT_EQ(
+            "lbl_winmark01",
+            loaded.controls.at("pazaakgame").at(tag)->borderFillResRef());
+        EXPECT_TRUE(loaded.controls.at("pazaakgame").at(tag)->isVisible());
+    }
+    EXPECT_EQ(
+        "End Turn",
+        loaded.controls.at("pazaakgame").at("BTN_XTEXT")->text().text);
+    EXPECT_TRUE(
+        loaded.controls.at("pazaakgame").at("BTN_XTEXT")->isDisabled());
+
+    fixture.game.update(1.49f);
+    EXPECT_EQ(
+        PazaakBoardState::SetComplete,
+        fixture.game.pazaakSession()->boardProjection().state);
+    fixture.game.update(0.01f);
+    EXPECT_EQ(
+        PazaakBoardState::PlayerTurn,
+        fixture.game.pazaakSession()->boardProjection().state);
+    EXPECT_EQ(
+        0,
+        fixture.game.pazaakSession()
+            ->match()
+            ->set()
+            .participant(Participant::One)
+            .board()
+            .size());
+    EXPECT_EQ(
+        TurnStage::AwaitingDraw,
+        fixture.game.pazaakSession()->match()->set().turnStage());
+    fixture.game.update(0.46f);
+    EXPECT_EQ(
+        1,
+        fixture.game.pazaakSession()
+            ->match()
+            ->set()
+            .participant(Participant::One)
+            .board()
+            .size());
+    EXPECT_EQ(
+        "End Turn",
+        loaded.controls.at("pazaakgame").at("BTN_XTEXT")->text().text);
+
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, AllThreeAuthoredPipsTrackBothParticipantsFromZeroToThree) {
+    auto verifyPips = [](const LoadedPazaakGUIs &loaded, bool player, int wins) {
+        const std::string prefix = player ? "LBL_PLRSCORE" : "LBL_NPCSCORE";
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_EQ(
+                i < wins ? "lbl_winmark02" : "lbl_winmark01",
+                loaded.controls.at("pazaakgame")
+                    .at(prefix + std::to_string(i))
+                    ->borderFillResRef());
+            EXPECT_TRUE(
+                loaded.controls.at("pazaakgame")
+                    .at(prefix + std::to_string(i))
+                    ->isVisible());
+        }
+    };
+
+    {
+        GameFixture fixture;
+        configure(
+            fixture.game,
+            true,
+            {});
+        TestGameModule::configurePazaak(
+            fixture.game,
+            true,
+            firstFour,
+            firstFour,
+            []() { return makeMainDeck({10, 9}); },
+            {});
+        TestGameModule::useRuntimePazaakGUIs(fixture.game);
+        LoadedPazaakGUIs loaded;
+        installPazaakGUIResources(fixture.engine, loaded);
+        ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+        chooseTen(*fixture.game.pazaakSession());
+        ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+        fixture.game.showPazaakBoard();
+        verifyPips(loaded, true, 0);
+        verifyPips(loaded, false, 0);
+
+        for (int wins = 1; wins <= 3; ++wins) {
+            ASSERT_EQ(
+                PazaakOpponentEvent::PlayerDraw,
+                fixture.game.pazaakSession()->advanceOpponentEvent());
+            ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+            ASSERT_EQ(
+                ActionError::None,
+                fixture.game.pazaakSession()->applyOpponentCommand(
+                    DrawCommand {Participant::Two}));
+            ASSERT_EQ(
+                ActionError::None,
+                fixture.game.pazaakSession()->applyOpponentCommand(
+                    StandCommand {Participant::Two}));
+            fixture.game.showPazaakBoard();
+            verifyPips(loaded, true, wins);
+            verifyPips(loaded, false, 0);
+            if (wins < 3) {
+                ASSERT_TRUE(
+                    fixture.game.pazaakSession()->advanceResultPresentation(1.5f));
+                fixture.game.showPazaakBoard();
+            }
+        }
+    }
+
+    {
+        GameFixture fixture;
+        TestGameModule::configurePazaak(
+            fixture.game,
+            true,
+            firstFour,
+            firstFour,
+            []() { return makeMainDeck({9, 10}); },
+            {});
+        TestGameModule::useRuntimePazaakGUIs(fixture.game);
+        LoadedPazaakGUIs loaded;
+        installPazaakGUIResources(fixture.engine, loaded);
+        ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+        chooseTen(*fixture.game.pazaakSession());
+        ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+        fixture.game.showPazaakBoard();
+        verifyPips(loaded, true, 0);
+        verifyPips(loaded, false, 0);
+
+        for (int wins = 1; wins <= 3; ++wins) {
+            ASSERT_EQ(
+                PazaakOpponentEvent::PlayerDraw,
+                fixture.game.pazaakSession()->advanceOpponentEvent());
+            ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+            ASSERT_EQ(
+                ActionError::None,
+                fixture.game.pazaakSession()->applyOpponentCommand(
+                    DrawCommand {Participant::Two}));
+            ASSERT_EQ(
+                ActionError::None,
+                fixture.game.pazaakSession()->applyOpponentCommand(
+                    StandCommand {Participant::Two}));
+            fixture.game.showPazaakBoard();
+            verifyPips(loaded, true, 0);
+            verifyPips(loaded, false, wins);
+            if (wins < 3) {
+                ASSERT_TRUE(
+                    fixture.game.pazaakSession()->advanceResultPresentation(1.5f));
+                fixture.game.showPazaakBoard();
+            }
+        }
+    }
+}
+
+TEST(PazaakGUIResources, BoardCardFacesFollowProvenanceGoldMainRedMinusBluePositive) {
+    GameFixture fixture;
+    // Surface a negative side card in the player's first hand slot so a red
+    // minus card (lbl_cardmneg) reaches the board next to the gold main-deck
+    // draw (lbl_cardstand) and a blue positive side card (lbl_cardmpos). The
+    // temporary side deck orders cards +1..+6 then -1..-4, so slot 6 is -1.
+    auto minusFirst = [](const SideDeck &) { return HandSelection {6, 0, 1, 2}; };
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        minusFirst,
+        firstFour,
+        []() { return makeMainDeck({3, 3}); },
+        {});
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    fixture.game.update(0.46f);
+
+    // Mandatory main-deck card renders gold and shows only its numeric value.
+    EXPECT_EQ(
+        "lbl_cardstand",
+        loaded.controls.at("pazaakgame").at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ(
+        "3",
+        loaded.controls.at("pazaakgame").at("LBL_PLR0")->text().text);
+    // Hand: slot 0 is a red -1 side card, slot 1 a blue +1 side card.
+    EXPECT_EQ(
+        "lbl_cardmneg",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_EQ(
+        "-1",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSIDE0")->text().text);
+    EXPECT_EQ(
+        "lbl_cardmpos",
+        loaded.controls.at("pazaakgame").at("BTN_PLRSIDE1")->borderFillResRef());
+
+    // Playing the red side card keeps its red provenance on the board, and the
+    // gold main-deck card is unchanged by the play.
+    click(loaded, "pazaakgame", "BTN_PLRSIDE0");
+    EXPECT_EQ(
+        "lbl_cardmneg",
+        loaded.controls.at("pazaakgame").at("BTN_PLR1")->borderFillResRef());
+    EXPECT_EQ(
+        "-1",
+        loaded.controls.at("pazaakgame").at("LBL_PLR1")->text().text);
+    EXPECT_EQ(
+        "lbl_cardstand",
+        loaded.controls.at("pazaakgame").at("BTN_PLR0")->borderFillResRef());
+
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, ScoreMarkersResetToGreyOnAConsecutiveMatch) {
+    GameFixture fixture;
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        firstFour,
+        firstFour,
+        []() { return makeMainDeck({10, 9}); },
+        {});
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded, {}, true, 2);
+
+    // First match: the player wins the opening set, lighting a gold pip.
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_EQ(
+        PazaakOpponentEvent::PlayerDraw,
+        fixture.game.pazaakSession()->advanceOpponentEvent());
+    ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            DrawCommand {Participant::Two}));
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            StandCommand {Participant::Two}));
+    fixture.game.showPazaakBoard();
+    EXPECT_EQ(
+        "lbl_winmark02",
+        loaded.controls.at("pazaakgame").at("LBL_PLRSCORE0")->borderFillResRef());
+    fixture.game.abortPazaak();
+
+    // Consecutive match: the reused marker controls must all read grey again,
+    // proving no win state is inherited from the previous match.
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    for (const std::string &tag : {
+             "LBL_PLRSCORE0",
+             "LBL_PLRSCORE1",
+             "LBL_PLRSCORE2",
+             "LBL_NPCSCORE0",
+             "LBL_NPCSCORE1",
+             "LBL_NPCSCORE2",
+         }) {
+        EXPECT_EQ(
+            "lbl_winmark01",
+            loaded.controls.at("pazaakgame").at(tag)->borderFillResRef());
+        EXPECT_TRUE(loaded.controls.at("pazaakgame").at(tag)->isVisible());
+    }
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, NoSetOrMatchResultTextIsShownWhileMarkersStillUpdate) {
+    GameFixture fixture;
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        firstFour,
+        firstFour,
+        []() { return makeMainDeck({10, 9}); },
+        {});
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    auto noResultText = [&]() {
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_PLRTURN")->text().text);
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_NPCTURN")->text().text);
+    };
+
+    for (int wins = 1; wins <= 3; ++wins) {
+        ASSERT_EQ(
+            PazaakOpponentEvent::PlayerDraw,
+            fixture.game.pazaakSession()->advanceOpponentEvent());
+        ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                DrawCommand {Participant::Two}));
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                StandCommand {Participant::Two}));
+        fixture.game.showPazaakBoard();
+        // The set (or, on the third win, the match) is resolved: the marker
+        // lights, but no textual "you win the set/match" message is shown.
+        noResultText();
+        EXPECT_EQ(
+            "lbl_winmark02",
+            loaded.controls.at("pazaakgame")
+                .at("LBL_PLRSCORE" + std::to_string(wins - 1))
+                ->borderFillResRef());
+        if (wins < 3) {
+            ASSERT_TRUE(
+                fixture.game.pazaakSession()->advanceResultPresentation(1.5f));
+            fixture.game.showPazaakBoard();
+            noResultText();
+        }
+    }
+    EXPECT_EQ(
+        PazaakBoardState::MatchComplete,
+        fixture.game.pazaakSession()->boardProjection().state);
+    noResultText();
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, NoResultTextOnTiedSetOrForfeitedMatch) {
+    // Tied set: both draw 10 and stand.
+    {
+        GameFixture fixture;
+        TestGameModule::configurePazaak(
+            fixture.game,
+            true,
+            firstFour,
+            firstFour,
+            []() { return makeMainDeck({10, 10}); },
+            {});
+        TestGameModule::useRuntimePazaakGUIs(fixture.game);
+        LoadedPazaakGUIs loaded;
+        installPazaakGUIResources(fixture.engine, loaded);
+        ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+        chooseTen(*fixture.game.pazaakSession());
+        ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+        fixture.game.showPazaakBoard();
+        ASSERT_EQ(
+            PazaakOpponentEvent::PlayerDraw,
+            fixture.game.pazaakSession()->advanceOpponentEvent());
+        ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                DrawCommand {Participant::Two}));
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                StandCommand {Participant::Two}));
+        fixture.game.showPazaakBoard();
+        EXPECT_EQ(SetResult::Tie, fixture.game.pazaakSession()->boardProjection().setResult);
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_PLRTURN")->text().text);
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_NPCTURN")->text().text);
+        fixture.game.abortPazaak();
+    }
+    // Forfeited match: no textual result either.
+    {
+        GameFixture fixture;
+        configure(fixture.game);
+        TestGameModule::useRuntimePazaakGUIs(fixture.game);
+        LoadedPazaakGUIs loaded;
+        installPazaakGUIResources(fixture.engine, loaded);
+        ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+        chooseTen(*fixture.game.pazaakSession());
+        ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+        fixture.game.showPazaakBoard();
+        fixture.game.update(0.46f);
+        ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+        ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+        fixture.game.showPazaakBoard();
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_PLRTURN")->text().text);
+        EXPECT_EQ(
+            "",
+            loaded.controls.at("pazaakgame").at("LBL_NPCTURN")->text().text);
+        fixture.game.abortPazaak();
+    }
+}
+
+TEST(PazaakGUIResources, VerifiedAudioCuesFireOncePerModelEventAndNotOnRefresh) {
+    using testing::_;
+    using testing::Return;
+
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+
+    auto clip = std::make_shared<audio::AudioClip>();
+    EXPECT_CALL(fixture.engine.resourceModule().audioClips(), get("mgs_startturn"))
+        .Times(2)
+        .WillRepeatedly(Return(clip));
+    EXPECT_CALL(fixture.engine.resourceModule().audioClips(), get("mgs_drawmain"))
+        .Times(2)
+        .WillRepeatedly(Return(clip));
+    EXPECT_CALL(fixture.engine.resourceModule().audioClips(), get("mgs_playside"))
+        .Times(1)
+        .WillRepeatedly(Return(clip));
+    EXPECT_CALL(fixture.engine.audioModule().mixer(), play(_, _, _, _, _))
+        .Times(5)
+        .WillRepeatedly(Return(std::shared_ptr<audio::AudioSource> {}));
+    installPazaakGUIResources(fixture.engine, loaded, {}, false);
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        0,
+        "",
+        0,
+        false,
+        fixture.opponent));
+    PazaakSession *session = fixture.game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+    ASSERT_TRUE(session->selectCard(12));
+    for (size_t index = 0; index < 9; ++index) {
+        ASSERT_TRUE(session->selectCard(index));
+    }
+    ASSERT_TRUE(session->confirmSetup());
+    fixture.game.showPazaakBoard();
+
+    // Refreshing the same projection consumes no new model event.
+    fixture.game.showPazaakBoard();
+    fixture.game.update(0.46f);
+    click(loaded, "pazaakgame", "BTN_FLIP0");
+    fixture.game.showPazaakBoard();
+    click(loaded, "pazaakgame", "BTN_PLRSIDE0");
+    click(loaded, "pazaakgame", "BTN_XTEXT");
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session->advanceOpponentEvent());
+    fixture.game.showPazaakBoard();
+    fixture.game.showPazaakBoard();
+
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.resourceModule().audioClips()));
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.audioModule().mixer()));
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, VerifiedAudioManifestMapsEveryEventAndLeavesTieSilent) {
+    EXPECT_STREQ(
+        "mgs_startturn",
+        pazaakAudioResRef(PazaakPresentationEventType::TurnStarted));
+    EXPECT_STREQ(
+        "mgs_drawmain",
+        pazaakAudioResRef(PazaakPresentationEventType::MainDeckDrawn));
+    EXPECT_STREQ(
+        "mgs_playside",
+        pazaakAudioResRef(PazaakPresentationEventType::HandCardPlayed));
+    EXPECT_STREQ(
+        "mgs_winset",
+        pazaakAudioResRef(PazaakPresentationEventType::PlayerSetWon));
+    EXPECT_STREQ(
+        "mgs_loseset",
+        pazaakAudioResRef(PazaakPresentationEventType::PlayerSetLost));
+    EXPECT_STREQ(
+        "mgs_winmatch",
+        pazaakAudioResRef(PazaakPresentationEventType::PlayerMatchWon));
+    EXPECT_STREQ(
+        "mgs_losematch",
+        pazaakAudioResRef(PazaakPresentationEventType::PlayerMatchLost));
+    EXPECT_EQ(
+        nullptr,
+        pazaakAudioResRef(PazaakPresentationEventType::SetTied));
+}
+
+TEST(PazaakGUIResources, MissingAuthoredControlFailsFlowSafely) {
+    using testing::_;
+    using testing::NiceMock;
+    using testing::Return;
+
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    auto malformed = std::make_shared<NiceMock<gui::MockGUI>>();
+    ON_CALL(*malformed, findControl(_))
+        .WillByDefault(Return(std::shared_ptr<gui::Control> {}));
+    EXPECT_CALL(fixture.engine.guiModule().guis(), get(_, _))
+        .Times(3)
+        .WillRepeatedly(Return(malformed));
+
+    EXPECT_FALSE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::None, fixture.game.currentScreen());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGUIResources, MissingKotorOneOptionalControlsUseDevelopmentFallbacks) {
+    GameFixture fixture;
+    configure(fixture.game);
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(
+        fixture.engine,
+        loaded,
+        {
+            "pazaaksetup:BTN_CLEARCARDS",
+            "pazaaksetup:LBL_HELP",
+            "pazaaksetup:BTN_AVAIL30",
+            "pazaaksetup:LBL_AVAIL30",
+            "pazaaksetup:LBL_AVAILNUM30",
+            "pazaakgame:BTN_FORFEITGAME",
+        });
+
+    ASSERT_TRUE(fixture.game.playPazaak(
+        0,
+        "",
+        0,
+        false,
+        fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    fixture.game.update(0.46f);
+
+    ASSERT_EQ(Game::Screen::PazaakBoard, fixture.game.currentScreen());
+    ASSERT_TRUE(
+        loaded.controls.at("pazaakgame").count("BTN_FLIP0"));
+    click(loaded, "pazaakgame", "BTN_FLIP0");
+    input::Event escape = input::Event::newKeyDown(
+        input::KeyEvent(true, input::KeyCode::Escape, 0, false));
+    EXPECT_TRUE(fixture.game.handle(escape));
+    ASSERT_TRUE(
+        fixture.game.pazaakSession()->boardProjection().forfeitRequested);
+    EXPECT_TRUE(fixture.game.handle(escape));
+    fixture.game.update(1.5f);
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakGameLifecycle, ResetAndTechnicalAbortDoNotInventResult) {
+    GameFixture fixture;
+    configure(fixture.game);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    fixture.game.resetGame();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+}
+
+TEST(PazaakGameLifecycle, TechnicalAbortCoversEveryPresentationPhase) {
+    GameFixture fixture;
+    int continuationCount = 0;
+    configure(
+        fixture.game,
+        true,
+        [&](const std::string &, uint32_t) {
+            ++continuationCount;
+        });
+
+    fixture.game.party().giveGold(5);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 5, false, fixture.opponent));
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+
+    TestGameModule::configurePazaak(
+        fixture.game,
+        true,
+        firstFour,
+        firstFour,
+        []() { return makeMainDeck({1, 2}); },
+        [&](const std::string &, uint32_t) {
+            ++continuationCount;
+        });
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 0, false, fixture.opponent));
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->endPlayerTurn());
+    fixture.game.update(0.46f);
+    fixture.game.abortPazaak();
+    fixture.game.update(1.0f);
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            DrawCommand {Participant::Two}));
+    ASSERT_EQ(
+        ActionError::None,
+        fixture.game.pazaakSession()->applyOpponentCommand(
+            StandCommand {Participant::Two}));
+    ASSERT_TRUE(fixture.game.pazaakSession()->presentationPending());
+    ASSERT_TRUE(
+        fixture.game.pazaakSession()->advanceResultPresentation(1.5f));
+    fixture.game.abortPazaak();
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "unused", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    for (int setIndex = 0; setIndex < 3; ++setIndex) {
+        ASSERT_EQ(ActionError::None, fixture.game.pazaakSession()->standPlayer());
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                DrawCommand {Participant::Two}));
+        ASSERT_EQ(
+            ActionError::None,
+            fixture.game.pazaakSession()->applyOpponentCommand(
+                StandCommand {Participant::Two}));
+        ASSERT_TRUE(
+            fixture.game.pazaakSession()->advanceResultPresentation(1.5f));
+    }
+    ASSERT_TRUE(fixture.game.pazaakSession()->completedResult().has_value());
+    fixture.game.abortPazaak();
+
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+    EXPECT_EQ(0, continuationCount);
+    EXPECT_EQ(5, fixture.game.party().gold());
+}
+
+TEST(PazaakGameLifecycle, GuiLoadFailureRestoresSafeScreenAndClearsFlow) {
+    GameFixture fixture;
+    configure(fixture.game, false);
+
+    EXPECT_FALSE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    EXPECT_EQ(nullptr, fixture.game.pazaakSession());
+    EXPECT_EQ(Game::Screen::None, fixture.game.currentScreen());
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+}
+
+TEST(PazaakGameLifecycle, LastResultChangesOnlyAtSemanticCompletion) {
+    GameFixture fixture;
+    configure(fixture.game);
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    fixture.game.cancelPazaak();
+    EXPECT_FALSE(fixture.game.lastPazaakResult().has_value());
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    chooseTen(*fixture.game.pazaakSession());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    ASSERT_TRUE(fixture.game.pazaakSession()->requestForfeit());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmForfeit());
+    fixture.game.update(1.5f);
+    ASSERT_TRUE(fixture.game.lastPazaakResult().has_value());
+
+    auto completed = fixture.game.lastPazaakResult();
+    fixture.game.abortPazaak();
+    EXPECT_EQ(completed, fixture.game.lastPazaakResult());
+}
+
+TEST(PazaakScriptBoundary, NoCompletedMatchUsesAuthoredLossValue) {
+    GameFixture fixture;
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+
+    script::Variable result = routines.get(365).invoke({}, execution);
+    EXPECT_EQ(script::VariableType::Int, result.type);
+    EXPECT_EQ(0, result.intValue);
+}
+
+TEST(PazaakScriptBoundary, AuthoredIntegerMappingIsOneForWinZeroForLossAndForfeit) {
+    GameFixture fixture;
+    configure(fixture.game);
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::PlayerWon);
+    EXPECT_EQ(1, routines.get(365).invoke({}, execution).intValue);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::OpponentWon);
+    EXPECT_EQ(0, routines.get(365).invoke({}, execution).intValue);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    TestGameModule::finishPazaak(
+        fixture.game,
+        PazaakCompletedResult::PlayerForfeited);
+    EXPECT_EQ(0, routines.get(365).invoke({}, execution).intValue);
+}
+
+// ---------------------------------------------------------------------------
+// KotOR II integration.
+// ---------------------------------------------------------------------------
+
+TEST(PazaakK2Data, DeckTokensParseToSemanticSpecialCards) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+    TestGameModule::useAuthoredPazaakDecks(game);
+    auto table = pazaakDeckTable({
+        {"$$", "F1", "F2", "TT", "VV", "+1", "-1", "*1", "+2", "-2"},
+    });
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return(table));
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    const auto &deck = game.pazaakSession()->opponentSideDeck();
+    EXPECT_EQ(CardDefinition::doubleCard(), deck[0]);
+    EXPECT_EQ(CardDefinition::flipTwoFour(), deck[1]);
+    EXPECT_EQ(CardDefinition::flipThreeSix(), deck[2]);
+    EXPECT_EQ(CardDefinition::tiebreaker(), deck[3]);
+    EXPECT_EQ(CardDefinition::valueChange(), deck[4]);
+    EXPECT_EQ(CardDefinition::fixedPositive(1), deck[5]);
+    EXPECT_EQ(CardDefinition::fixedNegative(1), deck[6]);
+    EXPECT_EQ(CardDefinition::signSelectable(1), deck[7]);
+    game.abortPazaak();
+}
+
+TEST(PazaakK2Data, MalformedKotorTwoDeckRowFailsSafely) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+    TestGameModule::useAuthoredPazaakDecks(game);
+    auto table = pazaakDeckTable({
+        {"$$", "F1", "F2", "TT", "VV", "+1", "-1", "*1", "+2", "F9"},
+    });
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return(table));
+
+    EXPECT_FALSE(game.playPazaak(0, "", 0, false, opponent));
+    EXPECT_EQ(nullptr, game.pazaakSession());
+}
+
+TEST(PazaakK2GUI, WidescreenVariantUsesKotorTwoArtAndPlaysAValueChangeCard) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    TestGameModule::configurePazaak(
+        game, true, firstFour, firstFour,
+        []() { return makeMainDeck({4}); }, {});
+    TestGameModule::useRuntimePazaakGUIs(game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(engine, loaded);
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    // The widescreen KotOR II _p GUI variant is loaded, not the KotOR I set.
+    EXPECT_TRUE(loaded.controls.count("pazaakgame_p"));
+    EXPECT_TRUE(loaded.controls.count("pazaaksetup_p"));
+    EXPECT_FALSE(loaded.controls.count("pazaakgame"));
+
+    auto &session = *game.pazaakSession();
+    ASSERT_TRUE(session.selectCard(22));   // ValueChange -> hand slot 0
+    ASSERT_TRUE(session.selectCard(19));   // Double -> hand slot 1
+    for (size_t i : {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u}) {
+        ASSERT_TRUE(session.selectCard(i));
+    }
+    ASSERT_EQ(kSideDeckSize, session.chosenCards().size());
+    ASSERT_TRUE(session.confirmSetup());
+    game.showPazaakBoard();
+    game.update(0.46f);
+
+    auto &board = loaded.controls.at("pazaakgame_p");
+    // The mandatory main-deck card uses the green main-deck face, a special card
+    // uses the gold face, and the concealed/hover families are the KotOR II ones.
+    EXPECT_EQ("pcards_generic_p", board.at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ("pcards_gold_p", board.at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_EQ("pcards_gold_p", board.at("BTN_PLRSIDE1")->borderFillResRef());
+    EXPECT_EQ("pcards_back_p", board.at("BTN_NPCSIDE0")->borderFillResRef());
+    EXPECT_EQ("pcards_hilite_p", board.at("BTN_PLRSIDE0")->hilightFillResRef());
+    EXPECT_EQ("pz_playerliteoff", board.at("LBL_PLRSCORE0")->borderFillResRef());
+    // The value switch belongs to the Value Change card's own slot only.
+    EXPECT_TRUE(board.at("BTN_CHANGE0")->isVisible());
+    EXPECT_FALSE(board.at("BTN_CHANGE1")->isVisible());
+
+    // The slot's own change control advances +1 -> +2, then play the card.
+    click(loaded, "pazaakgame_p", "BTN_CHANGE0");
+    EXPECT_EQ("+2", board.at("LBL_PLRSIDE0")->text().text);
+    click(loaded, "pazaakgame_p", "BTN_PLRSIDE0");
+    EXPECT_EQ("pcards_gold_p", board.at("BTN_PLR1")->borderFillResRef());
+    EXPECT_EQ("+2", board.at("LBL_PLR1")->text().text);
+    EXPECT_EQ(6, game.pazaakSession()->boardProjection().playerTotal);
+
+    game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&engine.guiModule().guis()));
+}
+
+TEST(PazaakK2GUI, EveryCardFamilyUsesItsShippedResourceAndNoBareOrMojibakeText) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    // Hand: +1 (blue), -1 (red), +/-1 (split), Flip 3&6 (gold special).
+    auto hand = [](const SideDeck &) { return HandSelection {2, 3, 1, 0}; };
+    TestGameModule::configurePazaak(
+        game, true, hand, firstFour,
+        []() { return makeMainDeck({7}); }, {});
+    TestGameModule::useRuntimePazaakGUIs(game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(engine, loaded);
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    auto &session = *game.pazaakSession();
+    ASSERT_TRUE(session.selectCard(21));   // Flip 3&6 -> hand slot 3
+    ASSERT_TRUE(session.selectCard(12));   // +/-1     -> hand slot 2
+    ASSERT_TRUE(session.selectCard(0));    // +1       -> hand slot 0
+    ASSERT_TRUE(session.selectCard(6));    // -1       -> hand slot 1
+    for (size_t i : {1u, 2u, 3u, 4u, 5u, 7u}) {
+        ASSERT_TRUE(session.selectCard(i));
+    }
+    ASSERT_EQ(kSideDeckSize, session.chosenCards().size());
+    ASSERT_TRUE(session.confirmSetup());
+    game.showPazaakBoard();
+    game.update(0.46f);
+
+    auto &board = loaded.controls.at("pazaakgame_p");
+    // Fixed positive is blue, fixed negative is red, a sign-selectable card uses
+    // the split family, and a special card is gold.
+    EXPECT_EQ("pcards_pos_p", board.at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_EQ("pcards_neg_p", board.at("BTN_PLRSIDE1")->borderFillResRef());
+    EXPECT_EQ("pcards_dblpos_p", board.at("BTN_PLRSIDE2")->borderFillResRef());
+    EXPECT_EQ("pcards_gold_p", board.at("BTN_PLRSIDE3")->borderFillResRef());
+    // The mandatory draw keeps the green main-deck face regardless of its value.
+    EXPECT_EQ("pcards_generic_p", board.at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ("7", board.at("LBL_PLR0")->text().text);
+
+    // Value text is present, and no card label carries the stray high byte that a
+    // multi-byte plus-minus sequence would produce, nor a raw deck token.
+    for (const std::string &tag : {
+             "LBL_PLRSIDE0", "LBL_PLRSIDE1", "LBL_PLRSIDE2", "LBL_PLRSIDE3",
+             "LBL_PLR0", "LBL_CHANGEICON", "LBL_CHANGELEGEND",
+         }) {
+        const std::string &text = board.at(tag)->text().text;
+        EXPECT_EQ(std::string::npos, text.find('\xC2')) << tag;
+        for (const std::string &token : {"$$", "F1", "F2", "TT", "VV"}) {
+            EXPECT_EQ(std::string::npos, text.find(token)) << tag;
+        }
+    }
+    EXPECT_EQ("+1", board.at("LBL_PLRSIDE0")->text().text);
+    EXPECT_EQ("-1", board.at("LBL_PLRSIDE1")->text().text);
+    EXPECT_EQ("3&6", board.at("LBL_PLRSIDE3")->text().text);
+    // The change icon/legend carry authored art only, never a duplicate value.
+    EXPECT_EQ("", board.at("LBL_CHANGEICON")->text().text);
+
+    // Sign switch only on the sign-selectable slot; no value switch anywhere.
+    EXPECT_FALSE(board.at("BTN_FLIP0")->isVisible());
+    EXPECT_FALSE(board.at("BTN_FLIP1")->isVisible());
+    EXPECT_TRUE(board.at("BTN_FLIP2")->isVisible());
+    EXPECT_FALSE(board.at("BTN_FLIP3")->isVisible());
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_FALSE(board.at("BTN_CHANGE" + std::to_string(i))->isVisible());
+    }
+    EXPECT_FALSE(board.at("LBL_CHANGELEGEND")->isVisible());
+
+    // Repeated refreshes must not accumulate controls onto the other slots.
+    game.showPazaakBoard();
+    game.showPazaakBoard();
+    EXPECT_FALSE(board.at("BTN_FLIP0")->isVisible());
+    EXPECT_TRUE(board.at("BTN_FLIP2")->isVisible());
+
+    // Playing the selectable card clears its control and keeps its split family.
+    click(loaded, "pazaakgame_p", "BTN_PLRSIDE2");
+    EXPECT_FALSE(board.at("BTN_FLIP2")->isVisible());
+    EXPECT_EQ("pcards_dblpos_p", board.at("BTN_PLR1")->borderFillResRef());
+    EXPECT_EQ("+1", board.at("LBL_PLR1")->text().text);
+
+    game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&engine.guiModule().guis()));
+}
+
+TEST(PazaakK1GUI, CardPresentationStillUsesTheKotorOneFamilies) {
+    GameFixture fixture;
+    TestGameModule::configurePazaak(
+        fixture.game, true, firstFour, firstFour,
+        []() { return makeMainDeck({3}); }, {});
+    TestGameModule::useRuntimePazaakGUIs(fixture.game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(fixture.engine, loaded);
+
+    ASSERT_TRUE(fixture.game.playPazaak(0, "", 0, false, fixture.opponent));
+    // Side deck ordered so the opening hand is -1, +1, +/-1 and +2.
+    auto &session = *fixture.game.pazaakSession();
+    for (size_t index : {6u, 0u, 12u, 1u, 2u, 3u, 4u, 5u, 7u, 8u}) {
+        ASSERT_TRUE(session.selectCard(index));
+    }
+    ASSERT_EQ(kSideDeckSize, session.chosenCards().size());
+    ASSERT_TRUE(fixture.game.pazaakSession()->confirmSetup());
+    fixture.game.showPazaakBoard();
+    fixture.game.update(0.46f);
+
+    auto &board = loaded.controls.at("pazaakgame");
+    EXPECT_EQ("lbl_cardstand", board.at("BTN_PLR0")->borderFillResRef());
+    EXPECT_EQ("lbl_cardmneg", board.at("BTN_PLRSIDE0")->borderFillResRef());
+    EXPECT_EQ("lbl_cardmpos", board.at("BTN_PLRSIDE1")->borderFillResRef());
+    EXPECT_EQ("lbl_cardrarem", board.at("BTN_PLRSIDE2")->borderFillResRef());
+    EXPECT_EQ("lbl_cardback", board.at("BTN_NPCSIDE0")->borderFillResRef());
+    EXPECT_EQ("lbl_cardhilite", board.at("BTN_PLRSIDE0")->hilightFillResRef());
+    EXPECT_EQ("lbl_winmark01", board.at("LBL_PLRSCORE0")->borderFillResRef());
+    EXPECT_EQ("3", board.at("LBL_PLR0")->text().text);
+    fixture.game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(
+        &fixture.engine.guiModule().guis()));
+}
+
+TEST(PazaakK2Showcase, DeveloperLaunchUsesOrderedDeterministicShowcaseData) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    engine.options().game.developer = true;
+    TestGameModule::initConsole(game);
+    TestGameModule::setActiveModule(game, true);
+    TestGameModule::setCurrentScreen(game, static_cast<int>(Game::Screen::InGame));
+    TestGameModule::configurePazaak(
+        game, true, {}, firstFour,
+        []() { return makeMainDeck({5}); }, {});
+    TestGameModule::useRuntimePazaakGUIs(game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(engine, loaded);
+
+    console.execute("startpazaak");
+    auto *session = game.pazaakSession();
+    ASSERT_NE(nullptr, session);
+
+    // The available cards are ordered +1..+6, -1..-6, +/-1..+/-6, then specials.
+    const auto &collection = session->collection();
+    ASSERT_EQ(23u, collection.size());
+    for (int m = 1; m <= 6; ++m) {
+        EXPECT_EQ(CardDefinition::fixedPositive(m), collection[m - 1].definition);
+        EXPECT_EQ(CardDefinition::fixedNegative(m), collection[5 + m].definition);
+        EXPECT_EQ(CardDefinition::signSelectable(m), collection[11 + m].definition);
+    }
+    EXPECT_EQ(CardDefinition::tiebreaker(), collection[18].definition);
+    EXPECT_EQ(CardDefinition::doubleCard(), collection[19].definition);
+    EXPECT_EQ(CardDefinition::flipTwoFour(), collection[20].definition);
+    EXPECT_EQ(CardDefinition::flipThreeSix(), collection[21].definition);
+    EXPECT_EQ(CardDefinition::valueChange(), collection[22].definition);
+
+    // The ten-card side deck is deterministic and already selected.
+    EXPECT_EQ(
+        std::vector<size_t>({22, 12, 0, 19, 20, 21, 18, 6, 4, 13}),
+        session->chosenCards());
+    ASSERT_TRUE(session->confirmSetup());
+    game.showPazaakBoard();
+
+    // The opening hand covers a Value Change card, a sign-selectable card, a
+    // fixed card and a non-switchable special.
+    PazaakBoardProjection projection = session->boardProjection();
+    ASSERT_TRUE(projection.playerHand[0].definition);
+    EXPECT_TRUE(projection.playerHand[0].definition->isValueSelectable());
+    EXPECT_EQ(CardBehavior::SignSelectable, projection.playerHand[1].definition->behavior());
+    EXPECT_EQ(CardBehavior::FixedPositive, projection.playerHand[2].definition->behavior());
+    EXPECT_EQ(CardBehavior::Double, projection.playerHand[3].definition->behavior());
+    game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&engine.guiModule().guis()));
+}
+
+TEST(PazaakK2Showcase, AuthoredMatchesDoNotUseShowcaseData) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    configure(game);
+
+    // A native launch leaves the side-deck selection to ordinary setup.
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    EXPECT_TRUE(game.pazaakSession()->chosenCards().empty());
+    game.abortPazaak();
+}
+
+TEST(PazaakK2GUI, SetupLoadsWithoutTheOptionalAddCardButton) {
+    // The shipped K2 pazaaksetup_p has no BTN_YTEXT ("Add card") that K1 has; a
+    // card is added by clicking it in the available grid. The setup GUI must
+    // still load, so the KotOR II development launch reaches the setup screen.
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    TestGameModule::configurePazaak(
+        game, true, firstFour, firstFour,
+        []() { return makeMainDeck({5}); }, {});
+    TestGameModule::useRuntimePazaakGUIs(game);
+    LoadedPazaakGUIs loaded;
+    installPazaakGUIResources(engine, loaded, {"pazaaksetup_p:BTN_YTEXT"});
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    ASSERT_NE(nullptr, game.pazaakSession());
+    EXPECT_EQ(Game::Screen::PazaakSetup, game.currentScreen());
+    EXPECT_TRUE(loaded.controls.count("pazaaksetup_p"));
+    game.abortPazaak();
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&engine.guiModule().guis()));
+}
+
+TEST(PazaakK2Match, OpponentWithSpecialCardsCompletesAMatchWithoutDeadlock) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    auto opponent = game.newCreature();
+    TestGameModule::configurePazaak(
+        game, true, firstFour, firstFour,
+        []() { return makeMainDeck({7, 6, 8, 5, 9, 4}); }, {});
+    TestGameModule::useAuthoredPazaakDecks(game);
+    auto table = pazaakDeckTable({
+        {"$$", "F1", "F2", "TT", "VV", "*3", "*4", "+5", "-3", "+2"},
+    });
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("pazaakdecks"))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return(table));
+
+    ASSERT_TRUE(game.playPazaak(0, "", 0, false, opponent));
+    auto &session = *game.pazaakSession();
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    // Drive the match to completion. The opponent policy uses the special cards
+    // through the real rules; the guard proves it never deadlocks.
+    int guard = 0;
+    while (!session.terminal() && guard++ < 4000) {
+        if (session.presentationPending()) {
+            session.advanceResultPresentation(2.0f);
+            continue;
+        }
+        PazaakBoardProjection proj = session.boardProjection();
+        if (proj.playerActive) {
+            if (proj.canStand) {
+                session.standPlayer();
+            } else {
+                session.advanceOpponentEvent();
+            }
+        } else if (proj.state == PazaakBoardState::AwaitingOpponentPolicy) {
+            session.advanceOpponentEvent();
+        } else {
+            break;
+        }
+    }
+    EXPECT_TRUE(session.terminal());
+    game.abortPazaak();
+}

--- a/test/game/pazaaksession.cpp
+++ b/test/game/pazaaksession.cpp
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/pazaaksession.h"
+
+#include <algorithm>
+
+using namespace reone::game;
+using namespace reone::game::pazaak;
+
+namespace {
+
+HandSelection firstFour(const SideDeck &) {
+    return {0, 1, 2, 3};
+}
+
+PazaakSession makeSession(
+    int maximumWager = 0,
+    int credits = 0,
+    PazaakSession::HandSelector playerSelector = firstFour,
+    std::vector<PazaakCollectionCard> collection = PazaakSession::temporaryK1TestCollection(),
+    PazaakSession::HandSelector opponentSelector = firstFour,
+    PazaakSession::MainDeckFactory mainDeckFactory = []() {
+        return MainDeck::standardOrdered();
+    },
+    PazaakSession::FirstParticipantSelector firstParticipantSelector = {}) {
+
+    PazaakSessionParams params;
+    params.maximumWager = maximumWager;
+    params.availableCredits = credits;
+    params.playerName = "Player";
+    params.opponentName = "Opponent";
+    params.collection = std::move(collection);
+    params.opponentSideDeck = PazaakSession::temporaryK1OpponentSideDeck();
+    return PazaakSession(
+        std::move(params),
+        std::move(playerSelector),
+        std::move(opponentSelector),
+        std::move(mainDeckFactory),
+        std::move(firstParticipantSelector));
+}
+
+void chooseTen(PazaakSession &session) {
+    for (size_t index = 0; index < kSideDeckSize; ++index) {
+        ASSERT_TRUE(session.selectCard(index));
+    }
+}
+
+MainDeck makeMainDeck(std::initializer_list<int> prefix) {
+    std::vector<int> cards(MainDeck::standardOrdered().cards());
+    size_t position = 0;
+    for (int value : prefix) {
+        auto found = std::find(cards.begin() + static_cast<ptrdiff_t>(position), cards.end(), value);
+        std::iter_swap(cards.begin() + static_cast<ptrdiff_t>(position), found);
+        ++position;
+    }
+    return MainDeck(std::move(cards));
+}
+
+} // namespace
+
+TEST(PazaakFlowWager, CapsAtScriptMaximumAndAvailableCredits) {
+    PazaakSession scriptLimited(makeSession(3, 20));
+    EXPECT_EQ(PazaakFlowScreen::Wager, scriptLimited.screen());
+    EXPECT_EQ(3, scriptLimited.wager());
+    for (int i = 0; i < 10; ++i) {
+        scriptLimited.increaseWager();
+    }
+    EXPECT_EQ(3, scriptLimited.wager());
+    EXPECT_EQ(3, scriptLimited.wagerLimit());
+
+    PazaakSession creditLimited(makeSession(20, 4));
+    EXPECT_EQ(4, creditLimited.wager());
+    for (int i = 0; i < 10; ++i) {
+        creditLimited.increaseWager();
+    }
+    EXPECT_EQ(4, creditLimited.wager());
+    EXPECT_EQ(4, creditLimited.wagerLimit());
+    for (int i = 0; i < 10; ++i) {
+        creditLimited.decreaseWager();
+    }
+    EXPECT_EQ(1, creditLimited.wager());
+}
+
+TEST(PazaakFlowWager, FiveCreditControlsClampToMinimumAndMaximum) {
+    PazaakSession session(makeSession(12, 20));
+    EXPECT_EQ(12, session.wager());
+    session.increaseWager();
+    EXPECT_EQ(12, session.wager());
+    session.decreaseWager();
+    EXPECT_EQ(7, session.wager());
+    session.decreaseWager();
+    EXPECT_EQ(2, session.wager());
+    session.decreaseWager();
+    EXPECT_EQ(1, session.wager());
+    session.decreaseWager();
+    EXPECT_EQ(1, session.wager());
+    session.increaseWager();
+    EXPECT_EQ(6, session.wager());
+}
+
+TEST(PazaakFlowWager, ZeroAllowedWagerBypassesWagerScreen) {
+    EXPECT_EQ(PazaakFlowScreen::Setup, makeSession(0, 100).screen());
+    EXPECT_EQ(PazaakFlowScreen::Setup, makeSession(100, 0).screen());
+    EXPECT_EQ(PazaakFlowScreen::Setup, makeSession(-1, 100).screen());
+}
+
+TEST(PazaakFlowSetup, RequiresExactlyTenCardsAndHonorsAvailableCopies) {
+    PazaakSession session(makeSession());
+    EXPECT_FALSE(session.canConfirmSetup());
+    EXPECT_FALSE(session.confirmSetup());
+
+    EXPECT_TRUE(session.selectCard(0));
+    EXPECT_TRUE(session.selectCard(0));
+    EXPECT_FALSE(session.selectCard(0));
+    EXPECT_EQ(0, session.remainingCopies(0));
+
+    for (size_t index = 1; session.chosenCards().size() < kSideDeckSize; ++index) {
+        ASSERT_TRUE(session.selectCard(index));
+    }
+    EXPECT_TRUE(session.canConfirmSetup());
+    EXPECT_FALSE(session.selectCard(10));
+    EXPECT_EQ(kSideDeckSize, session.chosenCards().size());
+
+    EXPECT_TRUE(session.removeChosenCard(0));
+    EXPECT_FALSE(session.canConfirmSetup());
+    session.clearChosenCards();
+    EXPECT_TRUE(session.chosenCards().empty());
+}
+
+TEST(PazaakFlowSetup, ConfirmationUsesInjectedDeterministicFourCardSelection) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        [](const SideDeck &) -> HandSelection { return {9, 7, 5, 3}; }));
+    chooseTen(session);
+
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_NE(nullptr, session.match());
+    const auto &hand = session.match()->participant(Participant::One).hand();
+    ASSERT_EQ(kHandSize, hand.size());
+    EXPECT_EQ(CardDefinition::fixedNegative(4), hand[0].definition);
+    EXPECT_EQ(CardDefinition::fixedNegative(2), hand[1].definition);
+    EXPECT_EQ(CardDefinition::fixedPositive(6), hand[2].definition);
+    EXPECT_EQ(CardDefinition::fixedPositive(4), hand[3].definition);
+}
+
+TEST(PazaakFlowBoard, ProjectionHasNineAndFourSlotsAndHidesUnusedOpponentHand) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    PazaakBoardProjection projection(session.boardProjection());
+    EXPECT_EQ(kBoardSize, projection.playerBoard.size());
+    EXPECT_EQ(kBoardSize, projection.opponentBoard.size());
+    EXPECT_EQ(kHandSize, projection.playerHand.size());
+    EXPECT_EQ(kHandSize, projection.opponentHand.size());
+    EXPECT_TRUE(projection.playerBoard[0].occupied);
+    EXPECT_TRUE(projection.playerActive);
+    for (const auto &slot : projection.opponentHand) {
+        EXPECT_TRUE(slot.occupied);
+        EXPECT_TRUE(slot.hidden);
+        EXPECT_FALSE(slot.definition.has_value());
+    }
+}
+
+TEST(PazaakFlowBoard, LegalCommandsReachRulesAndIllegalCommandsAreProjectionAtomic) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_TRUE(session.boardProjection().playerHand[0].playable);
+
+    ASSERT_EQ(ActionError::None, session.playPlayerHandCard(0));
+    EXPECT_EQ(2, session.match()->set().participant(Participant::One).board().size());
+    EXPECT_TRUE(session.match()->participant(Participant::One).hand()[0].used);
+
+    MatchState before(*session.match());
+    PazaakBoardProjection projectionBefore(session.boardProjection());
+    EXPECT_EQ(ActionError::HandCardAlreadyPlayedThisTurn, session.playPlayerHandCard(1));
+    EXPECT_EQ(before, *session.match());
+    EXPECT_EQ(projectionBefore, session.boardProjection());
+}
+
+TEST(PazaakFlowBoard, SignSelectionRoutesSelectableValueToRulesModel) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        [](const SideDeck &) -> HandSelection { return {9, 8, 7, 6}; }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    // Chosen positions 9/8/7/6 are fixed-negative in the temporary setup.
+    // Build a setup whose first hand position is explicitly selectable.
+    PazaakSession selectable(makeSession(
+        0,
+        0,
+        [](const SideDeck &) -> HandSelection { return {0, 1, 2, 3}; },
+        {
+            {CardDefinition::signSelectable(3), 10},
+        }));
+    for (size_t i = 0; i < kSideDeckSize; ++i) {
+        ASSERT_TRUE(selectable.selectCard(0));
+    }
+    ASSERT_TRUE(selectable.confirmSetup());
+    EXPECT_EQ(
+        CardDefinition::fixedPositive(1),
+        selectable.match()->participant(Participant::Two).hand()[0].definition);
+    ASSERT_TRUE(selectable.selectPlayerCardSign(0, CardSign::Negative));
+    ASSERT_EQ(ActionError::None, selectable.playPlayerHandCard(0));
+    EXPECT_EQ(-3, selectable.match()->set().participant(Participant::One).board().back().value());
+}
+
+TEST(PazaakFlowBoard, OpponentTurnIsExplicitlyAwaitingPolicy) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_EQ(ActionError::None, session.endPlayerTurn());
+
+    PazaakBoardProjection projection(session.boardProjection());
+    EXPECT_EQ(PazaakBoardState::AwaitingOpponentPolicy, projection.state);
+    EXPECT_TRUE(projection.opponentActive);
+    EXPECT_FALSE(projection.playerActive);
+    EXPECT_FALSE(projection.canEndTurn);
+    EXPECT_FALSE(projection.canStand);
+
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(DrawCommand {Participant::Two}));
+    EXPECT_EQ(1, session.match()->set().participant(Participant::Two).board().size());
+    EXPECT_EQ(PazaakBoardState::AwaitingOpponentPolicy, session.boardProjection().state);
+}
+
+TEST(PazaakFlowBoard, ForfeitCompletesSemanticallyOnce) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    EXPECT_TRUE(session.requestForfeit());
+    EXPECT_TRUE(session.boardProjection().forfeitRequested);
+    EXPECT_TRUE(session.confirmForfeit());
+    ASSERT_TRUE(session.completedResult().has_value());
+    EXPECT_EQ(PazaakCompletedResult::PlayerForfeited, *session.completedResult());
+    EXPECT_FALSE(session.confirmForfeit());
+    EXPECT_FALSE(session.requestForfeit());
+}
+
+TEST(PazaakFlowBoard, ParticipantTwoCanStartAndEventsDrawExactlyOneCardAtATime) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({8, 9}); },
+        [](size_t) { return Participant::Two; }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    EXPECT_TRUE(session.match()->set().participant(Participant::One).board().empty());
+    EXPECT_EQ(PazaakBoardState::AwaitingOpponentPolicy, session.boardProjection().state);
+
+    MatchState before(*session.match());
+    EXPECT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    EXPECT_EQ(1, session.match()->set().participant(Participant::Two).board().size());
+    EXPECT_TRUE(session.match()->set().participant(Participant::One).board().empty());
+    EXPECT_FALSE(before == *session.match());
+
+    before = *session.match();
+    EXPECT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    EXPECT_TRUE(session.match()->set().participant(Participant::One).board().empty());
+    EXPECT_EQ(TurnStage::AwaitingDraw, session.match()->set().turnStage());
+    EXPECT_FALSE(before == *session.match());
+
+    before = *session.match();
+    EXPECT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+    EXPECT_EQ(1, session.match()->set().participant(Participant::One).board().size());
+    EXPECT_EQ(1, session.match()->set().participant(Participant::Two).board().size());
+    EXPECT_FALSE(before == *session.match());
+}
+
+TEST(PazaakFlowBoard, AutoStandAtTwentyQueuesEachPlacementAndTurnOnce) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({10, 1, 10}); }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    std::vector<PazaakPresentationEvent> events =
+        session.takePresentationEvents();
+    ASSERT_EQ(2, events.size());
+    EXPECT_EQ(PazaakPresentationEventType::TurnStarted, events[0].type);
+    EXPECT_EQ(Participant::One, events[0].participant);
+    EXPECT_EQ(PazaakPresentationEventType::MainDeckDrawn, events[1].type);
+    EXPECT_EQ(Participant::One, events[1].participant);
+    EXPECT_TRUE(session.takePresentationEvents().empty());
+
+    ASSERT_EQ(ActionError::None, session.endPlayerTurn());
+    events = session.takePresentationEvents();
+    ASSERT_EQ(1, events.size());
+    EXPECT_EQ(PazaakPresentationEventType::TurnStarted, events[0].type);
+    EXPECT_EQ(Participant::Two, events[0].participant);
+
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    session.takePresentationEvents();
+    ASSERT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+
+    EXPECT_TRUE(
+        session.match()->set().participant(Participant::One).stood());
+    EXPECT_EQ(20, session.boardProjection().playerTotal);
+    EXPECT_FALSE(session.boardProjection().canEndTurn);
+    EXPECT_FALSE(session.boardProjection().canStand);
+    EXPECT_EQ(
+        ActionError::ParticipantStanding,
+        session.playPlayerHandCard(0));
+
+    events = session.takePresentationEvents();
+    ASSERT_EQ(2, events.size());
+    EXPECT_EQ(PazaakPresentationEventType::MainDeckDrawn, events[0].type);
+    EXPECT_EQ(Participant::One, events[0].participant);
+    EXPECT_EQ(PazaakPresentationEventType::TurnStarted, events[1].type);
+    EXPECT_EQ(Participant::Two, events[1].participant);
+    EXPECT_TRUE(session.takePresentationEvents().empty());
+}
+
+TEST(PazaakFlowBoard, PlayerHandCardAtTwentyQueuesOneCommitAndAutoStands) {
+    std::vector<PazaakCollectionCard> collection {
+        {CardDefinition::fixedPositive(4), kSideDeckSize},
+    };
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        std::move(collection),
+        firstFour,
+        []() { return makeMainDeck({10, 1, 6}); }));
+    for (size_t i = 0; i < kSideDeckSize; ++i) {
+        ASSERT_TRUE(session.selectCard(0));
+    }
+    ASSERT_TRUE(session.confirmSetup());
+    session.takePresentationEvents();
+    ASSERT_EQ(ActionError::None, session.endPlayerTurn());
+    session.takePresentationEvents();
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+    session.takePresentationEvents();
+
+    ASSERT_EQ(ActionError::None, session.playPlayerHandCard(0));
+    EXPECT_EQ(20, session.boardProjection().playerTotal);
+    EXPECT_TRUE(
+        session.match()->set().participant(Participant::One).stood());
+    std::vector<PazaakPresentationEvent> events =
+        session.takePresentationEvents();
+    ASSERT_EQ(2, events.size());
+    EXPECT_EQ(PazaakPresentationEventType::HandCardPlayed, events[0].type);
+    EXPECT_EQ(PazaakPresentationEventType::TurnStarted, events[1].type);
+    EXPECT_TRUE(session.takePresentationEvents().empty());
+}
+
+TEST(PazaakFlowBoard, SetCompletionAutoAdvancesAfterReadableIntervalAndPreservesUsedHand) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({10, 9}); },
+        [](size_t) { return Participant::One; }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_EQ(ActionError::None, session.playPlayerHandCard(0));
+    ASSERT_EQ(ActionError::None, session.standPlayer());
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(StandCommand {Participant::Two}));
+
+    ASSERT_EQ(SetResult::ParticipantOneWon, session.match()->set().result());
+    EXPECT_EQ(PazaakBoardState::SetComplete, session.boardProjection().state);
+    EXPECT_EQ(2, session.match()->set().participant(Participant::One).board().size());
+    EXPECT_TRUE(session.match()->participant(Participant::One).hand()[0].used);
+
+    MatchState completed(*session.match());
+    EXPECT_FALSE(session.advanceResultPresentation(1.0f));
+    EXPECT_EQ(completed, *session.match());
+    EXPECT_TRUE(session.advanceResultPresentation(0.5f));
+    EXPECT_EQ(SetResult::InProgress, session.match()->set().result());
+    EXPECT_EQ(1, session.match()->set().participant(Participant::One).board().size());
+    EXPECT_EQ(10, session.match()->set().participant(Participant::One).total());
+    EXPECT_TRUE(session.match()->participant(Participant::One).hand()[0].used);
+    EXPECT_EQ(1, session.match()->participant(Participant::One).setWins());
+
+    MatchState before(*session.match());
+    EXPECT_FALSE(session.advanceResultPresentation(10.0f));
+    EXPECT_EQ(before, *session.match());
+}
+
+TEST(PazaakFlowBoard, TiedSetAutoTransitionsWithoutPipOrInventedCue) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({10, 10}); }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    session.takePresentationEvents();
+    ASSERT_EQ(ActionError::None, session.standPlayer());
+    session.takePresentationEvents();
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(
+        ActionError::None,
+        session.applyOpponentCommand(StandCommand {Participant::Two}));
+
+    ASSERT_EQ(SetResult::Tie, session.match()->set().result());
+    EXPECT_EQ(0, session.boardProjection().playerSetWins);
+    EXPECT_EQ(0, session.boardProjection().opponentSetWins);
+    ASSERT_TRUE(session.presentationPending());
+    std::vector<PazaakPresentationEvent> events =
+        session.takePresentationEvents();
+    ASSERT_EQ(2, events.size());
+    EXPECT_EQ(PazaakPresentationEventType::MainDeckDrawn, events[0].type);
+    EXPECT_EQ(PazaakPresentationEventType::SetTied, events[1].type);
+
+    EXPECT_FALSE(session.advanceResultPresentation(1.49f));
+    EXPECT_TRUE(session.advanceResultPresentation(0.01f));
+    EXPECT_EQ(SetResult::InProgress, session.match()->set().result());
+    EXPECT_EQ(0, session.boardProjection().playerSetWins);
+    EXPECT_EQ(0, session.boardProjection().opponentSetWins);
+}
+
+TEST(PazaakFlowBoard, CompletedSetRejectsCommandsWithCompleteStateEquality) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({10, 9}); }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_EQ(ActionError::None, session.standPlayer());
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(StandCommand {Participant::Two}));
+    ASSERT_NE(SetResult::InProgress, session.match()->set().result());
+
+    MatchState before(*session.match());
+    PazaakBoardProjection projectionBefore(session.boardProjection());
+    EXPECT_EQ(ActionError::SetComplete, session.endPlayerTurn());
+    EXPECT_EQ(ActionError::SetComplete, session.standPlayer());
+    EXPECT_EQ(ActionError::SetComplete, session.playPlayerHandCard(0));
+    EXPECT_FALSE(session.selectPlayerCardSign(0, CardSign::Negative));
+    EXPECT_FALSE(session.requestForfeit());
+    EXPECT_EQ(before, *session.match());
+    EXPECT_EQ(projectionBefore, session.boardProjection());
+}
+
+TEST(PazaakFlowBoard, ForfeitMakesEveryMutationTerminalAndStatePreserving) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_TRUE(session.requestForfeit());
+    ASSERT_TRUE(session.confirmForfeit());
+
+    MatchState before(*session.match());
+    PazaakBoardProjection projectionBefore(session.boardProjection());
+    auto resultBefore = session.completedResult();
+    EXPECT_TRUE(session.terminal());
+    EXPECT_EQ(ActionError::MatchComplete, session.endPlayerTurn());
+    EXPECT_EQ(ActionError::MatchComplete, session.standPlayer());
+    EXPECT_EQ(ActionError::MatchComplete, session.playPlayerHandCard(0));
+    EXPECT_EQ(
+        ActionError::MatchComplete,
+        session.applyOpponentCommand(DrawCommand {Participant::Two}));
+    EXPECT_EQ(PazaakOpponentEvent::None, session.advanceOpponentEvent());
+    EXPECT_FALSE(session.selectPlayerCardSign(0, CardSign::Negative));
+    EXPECT_FALSE(session.requestForfeit());
+    EXPECT_FALSE(session.cancelForfeitRequest());
+    EXPECT_FALSE(session.confirmForfeit());
+    EXPECT_EQ(before, *session.match());
+    EXPECT_EQ(projectionBefore, session.boardProjection());
+    EXPECT_EQ(resultBefore, session.completedResult());
+}
+
+TEST(PazaakFlowBoard, SignSelectionRejectsInactiveAndStandingPlayerAtomically) {
+    std::vector<PazaakCollectionCard> selectable {
+        {CardDefinition::signSelectable(3), kSideDeckSize},
+    };
+    PazaakSession session(makeSession(0, 0, firstFour, std::move(selectable)));
+    for (size_t i = 0; i < kSideDeckSize; ++i) {
+        ASSERT_TRUE(session.selectCard(0));
+    }
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_TRUE(session.selectPlayerCardSign(0, CardSign::Negative));
+    ASSERT_EQ(ActionError::None, session.endPlayerTurn());
+
+    PazaakBoardProjection before(session.boardProjection());
+    EXPECT_FALSE(session.selectPlayerCardSign(0, CardSign::Positive));
+    EXPECT_EQ(before, session.boardProjection());
+
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(DrawCommand {Participant::Two}));
+    ASSERT_EQ(ActionError::None, session.applyOpponentCommand(StandCommand {Participant::Two}));
+    ASSERT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+    ASSERT_EQ(ActionError::None, session.standPlayer());
+    before = session.boardProjection();
+    EXPECT_FALSE(session.selectPlayerCardSign(0, CardSign::Positive));
+    EXPECT_EQ(before, session.boardProjection());
+}
+
+TEST(PazaakOpponentPolicy, RecoversAProvisionalBustWithDeterministicNegativeCard) {
+    std::vector<PazaakCollectionCard> negativeCollection {
+        {CardDefinition::fixedNegative(1), kSideDeckSize},
+    };
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        std::move(negativeCollection),
+        [](const SideDeck &) -> HandSelection { return {6, 7, 8, 9}; },
+        []() { return makeMainDeck({10, 8, 10, 10, 1, 5}); }));
+    for (size_t i = 0; i < kSideDeckSize; ++i) {
+        ASSERT_TRUE(session.selectCard(0));
+    }
+    ASSERT_TRUE(session.confirmSetup());
+
+    ASSERT_EQ(ActionError::None, session.endPlayerTurn());
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+    ASSERT_EQ(20, session.match()->set().participant(Participant::One).total());
+    ASSERT_TRUE(session.match()->set().participant(Participant::One).stood());
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(18, session.match()->set().participant(Participant::Two).total());
+    ASSERT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(19, session.match()->set().participant(Participant::Two).total());
+    ASSERT_EQ(PazaakOpponentEvent::EndTurn, session.advanceOpponentEvent());
+    ASSERT_EQ(PazaakOpponentEvent::Draw, session.advanceOpponentEvent());
+    ASSERT_EQ(24, session.match()->set().participant(Participant::Two).total());
+
+    ASSERT_EQ(PazaakOpponentEvent::PlayHandCard, session.advanceOpponentEvent());
+    EXPECT_EQ(20, session.match()->set().participant(Participant::Two).total());
+    EXPECT_TRUE(session.match()->set().participant(Participant::Two).stood());
+    const auto &opponentHand = session.match()->participant(Participant::Two).hand();
+    EXPECT_FALSE(opponentHand[2].used);
+    EXPECT_TRUE(opponentHand[3].used);
+}
+
+TEST(PazaakOpponentPolicy, ResultPresentationBlocksPolicyAndAdvancesOnlyAfterDuration) {
+    PazaakSession session(makeSession(
+        0,
+        0,
+        firstFour,
+        PazaakSession::temporaryK1TestCollection(),
+        firstFour,
+        []() { return makeMainDeck({10, 9, 2}); }));
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+    ASSERT_EQ(ActionError::None, session.standPlayer());
+
+    for (int count = 0;
+         count < 10 && session.match()->set().result() == SetResult::InProgress;
+         ++count) {
+        ASSERT_NE(PazaakOpponentEvent::None, session.advanceOpponentEvent());
+    }
+    ASSERT_NE(SetResult::InProgress, session.match()->set().result());
+    EXPECT_TRUE(session.presentationPending());
+
+    MatchState before(*session.match());
+    EXPECT_EQ(PazaakOpponentEvent::None, session.advanceOpponentEvent());
+    EXPECT_EQ(before, *session.match());
+    EXPECT_FALSE(session.advanceResultPresentation(1.49f));
+    EXPECT_EQ(before, *session.match());
+    EXPECT_TRUE(session.advanceResultPresentation(0.01f));
+    EXPECT_EQ(SetResult::InProgress, session.match()->set().result());
+    EXPECT_FALSE(session.presentationPending());
+}
+
+TEST(PazaakOpponentPolicy, DeterministicPolicyTerminatesACompleteMatch) {
+    PazaakSession session(makeSession());
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    for (int eventCount = 0;
+         eventCount < 300 && !session.completedResult();
+         ++eventCount) {
+        const SetState &set = session.match()->set();
+        if (set.result() != SetResult::InProgress) {
+            ASSERT_TRUE(session.advanceResultPresentation(1.5f));
+        } else if (set.activeParticipant() == Participant::One &&
+                   set.turnStage() == TurnStage::AwaitingAction) {
+            ASSERT_EQ(ActionError::None, session.standPlayer());
+        } else {
+            ASSERT_NE(PazaakOpponentEvent::None, session.advanceOpponentEvent());
+        }
+    }
+
+    ASSERT_TRUE(session.completedResult().has_value());
+    EXPECT_EQ(PazaakCompletedResult::OpponentWon, *session.completedResult());
+    EXPECT_TRUE(session.terminal());
+    EXPECT_NE(MatchResult::InProgress, session.match()->result());
+
+    MatchState before(*session.match());
+    PazaakBoardProjection projectionBefore(session.boardProjection());
+    EXPECT_EQ(ActionError::MatchComplete, session.endPlayerTurn());
+    EXPECT_EQ(ActionError::MatchComplete, session.standPlayer());
+    EXPECT_EQ(ActionError::MatchComplete, session.playPlayerHandCard(0));
+    EXPECT_EQ(PazaakOpponentEvent::None, session.advanceOpponentEvent());
+    EXPECT_TRUE(session.advanceResultPresentation(1.5f));
+    EXPECT_FALSE(session.advanceResultPresentation(1.5f));
+    EXPECT_EQ(before, *session.match());
+    EXPECT_EQ(projectionBefore, session.boardProjection());
+}
+
+TEST(PazaakFlowBoard, CompletedRulesMatchProducesSemanticPlayerWin) {
+    auto setNumber = std::make_shared<int>(0);
+    PazaakSessionParams params;
+    params.collection = PazaakSession::temporaryK1TestCollection();
+    params.opponentSideDeck = PazaakSession::temporaryK1OpponentSideDeck();
+    PazaakSession session(
+        std::move(params),
+        firstFour,
+        firstFour,
+        [setNumber]() {
+            bool playerStarts = ((*setNumber)++ % 2) == 0;
+            return playerStarts ? makeMainDeck({10, 9}) : makeMainDeck({9, 10});
+        },
+        [](size_t setIndex) {
+            return setIndex % 2 == 0 ? Participant::One : Participant::Two;
+        });
+    chooseTen(session);
+    ASSERT_TRUE(session.confirmSetup());
+
+    for (int commandCount = 0;
+         commandCount < 40 && !session.completedResult();
+         ++commandCount) {
+
+        if (session.match()->set().result() != SetResult::InProgress) {
+            ASSERT_TRUE(session.advanceResultPresentation(1.5f));
+        } else if (session.match()->set().activeParticipant() == Participant::One) {
+            if (session.match()->set().turnStage() == TurnStage::AwaitingDraw) {
+                ASSERT_EQ(PazaakOpponentEvent::PlayerDraw, session.advanceOpponentEvent());
+            } else {
+                ASSERT_EQ(ActionError::None, session.standPlayer());
+            }
+        } else if (session.match()->set().turnStage() == TurnStage::AwaitingDraw) {
+            ASSERT_EQ(ActionError::None, session.applyOpponentCommand(DrawCommand {Participant::Two}));
+        } else {
+            ASSERT_EQ(ActionError::None, session.applyOpponentCommand(StandCommand {Participant::Two}));
+        }
+    }
+
+    ASSERT_TRUE(session.completedResult().has_value());
+    EXPECT_EQ(PazaakCompletedResult::PlayerWon, *session.completedResult());
+    EXPECT_EQ(MatchResult::ParticipantOneWon, session.match()->result());
+    EXPECT_EQ(kSetWinsForMatch, session.match()->participant(Participant::One).setWins());
+}


### PR DESCRIPTION
## Summary

- Implements separate K1 and K2 versions of pazaak
- Launches from console or natively from NPC dialogue
- Wagering and side decks supported
- Test command `startpazaak` allows player to commence pazaak game using a test deck (with an example of every card)

## Testing

- `startpazaak` command on each game
- K1 warp `tar_m02ae`, purchase a deck with `givegold`
- K2 warp `207tel` and speak to Mebla Dule