### PR TITLE
[script] Fix increment/decrement operand iterators

### DIFF
--- a/src/libs/script/virtualmachine.cpp
+++ b/src/libs/script/virtualmachine.cpp
@@ -1001,7 +1001,7 @@ void VirtualMachine::executeDESTRUCT(const Instruction &ins) {
 
 void VirtualMachine::executeDECISP(const Instruction &ins) {
     int dstIdx = static_cast<int>(_stack.size()) + ins.stackOffset / 4;
-    auto it = std::reverse_iterator(_stack.begin() + dstIdx);
+    auto it = _stack.rbegin() + (static_cast<int>(_stack.size()) - dstIdx - 1);
     logOperandsIt(it, it + 1);
     _stack[dstIdx] = Variable::ofInt(_stack[dstIdx].intValue - 1);
     logResultsIt(it, it + 1);
@@ -1009,7 +1009,7 @@ void VirtualMachine::executeDECISP(const Instruction &ins) {
 
 void VirtualMachine::executeINCISP(const Instruction &ins) {
     int dstIdx = static_cast<int>(_stack.size()) + ins.stackOffset / 4;
-    auto it = std::reverse_iterator(_stack.begin() + dstIdx);
+    auto it = _stack.rbegin() + (static_cast<int>(_stack.size()) - dstIdx - 1);
     logOperandsIt(it, it + 1);
     _stack[dstIdx] = Variable::ofInt(_stack[dstIdx].intValue + 1);
     logResultsIt(it, it + 1);
@@ -1055,7 +1055,7 @@ void VirtualMachine::executeCPTOPBP(const Instruction &ins) {
 void VirtualMachine::executeDECIBP(const Instruction &ins) {
     int dstIdx = _globalCount + ins.stackOffset / 4;
 
-    auto it = std::reverse_iterator(_stack.begin() + dstIdx);
+    auto it = _stack.rbegin() + (static_cast<int>(_stack.size()) - dstIdx - 1);
     logOperandsIt(it, it + 1);
     _stack[dstIdx] = Variable::ofInt(_stack[dstIdx].intValue - 1);
     logResultsIt(it, it + 1);
@@ -1064,7 +1064,7 @@ void VirtualMachine::executeDECIBP(const Instruction &ins) {
 void VirtualMachine::executeINCIBP(const Instruction &ins) {
     int dstIdx = _globalCount + ins.stackOffset / 4;
 
-    auto it = std::reverse_iterator(_stack.begin() + dstIdx);
+    auto it = _stack.rbegin() + (static_cast<int>(_stack.size()) - dstIdx - 1);
     logOperandsIt(it, it + 1);
     _stack[dstIdx] = Variable::ofInt(_stack[dstIdx].intValue + 1);
     logResultsIt(it, it + 1);

--- a/test/script/virtualmachine.cpp
+++ b/test/script/virtualmachine.cpp
@@ -203,6 +203,49 @@ TEST(VirtualMachine, should_run_script_program__loop) {
     EXPECT_EQ(10, result);
 }
 
+TEST(VirtualMachine, should_run_script_program__increment_decrement_stack_relative) {
+    // given
+    auto program = std::make_shared<ScriptProgram>("some_program");
+    program->add(Instruction::newCONSTI(5));  // 5
+    program->add(Instruction::newINCISP(-4)); // 6
+    program->add(Instruction::newINCISP(-4)); // 7
+    program->add(Instruction::newDECISP(-4)); // 6
+    program->add(Instruction::newCONSTI(0));  // 6, 0
+    program->add(Instruction::newINCISP(-8)); // 7, 0
+    program->add(Instruction::newDECISP(-4)); // 7, -1
+    program->add(Instruction::newMOVSP(-4));  // 7
+
+    auto context = std::make_unique<ExecutionContext>();
+    auto machine = VirtualMachine(program, std::move(context));
+
+    // when
+    auto result = machine.run();
+
+    // then
+    EXPECT_EQ(7, result);
+}
+
+TEST(VirtualMachine, should_run_script_program__increment_decrement_base_relative) {
+    // given
+    auto program = std::make_shared<ScriptProgram>("some_program");
+    program->add(Instruction::newCONSTI(5));            // 5
+    program->add(Instruction::newCONSTI(9));            // 5, 9
+    program->add(Instruction(InstructionType::SAVEBP)); // 5, 9, 2
+    program->add(Instruction::newINCIBP(-8));           // 6, 9, 2
+    program->add(Instruction::newINCIBP(-8));           // 7, 9, 2
+    program->add(Instruction::newDECIBP(-4));           // 7, 8, 2
+    program->add(Instruction::newMOVSP(-8));            // 7
+
+    auto context = std::make_unique<ExecutionContext>();
+    auto machine = VirtualMachine(program, std::move(context));
+
+    // when
+    auto result = machine.run();
+
+    // then
+    EXPECT_EQ(7, result);
+}
+
 TEST(VirtualMachine, should_run_script_program__action) {
     // given
     auto program = std::make_shared<ScriptProgram>("some_program");


### PR DESCRIPTION
## Summary

- correct the reverse-iterator base used by `INCISP` operand/result logging
- ensure the iterator references `_stack[dstIdx]`
- avoid an invalid reverse-iterator operation when `dstIdx == 0`
- leave VM execution semantics unchanged