### PR TITLE
[game] K1 Turret minigame

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -70,6 +70,7 @@
 #include "statussummary.h"
 #include "swooprace.h"
 #include "talent.h"
+#include "turret.h"
 
 #include <queue>
 #include <vector>
@@ -106,7 +107,8 @@ public:
         SwoopRace,
         PazaakWager,
         PazaakSetup,
-        PazaakBoard
+        PazaakBoard,
+        Turret
     };
 
     Game(
@@ -123,6 +125,7 @@ public:
         _party(*this),
         _combat(*this, services),
         _swoopRace(*this),
+        _turret(*this, services),
         _journal(services.resource.gffs, services.resource.strings),
         _floatingText(*this, services) {
         initJournalNotifications();
@@ -177,6 +180,18 @@ public:
     void exitSwoopRace();
 
     // END Swoop race
+
+    // Turret minigame
+
+    void openTurret();
+    void closeTurret();
+
+    // Exit the active turret: returns to the lifecycle origin if a lifecycle
+    // session is in progress, otherwise just stops the dev session in place.
+    void exitTurret();
+
+    // END Turret minigame
+
     void openInGameMenu(InGameMenuTab tab);
     void openLevelUp();
     void notifyLevelUpPending(const Creature &creature);
@@ -438,11 +453,11 @@ private:
     DeveloperOverlay _developerOverlay;
     std::shared_ptr<graphics::Font> _developerFont;
 
-    // Non-blocking swoop lifecycle session: origin module/state -> swoop module
-    // -> auto-start race -> forced-success finish -> return to origin. Passive
+    // Non-blocking minigame lifecycle session: origin module/state -> minigame
+    // module -> auto-start -> forced-success finish -> return to origin. Passive
     // bookkeeping only; it does not touch party membership, inventory, or story.
-    struct SwoopLifecycle {
-        bool active {false};        // a lifecycle race is in progress (return pending)
+    struct MinigameLifecycle {
+        bool active {false};        // a lifecycle session is in progress (return pending)
         bool haveOrigin {false};    // origin position/facing captured
         std::string originModule;   // module resref to return to
         glm::vec3 originPosition {0.0f};
@@ -450,7 +465,23 @@ private:
         bool forcedSuccess {true};  // PR1: finish is always non-blocking success
     };
 
-    SwoopLifecycle _swoopLifecycle;
+    MinigameLifecycle _swoopLifecycle;
+    MinigameLifecycle _turretLifecycle;
+
+    // A turret session scheduled by the startturretgame console command. The
+    // transition goes through the normal deferred module load, so whether the
+    // target really is a turret area is only known once it has loaded; this
+    // carries the return origin across that gap.
+    struct PendingTurretRequest {
+        bool active {false};
+        std::string targetModule;
+        std::string originModule;
+        glm::vec3 originPosition {0.0f};
+        float originFacing {0.0f};
+        bool haveOrigin {false};
+    };
+
+    PendingTurretRequest _pendingTurret;
 
     std::shared_ptr<movie::IMovie> _movie;
     std::queue<std::string> _moduleTransitionMovies;
@@ -474,6 +505,7 @@ private:
     Party _party;
     Combat _combat;
     SwoopRace _swoopRace;
+    Turret _turret;
     Journal _journal;
     MessageLog _messageLog;
     FloatingText _floatingText;
@@ -566,6 +598,25 @@ private:
     // Stop the active lifecycle race and return to the stored origin module
     // (restoring the leader's position/facing). Safe no-op if no lifecycle race.
     void finishSwoopLifecycle(bool success);
+
+    // Same, for the turret minigame. The outcome is carried through rather than
+    // reduced to a success flag: a win, a loss and an abandoned session all
+    // return to the origin, but only a win emits the completion state.
+    void finishTurretLifecycle(Turret::Outcome outcome);
+
+    // Apply the vanilla post-turret globals for the given turret module
+    // (K1 M12ab confirmed; others no-op). Only a victory writes them.
+    void applyTurretResult(const std::string &turretModule, Turret::Outcome outcome);
+
+    // Give up on a scheduled turret session and go back where it started.
+    void abandonPendingTurret(const std::string &reason);
+
+    // Send the party back to a lifecycle session's origin, restoring the
+    // leader's recorded position and facing.
+    void returnToLifecycleOrigin(const std::string &module,
+                                 bool haveOrigin,
+                                 const glm::vec3 &position,
+                                 float facing);
 
     // Show/hide the active party creatures. Used to suppress the normal party
     // while a minigame is running: vanilla does not add the party to the scene
@@ -724,6 +775,10 @@ private:
     void consoleSwoopState(const ConsoleArgs &tokens);
     void consoleStartSwoopRace(const ConsoleArgs &tokens);
     void consoleFinishSwoop(const ConsoleArgs &tokens);
+    void consoleStartTurret(const ConsoleArgs &tokens);
+    void consoleStopTurret(const ConsoleArgs &tokens);
+    void consoleTurretState(const ConsoleArgs &tokens);
+    void consoleStartTurretGame(const ConsoleArgs &tokens);
     void consoleShowImGui(const ConsoleArgs &tokens);
 
     // END Console commands

--- a/include/reone/game/minigame.h
+++ b/include/reone/game/minigame.h
@@ -24,6 +24,16 @@
 
 namespace reone {
 
+namespace resource {
+
+namespace generated {
+
+struct ARE;
+
+}
+
+} // namespace resource
+
 namespace game {
 
 enum class MinigameType {
@@ -59,6 +69,43 @@ inline const char *minigameTypeName(MinigameType t) {
     }
 }
 
+struct MinigameModelSpec {
+    std::string resRef;
+
+    // Vanilla "RotatingModel": models flagged here follow the player/enemy
+    // rotation; the rest stay fixed in the track frame. On the K1 turret the
+    // gun and HUD models rotate while the Ebon Hawk hull does not.
+    bool rotating {false};
+};
+
+struct MinigameBulletSpec {
+    std::string modelResRef;
+    std::string collisionSound;
+    uint32_t damage {0};
+    float lifespan {0.0f};    // seconds before the bullet is culled
+    float rateOfFire {0.0f};  // seconds between shots from the owning bank
+    float speed {0.0f};       // world units per second
+    uint32_t targetType {0};  // 1 = player, 2 = enemies
+};
+
+struct MinigameGunBankSpec {
+    uint32_t bankId {0};
+    std::string gunModelResRef;
+    std::string fireSound;
+    MinigameBulletSpec bullet;
+
+    // Enemy-only aiming parameters; zero on player banks.
+    float horizSpread {0.0f};
+    float vertSpread {0.0f};
+    float inaccuracy {0.0f};
+    float sensingRadius {0.0f};
+};
+
+struct MinigameSoundSpec {
+    std::string death;
+    std::string engine;
+};
+
 struct MinigamePlayerScriptSpec {
     std::string onCreate;
     std::string onDeath;
@@ -66,33 +113,73 @@ struct MinigamePlayerScriptSpec {
     std::string onDamage;
     std::string onAccelerate;
     std::string onHeartbeat;
+    std::string onFire;
+    std::string onHitBullet;
+    std::string onHitFollower;
+    std::string onHitObstacle;
 };
 
 struct MinigamePlayerSpec {
     std::string cameraResRef;
     std::string trackResRef;
-    std::vector<std::string> modelResRefs;
+    std::vector<MinigameModelSpec> models;
+    std::vector<MinigameGunBankSpec> gunBanks;
     float minimumSpeed {0.0f};
     float maximumSpeed {0.0f};
     float accelSecs {0.0f};
     float sphereRadius {0.0f};
     uint32_t hitPoints {0};
+    uint32_t maxHitPoints {0};
+    float invincePeriod {0.0f};
+    int bumpDamage {0};
+    int numLoops {0};
+    bool cameraRotate {false};
+    MinigameSoundSpec sounds;
     MinigamePlayerScriptSpec scripts;
 
-    // Tunnel bounds, as stored in the .are (angular limits, in degrees, that
-    // vanilla applies to bike lean/rotation per axis - not lateral position).
+    // Placement of the player actor relative to its track hook, and of the
+    // aim/target point relative to the actor.
+    glm::vec3 startOffset {0.0f};
+    glm::vec3 targetOffset {0.0f};
+
+    // Tunnel bounds, as stored in the .are. For the swoop race these are the
+    // angular limits (degrees) vanilla applies to bike lean/rotation per axis;
+    // for the turret they are the aim limits (X = pitch, Z = yaw).
     float tunnelXPos {0.0f};
     float tunnelXNeg {0.0f};
     float tunnelYPos {0.0f};
     float tunnelYNeg {0.0f};
     float tunnelZPos {0.0f};
     float tunnelZNeg {0.0f};
+
+    // Per-axis "unbounded" flags. A non-zero component means the matching
+    // tunnel limits do not apply (the K1 turret sets Z, giving free 360 yaw).
+    glm::vec3 tunnelInfinite {0.0f};
+};
+
+struct MinigameEnemyScriptSpec {
+    std::string onCreate;
+    std::string onDeath;
+    std::string onDamage;
+    std::string onHeartbeat;
+    std::string onTrackLoop;
 };
 
 struct MinigameEnemySpec {
     std::string trackResRef;
-    std::vector<std::string> modelResRefs;
+    std::vector<MinigameModelSpec> models;
+    std::vector<MinigameGunBankSpec> gunBanks;
     uint32_t hitPoints {0};
+    uint32_t maxHitPoints {0};
+    float sphereRadius {0.0f};
+    float invincePeriod {0.0f};
+    int bumpDamage {0};
+    int numLoops {0};
+    bool trigger {false};
+    MinigameSoundSpec sounds;
+    MinigameEnemyScriptSpec scripts;
+
+    // Kept for call sites that only need the creation hook.
     std::string onCreate;
 };
 
@@ -101,16 +188,29 @@ struct MinigameObstacleSpec {
     std::string onCreate;
 };
 
+// Vanilla mouse axis binding for the minigame. The axis identifiers are opaque
+// engine constants; only the flip flags have a confirmed meaning.
+struct MinigameMouseSpec {
+    uint32_t axisX {0};
+    uint32_t axisY {0};
+    bool flipAxisX {false};
+    bool flipAxisY {false};
+};
+
 // Passive data parsed from the .are MiniGame struct. Stored on Area.
-// Not instantiated as a game object — that belongs to a future slice.
 struct MinigameSpec {
     MinigameType type {MinigameType::None};
     float cameraViewAngle {0.0f};
+    float nearClip {0.0f};
+    float farClip {0.0f};
     float lateralAccel {0.0f};
     float movementPerSec {0.0f};
     bool useInertia {false};
     uint32_t bumpPlane {0};
+    uint32_t depthOfField {0};
     bool doBumping {false};
+    std::string music;
+    MinigameMouseSpec mouse;
     MinigamePlayerSpec player;
     std::vector<MinigameEnemySpec> enemies;
     std::vector<MinigameObstacleSpec> obstacles;
@@ -119,6 +219,13 @@ struct MinigameSpec {
     // Derived at parse time; not stored separately in the .are format.
     std::vector<std::string> trackResRefs;
 };
+
+/**
+ * Convert the MiniGame struct of a parsed .are into engine-side metadata.
+ *
+ * Returns nullopt when the area declares no minigame (Type 0).
+ */
+std::optional<MinigameSpec> parseMinigameSpec(const resource::generated::ARE &are);
 
 } // namespace game
 

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -1,0 +1,641 @@
+/*
+ * Copyright (c) 2020-2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <limits>
+
+#include "reone/input/event.h"
+
+#include "minigame.h"
+
+namespace reone {
+
+namespace audio {
+
+class AudioClip;
+
+}
+
+namespace scene {
+
+class ModelSceneNode;
+
+}
+
+namespace game {
+
+class Game;
+class FirstPersonCamera;
+struct ServicesView;
+
+/**
+ * Aim state of the player turret, in radians.
+ *
+ * Vanilla stores the aim limits in the .are MiniGame Player "Tunnel" fields:
+ * X is the pitch axis and Z is the yaw axis (Y is unused by the turret). The
+ * stored values are signed degree limits, so the usable range of an axis is
+ * [Neg, Pos] rather than [-Neg, +Pos]; K1's Ebon Hawk turret pitches between
+ * TunnelXNeg = 2 and TunnelXPos = 45 degrees. An axis whose TunnelInfinite
+ * component is set is unbounded and wraps instead of clamping, which is how the
+ * turret gets free 360 degree yaw.
+ */
+class TurretAim {
+public:
+    void configure(const MinigamePlayerSpec &player);
+
+    /**
+     * Return to the authored starting aim. Replaying a session must not inherit
+     * the previous run's aim.
+     */
+    void reset();
+
+    void addPitch(float radians);
+    void addYaw(float radians);
+
+    float pitch() const { return _pitch; }
+    float yaw() const { return _yaw; }
+
+    // Authored starting aim, already clamped into the authored bounds.
+    float startPitch() const { return _startPitch; }
+    float startYaw() const { return _startYaw; }
+
+    // How far an axis can travel, in radians; a full turn when unbounded.
+    float pitchTravel() const;
+    float yawTravel() const;
+
+    /**
+     * Unit vector the turret is pointing along, in the track frame. Odyssey
+     * models look down +Y, so this is Rz(yaw) * Rx(pitch) applied to +Y.
+     */
+    glm::vec3 forward() const;
+
+    glm::quat orientation() const;
+
+    bool pitchBounded() const { return _pitchBounded; }
+    bool yawBounded() const { return _yawBounded; }
+    float minPitch() const { return _minPitch; }
+    float maxPitch() const { return _maxPitch; }
+    float minYaw() const { return _minYaw; }
+    float maxYaw() const { return _maxYaw; }
+
+private:
+    float _pitch {0.0f};
+    float _yaw {0.0f};
+    float _startPitch {0.0f};
+    float _startYaw {0.0f};
+
+    bool _pitchBounded {true};
+    bool _yawBounded {true};
+    float _minPitch {0.0f};
+    float _maxPitch {0.0f};
+    float _minYaw {0.0f};
+    float _maxYaw {0.0f};
+};
+
+/**
+ * Turn rate of one aim axis while a key is held.
+ *
+ * This is reone's existing keyboard rotation model (ThirdPersonCamera): a held
+ * key starts at a minimum rate and accelerates to a cap, so a tap gives fine
+ * adjustment while a hold sweeps. The rates are scaled by the axis's authored
+ * travel and calibrated so an unbounded axis reproduces ThirdPersonCamera's
+ * rates exactly; a narrow axis such as the turret's 43 degree pitch band then
+ * moves proportionally slower, and both axes cross their full authored travel
+ * in about the same time.
+ *
+ * The rate is integrated analytically rather than stepped, so the angle covered
+ * over a given interval does not depend on how many frames it is split into.
+ */
+class TurretAimRate {
+public:
+    void configure(float travelRadians);
+
+    /**
+     * -1, 0 or +1. Engaging an axis, or reversing it, restarts the acceleration
+     * ramp from the minimum rate.
+     */
+    void setDirection(int direction);
+
+    /**
+     * Angle to apply this step, signed by the held direction; zero when idle.
+     */
+    float advance(float dt);
+
+    /** Drop any held direction and accumulated acceleration. */
+    void reset();
+
+    int direction() const { return _direction; }
+    float minRate() const { return _minRate; }
+    float maxRate() const { return _maxRate; }
+    float rate() const;
+
+private:
+    float _minRate {0.0f};
+    float _maxRate {0.0f};
+    float _acceleration {0.0f};
+    int _direction {0};
+    float _held {0.0f}; // seconds the current direction has been engaged
+
+    float rateAt(float held) const;
+    float angleOver(float from, float to) const;
+};
+
+/**
+ * Rate-of-fire gate for a single gun bank. Vanilla stores the interval between
+ * shots in the bank's Bullet.Rate_Of_Fire.
+ */
+class TurretGunTimer {
+public:
+    explicit TurretGunTimer(float rateOfFire = 0.0f) :
+        _rateOfFire(rateOfFire) {
+    }
+
+    void update(float dt);
+
+    bool ready() const { return _cooldown <= 0.0f; }
+
+    /**
+     * Consume the gate: returns false (and changes nothing) when still cooling
+     * down, otherwise arms the cooldown and returns true.
+     */
+    bool tryFire();
+
+    float cooldown() const { return _cooldown; }
+    float rateOfFire() const { return _rateOfFire; }
+
+private:
+    float _rateOfFire {0.0f};
+    float _cooldown {0.0f};
+};
+
+/**
+ * Scene-free state of a bullet in flight.
+ */
+struct TurretBullet {
+    glm::vec3 position {0.0f};
+    glm::vec3 direction {0.0f, 1.0f, 0.0f};
+
+    // World orientation of the firing actor at the moment of the shot. Authored
+    // bolt models are modelled along +Y, so this is what makes the bolt's long
+    // axis lie along its travel instead of along world Y.
+    glm::quat orientation {1.0f, 0.0f, 0.0f, 0.0f};
+
+    float speed {0.0f};
+    float life {0.0f};
+    float lifespan {0.0f};
+    uint32_t damage {0};
+    bool fromPlayer {false};
+
+    /**
+     * Advance the bullet by one step. Returns false once it has outlived its
+     * lifespan and should be culled.
+     */
+    bool advance(float dt);
+
+    /**
+     * Mark the bullet spent so the next cull pass removes it.
+     */
+    void expire() { life = std::numeric_limits<float>::max(); }
+};
+
+/**
+ * Cockpit HUD state, reproducing what K1's module-local OnDamage script
+ * (k_pebo_hawkhit) computes. reone substitutes the minigame and cannot run that
+ * script - its SWMG_ routines are unimplemented - so the small part of it that
+ * drives the HUD is reproduced here from the shipped bytecode:
+ *
+ *   if (!GetGlobalBoolean("M12AB_END_SYNC")) {
+ *     if (SWMG_GetHitPoints(OBJECT_SELF) >= 2000) {
+ *       SWMG_OnDamage();
+ *       state = ((SWMG_GetHitPoints(OBJECT_SELF) - 2000) * 12) / 1000 + 1;
+ *       anim  = (state <= 9) ? "Health0" + IntToString(state)
+ *                            : "Health"  + IntToString(state);
+ *       SWMG_PlayAnimation(OBJECT_SELF, anim, TRUE, FALSE, FALSE);
+ *       if (state == 3) { SoundObjectPlay(GetObjectByTag("Alarm01")); }
+ *     } else {
+ *       ... SoundObjectStop(GetObjectByTag("Alarm01"));
+ *       SWMG_PlayAnimation(OBJECT_SELF, "Health00", TRUE, FALSE, FALSE);
+ *       ... loss presentation
+ *     }
+ *   }
+ */
+
+// The hit point floor the shipped script treats as destruction, and the span of
+// the authored gauge above it. The Ebon Hawk is authored with 3000 hit points,
+// so the gauge covers 2000..3000.
+constexpr int kTurretGaugeFloor = 2000;
+constexpr int kTurretGaugeSpan = 1000;
+constexpr int kTurretHealthStateCount = 13; // Health00..Health12
+
+/**
+ * Authored health state for a hit point total, clamped to Health00..Health12.
+ *
+ * Uses the shipped integer arithmetic verbatim, including its truncating
+ * division: a state covers a whole band of hit points, so ordinary damage steps
+ * the gauge down one state at a time rather than flickering between two.
+ */
+/**
+ * Whether the hawk has been destroyed. The shipped script takes its destruction
+ * branch below the gauge floor rather than at zero hit points.
+ */
+bool turretIsDestroyed(int hitPoints);
+
+int turretHealthState(int hitPoints);
+
+/** "Health00".."Health12" for a state index. */
+std::string turretHealthAnimation(int state);
+
+/**
+ * The shipped script starts the alarm when the computed state is exactly 3 -
+ * a boundary trigger as the gauge falls through that band, not a level test,
+ * and with no authored hysteresis or restart.
+ */
+constexpr int kTurretAlarmState = 3;
+
+bool turretAlarmStartsAtState(int state);
+
+/** Tag of the authored looping alarm sound object placed in the module. */
+extern const std::string kTurretAlarmTag;
+
+/**
+ * Radar contact channel for an enemy index (0-based). The shipped HUD authors
+ * one contact loop per enemy track: track m12ab_mgt02 is SithLoop02 on node
+ * sithhud002, and so on through mgt07 / SithLoop07 / sithhud007.
+ */
+std::string turretContactAnimation(size_t enemyIndex);
+
+/**
+ * The matching contact-removal pose ("SithLoop02d"..), a zero length pose that
+ * drops the contact's alpha.
+ */
+std::string turretContactDeathAnimation(size_t enemyIndex);
+
+/** How many contact channels the shipped HUD authors. */
+constexpr size_t kTurretContactCount = 6;
+
+/**
+ * Radar heading pose index for a turret yaw, as a whole degree in [0, 360).
+ */
+int turretHeadingState(float yawRadians);
+
+/** "HudRot_000".."HudRot_359" for a heading index. */
+std::string turretHeadingAnimation(int heading);
+
+/**
+ * Why a requested turret session cannot be scheduled.
+ */
+enum class TurretRequestError {
+    None,
+    MissingModule,  // no module argument
+    UnknownModule,  // not a module of this installation
+    SameModule,     // already in the requested module
+    NoOrigin,       // nothing loaded to return to
+    AlreadyActive   // a session is already scheduled or running
+};
+
+/**
+ * Validate a console-requested turret session before it is scheduled. The
+ * caller supplies what it knows synchronously; whether the target actually
+ * declares a turret minigame is only knowable once the module has loaded (see
+ * resolveTurretRequest).
+ */
+TurretRequestError validateTurretRequest(const std::string &target,
+                                         const std::string &originModule,
+                                         bool moduleKnown,
+                                         bool alreadyActive);
+
+const char *turretRequestErrorMessage(TurretRequestError error);
+
+/**
+ * What to do with a scheduled turret session once its module has loaded.
+ */
+enum class TurretRequestResolution {
+    NotPending,      // no session was scheduled for the loaded module
+    Start,           // the loaded area is a turret minigame
+    AbortNoMinigame, // the loaded area declares no minigame at all
+    AbortWrongType   // the loaded area declares a different minigame
+};
+
+TurretRequestResolution resolveTurretRequest(bool pendingForModule,
+                                             bool hasMinigame,
+                                             MinigameType type);
+
+const char *turretRequestResolutionMessage(TurretRequestResolution resolution);
+
+/**
+ * Where a finished turret session returns to: the vanilla end-script target for
+ * the turret module when one is known, otherwise the module it started from.
+ */
+std::string turretReturnModule(const std::string &turretModule,
+                               const std::string &originModule);
+
+/**
+ * Direction an actor with this world orientation fires along. Odyssey models
+ * look down +Y, so both the bolt's travel and its visual long axis come from the
+ * same orientation - which is also why every gun bank of one actor fires
+ * symmetrically, differing only in muzzle position.
+ */
+glm::vec3 turretFireDirection(const glm::quat &shooterOrientation);
+
+/**
+ * World transform of a bullet in flight: its position, oriented by the actor
+ * that fired it. Kept separate from the scene node so it can be checked without
+ * a graphics context.
+ */
+glm::mat4 turretBulletTransform(const TurretBullet &bullet);
+
+bool sphereContainsPoint(const glm::vec3 &center, float radius, const glm::vec3 &point);
+
+/**
+ * True when the ray from \p origin along \p direction (assumed normalized)
+ * enters the sphere ahead of the origin, within \p maxDistance.
+ */
+bool rayIntersectsSphere(const glm::vec3 &origin,
+                         const glm::vec3 &direction,
+                         const glm::vec3 &center,
+                         float radius,
+                         float maxDistance);
+
+/**
+ * The K1 Ebon Hawk turret minigame (.are MiniGame Type 2).
+ *
+ * The player is a gun turret riding an authored rail: the player track model
+ * animates a "modelhook" node, and everything is parented to it, so the whole
+ * scene flies past while the player only aims and shoots. Enemies ride their own
+ * tracks the same way. The resource relationships and the aim/fire/bullet model
+ * follow the public GPLv3 KotOR.js implementation (commit
+ * 9703b1c827b75312811a0fb95322d98902057599; see ModuleMGPlayer, ModuleMGGunBank
+ * and ModuleMGGunBullet).
+ *
+ * Player models are split by the .are "RotatingModel" flag: flagged models (the
+ * gun, the HUD panes) follow the aim, the rest (the Ebon Hawk hull) stay fixed
+ * in the track frame. Gun banks mount on the rotating group's "gunbankN" hooks
+ * and spawn bullets from the gun model's "bullethook0".
+ *
+ * Not implemented in this slice: the vanilla minigame scripts (the SWMG_*
+ * routines they need are unimplemented), obstacles, and the player invincibility
+ * period. Win/lose is decided engine-side: destroying every enemy wins, running
+ * out of hit points loses.
+ */
+class Turret {
+public:
+    struct GunBank {
+        const MinigameGunBankSpec *spec {nullptr};
+        std::shared_ptr<scene::ModelSceneNode> modelNode;
+        TurretGunTimer timer;
+    };
+
+    struct Enemy {
+        const MinigameEnemySpec *spec {nullptr};
+        std::shared_ptr<scene::ModelSceneNode> trackNode;
+        std::shared_ptr<scene::ModelSceneNode> modelNode;
+        std::vector<std::shared_ptr<scene::ModelSceneNode>> extraNodes;
+        std::vector<GunBank> gunBanks;
+        glm::vec3 position {0.0f};
+        glm::quat orientation {1.0f, 0.0f, 0.0f, 0.0f};
+        glm::vec3 forward {0.0f, 1.0f, 0.0f};
+        int hitPoints {0};
+        bool alive {true};
+        bool deathHandled {false};
+    };
+
+    struct Bullet {
+        TurretBullet sim;
+        std::shared_ptr<scene::ModelSceneNode> modelNode;
+        std::string modelResRef;
+        std::string collisionSound;
+    };
+
+    enum class Outcome {
+        InProgress,
+        Won,
+        Lost
+    };
+
+    Turret(Game &game, ServicesView &services) :
+        _game(game),
+        _services(services) {
+    }
+
+    /**
+     * Load the minigame actors for \p spec and activate the turret.
+     *
+     * @param camera the area first-person camera, reused as the turret camera; may be null
+     * @param areaName the area resref, used to look up the LYT track placements
+     * @return true when the turret became active
+     */
+    bool start(const MinigameSpec &spec, FirstPersonCamera *camera, const std::string &areaName);
+
+    /**
+     * Deactivate the turret and remove everything it added to the scene.
+     */
+    void stop();
+
+    void update(float dt);
+    bool handle(const input::Event &event);
+
+    bool isActive() const { return _active; }
+
+    // Diagnostics
+
+    Outcome outcome() const { return _outcome; }
+    bool finished() const { return _outcome != Outcome::InProgress; }
+
+    const TurretAim &aim() const { return _aim; }
+    glm::vec3 position() const { return _anchorPosition; }
+    int hitPoints() const { return _hitPoints; }
+    int maxHitPoints() const { return _maxHitPoints; }
+    float elapsed() const { return _elapsed; }
+    size_t enemyCount() const { return _enemies.size(); }
+    size_t enemiesAlive() const;
+    size_t bulletCount() const { return _bullets.size(); }
+    size_t gunBankCount() const { return _gunBanks.size(); }
+    const std::string &trackResRef() const { return _trackResRef; }
+    const std::string &anchorSource() const { return _anchorSource; }
+
+    // HUD diagnostics
+    int healthState() const { return _healthState; }
+    int headingState() const { return _headingState; }
+    bool alarmActive() const { return _alarmActive; }
+    bool haveHealthHud() const { return static_cast<bool>(_healthHud); }
+    bool haveRadarHud() const { return static_cast<bool>(_radarHud); }
+    size_t contactsLive() const;
+    size_t radarChannelCount() const;
+
+    // Eye offset the camera mount contributes, in the rotating group's frame.
+    glm::vec3 cameraHookOffset() const { return glm::vec3(_cameraHookLocal[3]); }
+    bool haveCameraHook() const { return _haveCameraHook; }
+
+    // END Diagnostics
+
+private:
+    Game &_game;
+    ServicesView &_services;
+
+    bool _active {false};
+    Outcome _outcome {Outcome::InProgress};
+
+    // Owned copy of the area metadata: the runtime holds pointers into its
+    // enemy and gun bank lists, which must outlive the area on a module change.
+    MinigameSpec _spec;
+
+    std::string _areaName;
+    std::string _trackResRef;
+    std::string _anchorSource;
+
+    FirstPersonCamera *_camera {nullptr};
+
+    // Player actors
+
+    std::shared_ptr<scene::ModelSceneNode> _playerTrackNode;
+
+    // Root of the models that stay fixed in the track frame (the hull).
+    std::shared_ptr<scene::ModelSceneNode> _bodyRoot;
+    std::vector<std::shared_ptr<scene::ModelSceneNode>> _bodyChildNodes;
+
+    // Root of the models that follow the aim (the gun, the HUD).
+    std::shared_ptr<scene::ModelSceneNode> _turretRoot;
+    std::vector<std::shared_ptr<scene::ModelSceneNode>> _turretChildNodes;
+
+    // Static model-space transform of the camera mount's "camerahook" node. The
+    // mount model itself is not added to the scene.
+    glm::mat4 _cameraHookLocal {1.0f};
+    bool _haveCameraHook {false};
+
+    // Cockpit HUD panes, picked out of the rotating model set by resref. The
+    // health gauge and the radar are separate authored models, each driven by
+    // overlay animation channels so their disjoint node sets can run at once.
+    std::shared_ptr<scene::ModelSceneNode> _healthHud;
+    std::shared_ptr<scene::ModelSceneNode> _radarHud;
+
+    int _healthState {-1};    // last applied Health00..12, -1 = none yet
+    int _headingState {-1};   // last applied HudRot degree, -1 = none yet
+    bool _alarmActive {false};
+    std::vector<bool> _contactAlive;
+
+    std::vector<GunBank> _gunBanks;
+    std::vector<Enemy> _enemies;
+    std::vector<Bullet> _bullets;
+
+    // Culled bullet models, kept for reuse: the scene graph owns every node it
+    // creates until the graph is cleared, so a node per shot would accumulate
+    // for the whole minigame.
+    std::map<std::string, std::vector<std::shared_ptr<scene::ModelSceneNode>>> _bulletNodePool;
+
+    // Runtime state
+
+    TurretAim _aim;
+    TurretAimRate _pitchRate;
+    TurretAimRate _yawRate;
+    glm::vec3 _anchorPosition {0.0f};
+    glm::mat4 _anchorTransform {1.0f};
+    float _playerSphereRadius {0.0f};
+    int _hitPoints {0};
+    int _maxHitPoints {0};
+    float _elapsed {0.0f};
+    bool _firing {false};
+
+    // Loading
+
+    std::shared_ptr<scene::ModelSceneNode> loadModel(const std::string &resRef);
+    std::shared_ptr<scene::ModelSceneNode> loadTrack(const std::string &resRef,
+                                                     const glm::vec3 &position);
+    bool loadPlayer(const MinigameSpec &spec);
+    void loadEnemies(const MinigameSpec &spec);
+    void loadGunBanks(const std::vector<MinigameGunBankSpec> &specs,
+                      scene::ModelSceneNode &mount,
+                      std::vector<GunBank> &out);
+
+    // Simulation
+
+    void updateAnchor();
+    void updatePlayerTransforms();
+    void updateCamera();
+    void updateEnemies(float dt);
+    void updateBullets(float dt);
+    void fire();
+    void spawnBullet(const MinigameGunBankSpec &bank,
+                     const glm::vec3 &origin,
+                     const glm::quat &orientation,
+                     bool fromPlayer);
+    void damagePlayer(uint32_t amount);
+    void damageEnemy(Enemy &enemy, uint32_t amount);
+    void playSound(const std::string &resRef);
+
+    // Hide the authored canopy glass shells for this session's cockpit only.
+    void suppressCanopyGlass();
+
+    // HUD
+
+    void bindHudPanes();
+    void resetHud();
+    void updateHealthHud();
+    void updateHeadingHud();
+    void startContactHud();
+    void killContactHud(size_t enemyIndex);
+    void clearHud();
+    void setAlarmActive(bool active);
+
+    // END HUD
+
+    void detachAll();
+    std::shared_ptr<scene::ModelSceneNode> acquireBulletNode(const std::string &resRef);
+    void releaseBulletNode(Bullet &bullet);
+    void setCameraFieldOfView(float fovDegrees);
+
+    // Input
+
+    bool handleKeyDown(const input::KeyEvent &event);
+    bool handleKeyUp(const input::KeyEvent &event);
+    bool handleMouseMotion(const input::MouseMotionEvent &event);
+    bool handleMouseButton(const input::MouseButtonEvent &event);
+
+    float cameraAspect() const;
+};
+
+/**
+ * A session is a success only when every enemy was destroyed. Abandoning a
+ * session mid-run is neither a win nor a loss, so it must not be reported as
+ * either - in particular it must not emit the victory-only completion state.
+ */
+inline bool turretSessionSucceeded(Turret::Outcome outcome) {
+    return outcome == Turret::Outcome::Won;
+}
+
+/**
+ * True when a session ended before reaching a win or a loss, i.e. the player
+ * left through Escape or stopturret.
+ */
+inline bool turretSessionAborted(Turret::Outcome outcome) {
+    return outcome == Turret::Outcome::InProgress;
+}
+
+inline const char *turretOutcomeName(Turret::Outcome outcome) {
+    switch (outcome) {
+    case Turret::Outcome::Won:
+        return "won";
+    case Turret::Outcome::Lost:
+        return "lost";
+    default:
+        return "aborted";
+    }
+}
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -201,9 +201,19 @@ struct TurretBullet {
     uint32_t damage {0};
     bool fromPlayer {false};
 
+    // Set on creation, cleared by the first advance(). Firing and bullet
+    // integration run in the same tick, so without this a bolt is carried
+    // speed*dt down range before it is ever drawn and never appears at the
+    // barrel it came from. Holding the first step presents the authored muzzle
+    // transform once; flight then proceeds normally.
+    bool atMuzzle {true};
+
     /**
      * Advance the bullet by one step. Returns false once it has outlived its
      * lifespan and should be culled.
+     *
+     * The first call after spawning consumes the muzzle frame and does not
+     * integrate; every later call moves the bullet.
      */
     bool advance(float dt);
 

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -309,6 +309,23 @@ constexpr size_t kTurretContactCount = 6;
 bool turretDeathEffectComplete(float elapsed, float duration);
 
 /**
+ * Switch off the always-on effect models a minigame actor carries.
+ *
+ * The model loader resolves every authored reference node into a separate
+ * model and attaches it there; on mgf_sithfighter those are the fx_ref engine
+ * flares hanging at its OmenRef nodes, which burn for as long as the node
+ * lives because nothing animates them. A fighter that has just been destroyed
+ * should stop showing engine glow at once, while its hull death animation and
+ * the emitters that animation detonates play out.
+ *
+ * Only loader-built reference attachments are touched, so the actor's meshes,
+ * lights, emitters and any gun bank models hooked on by the minigame are left
+ * running. Identifying them by the authored reference flag keeps this free of
+ * per-model node names.
+ */
+void turretDisableReferenceAttachments(scene::ModelSceneNode &model);
+
+/**
  * Radar heading pose index for a turret yaw, as a whole degree in [0, 360).
  */
 int turretHeadingState(float yawRadians);

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -473,6 +473,7 @@ public:
         float deathElapsed {0.0f};
         float deathDuration {0.0f};
         bool nodesReleased {false};
+        bool detachedFromTrack {false};
     };
 
     struct Bullet {
@@ -625,6 +626,17 @@ private:
      * and its rail. Safe to call twice.
      */
     void releaseEnemyNodes(Enemy &enemy);
+
+    /**
+     * Take a destroyed fighter off its flight rail, keeping the world pose it
+     * died in, and re-root it alongside the tracks.
+     *
+     * Emitter particles are children of the emitter that spawned them, so a
+     * wreck still attached to the looping rail hook carries its whole explosion
+     * with it. Detaching stops the rail translating the fighter; the authored
+     * "die" animation still plays on top. Safe to call twice.
+     */
+    void detachEnemyFromTrack(Enemy &enemy);
     void loadGunBanks(const std::vector<MinigameGunBankSpec> &specs,
                       scene::ModelSceneNode &mount,
                       std::vector<GunBank> &out);

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -326,6 +326,23 @@ bool turretDeathEffectComplete(float elapsed, float duration);
 void turretDisableReferenceAttachments(scene::ModelSceneNode &model);
 
 /**
+ * How far along its own forward axis a bolt must start so that none of its
+ * visible geometry lies behind the muzzle it was fired from.
+ *
+ * A bolt model's origin is not its tail. The shipped Ebon Hawk bolt
+ * (mgb_ebonleft) draws from -1.953 to +8.620 along model +Y, so pinning the
+ * origin to the authored bullethook0 buries nearly two units of bolt inside the
+ * gun. Starting the bolt ahead by however far it reaches backwards puts its
+ * tail on the muzzle plane instead.
+ *
+ * \param modelMinForward the model-space minimum of the bolt's visible bounds
+ *                        along the model forward axis (+Y)
+ * \return a non-negative displacement; zero for a bolt drawn wholly ahead of
+ *         its origin
+ */
+float turretMuzzleClearance(float modelMinForward);
+
+/**
  * Radar heading pose index for a turret yaw, as a whole degree in [0, 360).
  */
 int turretHeadingState(float yawRadians);

--- a/include/reone/game/turret.h
+++ b/include/reone/game/turret.h
@@ -299,6 +299,16 @@ std::string turretContactDeathAnimation(size_t enemyIndex);
 constexpr size_t kTurretContactCount = 6;
 
 /**
+ * Whether a destroyed fighter has finished presenting its death effect.
+ *
+ * The shipped fighter carries its destruction as a non-looping "die" animation
+ * (mgf_sithfighter authors 2.3s), so the animation's own length is how long the
+ * wreck is meant to stay on screen. A fighter with no authored death animation
+ * has nothing to wait for and is released at once.
+ */
+bool turretDeathEffectComplete(float elapsed, float duration);
+
+/**
  * Radar heading pose index for a turret yaw, as a whole degree in [0, 360).
  */
 int turretHeadingState(float yawRadians);
@@ -422,6 +432,13 @@ public:
         int hitPoints {0};
         bool alive {true};
         bool deathHandled {false};
+
+        // Death effect bookkeeping. A destroyed fighter keeps playing its
+        // authored "die" animation for that animation's own length, after which
+        // everything it owns leaves the scene.
+        float deathElapsed {0.0f};
+        float deathDuration {0.0f};
+        bool nodesReleased {false};
     };
 
     struct Bullet {
@@ -567,6 +584,13 @@ private:
                                                      const glm::vec3 &position);
     bool loadPlayer(const MinigameSpec &spec);
     void loadEnemies(const MinigameSpec &spec);
+
+    /**
+     * Retire everything a fighter owns: its gun bank models, its model root
+     * with the reference models, lights and emitters the loader built under it,
+     * and its rail. Safe to call twice.
+     */
+    void releaseEnemyNodes(Enemy &enemy);
     void loadGunBanks(const std::vector<MinigameGunBankSpec> &specs,
                       scene::ModelSceneNode &mount,
                       std::vector<GunBank> &out);

--- a/include/reone/scene/node/model.h
+++ b/include/reone/scene/node/model.h
@@ -134,6 +134,27 @@ public:
     void resumeAnimation();
     void setAnimationTime(float time);
 
+    /**
+     * Stop the channel playing the named animation, leaving every other channel
+     * alone.
+     *
+     * Overlay animations are additive by design: playing one pushes a channel
+     * and nothing ever pops it. That is fine for a fixed set of layers, but a
+     * model whose overlay state changes over time - a HUD that swaps one pose
+     * for another while unrelated layers keep running - would otherwise grow a
+     * channel per change. Removing the outgoing animation by name keeps the set
+     * bounded without disturbing the layers that should persist.
+     *
+     * Safe and idempotent: removing an animation that is not playing is a no-op.
+     *
+     * @return true if a channel was removed
+     */
+    bool removeAnimation(const std::string &name);
+
+    bool isAnimationPlaying(const std::string &name) const;
+
+    size_t animationChannelCount() const { return _animChannels.size(); }
+
     bool isAnimationFinished() const;
 
     std::string activeAnimationName() const;

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -338,6 +338,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/swooprace.h
     ${GAME_INCLUDE_DIR}/talent.h
     ${GAME_INCLUDE_DIR}/transitioncandidate.h
+    ${GAME_INCLUDE_DIR}/turret.h
     ${GAME_INCLUDE_DIR}/twodautil.h
     ${GAME_INCLUDE_DIR}/types.h
     ${GAME_INCLUDE_DIR}/visualeffects.h)
@@ -553,6 +554,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/surfaces.cpp
     ${GAME_SOURCE_DIR}/swooprace.cpp
     ${GAME_SOURCE_DIR}/transitioncandidate.cpp
+    ${GAME_SOURCE_DIR}/turret.cpp
     ${GAME_SOURCE_DIR}/twodautil.cpp
     ${GAME_SOURCE_DIR}/visualeffects.cpp)
 

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -516,6 +516,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/statussummary.cpp
     ${GAME_SOURCE_DIR}/messagebus.cpp
     ${GAME_SOURCE_DIR}/messagelog.cpp
+    ${GAME_SOURCE_DIR}/minigame.cpp
     ${GAME_SOURCE_DIR}/object.cpp
     ${GAME_SOURCE_DIR}/object/area.cpp
     ${GAME_SOURCE_DIR}/object/camera/animated.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -2002,7 +2002,8 @@ void Game::openSwoopRace() {
     std::vector<std::shared_ptr<ModelSceneNode>> bikeChildNodes;
     std::vector<std::string> modelDiag;
     bool anyMissing = false;
-    for (const auto &resRef : mg.player.modelResRefs) {
+    for (const auto &modelSpec : mg.player.models) {
+        const auto &resRef = modelSpec.resRef;
         if (resRef.empty()) {
             continue;
         }
@@ -2101,7 +2102,7 @@ void Game::openSwoopRace() {
     debug(str(boost::format("swoop: started type=%s track=%s models=%zu loaded=%zu camera=chase movePerSec=%.0f lataccel=%.0f camfov=%.0f")
               % minigameTypeName(mg.type)
               % mg.player.trackResRef
-              % mg.player.modelResRefs.size()
+              % mg.player.models.size()
               % loadedCount
               % mg.movementPerSec
               % mg.lateralAccel
@@ -3744,7 +3745,7 @@ void Game::consoleMiniGameInfo(const ConsoleArgs &args) {
                            % mg.player.maximumSpeed
                            % mg.player.accelSecs
                            % mg.player.hitPoints
-                           % mg.player.modelResRefs.size()));
+                           % mg.player.models.size()));
     _console.printLine(str(boost::format("  tunnel (deg): X=[%.1f,%.1f] Y=[%.1f,%.1f] Z=[%.1f,%.1f]")
                            % mg.player.tunnelXNeg % mg.player.tunnelXPos
                            % mg.player.tunnelYNeg % mg.player.tunnelYPos
@@ -3759,7 +3760,7 @@ void Game::consoleMiniGameInfo(const ConsoleArgs &args) {
     for (size_t i = 0; i < mg.enemies.size(); ++i) {
         const auto &e = mg.enemies[i];
         _console.printLine(str(boost::format("    enemy[%zu] track=%s hp=%u models=%zu")
-                               % i % e.trackResRef % e.hitPoints % e.modelResRefs.size()));
+                               % i % e.trackResRef % e.hitPoints % e.models.size()));
     }
     for (size_t i = 0; i < mg.obstacles.size(); ++i) {
         _console.printLine(str(boost::format("    obstacle[%zu] name=%s") % i % mg.obstacles[i].name));

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -470,6 +470,10 @@ void Game::initConsole() {
         registerConsoleCommand("swoopstate", "print the current swoop race progress/lateral state", &Game::consoleSwoopState);
         registerConsoleCommand("startswooprace", "enter a swoop module from the current one and auto-start the race", &Game::consoleStartSwoopRace);
         registerConsoleCommand("finishswoop", "finish the lifecycle swoop race (forced success) and return to origin", &Game::consoleFinishSwoop);
+        registerConsoleCommand("startturret", "enter the turret minigame for the current area", &Game::consoleStartTurret);
+        registerConsoleCommand("startturretgame", "enter a turret module from the current one and auto-start the minigame", &Game::consoleStartTurretGame);
+        registerConsoleCommand("stopturret", "exit the turret minigame", &Game::consoleStopTurret);
+        registerConsoleCommand("turretstate", "print the current turret aim/health/enemy state", &Game::consoleTurretState);
         registerConsoleCommand("showimgui", "open imgui demo", &Game::consoleShowImGui);
     }
 }
@@ -546,6 +550,11 @@ bool Game::handle(const input::Event &event) {
                 return true;
             }
             break;
+        case Screen::Turret:
+            if (_turret.handle(event)) {
+                return true;
+            }
+            break;
         default:
             break;
         }
@@ -601,6 +610,22 @@ void Game::update(float frameTime) {
                       % _swoopRace.finishProgress()
                       % _swoopLifecycle.originModule));
             finishSwoopLifecycle(/*success=*/true);
+        }
+    }
+
+    if (_turret.isActive()) {
+        _turret.update(dt);
+
+        // Non-blocking auto-finish: a lifecycle session ends as soon as the
+        // turret reaches a win or a loss and returns to the origin module. Plain
+        // dev sessions (no lifecycle) keep running so the dev stays in control.
+        if (_turretLifecycle.active && _turret.finished()) {
+            debug(str(boost::format("turret: auto-finish outcome=%s hp=%d/%d returning=%s")
+                      % turretOutcomeName(_turret.outcome())
+                      % _turret.hitPoints()
+                      % _turret.maxHitPoints()
+                      % _turretLifecycle.originModule));
+            finishTurretLifecycle(_turret.outcome());
         }
     }
 
@@ -761,11 +786,27 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
         _swoopRace.stop();
         _cameraType = _savedCameraType;
     }
-    // A direct module load (e.g. warp) while a lifecycle race is pending means
-    // the player navigated away; abandon the pending return. (Lifecycle-managed
-    // loads clear the session beforehand, so this only fires on external loads.)
+    if (_turret.isActive()) {
+        _turret.stop();
+        _cameraType = _savedCameraType;
+    }
+    // A direct module load (e.g. warp) while a lifecycle session is pending
+    // means the player navigated away; abandon the pending return.
+    // (Lifecycle-managed loads clear the session beforehand, so this only fires
+    // on external loads.)
     if (_swoopLifecycle.active) {
-        _swoopLifecycle = SwoopLifecycle();
+        _swoopLifecycle = MinigameLifecycle();
+    }
+    if (_turretLifecycle.active) {
+        _turretLifecycle = MinigameLifecycle();
+    }
+    // Likewise a scheduled turret session is only good for the module it named:
+    // any other load means the transition was superseded, and keeping the
+    // request would block startturretgame until the game was reset.
+    if (_pendingTurret.active && !boost::iequals(_pendingTurret.targetModule, name)) {
+        debug(str(boost::format("turret: scheduled session for '%s' dropped, loading '%s' instead")
+                  % _pendingTurret.targetModule % name));
+        _pendingTurret = PendingTurretRequest();
     }
 
     if (_screen == Screen::Conversation && _conversation) {
@@ -849,6 +890,10 @@ void Game::resetGame() {
     if (_swoopRace.isActive()) {
         _swoopRace.stop();
     }
+    if (_turret.isActive()) {
+        _turret.stop();
+    }
+    _pendingTurret = PendingTurretRequest();
     _screen = Screen::None;
     _services.audio.mixer.stopAll();
     _music.reset();
@@ -1595,34 +1640,77 @@ void Game::loadNextModule() {
             haveOrigin = true;
         }
     }
-    bool wasLifecycleActive = _swoopLifecycle.active;
+    bool wasLifecycleActive = _swoopLifecycle.active || _turretLifecycle.active;
 
     loadModule(_nextModule, _nextEntry);
 
     _nextModule.clear();
     _nextEntry.clear();
 
-    // Vanilla K1 swoop entry: a dialogue node fires a script that calls
+    // Vanilla K1 minigame entry: a dialogue node or cutscene script calls
     // StartNewModule("<*mg>"); the engine auto-enters the minigame on load (no
     // dedicated start routine). Route that generic transition through the
-    // forced-success lifecycle harness when the loaded area is a swoop minigame.
-    if (wasLifecycleActive || _swoopLifecycle.active) {
+    // forced-success lifecycle harness when the loaded area declares one.
+    // A session scheduled by startturretgame carries its own origin, captured
+    // before the transition was queued.
+    bool pendingTurret = _pendingTurret.active && boost::iequals(_pendingTurret.targetModule, target);
+    if (pendingTurret) {
+        originModule = _pendingTurret.originModule;
+        originPosition = _pendingTurret.originPosition;
+        originFacing = _pendingTurret.originFacing;
+        haveOrigin = _pendingTurret.haveOrigin;
+    }
+
+    if (wasLifecycleActive || _swoopLifecycle.active || _turretLifecycle.active) {
         return;
     }
     if (originModule.empty() || boost::iequals(originModule, target)) {
+        if (pendingTurret) {
+            abandonPendingTurret("no origin module");
+        }
         return;
     }
     auto mod = _module;
-    if (!mod || !mod->area() || !mod->area()->hasMinigame()) {
+    auto area = mod ? mod->area() : nullptr;
+    bool hasMinigame = area && area->hasMinigame();
+    MinigameType minigameType = hasMinigame ? area->miniGame().type : MinigameType::None;
+
+    auto resolution = resolveTurretRequest(pendingTurret, hasMinigame, minigameType);
+    if (resolution == TurretRequestResolution::AbortNoMinigame ||
+        resolution == TurretRequestResolution::AbortWrongType) {
+        abandonPendingTurret(turretRequestResolutionMessage(resolution));
         return;
     }
-    if (mod->area()->miniGame().type != MinigameType::SwoopRace) {
+
+    if (!hasMinigame) {
+        return;
+    }
+    if (minigameType == MinigameType::Turret) {
+        openTurret();
+        if (_turret.isActive()) {
+            _turretLifecycle = MinigameLifecycle();
+            _turretLifecycle.active = true;
+            _turretLifecycle.haveOrigin = haveOrigin;
+            _turretLifecycle.originModule = originModule;
+            _turretLifecycle.originPosition = originPosition;
+            _turretLifecycle.originFacing = originFacing;
+            _turretLifecycle.forcedSuccess = true;
+            _pendingTurret = PendingTurretRequest();
+            debug(str(boost::format("turret: lifecycle start origin=%s target=%s hook=%s")
+                      % originModule % target
+                      % (pendingTurret ? "startturretgame" : "StartNewModule")));
+        } else if (pendingTurret) {
+            abandonPendingTurret("turret failed to start");
+        }
+        return;
+    }
+    if (minigameType != MinigameType::SwoopRace) {
         return;
     }
 
     openSwoopRace();
     if (_swoopRace.isActive()) {
-        _swoopLifecycle = SwoopLifecycle();
+        _swoopLifecycle = MinigameLifecycle();
         _swoopLifecycle.active = true;
         _swoopLifecycle.haveOrigin = haveOrigin;
         _swoopLifecycle.originModule = originModule;
@@ -2218,8 +2306,8 @@ void Game::finishSwoopLifecycle(bool success) {
     // Capture and clear the session first so the upcoming module load does not
     // re-enter this path. The current module (before returning) is the race
     // module, which selects the planet-specific result contract.
-    SwoopLifecycle session = _swoopLifecycle;
-    _swoopLifecycle = SwoopLifecycle();
+    MinigameLifecycle session = _swoopLifecycle;
+    _swoopLifecycle = MinigameLifecycle();
     std::string raceModule = _module ? _module->name() : "";
 
     // Stop the race (removes bike models, restores camera/FOV/input, screen).
@@ -2349,6 +2437,227 @@ void Game::applySwoopForcedSuccessResult(const std::string &raceModule) {
     }
     setGlobalBoolean("TAR_SWOOP_RUN", true);
     applyTarisForcedWinningTime();
+}
+
+void Game::openTurret() {
+    if (_turret.isActive()) {
+        _console.printLine("turret: already running");
+        return;
+    }
+    if (!_module || !_module->area()) {
+        _console.printLine("turret: no module loaded");
+        return;
+    }
+    auto area = _module->area();
+    if (!area->hasMinigame() || area->miniGame().type != MinigameType::Turret) {
+        _console.printLine("turret: current area has no turret minigame");
+        return;
+    }
+
+    const auto &mg = area->miniGame();
+    auto camera = area->getCamera<FirstPersonCamera>(CameraType::FirstPerson);
+    if (camera) {
+        camera->stopMovement();
+    }
+
+    _savedCameraType = _cameraType;
+    if (!_turret.start(mg, camera, area->name())) {
+        _console.printLine("turret: failed to start (see log)");
+        return;
+    }
+
+    _cameraType = CameraType::FirstPerson;
+    setRelativeMouseMode(true);
+    changeScreen(Screen::Turret);
+
+    // The minigame owns the party now; drop any actions queued before entry so
+    // they do not survive the module transitions (mirrors the swoop entry).
+    for (auto &member : _party.members()) {
+        if (member.creature) {
+            member.creature->clearAllActions(/*force=*/true);
+        }
+    }
+
+    // Vanilla does not add the party to the scene in a minigame module; the
+    // turret actor represents the player. Restored on exit.
+    setPartyVisible(false);
+
+    if (!mg.music.empty()) {
+        playMusic(mg.music);
+    }
+
+    debug(str(boost::format("turret: started track=%s anchor=%s models=%zu banks=%zu enemies=%zu hp=%d camfov=%.0f clip=[%.2f,%.0f]")
+              % mg.player.trackResRef
+              % _turret.anchorSource()
+              % mg.player.models.size()
+              % _turret.gunBankCount()
+              % _turret.enemyCount()
+              % _turret.hitPoints()
+              % mg.cameraViewAngle
+              % mg.nearClip
+              % mg.farClip));
+    debug(str(boost::format("turret: hud gauge=%s radar=%s healthState=%d(%s) heading=%d contacts=%zu radarChannels=%zu alarm=%d")
+              % (_turret.haveHealthHud() ? "mgf_hud02" : "<missing>")
+              % (_turret.haveRadarHud() ? "mgf_hud01" : "<missing>")
+              % _turret.healthState()
+              % turretHealthAnimation(_turret.healthState())
+              % _turret.headingState()
+              % _turret.contactsLive()
+              % _turret.radarChannelCount()
+              % static_cast<int>(_turret.alarmActive())));
+    debug(str(boost::format("turret: camera mount=%s hook=%s eyeOffset=[%.3f,%.3f,%.3f] targetOffset=[%.1f,%.1f,%.1f] rotate=%d")
+              % (mg.player.cameraResRef.empty() ? "<none>" : mg.player.cameraResRef)
+              % (_turret.haveCameraHook() ? "camerahook" : "<missing>")
+              % _turret.cameraHookOffset().x
+              % _turret.cameraHookOffset().y
+              % _turret.cameraHookOffset().z
+              % mg.player.targetOffset.x
+              % mg.player.targetOffset.y
+              % mg.player.targetOffset.z
+              % static_cast<int>(mg.player.cameraRotate)));
+    debug(str(boost::format("turret: aim pitch=[%.1f,%.1f]%s yaw=[%.1f,%.1f]%s authoredStart=[%.1f,%.1f,%.1f] startPitch=%.1f startYaw=%.1f")
+              % glm::degrees(_turret.aim().minPitch())
+              % glm::degrees(_turret.aim().maxPitch())
+              % (_turret.aim().pitchBounded() ? "" : " (infinite)")
+              % glm::degrees(_turret.aim().minYaw())
+              % glm::degrees(_turret.aim().maxYaw())
+              % (_turret.aim().yawBounded() ? "" : " (infinite)")
+              % mg.player.startOffset.x
+              % mg.player.startOffset.y
+              % mg.player.startOffset.z
+              % glm::degrees(_turret.aim().startPitch())
+              % glm::degrees(_turret.aim().startYaw())));
+}
+
+void Game::closeTurret() {
+    if (!_turret.isActive()) {
+        debug("turret: closeTurret called but turret not active");
+        return;
+    }
+    _turret.stop();
+    setPartyVisible(true);
+    _cameraType = _savedCameraType;
+    setRelativeMouseMode(_cameraType == CameraType::FirstPerson);
+    openInGame();
+    debug("turret: stopped (party restored, camera reset)");
+}
+
+void Game::exitTurret() {
+    // Escape / stopturret entry point. If a lifecycle session is in progress,
+    // return to the origin module; otherwise just stop the dev session in place.
+    if (_turretLifecycle.active) {
+        // A session abandoned mid-run is still InProgress; it returns to the
+        // origin but is neither a win nor a loss.
+        finishTurretLifecycle(_turret.outcome());
+    } else if (_pendingTurret.active) {
+        // Scheduled but never started: drop the request rather than leaving it
+        // to fire on a later transition into the same module.
+        abandonPendingTurret("cancelled");
+    } else {
+        closeTurret();
+    }
+}
+
+void Game::returnToLifecycleOrigin(const std::string &module,
+                                   bool haveOrigin,
+                                   const glm::vec3 &position,
+                                   float facing) {
+    if (module.empty()) {
+        return;
+    }
+    loadModule(module);
+    if (!haveOrigin) {
+        return;
+    }
+    auto mod = _module;
+    if (!mod || !mod->area()) {
+        return;
+    }
+    auto leader = _party.getLeader();
+    if (!leader) {
+        return;
+    }
+    leader->setPosition(position);
+    leader->setFacing(facing);
+    mod->area()->determineObjectRoom(*leader);
+    mod->area()->onPartyLeaderMoved(/*roomChanged=*/true);
+}
+
+void Game::abandonPendingTurret(const std::string &reason) {
+    if (!_pendingTurret.active) {
+        return;
+    }
+    PendingTurretRequest request = _pendingTurret;
+    _pendingTurret = PendingTurretRequest();
+    _console.printLine(str(boost::format("turret: lifecycle aborted (%s), returning to origin=%s")
+                           % reason % request.originModule));
+    returnToLifecycleOrigin(request.originModule,
+                            request.haveOrigin,
+                            request.originPosition,
+                            request.originFacing);
+}
+
+void Game::finishTurretLifecycle(Turret::Outcome outcome) {
+    // Repeated calls are no-ops: the session is cleared below before anything
+    // else runs, so neither the return nor the completion state can be emitted
+    // twice for one session.
+    if (!_turretLifecycle.active) {
+        return;
+    }
+    // Capture and clear the session first so the upcoming module load does not
+    // re-enter this path. The current module (before returning) is the turret
+    // module, which selects the return contract.
+    MinigameLifecycle session = _turretLifecycle;
+    _turretLifecycle = MinigameLifecycle();
+    std::string turretModule = _module ? _module->name() : "";
+
+    closeTurret();
+
+    // Prefer the vanilla return module (the StartNewModule target the turret's
+    // end scripts use); fall back to the module the player came from.
+    std::string returnModule = game::turretReturnModule(turretModule, session.originModule);
+    if (returnModule.empty()) {
+        // Nothing authored and nothing captured: stay put rather than schedule
+        // a transition to an empty module name.
+        debug("turret: no return module, staying put");
+        applyTurretResult(turretModule, outcome);
+        return;
+    }
+    bool returningToOrigin = boost::iequals(returnModule, session.originModule);
+    returnToLifecycleOrigin(returnModule,
+                            returningToOrigin && session.haveOrigin,
+                            session.originPosition,
+                            session.originFacing);
+
+    applyTurretResult(turretModule, outcome);
+
+    debug(str(boost::format("turret: finished outcome=%s returning=%s")
+              % turretOutcomeName(outcome)
+              % returnModule));
+}
+
+void Game::applyTurretResult(const std::string &turretModule, Turret::Outcome outcome) {
+    // K1 M12ab result contract, confirmed from local assets: k_pebo_mgload seeds
+    // the globals ebo_num_fighters (Number) and ebo_turret_done (Boolean); each
+    // enemy death script decrements ebo_num_fighters and, on the last kill, sets
+    // ebo_turret_done before returning to ebo_m12aa. reone substitutes the
+    // minigame and never runs those scripts, so reproduce their outputs here.
+    //
+    // Only the last kill writes them in vanilla, so only a victory writes them
+    // here: a defeat or an abandoned session leaves the turret outstanding.
+    if (!boost::iequals(turretModule, "m12ab")) {
+        return;
+    }
+    if (!turretSessionSucceeded(outcome)) {
+        _console.printLine(str(boost::format(
+            "turret: result module=m12ab outcome=%s (no completion state written)")
+            % turretOutcomeName(outcome)));
+        return;
+    }
+    setGlobalNumber("ebo_num_fighters", 0);
+    setGlobalBoolean("ebo_turret_done", true);
+    _console.printLine(
+        "turret: result module=m12ab outcome=won ebo_turret_done=1 ebo_num_fighters=0");
 }
 
 void Game::openInGameMenu(InGameMenuTab tab) {
@@ -2951,6 +3260,8 @@ GameGUI *Game::getScreenGUI() const {
         return _pazaakSetup.get();
     case Screen::PazaakBoard:
         return _pazaakBoard.get();
+    case Screen::Turret:
+        return nullptr; // the turret HUD is part of the player model set
     default:
         return nullptr;
     }
@@ -3818,7 +4129,7 @@ void Game::consoleStartSwoopRace(const ConsoleArgs &args) {
     }
 
     // Capture origin module/state before transitioning.
-    SwoopLifecycle session;
+    MinigameLifecycle session;
     session.originModule = _module->name();
     session.forcedSuccess = true;
     if (auto leader = _party.getLeader()) {
@@ -3880,6 +4191,92 @@ void Game::consoleSwoopState(const ConsoleArgs &args) {
                            % pos.x % pos.y % pos.z
                            % _swoopRace.lateralLeftBound()
                            % _swoopRace.lateralRightBound()));
+}
+
+void Game::consoleStartTurret(const ConsoleArgs &args) {
+    openTurret();
+}
+
+void Game::consoleStartTurretGame(const ConsoleArgs &args) {
+    consoleCheckUsage(args, 1, 1, "module");
+
+    std::string target(boost::to_lower_copy(std::string(args[1].value())));
+    std::string originModule(_module ? _module->name() : "");
+    bool alreadyActive = _turretLifecycle.active || _pendingTurret.active || _turret.isActive();
+
+    auto error = validateTurretRequest(target,
+                                       originModule,
+                                       _moduleNames.count(target) > 0,
+                                       alreadyActive);
+    if (error != TurretRequestError::None) {
+        _console.printLine(str(boost::format("turret: %s") % turretRequestErrorMessage(error)));
+        return;
+    }
+
+    // Capture the origin now: the transition is deferred, and by the time it
+    // runs the current module is already gone.
+    _pendingTurret = PendingTurretRequest();
+    _pendingTurret.active = true;
+    _pendingTurret.targetModule = target;
+    _pendingTurret.originModule = originModule;
+    if (auto leader = _party.getLeader()) {
+        _pendingTurret.originPosition = leader->position();
+        _pendingTurret.originFacing = leader->getFacing();
+        _pendingTurret.haveOrigin = true;
+    }
+
+    // Go through the normal deferred transition so the Type 2 detection in
+    // loadNextModule starts the minigame, exactly as a script entry would.
+    scheduleModuleTransition(target, "");
+
+    _console.printLine(str(boost::format("turret: lifecycle scheduled origin=%s target=%s")
+                           % originModule % target));
+}
+
+void Game::consoleStopTurret(const ConsoleArgs &args) {
+    // If a lifecycle session is active, return to origin safely; otherwise stop
+    // in place.
+    exitTurret();
+}
+
+void Game::consoleTurretState(const ConsoleArgs &args) {
+    if (!_turret.isActive()) {
+        _console.printLine("turret: not active");
+        return;
+    }
+    glm::vec3 pos = _turret.position();
+    const char *outcome = "in-progress";
+    switch (_turret.outcome()) {
+    case Turret::Outcome::Won:
+        outcome = "won";
+        break;
+    case Turret::Outcome::Lost:
+        outcome = "lost";
+        break;
+    default:
+        break;
+    }
+    _console.printLine(str(boost::format("turret: pitch=%.1f yaw=%.1f hp=%d/%d enemies=%zu/%zu bullets=%zu elapsed=%.1f pos=[%.1f,%.1f,%.1f] outcome=%s")
+                           % glm::degrees(_turret.aim().pitch())
+                           % glm::degrees(_turret.aim().yaw())
+                           % _turret.hitPoints()
+                           % _turret.maxHitPoints()
+                           % _turret.enemiesAlive()
+                           % _turret.enemyCount()
+                           % _turret.bulletCount()
+                           % _turret.elapsed()
+                           % pos.x % pos.y % pos.z
+                           % outcome));
+    _console.printLine(str(boost::format("  hud: health=%d(%s) heading=%d alarm=%d contacts=%zu/%zu gauge=%d radar=%d radarChannels=%zu")
+                           % _turret.healthState()
+                           % turretHealthAnimation(_turret.healthState())
+                           % _turret.headingState()
+                           % static_cast<int>(_turret.alarmActive())
+                           % _turret.contactsLive()
+                           % kTurretContactCount
+                           % static_cast<int>(_turret.haveHealthHud())
+                           % static_cast<int>(_turret.haveRadarHud())
+                           % _turret.radarChannelCount()));
 }
 
 void Game::consoleShowImGui(const ConsoleArgs &args) {

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -2470,6 +2470,16 @@ void Game::openTurret() {
     setRelativeMouseMode(true);
     changeScreen(Screen::Turret);
 
+    // Every started session is a lifecycle session, so a win or a loss is
+    // consumed the same way however the turret was entered. A session started
+    // in place - the startturret developer command, or any entry that did not
+    // come from a module transition - captures no origin; finishing one falls
+    // through to the authored return module when the turret area names one and
+    // otherwise leaves the player where they are. A transition-driven entry
+    // overwrites this in onModuleLoaded with the origin it captured.
+    _turretLifecycle = MinigameLifecycle();
+    _turretLifecycle.active = true;
+
     // The minigame owns the party now; drop any actions queued before entry so
     // they do not survive the module transitions (mirrors the swoop entry).
     for (auto &member : _party.members()) {

--- a/src/libs/game/minigame.cpp
+++ b/src/libs/game/minigame.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2020-2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/minigame.h"
+
+#include "reone/resource/parser/gff/are.h"
+
+namespace reone {
+
+namespace game {
+
+namespace {
+
+template <class TModels>
+std::vector<MinigameModelSpec> parseModels(const TModels &models) {
+    std::vector<MinigameModelSpec> result;
+    for (const auto &m : models) {
+        if (m.Model.empty()) {
+            continue;
+        }
+        MinigameModelSpec spec;
+        spec.resRef = m.Model;
+        spec.rotating = m.RotatingModel != 0;
+        result.push_back(std::move(spec));
+    }
+    return result;
+}
+
+template <class TBullet>
+MinigameBulletSpec parseBullet(const TBullet &bullet) {
+    MinigameBulletSpec spec;
+    spec.modelResRef = bullet.Bullet_Model;
+    spec.collisionSound = bullet.Collision_Sound;
+    spec.damage = bullet.Damage;
+    spec.lifespan = bullet.Lifespan;
+    spec.rateOfFire = bullet.Rate_Of_Fire;
+    spec.speed = bullet.Speed;
+    spec.targetType = bullet.Target_Type;
+    return spec;
+}
+
+} // namespace
+
+std::optional<MinigameSpec> parseMinigameSpec(const resource::generated::ARE &are) {
+    if (are.MiniGame.Type == 0) {
+        return std::nullopt;
+    }
+    MinigameSpec spec;
+    spec.type = minigameTypeFromUint(are.MiniGame.Type);
+    spec.cameraViewAngle = are.MiniGame.CameraViewAngle;
+    spec.nearClip = are.MiniGame.Near_Clip;
+    spec.farClip = are.MiniGame.Far_Clip;
+    spec.lateralAccel = are.MiniGame.LateralAccel;
+    spec.movementPerSec = are.MiniGame.MovementPerSec;
+    spec.useInertia = are.MiniGame.UseInertia != 0;
+    spec.bumpPlane = are.MiniGame.Bump_Plane;
+    spec.depthOfField = are.MiniGame.DOF;
+    spec.doBumping = are.MiniGame.DoBumping != 0;
+    spec.music = are.MiniGame.Music;
+    spec.mouse.axisX = are.MiniGame.Mouse.AxisX;
+    spec.mouse.axisY = are.MiniGame.Mouse.AxisY;
+    spec.mouse.flipAxisX = are.MiniGame.Mouse.FlipAxisX != 0;
+    spec.mouse.flipAxisY = are.MiniGame.Mouse.FlipAxisY != 0;
+
+    const auto &src = are.MiniGame.Player;
+    spec.player.cameraResRef = src.Camera;
+    spec.player.trackResRef = src.Track;
+    spec.player.minimumSpeed = src.Minimum_Speed;
+    spec.player.maximumSpeed = src.Maximum_Speed;
+    spec.player.accelSecs = src.Accel_Secs;
+    spec.player.sphereRadius = src.Sphere_Radius;
+    spec.player.hitPoints = src.Hit_Points;
+    spec.player.maxHitPoints = src.Max_HPs;
+    spec.player.invincePeriod = src.Invince_Period;
+    spec.player.bumpDamage = src.Bump_Damage;
+    spec.player.numLoops = src.Num_Loops;
+    spec.player.cameraRotate = src.CameraRotate != 0;
+    spec.player.sounds.death = src.Sounds.Death;
+    spec.player.sounds.engine = src.Sounds.Engine;
+    spec.player.startOffset = glm::vec3(src.Start_Offset_X, src.Start_Offset_Y, src.Start_Offset_Z);
+    spec.player.targetOffset = glm::vec3(src.Target_Offset_X, src.Target_Offset_Y, src.Target_Offset_Z);
+    spec.player.tunnelXPos = src.TunnelXPos;
+    spec.player.tunnelXNeg = src.TunnelXNeg;
+    spec.player.tunnelYPos = src.TunnelYPos;
+    spec.player.tunnelYNeg = src.TunnelYNeg;
+    spec.player.tunnelZPos = src.TunnelZPos;
+    spec.player.tunnelZNeg = src.TunnelZNeg;
+    spec.player.tunnelInfinite = src.TunnelInfinite;
+    spec.player.scripts.onCreate = src.Scripts.OnCreate;
+    spec.player.scripts.onDeath = src.Scripts.OnDeath;
+    spec.player.scripts.onTrackLoop = src.Scripts.OnTrackLoop;
+    spec.player.scripts.onDamage = src.Scripts.OnDamage;
+    spec.player.scripts.onAccelerate = src.Scripts.OnAccelerate;
+    spec.player.scripts.onHeartbeat = src.Scripts.OnHeartbeat;
+    spec.player.scripts.onFire = src.Scripts.OnFire;
+    spec.player.scripts.onHitBullet = src.Scripts.OnHitBullet;
+    spec.player.scripts.onHitFollower = src.Scripts.OnHitFollower;
+    spec.player.scripts.onHitObstacle = src.Scripts.OnHitObstacle;
+    spec.player.models = parseModels(src.Models);
+    for (const auto &b : src.Gun_Banks) {
+        MinigameGunBankSpec bank;
+        bank.bankId = b.BankID;
+        bank.gunModelResRef = b.Gun_Model;
+        bank.fireSound = b.Fire_Sound;
+        bank.bullet = parseBullet(b.Bullet);
+        spec.player.gunBanks.push_back(std::move(bank));
+    }
+
+    std::set<std::string> seenTracks;
+    auto addTrack = [&](const std::string &ref) {
+        if (!ref.empty() && seenTracks.insert(ref).second) {
+            spec.trackResRefs.push_back(ref);
+        }
+    };
+    addTrack(src.Track);
+
+    for (const auto &e : are.MiniGame.Enemies) {
+        MinigameEnemySpec enemy;
+        enemy.trackResRef = e.Track;
+        enemy.hitPoints = e.Hit_Points;
+        enemy.maxHitPoints = e.Max_HPs;
+        enemy.sphereRadius = e.Sphere_Radius;
+        enemy.invincePeriod = e.Invince_Period;
+        enemy.bumpDamage = e.Bump_Damage;
+        enemy.numLoops = e.Num_Loops;
+        enemy.trigger = e.Trigger != 0;
+        enemy.sounds.death = e.Sounds.Death;
+        enemy.sounds.engine = e.Sounds.Engine;
+        enemy.scripts.onCreate = e.Scripts.OnCreate;
+        enemy.scripts.onDeath = e.Scripts.OnDeath;
+        enemy.scripts.onDamage = e.Scripts.OnDamage;
+        enemy.scripts.onHeartbeat = e.Scripts.OnHeartbeat;
+        enemy.scripts.onTrackLoop = e.Scripts.OnTrackLoop;
+        enemy.onCreate = e.Scripts.OnCreate;
+        enemy.models = parseModels(e.Models);
+        for (const auto &b : e.Gun_Banks) {
+            MinigameGunBankSpec bank;
+            bank.bankId = b.BankID;
+            bank.gunModelResRef = b.Gun_Model;
+            bank.fireSound = b.Fire_Sound;
+            bank.bullet = parseBullet(b.Bullet);
+            bank.horizSpread = b.Horiz_Spread;
+            bank.vertSpread = b.Vert_Spread;
+            bank.inaccuracy = b.Inaccuracy;
+            bank.sensingRadius = b.Sensing_Radius;
+            enemy.gunBanks.push_back(std::move(bank));
+        }
+        spec.enemies.push_back(std::move(enemy));
+        addTrack(e.Track);
+    }
+
+    for (const auto &o : are.MiniGame.Obstacles) {
+        MinigameObstacleSpec obs;
+        obs.name = o.Name;
+        obs.onCreate = o.Scripts.OnCreate;
+        spec.obstacles.push_back(std::move(obs));
+    }
+
+    return spec;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -276,74 +276,7 @@ void Area::loadFog(const resource::generated::ARE &are) {
 }
 
 void Area::loadMiniGame(const resource::generated::ARE &are) {
-    if (are.MiniGame.Type == 0) {
-        return;
-    }
-    MinigameSpec spec;
-    spec.type = minigameTypeFromUint(are.MiniGame.Type);
-    spec.cameraViewAngle = are.MiniGame.CameraViewAngle;
-    spec.lateralAccel = are.MiniGame.LateralAccel;
-    spec.movementPerSec = are.MiniGame.MovementPerSec;
-    spec.useInertia = are.MiniGame.UseInertia != 0;
-    spec.bumpPlane = are.MiniGame.Bump_Plane;
-    spec.doBumping = are.MiniGame.DoBumping != 0;
-
-    const auto &src = are.MiniGame.Player;
-    spec.player.cameraResRef = src.Camera;
-    spec.player.trackResRef = src.Track;
-    spec.player.minimumSpeed = src.Minimum_Speed;
-    spec.player.maximumSpeed = src.Maximum_Speed;
-    spec.player.accelSecs = src.Accel_Secs;
-    spec.player.sphereRadius = src.Sphere_Radius;
-    spec.player.hitPoints = src.Hit_Points;
-    spec.player.tunnelXPos = src.TunnelXPos;
-    spec.player.tunnelXNeg = src.TunnelXNeg;
-    spec.player.tunnelYPos = src.TunnelYPos;
-    spec.player.tunnelYNeg = src.TunnelYNeg;
-    spec.player.tunnelZPos = src.TunnelZPos;
-    spec.player.tunnelZNeg = src.TunnelZNeg;
-    spec.player.scripts.onCreate = src.Scripts.OnCreate;
-    spec.player.scripts.onDeath = src.Scripts.OnDeath;
-    spec.player.scripts.onTrackLoop = src.Scripts.OnTrackLoop;
-    spec.player.scripts.onDamage = src.Scripts.OnDamage;
-    spec.player.scripts.onAccelerate = src.Scripts.OnAccelerate;
-    spec.player.scripts.onHeartbeat = src.Scripts.OnHeartbeat;
-    for (const auto &m : src.Models) {
-        if (!m.Model.empty()) {
-            spec.player.modelResRefs.push_back(m.Model);
-        }
-    }
-
-    std::set<std::string> seenTracks;
-    auto addTrack = [&](const std::string &ref) {
-        if (!ref.empty() && seenTracks.insert(ref).second) {
-            spec.trackResRefs.push_back(ref);
-        }
-    };
-    addTrack(src.Track);
-
-    for (const auto &e : are.MiniGame.Enemies) {
-        MinigameEnemySpec enemy;
-        enemy.trackResRef = e.Track;
-        enemy.hitPoints = e.Hit_Points;
-        enemy.onCreate = e.Scripts.OnCreate;
-        for (const auto &m : e.Models) {
-            if (!m.Model.empty()) {
-                enemy.modelResRefs.push_back(m.Model);
-            }
-        }
-        spec.enemies.push_back(std::move(enemy));
-        addTrack(e.Track);
-    }
-
-    for (const auto &o : are.MiniGame.Obstacles) {
-        MinigameObstacleSpec obs;
-        obs.name = o.Name;
-        obs.onCreate = o.Scripts.OnCreate;
-        spec.obstacles.push_back(std::move(obs));
-    }
-
-    _miniGameSpec = std::move(spec);
+    _miniGameSpec = parseMinigameSpec(are);
 }
 
 void Area::applySceneProperties() {

--- a/src/libs/game/swooprace.cpp
+++ b/src/libs/game/swooprace.cpp
@@ -76,7 +76,7 @@ void SwoopRace::start(const MinigameSpec &spec,
     _lateralAccel = spec.lateralAccel;
     _camFov = spec.cameraViewAngle;
     _trackResRef = spec.player.trackResRef;
-    _modelCount = spec.player.modelResRefs.size();
+    _modelCount = spec.player.models.size();
     _finishProgress = finishProgress;
 
     computeLateralBounds(spec.player);

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -18,6 +18,7 @@
 #include "reone/game/turret.h"
 
 #include <array>
+#include <stack>
 
 #include "reone/audio/di/services.h"
 #include "reone/audio/mixer.h"
@@ -370,6 +371,25 @@ bool turretDeathEffectComplete(float elapsed, float duration) {
         return true;
     }
     return elapsed >= duration;
+}
+
+void turretDisableReferenceAttachments(ModelSceneNode &model) {
+    std::stack<std::reference_wrapper<const graphics::ModelNode>> pending;
+    if (auto root = model.model().rootNode()) {
+        pending.push(*root);
+    }
+    while (!pending.empty()) {
+        const auto &node = pending.top().get();
+        pending.pop();
+        if (node.isReference()) {
+            if (auto attachment = model.getAttachment(node.name())) {
+                attachment->setEnabled(false);
+            }
+        }
+        for (const auto &child : node.children()) {
+            pending.push(*child);
+        }
+    }
 }
 
 int turretHeadingState(float yawRadians) {
@@ -1067,6 +1087,10 @@ void Turret::updateEnemies(float dt) {
                 if (auto dying = enemy.modelNode->model().getAnimation("die")) {
                     enemy.deathDuration = dying->length();
                 }
+                // The engine glow is not part of the death presentation: it
+                // burns steadily for as long as its node lives, so a wreck that
+                // kept it would trail a lit flare through the whole animation.
+                turretDisableReferenceAttachments(*enemy.modelNode);
                 enemy.modelNode->playAnimation("die");
                 if (enemy.spec && !enemy.spec->sounds.death.empty()) {
                     playSound(enemy.spec->sounds.death);

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -1,0 +1,1411 @@
+/*
+ * Copyright (c) 2020-2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/turret.h"
+
+#include <array>
+
+#include "reone/audio/di/services.h"
+#include "reone/audio/mixer.h"
+#include "reone/game/di/services.h"
+#include "reone/game/game.h"
+#include "reone/game/object/camera/firstperson.h"
+#include "reone/graphics/types.h"
+#include "reone/resource/di/services.h"
+#include "reone/resource/provider/audioclips.h"
+#include "reone/resource/provider/layouts.h"
+#include "reone/resource/provider/models.h"
+#include "reone/scene/di/services.h"
+#include "reone/scene/graphs.h"
+#include "reone/scene/node/camera.h"
+#include "reone/scene/node/model.h"
+#include "reone/system/logutil.h"
+
+using namespace reone::audio;
+using namespace reone::graphics;
+using namespace reone::scene;
+
+namespace reone {
+
+namespace game {
+
+namespace {
+
+// Odyssey models look down +Y.
+const glm::vec3 kModelForward(0.0f, 1.0f, 0.0f);
+
+// reone's existing keyboard rotation rates (ThirdPersonCamera), used here as the
+// calibration point for a full-turn axis. MiniGame.LateralAccel is deliberately
+// not used: the swoop race authors 300 and steers laterally with it, the turret
+// authors 1200 and never translates at all, and KotOR.js ignores it for the
+// turret too, so it has no confirmed turret aim meaning.
+constexpr float kTurnRateMin = 1.0f;      // radians per second
+constexpr float kTurnRateMax = 2.5f;      // radians per second
+constexpr float kTurnAcceleration = 1.0f; // radians per second squared
+
+// Mouse aim sensitivity, matching FirstPersonCamera's kMouseMultiplier so the
+// turret feels like the rest of the engine.
+const float kMouseAimRadiansPerPixel = glm::pi<float>() / 4000.0f;
+
+// Engine default field of view, restored to the reused first-person camera on
+// exit (mirrors Area's default camera FOV).
+constexpr float kDefaultCameraFovDegrees = 75.0f;
+
+// Distance an enemy shoots from when its gun bank declares no sensing radius.
+constexpr float kFallbackSensingRadius = 200.0f;
+
+// Names of the hook nodes vanilla uses to assemble a minigame actor.
+const std::string kModelHookName("modelhook");
+const std::string kCameraHookName("camerahook");
+const std::string kBulletHookName("bullethook0");
+
+std::string gunBankHookName(uint32_t bankId) {
+    return str(boost::format("gunbank%u") % bankId);
+}
+
+glm::vec3 transformOrigin(const glm::mat4 &transform) {
+    return glm::vec3(transform[3]);
+}
+
+glm::vec3 transformForward(const glm::mat4 &transform) {
+    glm::vec3 forward(glm::mat3(transform) * kModelForward);
+    float length = glm::length(forward);
+    return length > 0.0f ? forward / length : kModelForward;
+}
+
+// Rotation of a world transform, with any scale divided out.
+glm::quat transformOrientation(const glm::mat4 &transform) {
+    glm::mat3 basis(transform);
+    for (int i = 0; i < 3; ++i) {
+        float length = glm::length(basis[i]);
+        basis[i] = length > 0.0f ? basis[i] / length : glm::vec3(0.0f);
+    }
+    return glm::normalize(glm::quat_cast(basis));
+}
+
+// Minigame actors idle on a looping "ready" animation (the fighters bank and
+// the turret lights cycle). Names differ between actor and gun models.
+void playIdleAnimation(ModelSceneNode &node) {
+    static const std::array<const char *, 2> kIdleNames {"ready_01", "ready"};
+    for (const auto *name : kIdleNames) {
+        if (node.model().getAnimation(name)) {
+            node.playAnimation(name, nullptr,
+                               AnimationProperties::fromFlags(AnimationFlags::loop));
+            return;
+        }
+    }
+}
+
+/**
+ * Silence a projectile's emitters for ordinary flight.
+ *
+ * EmitterSceneNode latches its birth rate from the model at time zero and, in
+ * Fountain mode, then emits for as long as the node lives - no animation is
+ * involved. The shipped bolt models carry the explosion presentation as
+ * emitters (mgb_ebonleft has plume, rim and inner nodes textured
+ * LMG_explplume01 / LMG_explrim01), so left alone every bolt trails an
+ * explosion for its whole flight and sustained fire fills the cockpit. Vanilla
+ * only shows those on the authored explosion event, which reone reaches through
+ * ModelSceneNode::signalEvent("detonate"), so free-running emission on a bolt in
+ * flight is never wanted. Mesh geometry - the visible bolt itself - is
+ * untouched.
+ */
+void silenceEmitters(SceneNode &node) {
+    for (auto &child : node.children()) {
+        if (child->type() == SceneNodeType::Emitter) {
+            child->setEnabled(false);
+            continue;
+        }
+        silenceEmitters(*child);
+    }
+}
+
+float normalizeAngle(float radians) {
+    while (radians > glm::pi<float>()) {
+        radians -= glm::two_pi<float>();
+    }
+    while (radians < -glm::pi<float>()) {
+        radians += glm::two_pi<float>();
+    }
+    return radians;
+}
+
+} // namespace
+
+void TurretAim::configure(const MinigamePlayerSpec &player) {
+    // The .are stores signed degree limits per axis, so the usable range is
+    // [Neg, Pos]; take the min/max in case an area authors them the other way
+    // round. An axis flagged in TunnelInfinite is unbounded and wraps instead.
+    _pitchBounded = player.tunnelInfinite.x == 0.0f;
+    _yawBounded = player.tunnelInfinite.z == 0.0f;
+    _minPitch = glm::radians(glm::min(player.tunnelXNeg, player.tunnelXPos));
+    _maxPitch = glm::radians(glm::max(player.tunnelXNeg, player.tunnelXPos));
+    _minYaw = glm::radians(glm::min(player.tunnelZNeg, player.tunnelZPos));
+    _maxYaw = glm::radians(glm::max(player.tunnelZNeg, player.tunnelZPos));
+
+    // Start_Offset is the authored starting aim, on the same axes and in the
+    // same units as the Tunnel limits: X is pitch, Z is yaw. K1 authors it only
+    // on the turret area - all three swoop areas leave Start_Offset, Tunnel and
+    // Mouse zeroed - and m12ab's Start_Offset_X of 7 degrees sits inside its
+    // authored 2..45 degree pitch band. It is an angle, not a translation.
+    _startPitch = glm::radians(player.startOffset.x);
+    _startYaw = glm::radians(player.startOffset.z);
+    if (_pitchBounded) {
+        _startPitch = glm::clamp(_startPitch, _minPitch, _maxPitch);
+    } else {
+        _startPitch = normalizeAngle(_startPitch);
+    }
+    if (_yawBounded) {
+        _startYaw = glm::clamp(_startYaw, _minYaw, _maxYaw);
+    } else {
+        _startYaw = normalizeAngle(_startYaw);
+    }
+
+    reset();
+}
+
+void TurretAim::reset() {
+    _pitch = _startPitch;
+    _yaw = _startYaw;
+}
+
+float TurretAim::pitchTravel() const {
+    return _pitchBounded ? glm::max(0.0f, _maxPitch - _minPitch) : glm::two_pi<float>();
+}
+
+float TurretAim::yawTravel() const {
+    return _yawBounded ? glm::max(0.0f, _maxYaw - _minYaw) : glm::two_pi<float>();
+}
+
+void TurretAimRate::configure(float travelRadians) {
+    // Scale reone's full-turn rates by how much travel this axis actually has,
+    // so a narrow axis is proportionally gentler and every axis crosses its
+    // authored range in about the same time.
+    float scale = travelRadians > 0.0f
+                      ? glm::min(travelRadians / glm::two_pi<float>(), 1.0f)
+                      : 1.0f;
+    _minRate = kTurnRateMin * scale;
+    _maxRate = kTurnRateMax * scale;
+    _acceleration = kTurnAcceleration * scale;
+    reset();
+}
+
+void TurretAimRate::setDirection(int direction) {
+    int clamped = direction > 0 ? 1 : (direction < 0 ? -1 : 0);
+    if (clamped == _direction) {
+        return;
+    }
+    _direction = clamped;
+    _held = 0.0f;
+}
+
+void TurretAimRate::reset() {
+    _direction = 0;
+    _held = 0.0f;
+}
+
+float TurretAimRate::rateAt(float held) const {
+    return glm::min(_maxRate, _minRate + _acceleration * glm::max(0.0f, held));
+}
+
+float TurretAimRate::rate() const {
+    return _direction != 0 ? rateAt(_held) : 0.0f;
+}
+
+float TurretAimRate::angleOver(float from, float to) const {
+    // Integrate the ramp exactly rather than stepping it, so the angle covered
+    // over an interval is the same however many frames it is split into.
+    if (to <= from) {
+        return 0.0f;
+    }
+    float capAt = _acceleration > 0.0f ? (_maxRate - _minRate) / _acceleration
+                                       : 0.0f;
+    float rampFrom = glm::min(from, capAt);
+    float rampTo = glm::min(to, capAt);
+    float angle = 0.0f;
+    if (rampTo > rampFrom) {
+        angle += _minRate * (rampTo - rampFrom) +
+                 0.5f * _acceleration * (rampTo * rampTo - rampFrom * rampFrom);
+    }
+    float flatFrom = glm::max(from, capAt);
+    float flatTo = glm::max(to, capAt);
+    if (flatTo > flatFrom) {
+        angle += _maxRate * (flatTo - flatFrom);
+    }
+    return angle;
+}
+
+float TurretAimRate::advance(float dt) {
+    if (_direction == 0 || dt <= 0.0f) {
+        return 0.0f;
+    }
+    float from = _held;
+    _held += dt;
+    return static_cast<float>(_direction) * angleOver(from, _held);
+}
+
+void TurretAim::addPitch(float radians) {
+    _pitch += radians;
+    if (_pitchBounded) {
+        _pitch = glm::clamp(_pitch, _minPitch, _maxPitch);
+    } else {
+        _pitch = normalizeAngle(_pitch);
+    }
+}
+
+void TurretAim::addYaw(float radians) {
+    _yaw += radians;
+    if (_yawBounded) {
+        _yaw = glm::clamp(_yaw, _minYaw, _maxYaw);
+    } else {
+        _yaw = normalizeAngle(_yaw);
+    }
+}
+
+glm::quat TurretAim::orientation() const {
+    return glm::angleAxis(_yaw, glm::vec3(0.0f, 0.0f, 1.0f)) *
+           glm::angleAxis(_pitch, glm::vec3(1.0f, 0.0f, 0.0f));
+}
+
+glm::vec3 TurretAim::forward() const {
+    return orientation() * kModelForward;
+}
+
+void TurretGunTimer::update(float dt) {
+    if (_cooldown > 0.0f) {
+        _cooldown = glm::max(0.0f, _cooldown - dt);
+    }
+}
+
+bool TurretGunTimer::tryFire() {
+    if (_cooldown > 0.0f) {
+        return false;
+    }
+    _cooldown = _rateOfFire;
+    return true;
+}
+
+bool TurretBullet::advance(float dt) {
+    life += dt;
+    if (life >= lifespan) {
+        return false;
+    }
+    position += direction * speed * dt;
+    return true;
+}
+
+const std::string kTurretAlarmTag("Alarm01");
+
+bool turretIsDestroyed(int hitPoints) {
+    // The shipped script's destruction branch: below the gauge floor the hawk is
+    // gone. It does not wait for hit points to reach zero, so the authored
+    // survivable band on a 3000 point hawk is 3000 down to 2000.
+    return hitPoints < kTurretGaugeFloor;
+}
+
+int turretHealthState(int hitPoints) {
+    // The shipped script only evaluates its formula on the healthy branch; below
+    // the floor it takes the destruction branch and plays Health00 outright. Do
+    // the same rather than extrapolating the formula, whose truncating division
+    // would otherwise still report a live state just under the floor.
+    if (hitPoints < kTurretGaugeFloor) {
+        return 0;
+    }
+    // Shipped arithmetic: ((hp - 2000) * 12) / 1000 + 1, integer division.
+    long long scaled = (static_cast<long long>(hitPoints) - kTurretGaugeFloor) *
+                       (kTurretHealthStateCount - 1);
+    int state = static_cast<int>(scaled / kTurretGaugeSpan) + 1;
+    // An undamaged hawk evaluates to 13; the script never sees it because
+    // OnDamage runs after damage, but clamp so full health reads as full.
+    return glm::clamp(state, 1, kTurretHealthStateCount - 1);
+}
+
+std::string turretHealthAnimation(int state) {
+    int clamped = glm::clamp(state, 0, kTurretHealthStateCount - 1);
+    // The script builds the name as "Health0" + n below ten, "Health" + n above.
+    return str(boost::format("health%02d") % clamped);
+}
+
+bool turretAlarmStartsAtState(int state) {
+    return state == kTurretAlarmState;
+}
+
+std::string turretContactAnimation(size_t enemyIndex) {
+    if (enemyIndex >= kTurretContactCount) {
+        return {};
+    }
+    // Enemy 0 rides track m12ab_mgt02, so the contact channels start at 02.
+    return str(boost::format("sithloop%02u") % (enemyIndex + 2));
+}
+
+std::string turretContactDeathAnimation(size_t enemyIndex) {
+    auto live = turretContactAnimation(enemyIndex);
+    return live.empty() ? live : live + "d";
+}
+
+int turretHeadingState(float yawRadians) {
+    float degrees = glm::degrees(yawRadians);
+    // Round to the nearest authored whole degree, then wrap into [0, 360).
+    int heading = static_cast<int>(glm::round(degrees));
+    heading %= 360;
+    if (heading < 0) {
+        heading += 360;
+    }
+    return heading;
+}
+
+std::string turretHeadingAnimation(int heading) {
+    int wrapped = heading % 360;
+    if (wrapped < 0) {
+        wrapped += 360;
+    }
+    return str(boost::format("hudrot_%03d") % wrapped);
+}
+
+TurretRequestError validateTurretRequest(const std::string &target,
+                                         const std::string &originModule,
+                                         bool moduleKnown,
+                                         bool alreadyActive) {
+    if (alreadyActive) {
+        return TurretRequestError::AlreadyActive;
+    }
+    if (target.empty()) {
+        return TurretRequestError::MissingModule;
+    }
+    if (originModule.empty()) {
+        return TurretRequestError::NoOrigin;
+    }
+    if (!moduleKnown) {
+        return TurretRequestError::UnknownModule;
+    }
+    if (boost::iequals(target, originModule)) {
+        return TurretRequestError::SameModule;
+    }
+    return TurretRequestError::None;
+}
+
+const char *turretRequestErrorMessage(TurretRequestError error) {
+    switch (error) {
+    case TurretRequestError::MissingModule:
+        return "no module given";
+    case TurretRequestError::UnknownModule:
+        return "unknown module";
+    case TurretRequestError::SameModule:
+        return "already in that module";
+    case TurretRequestError::NoOrigin:
+        return "no origin module loaded";
+    case TurretRequestError::AlreadyActive:
+        return "a turret session is already active";
+    default:
+        return "";
+    }
+}
+
+TurretRequestResolution resolveTurretRequest(bool pendingForModule,
+                                             bool hasMinigame,
+                                             MinigameType type) {
+    if (!pendingForModule) {
+        return TurretRequestResolution::NotPending;
+    }
+    if (!hasMinigame) {
+        return TurretRequestResolution::AbortNoMinigame;
+    }
+    if (type != MinigameType::Turret) {
+        return TurretRequestResolution::AbortWrongType;
+    }
+    return TurretRequestResolution::Start;
+}
+
+const char *turretRequestResolutionMessage(TurretRequestResolution resolution) {
+    switch (resolution) {
+    case TurretRequestResolution::AbortNoMinigame:
+        return "module has no minigame";
+    case TurretRequestResolution::AbortWrongType:
+        return "module is not a turret minigame";
+    default:
+        return "";
+    }
+}
+
+std::string turretReturnModule(const std::string &turretModule,
+                               const std::string &originModule) {
+    // Vanilla turret exit, confirmed from local assets: the M12ab enemy death
+    // scripts (k_pebo_sthdeath2..7) and the module heartbeat (k_pebo_mgheart)
+    // both end the sequence with StartNewModule("ebo_m12aa"). Other modules are
+    // not wired, so they fall back to wherever the session started.
+    if (boost::iequals(turretModule, "m12ab")) {
+        return "ebo_m12aa";
+    }
+    return originModule;
+}
+
+glm::vec3 turretFireDirection(const glm::quat &shooterOrientation) {
+    glm::vec3 direction(shooterOrientation * kModelForward);
+    float length = glm::length(direction);
+    return length > 0.0f ? direction / length : kModelForward;
+}
+
+glm::mat4 turretBulletTransform(const TurretBullet &bullet) {
+    glm::mat4 transform(1.0f);
+    transform *= glm::translate(bullet.position);
+    transform *= glm::mat4_cast(bullet.orientation);
+    return transform;
+}
+
+bool sphereContainsPoint(const glm::vec3 &center, float radius, const glm::vec3 &point) {
+    if (radius <= 0.0f) {
+        return false;
+    }
+    return glm::distance2(center, point) <= radius * radius;
+}
+
+bool rayIntersectsSphere(const glm::vec3 &origin,
+                         const glm::vec3 &direction,
+                         const glm::vec3 &center,
+                         float radius,
+                         float maxDistance) {
+    if (radius <= 0.0f || maxDistance <= 0.0f) {
+        return false;
+    }
+    glm::vec3 toCenter(center - origin);
+    float alongRay = glm::dot(toCenter, direction);
+    float perpSq = glm::dot(toCenter, toCenter) - alongRay * alongRay;
+    float radiusSq = radius * radius;
+    if (perpSq > radiusSq) {
+        return false;
+    }
+    float halfChord = glm::sqrt(radiusSq - perpSq);
+    float exit = alongRay + halfChord;
+    if (exit < 0.0f) {
+        return false;
+    }
+    float entry = alongRay - halfChord;
+    return glm::max(entry, 0.0f) <= maxDistance;
+}
+
+std::shared_ptr<ModelSceneNode> Turret::loadModel(const std::string &resRef) {
+    if (resRef.empty()) {
+        return nullptr;
+    }
+    auto model = _services.resource.models.get(resRef);
+    if (!model) {
+        return nullptr;
+    }
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+    auto node = sceneGraph.newModel(*model, ModelUsage::Placeable);
+    node->setDrawDistance(_game.options().graphics.drawDistance);
+    playIdleAnimation(*node);
+    return node;
+}
+
+std::shared_ptr<ModelSceneNode> Turret::loadTrack(const std::string &resRef,
+                                                  const glm::vec3 &position) {
+    auto node = loadModel(resRef);
+    if (!node) {
+        return nullptr;
+    }
+    node->setLocalTransform(glm::translate(position));
+    // Tracks are authored as a single looping animation that walks the
+    // "modelhook" node along the rail; everything riding the track is parented
+    // to that hook.
+    auto animations = node->model().getAnimationNames();
+    if (!animations.empty()) {
+        node->playAnimation(animations.front(), nullptr,
+                            AnimationProperties::fromFlags(AnimationFlags::loop));
+    }
+    // The scene graph decides culling per model root and prunes the whole
+    // subtree behind a culled one. A track root sits at its authored origin
+    // while the rail animation carries the hook - and everything riding it,
+    // including the camera - far away, so distance and frustum culling of the
+    // root would blink the actors in and out. This is the case the scene node
+    // culling flag exists for.
+    node->setCullingEnabled(false);
+    node->setDrawDistance(std::numeric_limits<float>::max());
+    _services.scene.graphs.get(kSceneMain).addRoot(node);
+    return node;
+}
+
+void Turret::loadGunBanks(const std::vector<MinigameGunBankSpec> &specs,
+                          ModelSceneNode &mount,
+                          std::vector<GunBank> &out) {
+    for (const auto &spec : specs) {
+        GunBank bank;
+        bank.spec = &spec;
+        bank.timer = TurretGunTimer(spec.bullet.rateOfFire);
+        bank.modelNode = loadModel(spec.gunModelResRef);
+        if (bank.modelNode) {
+            mount.attach(gunBankHookName(spec.bankId), *bank.modelNode);
+        }
+        out.push_back(std::move(bank));
+    }
+}
+
+bool Turret::loadPlayer(const MinigameSpec &spec) {
+    for (const auto &model : spec.player.models) {
+        auto node = loadModel(model.resRef);
+        if (!node) {
+            debug("turret: player model '" + model.resRef + "' missing");
+            continue;
+        }
+        if (model.rotating) {
+            if (!_turretRoot) {
+                _turretRoot = std::move(node);
+            } else {
+                _turretRoot->addChild(*node);
+                _turretChildNodes.push_back(std::move(node));
+            }
+        } else {
+            if (!_bodyRoot) {
+                _bodyRoot = std::move(node);
+            } else {
+                _bodyRoot->addChild(*node);
+                _bodyChildNodes.push_back(std::move(node));
+            }
+        }
+    }
+    if (!_turretRoot) {
+        return false;
+    }
+
+    // Both groups ride the player track's hook so the hull and the gun stay
+    // together; only the rotating group takes the aim rotation on top.
+    if (_playerTrackNode) {
+        _playerTrackNode->attach(kModelHookName, *_turretRoot);
+        if (_bodyRoot) {
+            _playerTrackNode->attach(kModelHookName, *_bodyRoot);
+        }
+    } else {
+        // No usable track: the actors become roots of their own. They are still
+        // driven by transform rather than by the camera's own frame, so keep
+        // them out of the culling pass for the same reason as the tracks.
+        auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+        _turretRoot->setCullingEnabled(false);
+        sceneGraph.addRoot(_turretRoot);
+        if (_bodyRoot) {
+            _bodyRoot->setCullingEnabled(false);
+            sceneGraph.addRoot(_bodyRoot);
+        }
+    }
+
+    loadGunBanks(spec.player.gunBanks, *_turretRoot, _gunBanks);
+    return true;
+}
+
+void Turret::loadEnemies(const MinigameSpec &spec) {
+    auto layout = _services.resource.layouts.get(_areaName);
+    for (const auto &enemySpec : spec.enemies) {
+        Enemy enemy;
+        enemy.spec = &enemySpec;
+        enemy.hitPoints = static_cast<int>(enemySpec.hitPoints);
+
+        glm::vec3 trackPos(0.0f);
+        if (layout) {
+            if (auto placement = layout->findTrackByName(enemySpec.trackResRef)) {
+                trackPos = placement->get().position;
+            }
+        }
+        enemy.trackNode = loadTrack(enemySpec.trackResRef, trackPos);
+
+        for (const auto &model : enemySpec.models) {
+            auto node = loadModel(model.resRef);
+            if (!node) {
+                continue;
+            }
+            if (!enemy.modelNode) {
+                enemy.modelNode = std::move(node);
+            } else {
+                enemy.modelNode->addChild(*node);
+                enemy.extraNodes.push_back(std::move(node));
+            }
+        }
+        if (!enemy.modelNode) {
+            debug("turret: enemy on track '" + enemySpec.trackResRef + "' has no model");
+            continue;
+        }
+        if (enemy.trackNode) {
+            enemy.trackNode->attach(kModelHookName, *enemy.modelNode);
+        } else {
+            enemy.modelNode->setCullingEnabled(false);
+            _services.scene.graphs.get(kSceneMain).addRoot(enemy.modelNode);
+        }
+        for (const auto &bankSpec : enemySpec.gunBanks) {
+            GunBank bank;
+            bank.spec = &bankSpec;
+            bank.timer = TurretGunTimer(bankSpec.bullet.rateOfFire);
+            bank.modelNode = loadModel(bankSpec.gunModelResRef);
+            if (bank.modelNode) {
+                enemy.modelNode->attach(gunBankHookName(bankSpec.bankId), *bank.modelNode);
+            }
+            enemy.gunBanks.push_back(std::move(bank));
+        }
+        _enemies.push_back(std::move(enemy));
+    }
+}
+
+bool Turret::start(const MinigameSpec &spec, FirstPersonCamera *camera, const std::string &areaName) {
+    if (_active) {
+        return false;
+    }
+    _spec = spec;
+    _areaName = areaName;
+    _camera = camera;
+    _outcome = Outcome::InProgress;
+    _elapsed = 0.0f;
+    _firing = false;
+
+    _trackResRef = _spec.player.trackResRef;
+    _playerSphereRadius = _spec.player.sphereRadius;
+    _maxHitPoints = static_cast<int>(_spec.player.maxHitPoints > 0
+                                         ? _spec.player.maxHitPoints
+                                         : _spec.player.hitPoints);
+    _hitPoints = static_cast<int>(_spec.player.hitPoints);
+    // Replaying a session starts from the authored aim with no carried-over
+    // input velocity.
+    _aim.configure(_spec.player);
+    _pitchRate.configure(_aim.pitchTravel());
+    _yawRate.configure(_aim.yawTravel());
+
+    glm::vec3 trackPos(0.0f);
+    _anchorSource = "origin";
+    if (auto layout = _services.resource.layouts.get(_areaName)) {
+        if (auto placement = layout->findTrackByName(_trackResRef)) {
+            trackPos = placement->get().position;
+            _anchorSource = "lyt-track";
+        }
+    }
+    _playerTrackNode = loadTrack(_trackResRef, trackPos);
+    if (_playerTrackNode) {
+        if (_anchorSource == "origin") {
+            _anchorSource = "track-model";
+        }
+    } else {
+        _anchorSource = "no-track";
+    }
+
+    if (!loadPlayer(_spec)) {
+        debug("turret: no visible player models loaded");
+        detachAll();
+        _camera = nullptr;
+        return false;
+    }
+    loadEnemies(_spec);
+
+    // The camera mount model is not added to the scene: only its static
+    // "camerahook" transform is needed, and vanilla hides the mount anyway.
+    _cameraHookLocal = glm::mat4(1.0f);
+    _haveCameraHook = false;
+    if (!_spec.player.cameraResRef.empty()) {
+        if (auto cameraModel = _services.resource.models.get(_spec.player.cameraResRef)) {
+            if (auto hook = cameraModel->getNodeByNameRecursive(kCameraHookName)) {
+                _cameraHookLocal = hook->absoluteTransform();
+                _haveCameraHook = true;
+            }
+        }
+    }
+
+    _active = true;
+    suppressCanopyGlass();
+    bindHudPanes();
+    resetHud();
+    setCameraFieldOfView(_spec.cameraViewAngle > 0.0f ? _spec.cameraViewAngle
+                                                      : kDefaultCameraFovDegrees);
+    updateAnchor();
+    updatePlayerTransforms();
+    updateCamera();
+    return true;
+}
+
+void Turret::stop() {
+    if (!_active) {
+        return;
+    }
+    // Restore the reused camera's projection before releasing it.
+    if (_camera) {
+        _camera->cameraSceneNode()->setPerspectiveProjection(
+            glm::radians(kDefaultCameraFovDegrees),
+            cameraAspect(),
+            kDefaultClipPlaneNear,
+            kDefaultClipPlaneFar);
+    }
+    clearHud();
+    _healthHud.reset();
+    _radarHud.reset();
+    _contactAlive.clear();
+    _healthState = -1;
+    _headingState = -1;
+    _active = false;
+    _camera = nullptr;
+    _pitchRate.reset();
+    _yawRate.reset();
+    _firing = false;
+    detachAll();
+}
+
+namespace {
+
+// Detach whatever was attached to a hook node of \p model. ModelSceneNode
+// attachments are parented to a nested node, so clearing the model's own
+// children is not enough.
+void clearHook(const std::shared_ptr<ModelSceneNode> &model, const std::string &hookName) {
+    if (!model) {
+        return;
+    }
+    if (auto hook = model->getNodeByName(hookName)) {
+        hook->removeAllChildren();
+    }
+}
+
+} // namespace
+
+void Turret::detachAll() {
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+
+    for (auto &bullet : _bullets) {
+        releaseBulletNode(bullet);
+    }
+    _bullets.clear();
+    for (auto &pooled : _bulletNodePool) {
+        pooled.second.clear();
+    }
+    _bulletNodePool.clear();
+
+    for (auto &enemy : _enemies) {
+        for (auto &bank : enemy.gunBanks) {
+            if (bank.spec) {
+                clearHook(enemy.modelNode, gunBankHookName(bank.spec->bankId));
+            }
+        }
+        enemy.gunBanks.clear();
+        clearHook(enemy.trackNode, kModelHookName);
+        if (enemy.modelNode) {
+            enemy.modelNode->removeAllChildren();
+            sceneGraph.removeRoot(*enemy.modelNode);
+        }
+        if (enemy.trackNode) {
+            sceneGraph.removeRoot(*enemy.trackNode);
+        }
+    }
+    _enemies.clear();
+
+    for (auto &bank : _gunBanks) {
+        if (bank.spec) {
+            clearHook(_turretRoot, gunBankHookName(bank.spec->bankId));
+        }
+    }
+    _gunBanks.clear();
+
+    clearHook(_playerTrackNode, kModelHookName);
+    if (_turretRoot) {
+        _turretRoot->removeAllChildren();
+        sceneGraph.removeRoot(*_turretRoot);
+    }
+    if (_bodyRoot) {
+        _bodyRoot->removeAllChildren();
+        sceneGraph.removeRoot(*_bodyRoot);
+    }
+    if (_playerTrackNode) {
+        sceneGraph.removeRoot(*_playerTrackNode);
+    }
+    _turretChildNodes.clear();
+    _bodyChildNodes.clear();
+    _turretRoot.reset();
+    _bodyRoot.reset();
+    _playerTrackNode.reset();
+}
+
+size_t Turret::contactsLive() const {
+    return static_cast<size_t>(std::count(_contactAlive.begin(), _contactAlive.end(), true));
+}
+
+size_t Turret::radarChannelCount() const {
+    return _radarHud ? _radarHud->animationChannelCount() : 0;
+}
+
+size_t Turret::enemiesAlive() const {
+    size_t count = 0;
+    for (const auto &enemy : _enemies) {
+        if (enemy.alive) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void Turret::update(float dt) {
+    if (!_active || dt <= 0.0f) {
+        return;
+    }
+    _elapsed += dt;
+
+    _aim.addPitch(_pitchRate.advance(dt));
+    _aim.addYaw(_yawRate.advance(dt));
+
+    updateAnchor();
+    updatePlayerTransforms();
+    updateCamera();
+
+    for (auto &bank : _gunBanks) {
+        bank.timer.update(dt);
+    }
+    if (_firing) {
+        fire();
+    }
+
+    updateEnemies(dt);
+    updateBullets(dt);
+    updateHeadingHud();
+
+    if (_outcome == Outcome::InProgress) {
+        if (turretIsDestroyed(_hitPoints)) {
+            _outcome = Outcome::Lost;
+        } else if (!_enemies.empty() && enemiesAlive() == 0) {
+            _outcome = Outcome::Won;
+        }
+    }
+}
+
+void Turret::updateAnchor() {
+    if (_playerTrackNode) {
+        if (auto hook = _playerTrackNode->getNodeByName(kModelHookName)) {
+            _anchorTransform = hook->absoluteTransform();
+        } else {
+            _anchorTransform = _playerTrackNode->absoluteTransform();
+        }
+    } else {
+        _anchorTransform = glm::mat4(1.0f);
+    }
+    _anchorPosition = transformOrigin(_anchorTransform);
+}
+
+void Turret::updatePlayerTransforms() {
+    // The roots are parented to the track hook, so their local transform is the
+    // actor's placement within the hook frame: both groups sit on the hook and
+    // only the rotating one takes the aim rotation.
+    //
+    // The authored Start_Offset is deliberately not applied. Its turret meaning
+    // is unconfirmed (KotOR.js ignores it too), and m12ab's Start_Offset_X of 7
+    // slides the gun sideways out of its mount, leaving the Ebon Hawk hull
+    // clipping through the turret frame.
+    if (_bodyRoot) {
+        _bodyRoot->setLocalTransform(glm::mat4(1.0f));
+    }
+    if (_turretRoot) {
+        _turretRoot->setLocalTransform(glm::mat4_cast(_aim.orientation()));
+    }
+}
+
+void Turret::updateCamera() {
+    if (!_camera || !_turretRoot) {
+        return;
+    }
+    glm::mat4 eye = _turretRoot->absoluteTransform();
+    if (_haveCameraHook) {
+        eye *= _cameraHookLocal;
+    }
+    _camera->cameraSceneNode()->setLocalTransform(eye);
+}
+
+void Turret::setCameraFieldOfView(float fovDegrees) {
+    if (!_camera) {
+        return;
+    }
+    float nearClip = _spec.nearClip > 0.0f ? _spec.nearClip : kDefaultClipPlaneNear;
+    float farClip = _spec.farClip > 0.0f ? _spec.farClip : kDefaultClipPlaneFar;
+    _camera->cameraSceneNode()->setPerspectiveProjection(
+        glm::radians(fovDegrees),
+        cameraAspect(),
+        nearClip,
+        farClip);
+}
+
+float Turret::cameraAspect() const {
+    const auto &graphicsOpts = _game.options().graphics;
+    if (graphicsOpts.height <= 0) {
+        return 1.0f;
+    }
+    return graphicsOpts.width / static_cast<float>(graphicsOpts.height);
+}
+
+void Turret::fire() {
+    if (!_turretRoot) {
+        return;
+    }
+    bool fired = false;
+    for (auto &bank : _gunBanks) {
+        if (!bank.spec || !bank.timer.tryFire()) {
+            continue;
+        }
+        glm::mat4 muzzle = _turretRoot->absoluteTransform();
+        if (bank.modelNode) {
+            if (auto hook = bank.modelNode->getNodeByName(kBulletHookName)) {
+                muzzle = hook->absoluteTransform();
+            } else {
+                muzzle = bank.modelNode->absoluteTransform();
+            }
+            bank.modelNode->playAnimation("fire");
+        }
+        // The muzzle decides only where the bolt appears; its travel and its
+        // orientation both come from the turret itself, so every bank fires
+        // symmetrically and the aim adds no extra rotation per bank.
+        spawnBullet(*bank.spec,
+                    transformOrigin(muzzle),
+                    transformOrientation(_turretRoot->absoluteTransform()),
+                    /*fromPlayer=*/true);
+        if (!bank.spec->fireSound.empty()) {
+            playSound(bank.spec->fireSound);
+        }
+        fired = true;
+    }
+    if (fired && _turretRoot) {
+        _turretRoot->playAnimation("fire");
+    }
+}
+
+void Turret::spawnBullet(const MinigameGunBankSpec &bank,
+                         const glm::vec3 &origin,
+                         const glm::quat &orientation,
+                         bool fromPlayer) {
+    Bullet bullet;
+    bullet.sim.position = origin;
+    bullet.sim.orientation = orientation;
+    bullet.sim.direction = turretFireDirection(orientation);
+    bullet.sim.speed = bank.bullet.speed;
+    bullet.sim.lifespan = bank.bullet.lifespan;
+    bullet.sim.damage = bank.bullet.damage;
+    bullet.sim.fromPlayer = fromPlayer;
+    bullet.modelResRef = bank.bullet.modelResRef;
+    bullet.collisionSound = bank.bullet.collisionSound;
+
+    bullet.modelNode = acquireBulletNode(bullet.modelResRef);
+    if (bullet.modelNode) {
+        bullet.modelNode->setLocalTransform(turretBulletTransform(bullet.sim));
+        _services.scene.graphs.get(kSceneMain).addRoot(bullet.modelNode);
+    }
+    _bullets.push_back(std::move(bullet));
+}
+
+std::shared_ptr<ModelSceneNode> Turret::acquireBulletNode(const std::string &resRef) {
+    auto pooled = _bulletNodePool.find(resRef);
+    if (pooled != _bulletNodePool.end() && !pooled->second.empty()) {
+        auto node = std::move(pooled->second.back());
+        pooled->second.pop_back();
+        return node;
+    }
+    auto node = loadModel(resRef);
+    if (node) {
+        silenceEmitters(*node);
+    }
+    return node;
+}
+
+void Turret::releaseBulletNode(Bullet &bullet) {
+    if (!bullet.modelNode) {
+        return;
+    }
+    _services.scene.graphs.get(kSceneMain).removeRoot(*bullet.modelNode);
+    _bulletNodePool[bullet.modelResRef].push_back(std::move(bullet.modelNode));
+}
+
+void Turret::updateEnemies(float dt) {
+    for (auto &enemy : _enemies) {
+        if (!enemy.modelNode) {
+            continue;
+        }
+        const glm::mat4 &transform = enemy.modelNode->absoluteTransform();
+        enemy.position = transformOrigin(transform);
+        enemy.orientation = transformOrientation(transform);
+        enemy.forward = turretFireDirection(enemy.orientation);
+
+        if (!enemy.alive) {
+            if (!enemy.deathHandled) {
+                enemy.deathHandled = true;
+                enemy.modelNode->playAnimation("die");
+                if (enemy.spec && !enemy.spec->sounds.death.empty()) {
+                    playSound(enemy.spec->sounds.death);
+                }
+            }
+            continue;
+        }
+
+        for (auto &bank : enemy.gunBanks) {
+            bank.timer.update(dt);
+            if (!bank.spec || !bank.timer.ready()) {
+                continue;
+            }
+            float sensing = bank.spec->sensingRadius > 0.0f
+                                ? bank.spec->sensingRadius
+                                : kFallbackSensingRadius;
+            if (!rayIntersectsSphere(enemy.position, enemy.forward,
+                                     _anchorPosition, _playerSphereRadius, sensing)) {
+                continue;
+            }
+            if (!bank.timer.tryFire()) {
+                continue;
+            }
+            glm::vec3 muzzle = enemy.position;
+            if (bank.modelNode) {
+                if (auto hook = bank.modelNode->getNodeByName(kBulletHookName)) {
+                    muzzle = transformOrigin(hook->absoluteTransform());
+                }
+            }
+            spawnBullet(*bank.spec, muzzle, enemy.orientation, /*fromPlayer=*/false);
+            if (!bank.spec->fireSound.empty()) {
+                playSound(bank.spec->fireSound);
+            }
+        }
+    }
+}
+
+void Turret::updateBullets(float dt) {
+    for (auto it = _bullets.begin(); it != _bullets.end();) {
+        auto &bullet = *it;
+        if (!bullet.sim.advance(dt)) {
+            releaseBulletNode(bullet);
+            it = _bullets.erase(it);
+            continue;
+        }
+        if (bullet.modelNode) {
+            bullet.modelNode->setLocalTransform(turretBulletTransform(bullet.sim));
+        }
+
+        bool hit = false;
+        if (bullet.sim.fromPlayer) {
+            for (auto &enemy : _enemies) {
+                if (!enemy.alive || !enemy.spec) {
+                    continue;
+                }
+                if (!sphereContainsPoint(enemy.position, enemy.spec->sphereRadius, bullet.sim.position)) {
+                    continue;
+                }
+                damageEnemy(enemy, bullet.sim.damage);
+                hit = true;
+                break;
+            }
+        } else if (sphereContainsPoint(_anchorPosition, _playerSphereRadius, bullet.sim.position)) {
+            damagePlayer(bullet.sim.damage);
+            hit = true;
+        }
+
+        if (hit) {
+            if (!bullet.collisionSound.empty()) {
+                playSound(bullet.collisionSound);
+            }
+            releaseBulletNode(bullet);
+            it = _bullets.erase(it);
+            continue;
+        }
+        ++it;
+    }
+}
+
+void Turret::damagePlayer(uint32_t amount) {
+    if (turretIsDestroyed(_hitPoints)) {
+        return; // already destroyed: the destruction branch runs once
+    }
+    _hitPoints = glm::max(0, _hitPoints - static_cast<int>(amount));
+    // Vanilla drives the gauge from the player's OnDamage script, i.e. once per
+    // hit rather than once per frame. That script plays no cockpit "damage"
+    // animation and touches no LED node, so neither is triggered here.
+    updateHealthHud();
+}
+
+void Turret::damageEnemy(Enemy &enemy, uint32_t amount) {
+    if (!enemy.alive) {
+        return;
+    }
+    enemy.hitPoints -= static_cast<int>(amount);
+    if (enemy.hitPoints <= 0) {
+        enemy.hitPoints = 0;
+        enemy.alive = false;
+        killContactHud(static_cast<size_t>(&enemy - _enemies.data()));
+    } else if (enemy.modelNode) {
+        enemy.modelNode->playAnimation("damage");
+    }
+}
+
+void Turret::suppressCanopyGlass() {
+    if (!_turretRoot) {
+        return;
+    }
+    // Hide the canopy glass until additive environment-mapped model materials
+    // can be rendered without compositing across the cockpit. Both shells are
+    // authored inward-facing and enclose the camera, so at full strength they
+    // lay the scratch texture over the whole field of view - twice. The nodes
+    // stay in the loaded model and the shipped resource is untouched; only this
+    // session's cockpit instance stops drawing them.
+    static const std::array<const char *, 2> kGlassNodes {"sphere04", "sphere05"};
+    for (const auto *name : kGlassNodes) {
+        auto node = _turretRoot->getNodeByName(name);
+        if (!node) {
+            debug(str(boost::format("turret: canopy glass node '%s' not present") % name));
+            continue;
+        }
+        node->setEnabled(false);
+    }
+}
+
+void Turret::bindHudPanes() {
+    // The HUD panes are ordinary entries in the player's rotating model set;
+    // find them by resref so the gauge and the radar can be driven separately.
+    auto findPane = [this](const std::string &resRef) -> std::shared_ptr<ModelSceneNode> {
+        if (_turretRoot && boost::iequals(_turretRoot->model().name(), resRef)) {
+            return _turretRoot;
+        }
+        for (const auto &node : _turretChildNodes) {
+            if (boost::iequals(node->model().name(), resRef)) {
+                return node;
+            }
+        }
+        return nullptr;
+    };
+    _healthHud = findPane("mgf_hud02");
+    _radarHud = findPane("mgf_hud01");
+}
+
+void Turret::resetHud() {
+    // A replayed session must not inherit the previous run's gauge, heading,
+    // contacts or alarm.
+    clearHud();
+    // No damage state is selected yet. The shipped script only ever plays a
+    // Health animation from its damage path, so a pristine session shows the
+    // model's authored rest pose - forcing Health12 up front would put the
+    // gauge into its healthiest *damaged* state, and on the lower states would
+    // switch on damage lighting that should not exist before the first hit.
+    _healthState = -1;
+    _headingState = -1;
+    _contactAlive.assign(_enemies.size(), true);
+    startContactHud();
+    updateHeadingHud();
+}
+
+void Turret::updateHealthHud() {
+    int state = turretHealthState(_hitPoints);
+    if (state == _healthState) {
+        // Nothing crossed a band boundary, so leave the running clip alone -
+        // the low states are animated and must not be restarted every frame.
+        return;
+    }
+
+    // The shipped script starts the alarm on the frame the state becomes 3, and
+    // never restarts or clears it except in the destruction branch.
+    if (turretAlarmStartsAtState(state)) {
+        setAlarmActive(true);
+    }
+
+    if (_healthHud) {
+        if (_healthState >= 0) {
+            _healthHud->removeAnimation(turretHealthAnimation(_healthState));
+        }
+        _healthHud->playAnimation(turretHealthAnimation(state), nullptr,
+                                  AnimationProperties::fromFlags(AnimationFlags::loopOverlay));
+    }
+    _healthState = state;
+}
+
+void Turret::updateHeadingHud() {
+    int heading = turretHeadingState(_aim.yaw());
+    if (heading == _headingState) {
+        return;
+    }
+    if (_radarHud) {
+        if (_headingState >= 0) {
+            _radarHud->removeAnimation(turretHeadingAnimation(_headingState));
+        }
+        // Heading poses are zero length; overlay keeps them from disturbing the
+        // contact loops, which animate entirely different nodes.
+        _radarHud->playAnimation(turretHeadingAnimation(heading), nullptr,
+                                 AnimationProperties::fromFlags(AnimationFlags::loopOverlay));
+    }
+    _headingState = heading;
+}
+
+void Turret::startContactHud() {
+    if (!_radarHud) {
+        return;
+    }
+    for (size_t i = 0; i < _enemies.size() && i < kTurretContactCount; ++i) {
+        // Clear any death pose left by a previous session before re-arming.
+        _radarHud->removeAnimation(turretContactDeathAnimation(i));
+        _radarHud->playAnimation(turretContactAnimation(i), nullptr,
+                                 AnimationProperties::fromFlags(AnimationFlags::loopOverlay));
+    }
+}
+
+void Turret::killContactHud(size_t enemyIndex) {
+    if (enemyIndex >= _contactAlive.size() || !_contactAlive[enemyIndex]) {
+        return; // already dead: repeated notification is harmless
+    }
+    _contactAlive[enemyIndex] = false;
+    if (!_radarHud || enemyIndex >= kTurretContactCount) {
+        return;
+    }
+    // Swap the live loop for the authored removal pose, leaving the other five
+    // contacts and the heading untouched.
+    _radarHud->removeAnimation(turretContactAnimation(enemyIndex));
+    _radarHud->playAnimation(turretContactDeathAnimation(enemyIndex), nullptr,
+                             AnimationProperties::fromFlags(AnimationFlags::loopOverlay));
+}
+
+void Turret::clearHud() {
+    setAlarmActive(false);
+    if (_radarHud) {
+        for (size_t i = 0; i < kTurretContactCount; ++i) {
+            _radarHud->removeAnimation(turretContactAnimation(i));
+            _radarHud->removeAnimation(turretContactDeathAnimation(i));
+        }
+        if (_headingState >= 0) {
+            _radarHud->removeAnimation(turretHeadingAnimation(_headingState));
+        }
+    }
+    if (_healthHud && _healthState >= 0) {
+        _healthHud->removeAnimation(turretHealthAnimation(_healthState));
+    }
+}
+
+void Turret::setAlarmActive(bool active) {
+    if (active == _alarmActive) {
+        return; // never restart a looping sound that is already running
+    }
+    _alarmActive = active;
+    // Drive the authored module sound object rather than an ad hoc source.
+    auto module = _game.module();
+    auto area = module ? module->area() : nullptr;
+    if (!area) {
+        return;
+    }
+    auto object = area->getObjectByTag(kTurretAlarmTag);
+    if (!object || object->type() != ObjectType::Sound) {
+        return;
+    }
+    std::static_pointer_cast<Sound>(object)->setActive(active);
+}
+
+void Turret::playSound(const std::string &resRef) {
+    auto clip = _services.resource.audioClips.get(resRef);
+    if (!clip) {
+        return;
+    }
+    _services.audio.mixer.play(std::move(clip), AudioType::Sound);
+}
+
+bool Turret::handle(const input::Event &event) {
+    switch (event.type) {
+    case input::EventType::KeyDown:
+        return handleKeyDown(event.key);
+    case input::EventType::KeyUp:
+        return handleKeyUp(event.key);
+    case input::EventType::MouseMotion:
+        return handleMouseMotion(event.motion);
+    case input::EventType::MouseButtonDown:
+    case input::EventType::MouseButtonUp:
+        return handleMouseButton(event.button);
+    default:
+        return false;
+    }
+}
+
+bool Turret::handleKeyDown(const input::KeyEvent &event) {
+    switch (event.code) {
+    case input::KeyCode::Up:
+    case input::KeyCode::W:
+        _pitchRate.setDirection(1);
+        return true;
+    case input::KeyCode::Down:
+    case input::KeyCode::S:
+        _pitchRate.setDirection(-1);
+        return true;
+    case input::KeyCode::Left:
+    case input::KeyCode::A:
+        _yawRate.setDirection(1);
+        return true;
+    case input::KeyCode::Right:
+    case input::KeyCode::D:
+        _yawRate.setDirection(-1);
+        return true;
+    case input::KeyCode::Space:
+        _firing = true;
+        return true;
+    case input::KeyCode::Escape:
+        _game.exitTurret();
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool Turret::handleKeyUp(const input::KeyEvent &event) {
+    switch (event.code) {
+    case input::KeyCode::Up:
+    case input::KeyCode::W:
+        if (_pitchRate.direction() == 1) {
+            _pitchRate.setDirection(0);
+        }
+        return true;
+    case input::KeyCode::Down:
+    case input::KeyCode::S:
+        if (_pitchRate.direction() == -1) {
+            _pitchRate.setDirection(0);
+        }
+        return true;
+    case input::KeyCode::Left:
+    case input::KeyCode::A:
+        if (_yawRate.direction() == 1) {
+            _yawRate.setDirection(0);
+        }
+        return true;
+    case input::KeyCode::Right:
+    case input::KeyCode::D:
+        if (_yawRate.direction() == -1) {
+            _yawRate.setDirection(0);
+        }
+        return true;
+    case input::KeyCode::Space:
+        _firing = false;
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool Turret::handleMouseMotion(const input::MouseMotionEvent &event) {
+    if (!_active) {
+        return false;
+    }
+    float yaw = -event.xrel * kMouseAimRadiansPerPixel;
+    float pitch = -event.yrel * kMouseAimRadiansPerPixel;
+    if (_spec.mouse.flipAxisX) {
+        yaw = -yaw;
+    }
+    if (_spec.mouse.flipAxisY) {
+        pitch = -pitch;
+    }
+    _aim.addYaw(yaw);
+    _aim.addPitch(pitch);
+    return true;
+}
+
+bool Turret::handleMouseButton(const input::MouseButtonEvent &event) {
+    if (event.button != input::MouseButton::Left) {
+        return false;
+    }
+    _firing = event.pressed;
+    return true;
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -300,6 +300,13 @@ bool TurretGunTimer::tryFire() {
 }
 
 bool TurretBullet::advance(float dt) {
+    // A bolt is created and integrated within the same tick, so its first step
+    // is spent standing at the muzzle: that is the only frame in which it is
+    // drawn where the authored gun bank actually points.
+    if (atMuzzle) {
+        atMuzzle = false;
+        return true;
+    }
     life += dt;
     if (life >= lifespan) {
         return false;

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -810,6 +810,27 @@ void clearHook(const std::shared_ptr<ModelSceneNode> &model, const std::string &
 
 } // namespace
 
+void Turret::detachEnemyFromTrack(Enemy &enemy) {
+    if (!enemy.modelNode || enemy.detachedFromTrack) {
+        return;
+    }
+    enemy.detachedFromTrack = true;
+    if (!enemy.trackNode) {
+        return; // already a scene root: nothing is translating it
+    }
+    // Preserve the pose the fighter died in, then move it from the rail's hook
+    // to the scene root the tracks themselves live under. The hook keeps
+    // looping, but the wreck no longer inherits it; anything the "die"
+    // animation does to the model still applies on top of this transform.
+    glm::mat4 world = enemy.modelNode->absoluteTransform();
+    clearHook(enemy.trackNode, kModelHookName);
+    enemy.modelNode->setLocalTransform(world);
+    // A wreck sits where it was killed while the rail carries on, so the
+    // culling that assumes actors stay near their track root no longer holds.
+    enemy.modelNode->setCullingEnabled(false);
+    _services.scene.graphs.get(kSceneMain).addRoot(enemy.modelNode);
+}
+
 void Turret::releaseEnemyNodes(Enemy &enemy) {
     // Everything a fighter owns hangs off its model root: the authored gun bank
     // models on their hooks, and - built by the model loader itself - the
@@ -1103,6 +1124,12 @@ void Turret::updateEnemies(float dt) {
                 // burns steadily for as long as its node lives, so a wreck that
                 // kept it would trail a lit flare through the whole animation.
                 turretDisableReferenceAttachments(*enemy.modelNode);
+                // Particles are children of the emitter that made them, so a
+                // wreck still riding its rail carries its whole explosion along
+                // with it. Take the fighter off the rail first, keeping it where
+                // it died, and the blast stays at the kill instead of sailing
+                // across the sky.
+                detachEnemyFromTrack(enemy);
                 enemy.modelNode->playAnimation("die");
                 if (enemy.spec && !enemy.spec->sounds.death.empty()) {
                     playSound(enemy.spec->sounds.death);

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -1012,12 +1012,15 @@ void Turret::fire() {
             }
             bank.modelNode->playAnimation("fire");
         }
-        // The muzzle decides only where the bolt appears; its travel and its
-        // orientation both come from the turret itself, so every bank fires
-        // symmetrically and the aim adds no extra rotation per bank.
+        // The muzzle decides where the bolt appears and where it goes. The gun
+        // banks are not aligned with the hull they are mounted on: on the K1
+        // turret each bullethook0 sits five degrees below the turret body and
+        // toed half a degree inboard, so the pair converges down range. Taking
+        // the heading from the turret root instead threw both corrections away
+        // and fired every bank on the hull axis - above the guns, and parallel.
         spawnBullet(*bank.spec,
                     transformOrigin(muzzle),
-                    transformOrientation(_turretRoot->absoluteTransform()),
+                    transformOrientation(muzzle),
                     /*fromPlayer=*/true);
         if (!bank.spec->fireSound.empty()) {
             playSound(bank.spec->fireSound);

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -373,6 +373,10 @@ bool turretDeathEffectComplete(float elapsed, float duration) {
     return elapsed >= duration;
 }
 
+float turretMuzzleClearance(float modelMinForward) {
+    return glm::max(0.0f, -modelMinForward);
+}
+
 void turretDisableReferenceAttachments(ModelSceneNode &model) {
     std::stack<std::reference_wrapper<const graphics::ModelNode>> pending;
     if (auto root = model.model().rootNode()) {
@@ -1042,6 +1046,11 @@ void Turret::spawnBullet(const MinigameGunBankSpec &bank,
 
     bullet.modelNode = acquireBulletNode(bullet.modelResRef);
     if (bullet.modelNode) {
+        // The bolt is drawn from its own origin, which sits partway along the
+        // shot rather than at its tail. Start it far enough ahead that the part
+        // reaching backwards clears the gun instead of being drawn inside it.
+        bullet.sim.position += bullet.sim.direction *
+                               turretMuzzleClearance(bullet.modelNode->model().aabb().min().y);
         bullet.modelNode->setLocalTransform(turretBulletTransform(bullet.sim));
         _services.scene.graphs.get(kSceneMain).addRoot(bullet.modelNode);
     }

--- a/src/libs/game/turret.cpp
+++ b/src/libs/game/turret.cpp
@@ -24,6 +24,7 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/object/camera/firstperson.h"
+#include "reone/graphics/animation.h"
 #include "reone/graphics/types.h"
 #include "reone/resource/di/services.h"
 #include "reone/resource/provider/audioclips.h"
@@ -362,6 +363,13 @@ std::string turretContactAnimation(size_t enemyIndex) {
 std::string turretContactDeathAnimation(size_t enemyIndex) {
     auto live = turretContactAnimation(enemyIndex);
     return live.empty() ? live : live + "d";
+}
+
+bool turretDeathEffectComplete(float elapsed, float duration) {
+    if (duration <= 0.0f) {
+        return true;
+    }
+    return elapsed >= duration;
 }
 
 int turretHeadingState(float yawRadians) {
@@ -778,6 +786,34 @@ void clearHook(const std::shared_ptr<ModelSceneNode> &model, const std::string &
 
 } // namespace
 
+void Turret::releaseEnemyNodes(Enemy &enemy) {
+    // Everything a fighter owns hangs off its model root: the authored gun bank
+    // models on their hooks, and - built by the model loader itself - the
+    // reference models the fighter names (mgf_sithfighter attaches an fx_ref
+    // engine flare at each of its OmenRef nodes), plus its lights and emitters.
+    // Dropping the root and its rail therefore retires the whole fighter,
+    // without this code having to know which effects it authored.
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
+    for (auto &bank : enemy.gunBanks) {
+        if (bank.spec) {
+            clearHook(enemy.modelNode, gunBankHookName(bank.spec->bankId));
+        }
+    }
+    enemy.gunBanks.clear();
+    clearHook(enemy.trackNode, kModelHookName);
+    if (enemy.modelNode) {
+        enemy.modelNode->removeAllChildren();
+        sceneGraph.removeRoot(*enemy.modelNode);
+    }
+    if (enemy.trackNode) {
+        sceneGraph.removeRoot(*enemy.trackNode);
+    }
+    enemy.extraNodes.clear();
+    enemy.modelNode.reset();
+    enemy.trackNode.reset();
+    enemy.nodesReleased = true;
+}
+
 void Turret::detachAll() {
     auto &sceneGraph = _services.scene.graphs.get(kSceneMain);
 
@@ -791,20 +827,7 @@ void Turret::detachAll() {
     _bulletNodePool.clear();
 
     for (auto &enemy : _enemies) {
-        for (auto &bank : enemy.gunBanks) {
-            if (bank.spec) {
-                clearHook(enemy.modelNode, gunBankHookName(bank.spec->bankId));
-            }
-        }
-        enemy.gunBanks.clear();
-        clearHook(enemy.trackNode, kModelHookName);
-        if (enemy.modelNode) {
-            enemy.modelNode->removeAllChildren();
-            sceneGraph.removeRoot(*enemy.modelNode);
-        }
-        if (enemy.trackNode) {
-            sceneGraph.removeRoot(*enemy.trackNode);
-        }
+        releaseEnemyNodes(enemy);
     }
     _enemies.clear();
 
@@ -1040,9 +1063,22 @@ void Turret::updateEnemies(float dt) {
         if (!enemy.alive) {
             if (!enemy.deathHandled) {
                 enemy.deathHandled = true;
+                // The authored death animation decides how long the wreck stays.
+                if (auto dying = enemy.modelNode->model().getAnimation("die")) {
+                    enemy.deathDuration = dying->length();
+                }
                 enemy.modelNode->playAnimation("die");
                 if (enemy.spec && !enemy.spec->sounds.death.empty()) {
                     playSound(enemy.spec->sounds.death);
+                }
+            } else if (!enemy.nodesReleased) {
+                // "die" only fades the hull mesh; the fx_ref flares, lights and
+                // emitters the fighter owns are untouched by it and would keep
+                // riding the rail forever. Retire the whole fighter once the
+                // authored effect has played out.
+                enemy.deathElapsed += dt;
+                if (turretDeathEffectComplete(enemy.deathElapsed, enemy.deathDuration)) {
+                    releaseEnemyNodes(enemy);
                 }
             }
             continue;

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -275,6 +275,33 @@ void ModelSceneNode::playAnimation(Animation &anim, std::shared_ptr<LipAnimation
     }
 }
 
+bool ModelSceneNode::removeAnimation(const std::string &name) {
+    std::string lower(boost::to_lower_copy(name));
+    bool removed = false;
+    for (auto it = _animChannels.begin(); it != _animChannels.end();) {
+        if (it->anim && it->anim->name() == lower) {
+            it = _animChannels.erase(it);
+            removed = true;
+            continue;
+        }
+        ++it;
+    }
+    if (removed && _animChannels.empty()) {
+        _animBlendMode = AnimationBlendMode::Single;
+    }
+    return removed;
+}
+
+bool ModelSceneNode::isAnimationPlaying(const std::string &name) const {
+    std::string lower(boost::to_lower_copy(name));
+    for (const auto &channel : _animChannels) {
+        if (channel.anim && channel.anim->name() == lower) {
+            return true;
+        }
+    }
+    return false;
+}
+
 ModelSceneNode::AnimationBlendMode ModelSceneNode::getAnimationBlendMode(int flags) {
     return (flags & AnimationFlags::blend) ? AnimationBlendMode::Blend : ((flags & AnimationFlags::overlay) ? AnimationBlendMode::Overlay : AnimationBlendMode::Single);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
     ${TESTS_SOURCE_DIR}/game/journal.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
+    ${TESTS_SOURCE_DIR}/game/minigame.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp
     ${TESTS_SOURCE_DIR}/game/pazaak.cpp
     ${TESTS_SOURCE_DIR}/game/pazaakintegration.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/reputes.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp
+    ${TESTS_SOURCE_DIR}/game/turret.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/bwmreader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/mdlmdxreader.cpp

--- a/test/game/minigame.cpp
+++ b/test/game/minigame.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/minigame.h"
+#include "reone/resource/parser/gff/are.h"
+
+using namespace reone::game;
+using namespace reone::resource::generated;
+
+namespace {
+
+// The .are MiniGame struct of K1's m12ab (the Ebon Hawk turret), reduced to the
+// fields the runtime consumes.
+ARE makeEbonHawkTurretARE() {
+    ARE are;
+    are.MiniGame.Type = 2;
+    are.MiniGame.CameraViewAngle = 65.0f;
+    are.MiniGame.Near_Clip = 0.1f;
+    are.MiniGame.Far_Clip = 2000.0f;
+    are.MiniGame.Bump_Plane = 3;
+    are.MiniGame.DOF = 5;
+    are.MiniGame.MovementPerSec = 100.0f;
+    are.MiniGame.LateralAccel = 1200.0f;
+    are.MiniGame.Music = "mus_bat_sithbs";
+    are.MiniGame.Mouse.AxisX = 3;
+    are.MiniGame.Mouse.AxisY = 1;
+
+    auto &player = are.MiniGame.Player;
+    player.Track = "m12ab_mgt01";
+    player.Camera = "m12ab_camera";
+    player.CameraRotate = 1;
+    player.Sphere_Radius = 40.0f;
+    player.Hit_Points = 3000;
+    player.Max_HPs = 3000;
+    player.Start_Offset_X = 7.0f;
+    player.Target_Offset_Z = -5.0f;
+    player.TunnelInfinite = glm::vec3(0.0f, 0.0f, 1.0f);
+    player.TunnelXPos = 45.0f;
+    player.TunnelXNeg = 2.0f;
+    player.TunnelZPos = 9999.0f;
+    player.TunnelZNeg = -9999.0f;
+    player.Scripts.OnHeartbeat = "k_heartbeat";
+    player.Scripts.OnDamage = "k_pebo_hawkhit";
+
+    ARE_MiniGame_Player_Models gun;
+    gun.Model = "mgf_turret";
+    gun.RotatingModel = 1;
+    ARE_MiniGame_Player_Models hull;
+    hull.Model = "mgf_ebonhawk";
+    hull.RotatingModel = 0;
+    player.Models = {gun, hull};
+
+    ARE_MiniGame_Player_Gun_Banks bank;
+    bank.BankID = 0;
+    bank.Gun_Model = "mgg_turret";
+    bank.Fire_Sound = "mgs_ebon_fire";
+    bank.Bullet.Bullet_Model = "mgb_ebonleft";
+    bank.Bullet.Collision_Sound = "mgs_sith_hit";
+    bank.Bullet.Damage = 30;
+    bank.Bullet.Lifespan = 3.0f;
+    bank.Bullet.Rate_Of_Fire = 0.3f;
+    bank.Bullet.Speed = 300.0f;
+    bank.Bullet.Target_Type = 2;
+    player.Gun_Banks = {bank};
+
+    ARE_MiniGame_Enemies enemy;
+    enemy.Track = "m12ab_mgt02";
+    enemy.Hit_Points = 100;
+    enemy.Max_HPs = 100;
+    enemy.Sphere_Radius = 20.0f;
+    enemy.Sounds.Death = "mgs_sith_expl";
+    enemy.Scripts.OnCreate = "k_pebo_sthcreate";
+    enemy.Scripts.OnDeath = "k_pebo_sthdeath2";
+    ARE_MiniGame_Enemies_Models fighter;
+    fighter.Model = "mgf_sithfighter";
+    fighter.RotatingModel = 1;
+    enemy.Models = {fighter};
+    ARE_MiniGame_Enemies_Gun_Banks enemyBank;
+    enemyBank.BankID = 0;
+    enemyBank.Gun_Model = "mgg_null";
+    enemyBank.Fire_Sound = "mgs_sith_fire";
+    enemyBank.Inaccuracy = 0.01f;
+    enemyBank.Sensing_Radius = 200.0f;
+    enemyBank.Horiz_Spread = 70.0f;
+    enemyBank.Vert_Spread = 70.0f;
+    enemyBank.Bullet.Bullet_Model = "mgb_sithfighter";
+    enemyBank.Bullet.Collision_Sound = "mgs_ebon_hit";
+    enemyBank.Bullet.Damage = 10;
+    enemyBank.Bullet.Lifespan = 2.0f;
+    enemyBank.Bullet.Rate_Of_Fire = 0.4f;
+    enemyBank.Bullet.Speed = 200.0f;
+    enemyBank.Bullet.Target_Type = 1;
+    enemy.Gun_Banks = {enemyBank};
+    are.MiniGame.Enemies = {enemy};
+
+    ARE_MiniGame_Obstacles obstacle;
+    obstacle.Name = "m12ab_mgo01";
+    are.MiniGame.Obstacles = {obstacle};
+
+    return are;
+}
+
+} // namespace
+
+TEST(MinigameSpec, area_without_minigame_yields_no_spec) {
+    ARE are;
+
+    EXPECT_FALSE(parseMinigameSpec(are).has_value());
+}
+
+TEST(MinigameSpec, turret_area_is_recognized) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_EQ(spec->type, MinigameType::Turret);
+    EXPECT_STREQ(minigameTypeName(spec->type), "turret");
+    EXPECT_FLOAT_EQ(spec->cameraViewAngle, 65.0f);
+    EXPECT_FLOAT_EQ(spec->nearClip, 0.1f);
+    EXPECT_FLOAT_EQ(spec->farClip, 2000.0f);
+    EXPECT_EQ(spec->music, "mus_bat_sithbs");
+    EXPECT_EQ(spec->mouse.axisX, 3u);
+    EXPECT_FALSE(spec->mouse.flipAxisX);
+}
+
+TEST(MinigameSpec, player_models_keep_their_rotating_flag) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    ASSERT_EQ(spec->player.models.size(), 2u);
+    EXPECT_EQ(spec->player.models[0].resRef, "mgf_turret");
+    EXPECT_TRUE(spec->player.models[0].rotating);
+    EXPECT_EQ(spec->player.models[1].resRef, "mgf_ebonhawk");
+    EXPECT_FALSE(spec->player.models[1].rotating);
+}
+
+TEST(MinigameSpec, player_gun_bank_and_bullet_are_parsed) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    ASSERT_EQ(spec->player.gunBanks.size(), 1u);
+    const auto &bank = spec->player.gunBanks.front();
+    EXPECT_EQ(bank.bankId, 0u);
+    EXPECT_EQ(bank.gunModelResRef, "mgg_turret");
+    EXPECT_EQ(bank.fireSound, "mgs_ebon_fire");
+    EXPECT_EQ(bank.bullet.modelResRef, "mgb_ebonleft");
+    EXPECT_EQ(bank.bullet.collisionSound, "mgs_sith_hit");
+    EXPECT_EQ(bank.bullet.damage, 30u);
+    EXPECT_FLOAT_EQ(bank.bullet.lifespan, 3.0f);
+    EXPECT_FLOAT_EQ(bank.bullet.rateOfFire, 0.3f);
+    EXPECT_FLOAT_EQ(bank.bullet.speed, 300.0f);
+    EXPECT_EQ(bank.bullet.targetType, 2u);
+}
+
+TEST(MinigameSpec, player_placement_and_tunnel_limits_are_parsed) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_EQ(spec->player.startOffset, glm::vec3(7.0f, 0.0f, 0.0f));
+    EXPECT_EQ(spec->player.targetOffset, glm::vec3(0.0f, 0.0f, -5.0f));
+    EXPECT_EQ(spec->player.tunnelInfinite, glm::vec3(0.0f, 0.0f, 1.0f));
+    EXPECT_FLOAT_EQ(spec->player.tunnelXPos, 45.0f);
+    EXPECT_FLOAT_EQ(spec->player.tunnelXNeg, 2.0f);
+    EXPECT_TRUE(spec->player.cameraRotate);
+    EXPECT_EQ(spec->player.cameraResRef, "m12ab_camera");
+    EXPECT_EQ(spec->player.hitPoints, 3000u);
+    EXPECT_EQ(spec->player.maxHitPoints, 3000u);
+    EXPECT_FLOAT_EQ(spec->player.sphereRadius, 40.0f);
+}
+
+TEST(MinigameSpec, enemy_gun_banks_carry_aiming_parameters) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    ASSERT_EQ(spec->enemies.size(), 1u);
+    const auto &enemy = spec->enemies.front();
+    EXPECT_EQ(enemy.trackResRef, "m12ab_mgt02");
+    EXPECT_EQ(enemy.hitPoints, 100u);
+    EXPECT_FLOAT_EQ(enemy.sphereRadius, 20.0f);
+    EXPECT_EQ(enemy.sounds.death, "mgs_sith_expl");
+    EXPECT_EQ(enemy.scripts.onDeath, "k_pebo_sthdeath2");
+    ASSERT_EQ(enemy.models.size(), 1u);
+    EXPECT_EQ(enemy.models.front().resRef, "mgf_sithfighter");
+    ASSERT_EQ(enemy.gunBanks.size(), 1u);
+    const auto &bank = enemy.gunBanks.front();
+    EXPECT_FLOAT_EQ(bank.sensingRadius, 200.0f);
+    EXPECT_FLOAT_EQ(bank.inaccuracy, 0.01f);
+    EXPECT_FLOAT_EQ(bank.horizSpread, 70.0f);
+    EXPECT_FLOAT_EQ(bank.vertSpread, 70.0f);
+    EXPECT_EQ(bank.bullet.damage, 10u);
+}
+
+TEST(MinigameSpec, track_resrefs_are_deduplicated_across_player_and_enemies) {
+    auto are = makeEbonHawkTurretARE();
+    // A second enemy sharing the first enemy's rail must not add a duplicate.
+    auto sharedRail = are.MiniGame.Enemies.front();
+    are.MiniGame.Enemies.push_back(sharedRail);
+
+    auto spec = parseMinigameSpec(are);
+
+    ASSERT_TRUE(spec.has_value());
+    EXPECT_EQ(spec->enemies.size(), 2u);
+    EXPECT_EQ(spec->trackResRefs, (std::vector<std::string> {"m12ab_mgt01", "m12ab_mgt02"}));
+}
+
+TEST(MinigameSpec, obstacles_are_parsed) {
+    auto spec = parseMinigameSpec(makeEbonHawkTurretARE());
+
+    ASSERT_TRUE(spec.has_value());
+    ASSERT_EQ(spec->obstacles.size(), 1u);
+    EXPECT_EQ(spec->obstacles.front().name, "m12ab_mgo01");
+}

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -591,6 +591,45 @@ TEST(TurretDestruction, the_destruction_band_selects_the_empty_gauge) {
     EXPECT_EQ(turretHealthAnimation(turretHealthState(1999)), "health00");
 }
 
+// A destroyed fighter keeps its authored "die" animation on screen for that
+// animation's own length, then everything it owns is retired. Without the
+// retirement the fighter's fx_ref engine flares, lights and emitters survive
+// the hull fade and keep riding the rail.
+
+TEST(TurretDestruction, the_death_effect_lasts_the_authored_animation_length) {
+    // mgf_sithfighter authors a 2.3s non-looping "die".
+    EXPECT_FALSE(turretDeathEffectComplete(0.0f, 2.3f));
+    EXPECT_FALSE(turretDeathEffectComplete(1.0f, 2.3f));
+    EXPECT_FALSE(turretDeathEffectComplete(2.29f, 2.3f));
+    EXPECT_TRUE(turretDeathEffectComplete(2.3f, 2.3f));
+    EXPECT_TRUE(turretDeathEffectComplete(5.0f, 2.3f));
+}
+
+TEST(TurretDestruction, a_fighter_with_no_death_animation_is_retired_at_once) {
+    EXPECT_TRUE(turretDeathEffectComplete(0.0f, 0.0f));
+    EXPECT_TRUE(turretDeathEffectComplete(0.0f, -1.0f));
+}
+
+TEST(TurretDestruction, death_effects_of_separate_fighters_are_independent) {
+    // Each fighter accumulates its own elapsed time, so one dying later does
+    // not retire early on another's clock.
+    const float duration = 2.3f;
+    float first = 0.0f;
+    float second = 0.0f;
+
+    for (int i = 0; i < 100; ++i) { // ~1.67s
+        first += 1.0f / 60.0f;
+    }
+    EXPECT_FALSE(turretDeathEffectComplete(first, duration));
+
+    for (int i = 0; i < 40; ++i) {
+        first += 1.0f / 60.0f;
+        second += 1.0f / 60.0f;
+    }
+    EXPECT_TRUE(turretDeathEffectComplete(first, duration));
+    EXPECT_FALSE(turretDeathEffectComplete(second, duration));
+}
+
 TEST(TurretHealthGauge, an_undamaged_hawk_reads_full) {
     // 3000 is the authored Hit_Points/Max_HPs; the first damage lands below it.
     EXPECT_EQ(turretHealthState(2999), 12);

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -619,6 +619,135 @@ TEST(TurretProjectile, a_bolt_advances_along_its_oriented_direction) {
     EXPECT_NEAR(bullet.position.y, 0.0f, 1e-3f);
 }
 
+// Muzzle heading. The gun banks are not aligned with the hull they hang on: on
+// the K1 turret each bullethook0 sits about five degrees below the turret body
+// and half a degree inboard, so the pair converges down range. Firing on the
+// turret root's heading throws both corrections away.
+
+namespace {
+
+// The authored hook orientations, as measured from the shipped models: pitch up
+// 2 degrees, toed inboard 0.5 degrees, mirrored per bank. The turret body they
+// hang on is pitched 7 degrees.
+glm::quat makeMuzzleOrientation(float pitchDeg, float toeDeg) {
+    return glm::angleAxis(glm::radians(toeDeg), glm::vec3(0.0f, 0.0f, 1.0f)) *
+           glm::angleAxis(glm::radians(pitchDeg), glm::vec3(1.0f, 0.0f, 0.0f));
+}
+
+} // namespace
+
+TEST(TurretProjectile, each_bank_fires_on_its_own_muzzle_heading) {
+    glm::vec3 left = turretFireDirection(makeMuzzleOrientation(2.0f, 0.5f));
+    glm::vec3 right = turretFireDirection(makeMuzzleOrientation(2.0f, -0.5f));
+
+    // Distinct headings, mirrored about the centre plane.
+    EXPECT_NEAR(left.x, -right.x, 1e-5f);
+    EXPECT_GT(glm::abs(left.x), 1e-4f);
+    EXPECT_NEAR(left.y, right.y, 1e-5f);
+    EXPECT_NEAR(left.z, right.z, 1e-5f);
+}
+
+TEST(TurretProjectile, the_authored_toe_in_makes_the_banks_converge) {
+    glm::vec3 leftOrigin(-1.2848f, 2.0665f, 0.7359f);
+    glm::vec3 rightOrigin(1.2848f, 2.0665f, 0.7359f);
+    glm::vec3 left = turretFireDirection(makeMuzzleOrientation(2.0f, -0.5f));
+    glm::vec3 right = turretFireDirection(makeMuzzleOrientation(2.0f, 0.5f));
+
+    float startGap = rightOrigin.x - leftOrigin.x;
+    glm::vec3 leftFar = leftOrigin + left * 100.0f;
+    glm::vec3 rightFar = rightOrigin + right * 100.0f;
+
+    // Toed inboard: the gap closes with distance instead of staying constant.
+    EXPECT_LT(rightFar.x - leftFar.x, startGap);
+}
+
+TEST(TurretProjectile, the_authored_muzzle_pitch_is_not_replaced_by_the_hull) {
+    glm::vec3 fromMuzzle = turretFireDirection(makeMuzzleOrientation(2.0f, 0.0f));
+    glm::vec3 fromRoot = turretFireDirection(makeMuzzleOrientation(7.0f, 0.0f));
+
+    EXPECT_NEAR(glm::degrees(glm::asin(fromMuzzle.z)), 2.0f, 1e-3f);
+    EXPECT_NEAR(glm::degrees(glm::asin(fromRoot.z)), 7.0f, 1e-3f);
+    // Substituting the hull heading would raise the shot five degrees.
+    EXPECT_GT(fromRoot.z, fromMuzzle.z);
+}
+
+TEST(TurretProjectile, the_muzzle_heading_survives_turret_pitch_and_yaw) {
+    // A hook keeps its authored offset from the body under any aim, because it
+    // is composed with the turret transform rather than replacing it.
+    glm::quat body = glm::angleAxis(glm::radians(40.0f), glm::vec3(0.0f, 0.0f, 1.0f)) *
+                     glm::angleAxis(glm::radians(25.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+    glm::quat hookLocal = makeMuzzleOrientation(-5.0f, 0.5f);
+
+    glm::vec3 bodyDir = turretFireDirection(body);
+    glm::vec3 muzzleDir = turretFireDirection(body * hookLocal);
+
+    EXPECT_NEAR(glm::length(muzzleDir), 1.0f, 1e-5f);
+    // Still offset from the hull heading after the aim is applied.
+    float cosAngle = glm::clamp(glm::dot(bodyDir, muzzleDir), -1.0f, 1.0f);
+    EXPECT_NEAR(glm::degrees(glm::acos(cosAngle)), 5.025f, 0.05f);
+}
+
+TEST(TurretProjectile, clearance_is_applied_along_the_muzzle_heading) {
+    glm::quat muzzle = makeMuzzleOrientation(2.0f, 0.5f);
+
+    TurretBullet bullet;
+    bullet.position = glm::vec3(-1.2848f, 2.0665f, 0.7359f);
+    bullet.orientation = muzzle;
+    bullet.direction = turretFireDirection(muzzle);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    glm::vec3 origin = bullet.position;
+    float clearance = turretMuzzleClearance(-1.953f);
+    bullet.position += bullet.direction * clearance;
+
+    // Displaced exactly along the heading it will fly, not along world Y.
+    glm::vec3 delta = bullet.position - origin;
+    EXPECT_NEAR(glm::length(delta), clearance, 1e-4f);
+    EXPECT_NEAR(glm::dot(glm::normalize(delta), bullet.direction), 1.0f, 1e-5f);
+}
+
+TEST(TurretProjectile, the_drawn_bolt_and_its_collision_path_share_one_heading) {
+    glm::quat muzzle = makeMuzzleOrientation(2.0f, -0.5f);
+
+    TurretBullet bullet;
+    bullet.orientation = muzzle;
+    bullet.direction = turretFireDirection(muzzle);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    // The model is drawn along its own +Y, transformed by the same orientation
+    // the simulation integrates along.
+    glm::mat4 transform = turretBulletTransform(bullet);
+    glm::vec3 drawnAxis = glm::normalize(glm::vec3(glm::mat3(transform) * glm::vec3(0.0f, 1.0f, 0.0f)));
+
+    EXPECT_NEAR(drawnAxis.x, bullet.direction.x, 1e-5f);
+    EXPECT_NEAR(drawnAxis.y, bullet.direction.y, 1e-5f);
+    EXPECT_NEAR(drawnAxis.z, bullet.direction.z, 1e-5f);
+
+    bullet.advance(1.0f / 60.0f); // muzzle frame
+    glm::vec3 before = bullet.position;
+    bullet.advance(1.0f / 60.0f);
+    glm::vec3 travelled = glm::normalize(bullet.position - before);
+    EXPECT_NEAR(glm::dot(travelled, drawnAxis), 1.0f, 1e-5f);
+}
+
+TEST(TurretProjectile, a_bolt_on_its_muzzle_heading_reaches_a_target_on_that_axis) {
+    glm::vec3 origin(1.2848f, 2.0665f, 0.7359f);
+    glm::quat muzzle = makeMuzzleOrientation(2.0f, 0.5f);
+    glm::vec3 direction = turretFireDirection(muzzle);
+
+    // A fighter sitting on the authored firing axis is hit. Fired on the hull
+    // heading instead, the same shot is five degrees high and clears the
+    // authored 20 unit sphere well inside the bolt's 900 unit range.
+    const float range = 300.0f;
+    glm::vec3 target = origin + direction * range;
+    glm::vec3 hullDirection = turretFireDirection(makeMuzzleOrientation(7.0f, 0.0f));
+
+    EXPECT_TRUE(sphereContainsPoint(target, 20.0f, origin + direction * range));
+    EXPECT_FALSE(sphereContainsPoint(target, 20.0f, origin + hullDirection * range));
+}
+
 TEST(TurretCollision, sphere_contains_points_within_its_radius) {
     glm::vec3 center(10.0f, 20.0f, 30.0f);
 

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -881,6 +881,29 @@ TEST(TurretReturn, an_authored_destination_still_applies_with_no_captured_origin
     EXPECT_EQ(turretReturnModule("m12ab", ""), "ebo_m12aa");
 }
 
+// Launch parity. A session started in place (startturret) captures no origin;
+// one entered through a module transition (startturretgame) captures the module
+// it came from. Both are lifecycle sessions, so an outcome resolves the same
+// way for either - the entry route may only decide where the player lands.
+
+TEST(TurretReturn, both_launch_routes_resolve_a_win_the_same_way) {
+    const auto direct = turretReturnModule("m12ab", "");                 // startturret
+    const auto viaTransition = turretReturnModule("m12ab", "ebo_m12aa"); // startturretgame
+
+    EXPECT_EQ(direct, viaTransition);
+    EXPECT_EQ(direct, "ebo_m12aa");
+    EXPECT_TRUE(turretSessionSucceeded(Turret::Outcome::Won));
+}
+
+TEST(TurretReturn, a_direct_session_stays_put_only_when_nothing_is_authored) {
+    // No authored destination and no captured origin: the only case in which a
+    // resolved session leaves the player where they are.
+    EXPECT_EQ(turretReturnModule("custom_mg", ""), "");
+    // An authored destination is honoured even without an origin, so a direct
+    // session is not stranded in the minigame module.
+    EXPECT_FALSE(turretReturnModule("m12ab", "").empty());
+}
+
 // Outcome semantics. Only a victory may emit the completion state; a defeat and
 // an abandoned session must both be distinguishable from it and from each other.
 

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -335,6 +335,7 @@ TEST(TurretBullet, advances_along_its_direction_at_the_authored_speed) {
     bullet.speed = 300.0f;
     bullet.lifespan = 3.0f;
 
+    ASSERT_TRUE(bullet.advance(0.0f)); // muzzle frame
     ASSERT_TRUE(bullet.advance(0.5f));
 
     EXPECT_NEAR(bullet.position.y, 150.0f, 1e-3f);
@@ -347,6 +348,7 @@ TEST(TurretBullet, is_culled_once_it_outlives_its_lifespan) {
     bullet.speed = 300.0f;
     bullet.lifespan = 1.0f;
 
+    ASSERT_TRUE(bullet.advance(0.0f)); // muzzle frame
     ASSERT_TRUE(bullet.advance(0.9f));
     EXPECT_FALSE(bullet.advance(0.2f));
 }
@@ -357,7 +359,71 @@ TEST(TurretBullet, an_expired_bullet_is_culled_on_the_next_step) {
 
     bullet.expire();
 
+    ASSERT_TRUE(bullet.advance(0.01f)); // the muzzle frame is presented first
     EXPECT_FALSE(bullet.advance(0.01f));
+}
+
+// Firing and bullet integration run in the same tick, so without a held first
+// step every bolt is carried speed*dt down range before it is ever drawn, and
+// never appears at the barrel that fired it.
+
+TEST(TurretBullet, the_first_step_presents_the_muzzle_without_moving) {
+    TurretBullet bullet;
+    bullet.position = glm::vec3(1.285f, 2.067f, 0.736f); // authored bullethook0
+    bullet.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    ASSERT_TRUE(bullet.advance(1.0f / 60.0f));
+
+    EXPECT_NEAR(bullet.position.x, 1.285f, 1e-4f);
+    EXPECT_NEAR(bullet.position.y, 2.067f, 1e-4f);
+    EXPECT_NEAR(bullet.position.z, 0.736f, 1e-4f);
+    EXPECT_FLOAT_EQ(bullet.life, 0.0f);
+    EXPECT_FALSE(bullet.atMuzzle);
+}
+
+TEST(TurretBullet, flight_resumes_normally_after_the_muzzle_frame) {
+    TurretBullet bullet;
+    bullet.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    bullet.advance(1.0f / 60.0f);
+    bullet.advance(1.0f / 60.0f);
+    bullet.advance(1.0f / 60.0f);
+
+    // Two integrating steps, not three: the muzzle frame is held.
+    EXPECT_NEAR(bullet.position.y, 2.0f * 300.0f / 60.0f, 1e-3f);
+}
+
+TEST(TurretBullet, both_banks_hold_their_own_muzzle_on_the_first_frame) {
+    // The authored gun bank hooks of mgf_turret, carrying mgg_turret's
+    // bullethook0: distinct, symmetric, 2.57 units apart.
+    TurretBullet left;
+    left.position = glm::vec3(-1.285f, 2.067f, 0.736f);
+    left.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    left.speed = 300.0f;
+    left.lifespan = 3.0f;
+
+    TurretBullet right;
+    right.position = glm::vec3(1.285f, 2.067f, 0.736f);
+    right.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    right.speed = 300.0f;
+    right.lifespan = 3.0f;
+
+    left.advance(1.0f / 60.0f);
+    right.advance(1.0f / 60.0f);
+
+    EXPECT_NEAR(right.position.x - left.position.x, 2.570f, 1e-3f);
+    EXPECT_NEAR(left.position.x, -right.position.x, 1e-4f);
+    EXPECT_GT(glm::abs(right.position.x), 1.0f); // neither collapses to centre
+
+    // Separation survives flight: the banks fire on parallel headings.
+    left.advance(0.5f);
+    right.advance(0.5f);
+    EXPECT_NEAR(right.position.x - left.position.x, 2.570f, 1e-3f);
+    EXPECT_NEAR(left.position.y, right.position.y, 1e-4f);
 }
 
 // Projectile presentation. The bolt models are authored along +Y, so a bullet
@@ -453,6 +519,7 @@ TEST(TurretProjectile, a_bolt_advances_along_its_oriented_direction) {
     bullet.speed = 300.0f;
     bullet.lifespan = 3.0f;
 
+    ASSERT_TRUE(bullet.advance(0.0f)); // muzzle frame
     ASSERT_TRUE(bullet.advance(0.1f));
 
     // Yawed 90 degrees, +Y maps onto -X.

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -412,6 +412,83 @@ TEST(TurretBullet, flight_resumes_normally_after_the_muzzle_frame) {
     EXPECT_NEAR(bullet.position.y, 2.0f * 300.0f / 60.0f, 1e-3f);
 }
 
+// A bolt model's origin is not its tail. mgb_ebonleft draws from -1.953 to
+// +8.620 along model +Y, so pinning the origin to bullethook0 buries nearly two
+// units of bolt inside the gun.
+
+TEST(TurretBullet, a_bolt_starts_clear_of_the_muzzle_by_its_own_reach_behind) {
+    EXPECT_NEAR(turretMuzzleClearance(-1.953f), 1.953f, 1e-4f); // mgb_ebonleft
+    EXPECT_NEAR(turretMuzzleClearance(-1.520f), 1.520f, 1e-4f); // mgb_sithfighter
+}
+
+TEST(TurretBullet, a_bolt_drawn_wholly_ahead_of_its_origin_is_not_displaced) {
+    EXPECT_FLOAT_EQ(turretMuzzleClearance(0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(turretMuzzleClearance(2.5f), 0.0f);
+}
+
+TEST(TurretBullet, no_visible_geometry_is_left_behind_the_muzzle_plane) {
+    const float modelMin = -1.953f; // mgb_ebonleft rear reach
+    const float muzzleY = 2.067f;   // authored bullethook0
+
+    float spawnY = muzzleY + turretMuzzleClearance(modelMin);
+    float tailY = spawnY + modelMin;
+
+    EXPECT_GE(tailY, muzzleY - 1e-4f);
+    EXPECT_NEAR(tailY, muzzleY, 1e-4f); // sits exactly on the plane, no further
+}
+
+TEST(TurretBullet, the_clearance_follows_the_bolt_heading_not_a_world_axis) {
+    // Yawed 90 degrees, model +Y maps onto -X, so the displacement must too.
+    glm::quat yawed = glm::angleAxis(glm::radians(90.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+
+    TurretBullet bullet;
+    bullet.position = glm::vec3(1.285f, 2.067f, 0.736f);
+    bullet.orientation = yawed;
+    bullet.direction = turretFireDirection(yawed);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    float clearance = turretMuzzleClearance(-1.953f);
+    bullet.position += bullet.direction * clearance;
+
+    EXPECT_NEAR(bullet.position.x, 1.285f - 1.953f, 1e-3f);
+    EXPECT_NEAR(bullet.position.y, 2.067f, 1e-3f);
+}
+
+TEST(TurretBullet, clearance_does_not_consume_the_muzzle_frame_or_alter_speed) {
+    TurretBullet bullet;
+    bullet.position = glm::vec3(0.0f, 2.067f, 0.0f);
+    bullet.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+    bullet.position += bullet.direction * turretMuzzleClearance(-1.953f);
+    float spawnY = bullet.position.y;
+
+    // Still a held first frame: placement is not a movement step.
+    ASSERT_TRUE(bullet.advance(1.0f / 60.0f));
+    EXPECT_NEAR(bullet.position.y, spawnY, 1e-4f);
+    EXPECT_FLOAT_EQ(bullet.life, 0.0f);
+
+    // Flight then runs at the authored speed, unchanged by the displacement.
+    ASSERT_TRUE(bullet.advance(1.0f / 60.0f));
+    EXPECT_NEAR(bullet.position.y, spawnY + 300.0f / 60.0f, 1e-3f);
+    EXPECT_NEAR(bullet.life, 1.0f / 60.0f, 1e-5f);
+}
+
+TEST(TurretBullet, clearance_keeps_the_banks_distinct_and_symmetric) {
+    float clearance = turretMuzzleClearance(-1.953f);
+    glm::vec3 forward(0.0f, 1.0f, 0.0f);
+
+    glm::vec3 left = glm::vec3(-1.285f, 2.067f, 0.736f) + forward * clearance;
+    glm::vec3 right = glm::vec3(1.285f, 2.067f, 0.736f) + forward * clearance;
+
+    // The displacement is along the shared heading, so it cannot pull the two
+    // banks together.
+    EXPECT_NEAR(right.x - left.x, 2.570f, 1e-3f);
+    EXPECT_NEAR(left.x, -right.x, 1e-4f);
+    EXPECT_NEAR(left.y, right.y, 1e-4f);
+}
+
 TEST(TurretBullet, both_banks_hold_their_own_muzzle_on_the_first_frame) {
     // The authored gun bank hooks of mgf_turret, carrying mgg_turret's
     // bullethook0: distinct, symmetric, 2.57 units apart.

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -920,6 +920,97 @@ struct FighterFixture {
 
 } // namespace
 
+// Rail detachment. Emitter particles are children of the emitter that spawned
+// them, so a wreck still attached to the looping rail hook carries its whole
+// explosion along with it. These cover the transform bookkeeping the detach
+// depends on; the wiring itself is exercised in the engine.
+
+namespace {
+
+// A rail carrying a fighter on its "modelhook", the way loadEnemies builds it.
+struct RailFixture : FighterFixture {
+    std::unique_ptr<Model> railModel;
+    std::shared_ptr<ModelSceneNode> rail;
+
+    RailFixture() {
+        auto railRoot = std::make_shared<ModelNode>(0, "m12ab_mgt02", glm::vec3(0.0f),
+                                                    glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+        auto hook = std::make_shared<ModelNode>(1, "modelhook", glm::vec3(0.0f),
+                                                glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, railRoot.get());
+        railRoot->addChild(hook);
+        railModel = std::make_unique<Model>("m12ab_mgt02", 0, railRoot,
+                                            std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+        rail = makeModelSceneNode(*railModel);
+        rail->attach("modelhook", *node);
+    }
+
+    // Where the rail's hook has carried the fighter to.
+    glm::vec3 fighterWorldPos() const {
+        return glm::vec3(node->absoluteTransform()[3]);
+    }
+
+    void moveRail(const glm::vec3 &to) {
+        rail->getNodeByName("modelhook")->setLocalTransform(glm::translate(to));
+    }
+};
+
+} // namespace
+
+TEST(TurretDestruction, a_wreck_keeps_the_pose_it_died_in_when_it_leaves_the_rail) {
+    RailFixture fixture;
+    fixture.moveRail(glm::vec3(40.0f, 12.0f, -3.0f));
+    glm::mat4 atDeath = fixture.node->absoluteTransform();
+
+    // What detachEnemyFromTrack does: capture the world pose, drop the hook
+    // attachment, then re-root at that pose.
+    fixture.rail->getNodeByName("modelhook")->removeAllChildren();
+    fixture.node->setLocalTransform(atDeath);
+
+    EXPECT_NEAR(fixture.fighterWorldPos().x, 40.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().y, 12.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().z, -3.0f, 1e-4f);
+}
+
+TEST(TurretDestruction, the_rail_no_longer_carries_a_detached_wreck) {
+    RailFixture fixture;
+    fixture.moveRail(glm::vec3(40.0f, 12.0f, -3.0f));
+    glm::mat4 atDeath = fixture.node->absoluteTransform();
+    fixture.rail->getNodeByName("modelhook")->removeAllChildren();
+    fixture.node->setLocalTransform(atDeath);
+
+    // The rail keeps looping; the wreck must not follow it any more.
+    fixture.moveRail(glm::vec3(500.0f, -250.0f, 90.0f));
+
+    EXPECT_NEAR(fixture.fighterWorldPos().x, 40.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().y, 12.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().z, -3.0f, 1e-4f);
+}
+
+TEST(TurretDestruction, a_live_fighter_still_rides_its_rail) {
+    RailFixture fixture;
+
+    fixture.moveRail(glm::vec3(7.0f, 8.0f, 9.0f));
+
+    EXPECT_NEAR(fixture.fighterWorldPos().x, 7.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().y, 8.0f, 1e-4f);
+    EXPECT_NEAR(fixture.fighterWorldPos().z, 9.0f, 1e-4f);
+}
+
+TEST(TurretDestruction, detaching_leaves_the_death_effects_running) {
+    RailFixture fixture;
+    glm::mat4 atDeath = fixture.node->absoluteTransform();
+    fixture.rail->getNodeByName("modelhook")->removeAllChildren();
+    fixture.node->setLocalTransform(atDeath);
+    turretDisableReferenceAttachments(*fixture.node);
+
+    // Only the engine flare goes out. The explosion emitter, the hull and the
+    // wreck itself must all survive the detach so the blast can play.
+    EXPECT_TRUE(fixture.node->isEnabled());
+    EXPECT_TRUE(fixture.node->getNodeByName("explode")->isEnabled());
+    EXPECT_TRUE(fixture.node->getNodeByName("sith_wing")->isEnabled());
+    EXPECT_FALSE(fixture.flare->isEnabled());
+}
+
 TEST(TurretDestruction, the_engine_flare_goes_out_the_moment_a_fighter_dies) {
     FighterFixture fighter;
     ASSERT_TRUE(fighter.flare->isEnabled());

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -1,0 +1,811 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/turret.h"
+
+using namespace reone::game;
+
+namespace {
+
+// The K1 Ebon Hawk turret aim limits: pitch clamped to [2, 45] degrees, yaw
+// flagged infinite on the Z axis.
+MinigamePlayerSpec makeEbonHawkPlayerSpec() {
+    MinigamePlayerSpec player;
+    player.startOffset = glm::vec3(7.0f, 0.0f, 0.0f);
+    player.tunnelXNeg = 2.0f;
+    player.tunnelXPos = 45.0f;
+    player.tunnelZNeg = -9999.0f;
+    player.tunnelZPos = 9999.0f;
+    player.tunnelInfinite = glm::vec3(0.0f, 0.0f, 1.0f);
+    return player;
+}
+
+} // namespace
+
+TEST(TurretAim, a_session_starts_at_the_authored_pitch) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+
+    EXPECT_TRUE(aim.pitchBounded());
+    EXPECT_FALSE(aim.yawBounded());
+    // Start_Offset_X, not the lower tunnel bound.
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 7.0f, 1e-3f);
+    EXPECT_NEAR(glm::degrees(aim.startPitch()), 7.0f, 1e-3f);
+    EXPECT_NEAR(glm::degrees(aim.yaw()), 0.0f, 1e-6f);
+}
+
+TEST(TurretAim, an_authored_start_outside_the_bounds_is_clamped) {
+    auto player = makeEbonHawkPlayerSpec();
+    player.startOffset = glm::vec3(90.0f, 0.0f, 0.0f);
+
+    TurretAim aim;
+    aim.configure(player);
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 45.0f, 1e-3f);
+
+    player.startOffset = glm::vec3(-30.0f, 0.0f, 0.0f);
+    aim.configure(player);
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 2.0f, 1e-3f);
+}
+
+TEST(TurretAim, an_authored_start_of_zero_still_clamps_to_the_lower_bound) {
+    auto player = makeEbonHawkPlayerSpec();
+    player.startOffset = glm::vec3(0.0f);
+
+    TurretAim aim;
+    aim.configure(player);
+
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 2.0f, 1e-3f);
+}
+
+TEST(TurretAim, the_authored_start_applies_to_yaw_as_well) {
+    MinigamePlayerSpec player;
+    player.startOffset = glm::vec3(0.0f, 0.0f, 30.0f);
+    player.tunnelZNeg = -90.0f;
+    player.tunnelZPos = 90.0f;
+
+    TurretAim aim;
+    aim.configure(player);
+
+    EXPECT_NEAR(glm::degrees(aim.yaw()), 30.0f, 1e-3f);
+}
+
+TEST(TurretAim, reset_restores_the_authored_start_after_aiming_away) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+    aim.addPitch(glm::radians(20.0f));
+    aim.addYaw(glm::radians(120.0f));
+    ASSERT_GT(glm::degrees(aim.pitch()), 20.0f);
+
+    aim.reset();
+
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 7.0f, 1e-3f);
+    EXPECT_NEAR(glm::degrees(aim.yaw()), 0.0f, 1e-6f);
+}
+
+TEST(TurretAim, reconfiguring_a_session_restores_the_authored_start) {
+    auto player = makeEbonHawkPlayerSpec();
+    TurretAim aim;
+    aim.configure(player);
+    aim.addPitch(glm::radians(30.0f));
+
+    aim.configure(player);
+
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 7.0f, 1e-3f);
+}
+
+TEST(TurretAim, axis_travel_reports_the_authored_range) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+
+    EXPECT_NEAR(glm::degrees(aim.pitchTravel()), 43.0f, 1e-3f);
+    // An infinite axis travels a full turn.
+    EXPECT_NEAR(aim.yawTravel(), glm::two_pi<float>(), 1e-5f);
+}
+
+TEST(TurretAim, pitch_clamps_at_both_tunnel_limits) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+
+    aim.addPitch(glm::radians(90.0f));
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 45.0f, 1e-3f);
+
+    aim.addPitch(glm::radians(-90.0f));
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 2.0f, 1e-3f);
+}
+
+TEST(TurretAim, infinite_axis_wraps_instead_of_clamping) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+
+    aim.addYaw(glm::radians(190.0f));
+
+    EXPECT_NEAR(glm::degrees(aim.yaw()), -170.0f, 1e-3f);
+}
+
+TEST(TurretAim, bounded_axis_uses_signed_limits_from_the_are) {
+    MinigamePlayerSpec player;
+    player.tunnelZNeg = -30.0f;
+    player.tunnelZPos = 30.0f;
+
+    TurretAim aim;
+    aim.configure(player);
+
+    EXPECT_TRUE(aim.yawBounded());
+    aim.addYaw(glm::radians(45.0f));
+    EXPECT_NEAR(glm::degrees(aim.yaw()), 30.0f, 1e-3f);
+    aim.addYaw(glm::radians(-90.0f));
+    EXPECT_NEAR(glm::degrees(aim.yaw()), -30.0f, 1e-3f);
+}
+
+TEST(TurretAim, forward_points_down_model_y_when_level) {
+    MinigamePlayerSpec player;
+    player.tunnelInfinite = glm::vec3(1.0f, 0.0f, 1.0f);
+
+    TurretAim aim;
+    aim.configure(player);
+    glm::vec3 forward = aim.forward();
+
+    EXPECT_NEAR(forward.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(forward.y, 1.0f, 1e-5f);
+    EXPECT_NEAR(forward.z, 0.0f, 1e-5f);
+}
+
+TEST(TurretAim, yaw_rotates_forward_about_z_and_pitch_lifts_it) {
+    MinigamePlayerSpec player;
+    player.tunnelInfinite = glm::vec3(1.0f, 0.0f, 1.0f);
+
+    TurretAim aim;
+    aim.configure(player);
+    aim.addYaw(glm::radians(90.0f));
+    aim.addPitch(glm::radians(30.0f));
+
+    glm::vec3 forward = aim.forward();
+    // Rz(yaw) * Rx(pitch) applied to +Y.
+    EXPECT_NEAR(forward.x, -glm::cos(glm::radians(30.0f)), 1e-5f);
+    EXPECT_NEAR(forward.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(forward.z, glm::sin(glm::radians(30.0f)), 1e-5f);
+    EXPECT_NEAR(glm::length(forward), 1.0f, 1e-5f);
+}
+
+// Aim rate: reone's accelerating keyboard turn model, scaled by axis travel.
+
+TEST(TurretAimRate, an_idle_axis_does_not_move) {
+    TurretAimRate rate;
+    rate.configure(glm::two_pi<float>());
+
+    EXPECT_EQ(rate.direction(), 0);
+    EXPECT_FLOAT_EQ(rate.advance(1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(rate.rate(), 0.0f);
+}
+
+TEST(TurretAimRate, a_full_turn_axis_reproduces_reone_turn_rates) {
+    TurretAimRate rate;
+    rate.configure(glm::two_pi<float>());
+
+    EXPECT_NEAR(rate.minRate(), 1.0f, 1e-5f);
+    EXPECT_NEAR(rate.maxRate(), 2.5f, 1e-5f);
+}
+
+TEST(TurretAimRate, a_narrow_axis_moves_proportionally_slower) {
+    TurretAimRate rate;
+    rate.configure(glm::radians(43.0f));
+
+    // 43 degrees of 360 is about a twelfth of a turn.
+    float scale = glm::radians(43.0f) / glm::two_pi<float>();
+    EXPECT_NEAR(rate.minRate(), 1.0f * scale, 1e-5f);
+    EXPECT_NEAR(rate.maxRate(), 2.5f * scale, 1e-5f);
+    // Fine control: a brief tap moves a fraction of a degree.
+    rate.setDirection(1);
+    EXPECT_LT(glm::degrees(rate.advance(1.0f / 60.0f)), 0.2f);
+}
+
+TEST(TurretAimRate, movement_over_an_interval_does_not_depend_on_step_size) {
+    auto travelled = [](float step, float total) {
+        TurretAimRate rate;
+        rate.configure(glm::radians(43.0f));
+        rate.setDirection(1);
+        float sum = 0.0f;
+        for (float t = 0.0f; t < total - 1e-6f; t += step) {
+            sum += rate.advance(step);
+        }
+        return sum;
+    };
+
+    float coarse = travelled(1.0f / 15.0f, 2.0f);
+    float fine = travelled(1.0f / 240.0f, 2.0f);
+    float single = travelled(2.0f, 2.0f);
+
+    EXPECT_NEAR(coarse, fine, 1e-4f);
+    EXPECT_NEAR(single, fine, 1e-4f);
+}
+
+TEST(TurretAimRate, a_held_axis_accelerates_to_its_cap) {
+    TurretAimRate rate;
+    rate.configure(glm::two_pi<float>());
+    rate.setDirection(1);
+
+    EXPECT_NEAR(rate.rate(), rate.minRate(), 1e-5f);
+    rate.advance(10.0f);
+    EXPECT_NEAR(rate.rate(), rate.maxRate(), 1e-5f);
+}
+
+TEST(TurretAimRate, reversing_restarts_the_acceleration_ramp) {
+    TurretAimRate rate;
+    rate.configure(glm::two_pi<float>());
+    rate.setDirection(1);
+    rate.advance(10.0f);
+    ASSERT_NEAR(rate.rate(), rate.maxRate(), 1e-5f);
+
+    rate.setDirection(-1);
+
+    EXPECT_EQ(rate.direction(), -1);
+    EXPECT_NEAR(rate.rate(), rate.minRate(), 1e-5f);
+    EXPECT_LT(rate.advance(0.1f), 0.0f);
+}
+
+TEST(TurretAimRate, reset_clears_direction_and_accumulated_acceleration) {
+    TurretAimRate rate;
+    rate.configure(glm::two_pi<float>());
+    rate.setDirection(1);
+    rate.advance(10.0f);
+
+    rate.reset();
+
+    EXPECT_EQ(rate.direction(), 0);
+    EXPECT_FLOAT_EQ(rate.rate(), 0.0f);
+    EXPECT_FLOAT_EQ(rate.advance(1.0f), 0.0f);
+}
+
+TEST(TurretAimRate, the_authored_pitch_range_is_traversable_but_not_instant) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+    TurretAimRate rate;
+    rate.configure(aim.pitchTravel());
+    rate.setDirection(1);
+
+    // Half a second of hold must not consume the whole band, but a few seconds
+    // must reach the top.
+    aim.addPitch(rate.advance(0.5f));
+    EXPECT_LT(glm::degrees(aim.pitch()), 45.0f);
+
+    for (int i = 0; i < 300; ++i) {
+        aim.addPitch(rate.advance(1.0f / 60.0f));
+    }
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 45.0f, 1e-3f);
+}
+
+TEST(TurretAimRate, driving_an_axis_never_escapes_the_authored_bounds) {
+    TurretAim aim;
+    aim.configure(makeEbonHawkPlayerSpec());
+    TurretAimRate rate;
+    rate.configure(aim.pitchTravel());
+
+    rate.setDirection(-1);
+    for (int i = 0; i < 600; ++i) {
+        aim.addPitch(rate.advance(1.0f / 60.0f));
+    }
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 2.0f, 1e-3f);
+
+    rate.setDirection(1);
+    for (int i = 0; i < 600; ++i) {
+        aim.addPitch(rate.advance(1.0f / 60.0f));
+    }
+    EXPECT_NEAR(glm::degrees(aim.pitch()), 45.0f, 1e-3f);
+}
+
+TEST(TurretGunTimer, first_shot_is_free_then_the_rate_of_fire_gates) {
+    TurretGunTimer timer(0.3f);
+
+    EXPECT_TRUE(timer.ready());
+    EXPECT_TRUE(timer.tryFire());
+    EXPECT_FALSE(timer.ready());
+    EXPECT_FALSE(timer.tryFire());
+}
+
+TEST(TurretGunTimer, cooldown_expires_after_the_rate_of_fire_elapses) {
+    TurretGunTimer timer(0.3f);
+    ASSERT_TRUE(timer.tryFire());
+
+    timer.update(0.2f);
+    EXPECT_FALSE(timer.tryFire());
+
+    timer.update(0.15f);
+    EXPECT_TRUE(timer.ready());
+    EXPECT_TRUE(timer.tryFire());
+}
+
+TEST(TurretGunTimer, a_zero_rate_of_fire_never_gates) {
+    TurretGunTimer timer(0.0f);
+
+    EXPECT_TRUE(timer.tryFire());
+    EXPECT_TRUE(timer.tryFire());
+}
+
+TEST(TurretBullet, advances_along_its_direction_at_the_authored_speed) {
+    TurretBullet bullet;
+    bullet.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    ASSERT_TRUE(bullet.advance(0.5f));
+
+    EXPECT_NEAR(bullet.position.y, 150.0f, 1e-3f);
+    EXPECT_FLOAT_EQ(bullet.life, 0.5f);
+}
+
+TEST(TurretBullet, is_culled_once_it_outlives_its_lifespan) {
+    TurretBullet bullet;
+    bullet.direction = glm::vec3(0.0f, 1.0f, 0.0f);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 1.0f;
+
+    ASSERT_TRUE(bullet.advance(0.9f));
+    EXPECT_FALSE(bullet.advance(0.2f));
+}
+
+TEST(TurretBullet, an_expired_bullet_is_culled_on_the_next_step) {
+    TurretBullet bullet;
+    bullet.lifespan = 10.0f;
+
+    bullet.expire();
+
+    EXPECT_FALSE(bullet.advance(0.01f));
+}
+
+// Projectile presentation. The bolt models are authored along +Y, so a bullet
+// carrying no orientation renders across world Y regardless of where it is
+// travelling - which is what made a single bolt impossible to pick out.
+
+TEST(TurretProjectile, a_bolt_fired_level_travels_and_points_down_model_y) {
+    glm::quat level(1.0f, 0.0f, 0.0f, 0.0f);
+
+    glm::vec3 direction = turretFireDirection(level);
+
+    EXPECT_NEAR(direction.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(direction.y, 1.0f, 1e-5f);
+    EXPECT_NEAR(direction.z, 0.0f, 1e-5f);
+}
+
+TEST(TurretProjectile, the_visual_long_axis_follows_the_direction_of_travel) {
+    TurretAim aim;
+    MinigamePlayerSpec player;
+    player.tunnelInfinite = glm::vec3(1.0f, 0.0f, 1.0f);
+    aim.configure(player);
+    aim.addYaw(glm::radians(70.0f));
+    aim.addPitch(glm::radians(25.0f));
+
+    TurretBullet bullet;
+    bullet.orientation = aim.orientation();
+    bullet.direction = turretFireDirection(bullet.orientation);
+
+    // The model's +Y axis, once transformed, must coincide with travel.
+    glm::mat4 transform = turretBulletTransform(bullet);
+    glm::vec3 modelAxis = glm::normalize(glm::vec3(glm::mat3(transform) * glm::vec3(0.0f, 1.0f, 0.0f)));
+
+    EXPECT_NEAR(modelAxis.x, bullet.direction.x, 1e-5f);
+    EXPECT_NEAR(modelAxis.y, bullet.direction.y, 1e-5f);
+    EXPECT_NEAR(modelAxis.z, bullet.direction.z, 1e-5f);
+}
+
+TEST(TurretProjectile, the_transform_places_the_bolt_at_its_muzzle_position) {
+    TurretBullet bullet;
+    bullet.position = glm::vec3(12.0f, -3.0f, 4.5f);
+    bullet.orientation = glm::angleAxis(glm::radians(40.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+
+    glm::mat4 transform = turretBulletTransform(bullet);
+
+    EXPECT_NEAR(transform[3].x, 12.0f, 1e-5f);
+    EXPECT_NEAR(transform[3].y, -3.0f, 1e-5f);
+    EXPECT_NEAR(transform[3].z, 4.5f, 1e-5f);
+}
+
+TEST(TurretProjectile, both_gun_banks_of_one_actor_fire_in_the_same_direction) {
+    // The muzzles differ, the orientation does not, so banks stay symmetrical.
+    glm::quat shooter = glm::angleAxis(glm::radians(33.0f), glm::vec3(0.0f, 0.0f, 1.0f)) *
+                        glm::angleAxis(glm::radians(12.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+
+    TurretBullet left;
+    left.position = glm::vec3(-2.0f, 0.0f, 0.0f);
+    left.orientation = shooter;
+    left.direction = turretFireDirection(shooter);
+
+    TurretBullet right;
+    right.position = glm::vec3(2.0f, 0.0f, 0.0f);
+    right.orientation = shooter;
+    right.direction = turretFireDirection(shooter);
+
+    EXPECT_NEAR(left.direction.x, right.direction.x, 1e-6f);
+    EXPECT_NEAR(left.direction.y, right.direction.y, 1e-6f);
+    EXPECT_NEAR(left.direction.z, right.direction.z, 1e-6f);
+    EXPECT_NE(turretBulletTransform(left)[3].x, turretBulletTransform(right)[3].x);
+}
+
+TEST(TurretProjectile, aiming_adds_no_rotation_beyond_the_aim_itself) {
+    // A bolt fired at neutral aim must not be rotated at all.
+    MinigamePlayerSpec player;
+    player.tunnelInfinite = glm::vec3(1.0f, 0.0f, 1.0f);
+    TurretAim aim;
+    aim.configure(player);
+
+    TurretBullet bullet;
+    bullet.orientation = aim.orientation();
+
+    glm::mat4 transform = turretBulletTransform(bullet);
+    glm::mat3 basis(transform);
+
+    EXPECT_NEAR(basis[0].x, 1.0f, 1e-5f);
+    EXPECT_NEAR(basis[1].y, 1.0f, 1e-5f);
+    EXPECT_NEAR(basis[2].z, 1.0f, 1e-5f);
+}
+
+TEST(TurretProjectile, a_bolt_advances_along_its_oriented_direction) {
+    TurretBullet bullet;
+    bullet.orientation = glm::angleAxis(glm::radians(90.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+    bullet.direction = turretFireDirection(bullet.orientation);
+    bullet.speed = 300.0f;
+    bullet.lifespan = 3.0f;
+
+    ASSERT_TRUE(bullet.advance(0.1f));
+
+    // Yawed 90 degrees, +Y maps onto -X.
+    EXPECT_NEAR(bullet.position.x, -30.0f, 1e-3f);
+    EXPECT_NEAR(bullet.position.y, 0.0f, 1e-3f);
+}
+
+TEST(TurretCollision, sphere_contains_points_within_its_radius) {
+    glm::vec3 center(10.0f, 20.0f, 30.0f);
+
+    EXPECT_TRUE(sphereContainsPoint(center, 20.0f, glm::vec3(10.0f, 35.0f, 30.0f)));
+    EXPECT_FALSE(sphereContainsPoint(center, 20.0f, glm::vec3(10.0f, 45.0f, 30.0f)));
+}
+
+TEST(TurretCollision, a_zero_radius_sphere_never_contains_anything) {
+    EXPECT_FALSE(sphereContainsPoint(glm::vec3(0.0f), 0.0f, glm::vec3(0.0f)));
+}
+
+TEST(TurretCollision, ray_hits_a_sphere_ahead_of_it_within_range) {
+    glm::vec3 origin(0.0f);
+    glm::vec3 direction(0.0f, 1.0f, 0.0f);
+
+    EXPECT_TRUE(rayIntersectsSphere(origin, direction, glm::vec3(0.0f, 100.0f, 0.0f), 40.0f, 200.0f));
+}
+
+TEST(TurretCollision, ray_misses_a_sphere_off_to_the_side) {
+    glm::vec3 origin(0.0f);
+    glm::vec3 direction(0.0f, 1.0f, 0.0f);
+
+    EXPECT_FALSE(rayIntersectsSphere(origin, direction, glm::vec3(80.0f, 100.0f, 0.0f), 40.0f, 200.0f));
+}
+
+TEST(TurretCollision, ray_misses_a_sphere_behind_it) {
+    glm::vec3 origin(0.0f);
+    glm::vec3 direction(0.0f, 1.0f, 0.0f);
+
+    EXPECT_FALSE(rayIntersectsSphere(origin, direction, glm::vec3(0.0f, -100.0f, 0.0f), 40.0f, 200.0f));
+}
+
+TEST(TurretCollision, ray_misses_a_sphere_beyond_the_sensing_radius) {
+    glm::vec3 origin(0.0f);
+    glm::vec3 direction(0.0f, 1.0f, 0.0f);
+
+    EXPECT_FALSE(rayIntersectsSphere(origin, direction, glm::vec3(0.0f, 500.0f, 0.0f), 40.0f, 200.0f));
+    EXPECT_TRUE(rayIntersectsSphere(origin, direction, glm::vec3(0.0f, 500.0f, 0.0f), 40.0f, 600.0f));
+}
+
+// Cockpit HUD state, reproducing k_pebo_hawkhit's shipped arithmetic:
+//   state = ((hp - 2000) * 12) / 1000 + 1
+// so each state covers a band of hit points and the gauge steps down cleanly.
+
+TEST(TurretDestruction, the_hawk_is_lost_below_the_gauge_floor_not_at_zero) {
+    EXPECT_FALSE(turretIsDestroyed(3000));
+    EXPECT_FALSE(turretIsDestroyed(2001));
+    EXPECT_FALSE(turretIsDestroyed(2000));
+    EXPECT_TRUE(turretIsDestroyed(1999));
+    EXPECT_TRUE(turretIsDestroyed(0));
+    EXPECT_TRUE(turretIsDestroyed(-50));
+}
+
+TEST(TurretDestruction, the_authored_survivable_band_is_one_thousand_points) {
+    // A 3000 point hawk is destroyed after 1001 points of damage, not 3000.
+    EXPECT_FALSE(turretIsDestroyed(3000 - 1000));
+    EXPECT_TRUE(turretIsDestroyed(3000 - 1001));
+}
+
+TEST(TurretDestruction, the_destruction_band_selects_the_empty_gauge) {
+    EXPECT_EQ(turretHealthState(1999), 0);
+    EXPECT_EQ(turretHealthAnimation(turretHealthState(1999)), "health00");
+}
+
+TEST(TurretHealthGauge, an_undamaged_hawk_reads_full) {
+    // 3000 is the authored Hit_Points/Max_HPs; the first damage lands below it.
+    EXPECT_EQ(turretHealthState(2999), 12);
+    EXPECT_EQ(turretHealthAnimation(12), "health12");
+}
+
+TEST(TurretHealthGauge, the_destruction_floor_reads_the_lowest_live_state) {
+    EXPECT_EQ(turretHealthState(2000), 1);
+    EXPECT_EQ(turretHealthAnimation(1), "health01");
+}
+
+TEST(TurretHealthGauge, below_the_floor_reads_empty) {
+    EXPECT_EQ(turretHealthState(1999), 0);
+    EXPECT_EQ(turretHealthState(0), 0);
+    EXPECT_EQ(turretHealthAnimation(0), "health00");
+}
+
+TEST(TurretHealthGauge, every_authored_state_band_is_reachable) {
+    // Each state n covers hp in [2000 + ceil((n-1)*1000/12), ...]; walking the
+    // whole range must visit all thirteen states.
+    std::set<int> seen;
+    for (int hp = 0; hp <= 3000; ++hp) {
+        seen.insert(turretHealthState(hp));
+    }
+    for (int state = 0; state < kTurretHealthStateCount; ++state) {
+        EXPECT_TRUE(seen.count(state) == 1) << "state " << state << " unreachable";
+    }
+}
+
+TEST(TurretHealthGauge, state_boundaries_match_the_shipped_arithmetic) {
+    // Spot-check the exact truncating-division boundaries.
+    EXPECT_EQ(turretHealthState(2083), 1);
+    EXPECT_EQ(turretHealthState(2084), 2);
+    EXPECT_EQ(turretHealthState(2166), 2);
+    EXPECT_EQ(turretHealthState(2167), 3);
+    EXPECT_EQ(turretHealthState(2249), 3);
+    EXPECT_EQ(turretHealthState(2250), 4);
+    EXPECT_EQ(turretHealthState(2916), 11);
+    EXPECT_EQ(turretHealthState(2917), 12);
+}
+
+TEST(TurretHealthGauge, the_gauge_never_rises_as_hit_points_fall) {
+    int previous = turretHealthState(3000);
+    for (int hp = 3000; hp >= 0; --hp) {
+        int state = turretHealthState(hp);
+        EXPECT_LE(state, previous) << "gauge rose at hp " << hp;
+        previous = state;
+    }
+}
+
+TEST(TurretHealthGauge, values_beyond_the_authored_range_clamp) {
+    EXPECT_EQ(turretHealthState(999999), kTurretHealthStateCount - 1);
+    EXPECT_EQ(turretHealthState(-999999), 0);
+    EXPECT_EQ(turretHealthAnimation(99), "health12");
+    EXPECT_EQ(turretHealthAnimation(-5), "health00");
+}
+
+TEST(TurretHealthGauge, unchanged_hit_points_select_the_same_state) {
+    EXPECT_EQ(turretHealthState(2500), turretHealthState(2500));
+    // A hit too small to cross a band boundary must not change the state, so
+    // the caller can skip restarting the animation. 2500 and 2502 both sit in
+    // the band that truncates to 6, i.e. state 7.
+    EXPECT_EQ(turretHealthState(2500), 7);
+    EXPECT_EQ(turretHealthState(2502), 7);
+}
+
+// Alarm01: the shipped script plays the authored looping sound object when the
+// computed state is exactly 3, and stops it only in the destruction branch.
+
+TEST(TurretAlarm, it_triggers_only_on_the_authored_state) {
+    EXPECT_TRUE(turretAlarmStartsAtState(3));
+    EXPECT_FALSE(turretAlarmStartsAtState(2));
+    EXPECT_FALSE(turretAlarmStartsAtState(4));
+    EXPECT_FALSE(turretAlarmStartsAtState(0));
+    EXPECT_FALSE(turretAlarmStartsAtState(12));
+}
+
+TEST(TurretAlarm, the_trigger_band_matches_the_shipped_hit_points) {
+    EXPECT_FALSE(turretAlarmStartsAtState(turretHealthState(2250)));
+    EXPECT_TRUE(turretAlarmStartsAtState(turretHealthState(2249)));
+    EXPECT_TRUE(turretAlarmStartsAtState(turretHealthState(2167)));
+    EXPECT_FALSE(turretAlarmStartsAtState(turretHealthState(2166)));
+}
+
+TEST(TurretAlarm, it_uses_the_authored_module_sound_object_tag) {
+    EXPECT_EQ(kTurretAlarmTag, "Alarm01");
+}
+
+// Radar contacts: one authored loop per enemy track, plus a removal pose.
+
+TEST(TurretRadar, every_enemy_maps_to_its_authored_contact_loop) {
+    EXPECT_EQ(turretContactAnimation(0), "sithloop02");
+    EXPECT_EQ(turretContactAnimation(1), "sithloop03");
+    EXPECT_EQ(turretContactAnimation(2), "sithloop04");
+    EXPECT_EQ(turretContactAnimation(3), "sithloop05");
+    EXPECT_EQ(turretContactAnimation(4), "sithloop06");
+    EXPECT_EQ(turretContactAnimation(5), "sithloop07");
+}
+
+TEST(TurretRadar, each_contact_has_a_matching_removal_pose) {
+    for (size_t i = 0; i < kTurretContactCount; ++i) {
+        EXPECT_EQ(turretContactDeathAnimation(i), turretContactAnimation(i) + "d");
+    }
+    EXPECT_EQ(turretContactDeathAnimation(0), "sithloop02d");
+    EXPECT_EQ(turretContactDeathAnimation(5), "sithloop07d");
+}
+
+TEST(TurretRadar, an_index_beyond_the_authored_contacts_has_no_channel) {
+    EXPECT_TRUE(turretContactAnimation(kTurretContactCount).empty());
+    EXPECT_TRUE(turretContactDeathAnimation(99).empty());
+}
+
+// Radar heading: one authored pose per whole degree.
+
+TEST(TurretHeading, zero_yaw_selects_the_authored_forward_pose) {
+    EXPECT_EQ(turretHeadingState(0.0f), 0);
+    EXPECT_EQ(turretHeadingAnimation(0), "hudrot_000");
+}
+
+TEST(TurretHeading, positive_yaw_counts_up_in_whole_degrees) {
+    EXPECT_EQ(turretHeadingState(glm::radians(1.0f)), 1);
+    EXPECT_EQ(turretHeadingState(glm::radians(90.0f)), 90);
+    EXPECT_EQ(turretHeadingAnimation(90), "hudrot_090");
+    EXPECT_EQ(turretHeadingAnimation(359), "hudrot_359");
+}
+
+TEST(TurretHeading, negative_yaw_wraps_into_the_authored_range) {
+    EXPECT_EQ(turretHeadingState(glm::radians(-1.0f)), 359);
+    EXPECT_EQ(turretHeadingState(glm::radians(-90.0f)), 270);
+    EXPECT_EQ(turretHeadingAnimation(turretHeadingState(glm::radians(-90.0f))), "hudrot_270");
+}
+
+TEST(TurretHeading, it_wraps_cleanly_across_the_seam) {
+    EXPECT_EQ(turretHeadingState(glm::radians(359.6f)), 0);
+    EXPECT_EQ(turretHeadingState(glm::radians(360.0f)), 0);
+    EXPECT_EQ(turretHeadingState(glm::radians(361.0f)), 1);
+}
+
+TEST(TurretHeading, several_full_rotations_stay_in_range) {
+    for (float turns = -5.0f; turns <= 5.0f; turns += 0.25f) {
+        int heading = turretHeadingState(turns * glm::two_pi<float>());
+        EXPECT_GE(heading, 0);
+        EXPECT_LT(heading, 360);
+    }
+}
+
+TEST(TurretHeading, a_yaw_within_the_same_degree_does_not_change_state) {
+    int before = turretHeadingState(glm::radians(45.1f));
+    int after = turretHeadingState(glm::radians(45.2f));
+    EXPECT_EQ(before, after);
+}
+
+// The startturretgame lifecycle: the command validates what it can up front,
+// schedules an ordinary module transition, and the request is resolved against
+// whatever module actually loaded.
+
+TEST(TurretRequest, a_valid_request_from_a_gameplay_module_is_accepted) {
+    EXPECT_EQ(validateTurretRequest("m12ab", "ebo_m12aa", /*moduleKnown=*/true, /*alreadyActive=*/false),
+              TurretRequestError::None);
+}
+
+TEST(TurretRequest, the_module_argument_is_required) {
+    EXPECT_EQ(validateTurretRequest("", "ebo_m12aa", /*moduleKnown=*/false, /*alreadyActive=*/false),
+              TurretRequestError::MissingModule);
+}
+
+TEST(TurretRequest, an_unknown_module_is_rejected) {
+    EXPECT_EQ(validateTurretRequest("not_a_module", "ebo_m12aa", /*moduleKnown=*/false, /*alreadyActive=*/false),
+              TurretRequestError::UnknownModule);
+}
+
+TEST(TurretRequest, requesting_the_current_module_is_rejected) {
+    EXPECT_EQ(validateTurretRequest("m12ab", "M12ab", /*moduleKnown=*/true, /*alreadyActive=*/false),
+              TurretRequestError::SameModule);
+}
+
+TEST(TurretRequest, a_request_without_an_origin_module_is_rejected) {
+    EXPECT_EQ(validateTurretRequest("m12ab", "", /*moduleKnown=*/true, /*alreadyActive=*/false),
+              TurretRequestError::NoOrigin);
+}
+
+TEST(TurretRequest, a_second_request_is_rejected_while_one_is_active) {
+    EXPECT_EQ(validateTurretRequest("m12ab", "ebo_m12aa", /*moduleKnown=*/true, /*alreadyActive=*/true),
+              TurretRequestError::AlreadyActive);
+}
+
+TEST(TurretRequest, every_rejection_carries_a_message) {
+    for (auto error : {TurretRequestError::MissingModule,
+                       TurretRequestError::UnknownModule,
+                       TurretRequestError::SameModule,
+                       TurretRequestError::NoOrigin,
+                       TurretRequestError::AlreadyActive}) {
+        EXPECT_STRNE(turretRequestErrorMessage(error), "");
+    }
+    EXPECT_STREQ(turretRequestErrorMessage(TurretRequestError::None), "");
+}
+
+TEST(TurretRequest, a_loaded_turret_module_starts_the_minigame) {
+    EXPECT_EQ(resolveTurretRequest(/*pendingForModule=*/true, /*hasMinigame=*/true, MinigameType::Turret),
+              TurretRequestResolution::Start);
+}
+
+TEST(TurretRequest, a_module_without_a_minigame_aborts_the_session) {
+    EXPECT_EQ(resolveTurretRequest(/*pendingForModule=*/true, /*hasMinigame=*/false, MinigameType::None),
+              TurretRequestResolution::AbortNoMinigame);
+}
+
+TEST(TurretRequest, a_module_with_a_different_minigame_aborts_the_session) {
+    EXPECT_EQ(resolveTurretRequest(/*pendingForModule=*/true, /*hasMinigame=*/true, MinigameType::SwoopRace),
+              TurretRequestResolution::AbortWrongType);
+}
+
+TEST(TurretRequest, an_unrelated_module_load_leaves_the_request_alone) {
+    EXPECT_EQ(resolveTurretRequest(/*pendingForModule=*/false, /*hasMinigame=*/true, MinigameType::Turret),
+              TurretRequestResolution::NotPending);
+    EXPECT_EQ(resolveTurretRequest(/*pendingForModule=*/false, /*hasMinigame=*/false, MinigameType::None),
+              TurretRequestResolution::NotPending);
+}
+
+TEST(TurretRequest, only_the_aborting_resolutions_carry_a_message) {
+    EXPECT_STRNE(turretRequestResolutionMessage(TurretRequestResolution::AbortNoMinigame), "");
+    EXPECT_STRNE(turretRequestResolutionMessage(TurretRequestResolution::AbortWrongType), "");
+    EXPECT_STREQ(turretRequestResolutionMessage(TurretRequestResolution::Start), "");
+    EXPECT_STREQ(turretRequestResolutionMessage(TurretRequestResolution::NotPending), "");
+}
+
+// Return-destination precedence. Note that starting m12ab from ebo_m12aa
+// cannot distinguish these cases, because the authored return and the captured
+// origin are the same module there; each case below uses a distinct origin.
+
+TEST(TurretReturn, an_authored_destination_overrides_the_captured_origin) {
+    // K1 m12ab always returns to ebo_m12aa, wherever the session started.
+    EXPECT_EQ(turretReturnModule("m12ab", "tar_m02ab"), "ebo_m12aa");
+    EXPECT_EQ(turretReturnModule("M12ab", "somewhere_else"), "ebo_m12aa");
+}
+
+TEST(TurretReturn, the_captured_origin_is_used_when_no_destination_is_authored) {
+    EXPECT_EQ(turretReturnModule("custom_mg", "tar_m02ab"), "tar_m02ab");
+}
+
+TEST(TurretReturn, with_neither_destination_no_module_is_named) {
+    // An empty result is the caller's signal to stay put rather than schedule a
+    // transition to an empty module name.
+    EXPECT_EQ(turretReturnModule("custom_mg", ""), "");
+    EXPECT_EQ(turretReturnModule("", ""), "");
+}
+
+TEST(TurretReturn, an_authored_destination_still_applies_with_no_captured_origin) {
+    EXPECT_EQ(turretReturnModule("m12ab", ""), "ebo_m12aa");
+}
+
+// Outcome semantics. Only a victory may emit the completion state; a defeat and
+// an abandoned session must both be distinguishable from it and from each other.
+
+TEST(TurretOutcome, only_a_victory_is_a_success) {
+    EXPECT_TRUE(turretSessionSucceeded(Turret::Outcome::Won));
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::Lost));
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::InProgress));
+}
+
+TEST(TurretOutcome, an_abandoned_session_is_neither_a_win_nor_a_loss) {
+    EXPECT_TRUE(turretSessionAborted(Turret::Outcome::InProgress));
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::InProgress));
+    EXPECT_FALSE(turretSessionAborted(Turret::Outcome::Won));
+    EXPECT_FALSE(turretSessionAborted(Turret::Outcome::Lost));
+}
+
+TEST(TurretOutcome, a_defeat_does_not_masquerade_as_a_victory) {
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::Lost));
+    EXPECT_FALSE(turretSessionAborted(Turret::Outcome::Lost));
+    EXPECT_STREQ(turretOutcomeName(Turret::Outcome::Lost), "lost");
+}
+
+TEST(TurretOutcome, every_outcome_reports_a_distinct_name) {
+    EXPECT_STREQ(turretOutcomeName(Turret::Outcome::Won), "won");
+    EXPECT_STREQ(turretOutcomeName(Turret::Outcome::Lost), "lost");
+    EXPECT_STREQ(turretOutcomeName(Turret::Outcome::InProgress), "aborted");
+}
+
+TEST(TurretOutcome, a_defeat_and_an_abort_still_name_a_return_destination) {
+    // Every outcome returns; only the completion state is victory-gated.
+    EXPECT_EQ(turretReturnModule("m12ab", "tar_m02ab"), "ebo_m12aa");
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::Lost));
+    EXPECT_FALSE(turretSessionSucceeded(Turret::Outcome::InProgress));
+}

--- a/test/game/turret.cpp
+++ b/test/game/turret.cpp
@@ -10,8 +10,23 @@
 #include <gtest/gtest.h>
 
 #include "reone/game/turret.h"
+#include "reone/graphics/animation.h"
+#include "reone/graphics/model.h"
+#include "reone/graphics/options.h"
+#include "reone/scene/graph.h"
+#include "reone/scene/node/model.h"
+#include "reone/scene/node/modelnode.h"
 
+#include "../fixtures/audio.h"
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/scene.h"
+
+using namespace reone::audio;
 using namespace reone::game;
+using namespace reone::graphics;
+using namespace reone::resource;
+using namespace reone::scene;
 
 namespace {
 
@@ -608,6 +623,139 @@ TEST(TurretDestruction, the_death_effect_lasts_the_authored_animation_length) {
 TEST(TurretDestruction, a_fighter_with_no_death_animation_is_retired_at_once) {
     EXPECT_TRUE(turretDeathEffectComplete(0.0f, 0.0f));
     EXPECT_TRUE(turretDeathEffectComplete(0.0f, -1.0f));
+}
+
+namespace {
+
+// A fighter shaped like mgf_sithfighter: a hull mesh, an explosion emitter, a
+// reference node the loader hangs an engine flare on, and a plain hook the
+// minigame attaches a gun bank model to.
+struct FighterFixture {
+    MockRenderPipelineFactory pipelineFactory;
+    GraphicsOptions graphicsOpt;
+    TestGraphicsModule graphicsModule;
+    TestAudioModule audioModule;
+    TestResourceModule resourceModule;
+    std::unique_ptr<SceneGraph> scene;
+
+    std::shared_ptr<ModelNode> root;
+    std::unique_ptr<Model> model;
+    std::shared_ptr<ModelSceneNode> node;
+
+    std::unique_ptr<Model> flareModel;
+    std::shared_ptr<ModelSceneNode> flare;
+    std::unique_ptr<Model> gunModel;
+    std::shared_ptr<ModelSceneNode> gun;
+
+    FighterFixture() {
+        graphicsModule.init();
+        audioModule.init();
+        resourceModule.init();
+        scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt,
+                                             graphicsModule.services(),
+                                             audioModule.services(),
+                                             resourceModule.services());
+
+        root = std::make_shared<ModelNode>(0, "fighter", glm::vec3(0.0f),
+                                           glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+
+        auto hull = std::make_shared<ModelNode>(1, "sith_wing", glm::vec3(0.0f),
+                                                glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, root.get());
+        hull->setMesh(std::make_shared<ModelNode::TriangleMesh>());
+        root->addChild(hull);
+
+        auto explode = std::make_shared<ModelNode>(2, "explode", glm::vec3(0.0f),
+                                                   glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, root.get());
+        explode->setEmitter(std::make_shared<ModelNode::Emitter>());
+        root->addChild(explode);
+
+        // An authored reference node. The referenced model name is left empty so
+        // the loader does not try to resolve it; the flare is attached below the
+        // same way the loader would.
+        auto omenRef = std::make_shared<ModelNode>(3, "omenref05", glm::vec3(0.0f),
+                                                   glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, root.get());
+        omenRef->setReference(std::make_shared<ModelNode::Reference>());
+        root->addChild(omenRef);
+
+        auto gunHook = std::make_shared<ModelNode>(4, "gunbank0", glm::vec3(0.0f),
+                                                   glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, root.get());
+        root->addChild(gunHook);
+
+        model = std::make_unique<Model>("fighter", 0, root,
+                                        std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+        node = makeModelSceneNode(*model);
+
+        flareModel = makeSimpleModel("fx_ref");
+        flare = makeModelSceneNode(*flareModel);
+        node->attach("omenref05", *flare);
+
+        gunModel = makeSimpleModel("mgg_null");
+        gun = makeModelSceneNode(*gunModel);
+        node->attach("gunbank0", *gun);
+    }
+
+    std::unique_ptr<Model> makeSimpleModel(const std::string &name) {
+        auto modelRoot = std::make_shared<ModelNode>(0, name, glm::vec3(0.0f),
+                                                     glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+        modelRoot->setMesh(std::make_shared<ModelNode::TriangleMesh>());
+        return std::make_unique<Model>(name, 0, modelRoot,
+                                       std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+    }
+
+    std::shared_ptr<ModelSceneNode> makeModelSceneNode(Model &m) {
+        auto n = std::make_shared<ModelSceneNode>(m, ModelUsage::Creature, *scene,
+                                                  graphicsModule.services(),
+                                                  audioModule.services(),
+                                                  resourceModule.services());
+        n->init();
+        return n;
+    }
+};
+
+} // namespace
+
+TEST(TurretDestruction, the_engine_flare_goes_out_the_moment_a_fighter_dies) {
+    FighterFixture fighter;
+    ASSERT_TRUE(fighter.flare->isEnabled());
+
+    turretDisableReferenceAttachments(*fighter.node);
+
+    EXPECT_FALSE(fighter.flare->isEnabled());
+}
+
+TEST(TurretDestruction, the_hull_survives_for_its_death_animation) {
+    FighterFixture fighter;
+
+    turretDisableReferenceAttachments(*fighter.node);
+
+    // The wreck itself, its explosion emitter and the gun bank model hooked on
+    // by the minigame all keep running: only loader-built reference
+    // attachments are switched off.
+    EXPECT_TRUE(fighter.node->isEnabled());
+    EXPECT_TRUE(fighter.gun->isEnabled());
+    EXPECT_TRUE(fighter.node->getNodeByName("sith_wing")->isEnabled());
+    EXPECT_TRUE(fighter.node->getNodeByName("explode")->isEnabled());
+}
+
+TEST(TurretDestruction, disabling_the_flare_twice_is_harmless) {
+    FighterFixture fighter;
+
+    turretDisableReferenceAttachments(*fighter.node);
+    turretDisableReferenceAttachments(*fighter.node);
+
+    EXPECT_FALSE(fighter.flare->isEnabled());
+    EXPECT_TRUE(fighter.gun->isEnabled());
+}
+
+TEST(TurretDestruction, a_replayed_fighter_starts_with_its_flare_lit) {
+    // Sessions build their fighters fresh, so a kill in one run cannot leave a
+    // later run's flare switched off.
+    FighterFixture first;
+    turretDisableReferenceAttachments(*first.node);
+    ASSERT_FALSE(first.flare->isEnabled());
+
+    FighterFixture replay;
+    EXPECT_TRUE(replay.flare->isEnabled());
 }
 
 TEST(TurretDestruction, death_effects_of_separate_fighters_are_independent) {

--- a/test/scene/model.cpp
+++ b/test/scene/model.cpp
@@ -112,6 +112,128 @@ TEST(ModelSceneNode, should_build_from_model) {
     EXPECT_EQ(static_cast<int>(SceneNodeType::Emitter), static_cast<int>(emitterSceneNode->type()));
 }
 
+namespace {
+
+// A model carrying several zero-length animations on disjoint nodes, which is
+// the shape of the shipped minigame HUD: one heading pose plus a contact loop
+// per fighter, all needing to run at once.
+struct OverlayModelFixture {
+    GraphicsOptions graphicsOpt;
+    MockRenderPipelineFactory pipelineFactory;
+    TestGraphicsModule graphicsModule;
+    TestAudioModule audioModule;
+    TestResourceModule resourceModule;
+    std::unique_ptr<SceneGraph> scene;
+    std::shared_ptr<ModelNode> rootNode;
+    std::vector<std::shared_ptr<Animation>> animations;
+    std::unique_ptr<Model> model;
+    std::shared_ptr<ModelSceneNode> node;
+
+    explicit OverlayModelFixture(const std::vector<std::string> &names) {
+        graphicsModule.init();
+        audioModule.init();
+        resourceModule.init();
+        scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt,
+                                             graphicsModule.services(),
+                                             audioModule.services(),
+                                             resourceModule.services());
+        rootNode = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f),
+                                               glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+        for (const auto &name : names) {
+            auto animRoot = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f),
+                                                        glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+            animations.push_back(std::make_shared<Animation>(
+                name, 0.0f, 0.0f, "", animRoot, std::vector<Animation::Event>()));
+        }
+        model = std::make_unique<Model>("hud_model", 0, rootNode, animations, "", 1.0f);
+        node = std::make_shared<ModelSceneNode>(*model, ModelUsage::Placeable, *scene,
+                                                graphicsModule.services(),
+                                                audioModule.services(),
+                                                resourceModule.services());
+        node->init();
+    }
+
+    void overlay(const std::string &name) {
+        node->playAnimation(name, nullptr,
+                            AnimationProperties::fromFlags(AnimationFlags::loopOverlay));
+    }
+};
+
+} // namespace
+
+TEST(ModelSceneNode, overlay_animations_on_disjoint_nodes_run_together) {
+    OverlayModelFixture fixture({"contact01", "contact02", "heading000"});
+
+    fixture.overlay("contact01");
+    fixture.overlay("contact02");
+    fixture.overlay("heading000");
+
+    EXPECT_EQ(fixture.node->animationChannelCount(), 3u);
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("contact01"));
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("heading000"));
+}
+
+TEST(ModelSceneNode, removing_one_overlay_leaves_the_others_running) {
+    OverlayModelFixture fixture({"contact01", "contact02", "heading000"});
+    fixture.overlay("contact01");
+    fixture.overlay("contact02");
+    fixture.overlay("heading000");
+
+    EXPECT_TRUE(fixture.node->removeAnimation("contact01"));
+
+    EXPECT_EQ(fixture.node->animationChannelCount(), 2u);
+    EXPECT_FALSE(fixture.node->isAnimationPlaying("contact01"));
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("contact02"));
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("heading000"));
+}
+
+TEST(ModelSceneNode, removing_an_animation_that_is_not_playing_is_harmless) {
+    OverlayModelFixture fixture({"contact01", "heading000"});
+    fixture.overlay("contact01");
+
+    EXPECT_FALSE(fixture.node->removeAnimation("heading000"));
+    EXPECT_FALSE(fixture.node->removeAnimation("no_such_animation"));
+
+    EXPECT_EQ(fixture.node->animationChannelCount(), 1u);
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("contact01"));
+}
+
+TEST(ModelSceneNode, repeated_removal_is_idempotent) {
+    OverlayModelFixture fixture({"contact01"});
+    fixture.overlay("contact01");
+
+    EXPECT_TRUE(fixture.node->removeAnimation("contact01"));
+    EXPECT_FALSE(fixture.node->removeAnimation("contact01"));
+    EXPECT_FALSE(fixture.node->removeAnimation("contact01"));
+
+    EXPECT_EQ(fixture.node->animationChannelCount(), 0u);
+}
+
+TEST(ModelSceneNode, replacing_a_pose_keeps_the_channel_count_bounded) {
+    // Swapping one zero-length heading pose for the next, as the turret does
+    // every time its yaw crosses a whole degree, must not accumulate channels.
+    std::vector<std::string> names {"contact01"};
+    for (int i = 0; i < 8; ++i) {
+        names.push_back(str(boost::format("heading%03d") % i));
+    }
+    OverlayModelFixture fixture(names);
+    fixture.overlay("contact01");
+
+    std::string previous;
+    for (int i = 0; i < 8; ++i) {
+        std::string next = str(boost::format("heading%03d") % i);
+        if (!previous.empty()) {
+            fixture.node->removeAnimation(previous);
+        }
+        fixture.overlay(next);
+        previous = next;
+        EXPECT_EQ(fixture.node->animationChannelCount(), 2u) << "after " << next;
+    }
+
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("contact01"));
+    EXPECT_TRUE(fixture.node->isAnimationPlaying("heading007"));
+}
+
 TEST(ModelSceneNode, should_play_single_fire_forget_animation) {
     // given
     auto graphicsOpt = GraphicsOptions();


### PR DESCRIPTION
## Summary

Restores the K1 Ebon Hawk turret minigame.

- Parses the complete `.are` `MiniGame` structure.
- Adds reusable named animation-channel removal to `ModelSceneNode`.
- Implements turret entry and exit, actors, aiming, projectiles, collision, damage, victory, defeat and replay.
- Implements the authored health display, alarm, radar contacts and heading display.
- Adds developer commands and focused tests.

## Testing

- warp to `m12ab` then use command `startturret`, or
- warp to ebon hawk then use command `startturretgame m12ab`
- additional command `turretstate` provides a snapshot of turret game data.  `stopturret` stops game

## Known limitations

- The authored canopy glass is temporarily hidden because the current renderer makes it obscure the cockpit. Proper glass rendering will be handled separately.
- Projectiles are drawn from their mesh geometry only. The authored bolt models carry most of their glow as emitters, which are suppressed in flight because the current emitter path emits continuously rather than on the authored event, so bolts read as more compact than vanilla. Correct moving-projectile emitter rendering will be handled separately.
- Encounter-specific room backgrounds depend on the general `PlayRoomAnimation` and delayed room-action paths, which will be implemented separately.
- K2 turret behaviour is not included.
