### PR TITLE
[game] Implement core KOTOR 1 physical combat

### DIFF
--- a/glsl/f_text.glsl
+++ b/glsl/f_text.glsl
@@ -12,5 +12,5 @@ void main() {
     vec2 uv = fragUV1 * uTextChars[fragInstanceID].uv.zw + uTextChars[fragInstanceID].uv.xy;
     vec4 mainTexSample = texture(sMainTex, uv);
     vec3 objectColor = uColor.rgb * mainTexSample.rgb;
-    fragColor = vec4(objectColor, mainTexSample.a);
+    fragColor = vec4(objectColor, uColor.a * mainTexSample.a);
 }

--- a/include/reone/game/action.h
+++ b/include/reone/game/action.h
@@ -71,8 +71,10 @@ public:
 
     bool isUserAction() const { return _userAction; }
     bool isCompleted() const { return _completed; }
+    bool isCancelled() const { return _cancelled; }
 
     void setUserAction(bool val) { _userAction = val; }
+    void markCancelled() { _cancelled = true; }
 
 protected:
     const float kDefaultMaxObjectDistance = 2.0f;
@@ -84,6 +86,7 @@ protected:
 
     bool _userAction {false};
     bool _completed {false};
+    bool _cancelled {false};
     bool _locked {false};
 
     Action(

--- a/include/reone/game/attack.h
+++ b/include/reone/game/attack.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "reone/game/effect/damage.h"
 #include "reone/game/types.h"
 #include "reone/system/smallvector.h"
 #include "reone/system/timeevents.h"
@@ -55,15 +56,6 @@ AttackResultType computeWeaponAttack(
     int rollBonus = 0, int threatBonus = 0);
 
 /**
- * Descriptor for a delayed DamageEffect.
- */
-struct Damage {
-    int amount;
-    DamageType type;
-    DamagePower power;
-};
-
-/**
  * Predicate for melee weapon.
  *
  * Stun Baton and Hand-to-Hand is NOT a melee weapon. These require special
@@ -83,33 +75,71 @@ bool isRangedWieldType(CreatureWieldType type);
 bool isAttackSuccessful(AttackResultType result);
 
 /**
+ * Predicate for feats that resolve as a physical weapon or unarmed attack.
+ */
+bool isPhysicalAttackFeat(FeatType feat);
+
+struct AttackBonusBreakdown {
+    int baseAttackBonus {0};
+    int strengthModifier {0};
+    int dexterityModifier {0};
+    int dualWieldPenalty {0};
+    int smallOffhandBonus {0};
+    int featBonus {0};
+    FeatType duelingFeat {FeatType::Invalid};
+    int duelingBonus {0};
+    int closeProximityRangedBonus {0};
+    int meleeOnRangedBonus {0};
+    int weaponFocusBonus {0};
+    int effectBonus {0};
+
+    int total() const {
+        return baseAttackBonus +
+               strengthModifier +
+               dexterityModifier +
+               dualWieldPenalty +
+               smallOffhandBonus +
+               featBonus +
+               duelingBonus +
+               closeProximityRangedBonus +
+               meleeOnRangedBonus +
+               weaponFocusBonus +
+               effectBonus;
+    }
+};
+
+/**
  * Make and collect multiple attacks, but delay damage effects until later.
  */
 class AttackBuffer {
 public:
-    /**
-     * Calculate attack roll and damage effects for a weapon attack. Damage is
-     * added to AttackBuffer, and can be applied later with applyEffects().
-     */
-    void addWeaponAttack(const Creature &attacker, const Object &target, const Item &weapon,
-                         int attackRollBonus = 0,
-                         int attackThreatBonus = 0,
-                         int damageBonus = 0);
+    enum class Source {
+        Main,
+        Offhand,
+    };
 
     /**
-     * Calculate attack roll and damage effects for an unarmed attack. Damage is
-     * added to AttackBuffer, and can be applied later with applyEffects().
+     * Construct an ordered physical attack round from the attacker's equipped
+     * weapons, active effects, and optional combat feat.
      */
-    void addUnarmedAttack(const Creature &attacker, const Object &target,
-                          int attackRollBonus = 0,
-                          int attackThreatBonus = 0,
-                          int damageBonus = 0);
+    void addPhysicalAttacks(const Creature &attacker, const Object &target,
+                            FeatType feat = FeatType::Invalid);
 
     /**
-     * Apply all previously collected damage effects from \p attacker to \p
-     * target.
+     * Apply the once-per-action effects of a melee combat feat.
      */
-    void applyEffects(Creature &attacker, Object &target, Game &game);
+    void resolveMeleeSpecialAttack(
+        FeatType feat,
+        Creature &attacker,
+        Object &target,
+        Game &game);
+
+    void resolve(Creature &attacker, Object &target);
+    void signal(
+        Game &game,
+        ServicesView &services,
+        Creature &attacker,
+        Object &target);
 
     /**
      * Get the best result for a series of attacks collected in AttackBuffer.
@@ -118,14 +148,51 @@ public:
 
 private:
     struct Attack {
-        explicit Attack(AttackResultType result) :
-            result(result) {}
+        Attack(
+            Source source,
+            bool ranged,
+            AttackResultType result,
+            int roll,
+            AttackBonusBreakdown attackBonusBreakdown,
+            int defense,
+            bool assuredHit) :
+            source(source),
+            ranged(ranged),
+            result(result),
+            roll(roll),
+            attackBonusBreakdown(std::move(attackBonusBreakdown)),
+            defense(defense),
+            assuredHit(assuredHit) {}
 
+        Source source;
+        bool ranged;
         AttackResultType result;
-        SmallVector<Damage, 4> damage;
+        int roll;
+        AttackBonusBreakdown attackBonusBreakdown;
+        int defense;
+        bool assuredHit;
+        bool stunTarget {false};
+        DamagePacket damage;
     };
 
+    void addPhysicalAttack(
+        const Creature &attacker,
+        const Object &target,
+        const Item *weapon,
+        Source source,
+        int attackRollBonus,
+        int attackThreatBonus,
+        int damageBonus);
+    void resolveDamage(Object &target);
+    void applyEffects(Creature &attacker, Object &target, Game &game);
+    void addCombatFeedback(
+        Game &game,
+        ServicesView &services,
+        const Creature &attacker,
+        const Object &target) const;
+
     SmallVector<Attack, 8> _attacks;
+    FeatType _feat {FeatType::Invalid};
 };
 
 /**

--- a/include/reone/game/character.h
+++ b/include/reone/game/character.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "d20/attributes.h"
 
 #include "types.h"
@@ -26,6 +28,7 @@ namespace reone {
 namespace game {
 
 struct Character {
+    std::string name;
     Gender gender {Gender::Male};
     int appearance {0};
     CreatureAttributes attributes;

--- a/include/reone/game/combat.h
+++ b/include/reone/game/combat.h
@@ -96,16 +96,9 @@ public:
     void update(float dt);
     void reset() { _rounds.clear(); }
 
-public:
+private:
     using RoundQueue = std::deque<std::unique_ptr<CombatRound>>;
 
-    /**
-     * Returns a list of past (completed) rounds as well as current rounds
-     * ordered from oldest to newest.
-     */
-    const RoundQueue &rounds() const { return _rounds; }
-
-private:
     Game &_game;
     ServicesView &_services;
 
@@ -113,6 +106,7 @@ private:
 
     void updateRound(CombatRound &round, float dt);
     void finishRound(CombatRound &round);
+    void retireCompletedRounds();
 
     CombatRound *findRoundForAction(const std::shared_ptr<Action> &action, uint32_t attacker);
     CombatRound *tryAppendAction(const std::shared_ptr<Action> &action, uint32_t attacker, uint32_t target);

--- a/include/reone/game/d20/attributes.h
+++ b/include/reone/game/d20/attributes.h
@@ -62,6 +62,7 @@ public:
     ClassType getEffectiveClass() const;
     int getClassLevel(ClassType clazz) const;
     int getAggregateAttackBonus() const;
+    int getAggregateDefenseBonus() const;
     SavingThrows getAggregateSavingThrows() const;
 
     // END Class Levels

--- a/include/reone/game/d20/class.h
+++ b/include/reone/game/d20/class.h
@@ -64,6 +64,11 @@ public:
      */
     int getAttackBonus(int level) const;
 
+    /**
+     * @return defense bonus at the specified creature level
+     */
+    int getDefenseBonus(int level) const;
+
     ClassType type() const { return _type; }
     const std::string &name() const { return _name; }
     const std::string &description() const { return _description; }
@@ -91,6 +96,7 @@ private:
     std::unordered_map<int, int> _featGainsByLevel;
     std::unordered_map<int, int> _powerGainsByLevel;
     std::vector<int> _attackBonuses;
+    std::vector<int> _defenseBonuses;
 
     // Services
 
@@ -104,6 +110,7 @@ private:
     void loadClassSkills(const std::string &skillsTable);
     void loadSavingThrows(const std::string &savingThrowTable);
     void loadAttackBonuses(const std::string &attackBonusTable);
+    void loadDefenseBonuses(const std::string &defenseBonusColumn);
     void loadFeatListValues(const std::string &featsPrefix);
     void loadFeatGains(const std::string &featGainPrefix);
     void loadPowerGains(const std::string &powerGainPrefix);

--- a/include/reone/game/effect.h
+++ b/include/reone/game/effect.h
@@ -34,6 +34,8 @@ public:
     }
 
     virtual void applyTo(Object &object);
+    virtual bool onApply(Object &object);
+    virtual void onRemove(Object &object);
 
     EffectType type() const { return _type; }
 

--- a/include/reone/game/effect/acdecrease.h
+++ b/include/reone/game/effect/acdecrease.h
@@ -34,6 +34,10 @@ public:
 
     void applyTo(Object &object) override;
 
+    int penalty() const { return _value; }
+    ACBonus modifierType() const { return _modifyType; }
+    int damageType() const { return _damageType; }
+
 private:
     int _value;
     ACBonus _modifyType;

--- a/include/reone/game/effect/acincrease.h
+++ b/include/reone/game/effect/acincrease.h
@@ -34,6 +34,10 @@ public:
 
     void applyTo(Object &object) override;
 
+    int bonus() const { return _value; }
+    ACBonus modifierType() const { return _modifyType; }
+    int damageType() const { return _damageType; }
+
 private:
     int _value;
     ACBonus _modifyType;

--- a/include/reone/game/effect/assuredhit.h
+++ b/include/reone/game/effect/assuredhit.h
@@ -29,7 +29,8 @@ public:
         Effect(EffectType::AssuredHit) {
     }
 
-    void applyTo(Object &object) override;
+    bool onApply(Object &object) override;
+    void onRemove(Object &object) override;
 };
 
 } // namespace game

--- a/include/reone/game/effect/attackdecrease.h
+++ b/include/reone/game/effect/attackdecrease.h
@@ -33,6 +33,9 @@ public:
 
     void applyTo(Object &object) override;
 
+    int penalty() const { return _penalty; }
+    AttackBonus modifierType() const { return _modifierType; }
+
 private:
     int _penalty;
     AttackBonus _modifierType;

--- a/include/reone/game/effect/attackincrease.h
+++ b/include/reone/game/effect/attackincrease.h
@@ -33,6 +33,9 @@ public:
 
     void applyTo(Object &object) override;
 
+    int bonus() const { return _bonus; }
+    AttackBonus modifierType() const { return _modifierType; }
+
 private:
     int _bonus;
     AttackBonus _modifierType;

--- a/include/reone/game/effect/damage.h
+++ b/include/reone/game/effect/damage.h
@@ -17,13 +17,59 @@
 
 #pragma once
 
+#include <optional>
+#include <stdexcept>
+
+#include "reone/system/smallvector.h"
+
 #include "../effect.h"
 
 namespace reone {
 
 namespace game {
 
-class Creature;
+inline constexpr int kAllDamageTypeFlags = 8199;
+inline constexpr int kPhysicalDamageTypeFlags = 16391;
+
+DamageType getPrimaryDamageType(int damageFlags);
+bool damageTypeMatches(int modifierFlags, int damageFlags);
+
+/**
+ * Typed damage caused by one hit.
+ *
+ * A packet may contain multiple damage types, but it is applied to the target
+ * as one damage event.
+ */
+class DamagePacket {
+public:
+    explicit DamagePacket(DamagePower power = DamagePower::Normal) :
+        _power(power) {
+    }
+
+    void add(int amount, DamageType type);
+    void setDamageFlags(int damageFlags);
+    void setPower(DamagePower power);
+    void resolve(Object &object);
+
+    int total() const;
+    int resolvedDamage() const;
+    bool empty() const { return _components.empty(); }
+    bool isResolved() const { return _resolvedDamage.has_value(); }
+
+private:
+    struct Component {
+        int amount;
+        DamageType type;
+    };
+
+    void requireUnresolved() const;
+    void addResolved(int amount, DamageType type);
+
+    DamagePower _power;
+    int _damageFlags {0};
+    SmallVector<Component, 4> _components;
+    std::optional<int> _resolvedDamage;
+};
 
 class DamageEffect : public Effect {
 public:
@@ -32,22 +78,27 @@ public:
                  DamagePower power,
                  uint32_t damager) :
         Effect(EffectType::Damage),
-        _amount(amount),
-        _type(type),
-        _power(power),
+        _damage(power),
         _damager(damager) {
+        _damage.add(amount, type);
+        _damage.setDamageFlags(static_cast<int>(type));
+    }
+
+    DamageEffect(DamagePacket damage, uint32_t damager) :
+        Effect(EffectType::Damage),
+        _damage(std::move(damage)),
+        _damager(damager) {
+        if (!_damage.isResolved()) {
+            throw std::invalid_argument("Damage packet has not been resolved");
+        }
     }
 
     void applyTo(Object &object) override;
 
-    int amount() const { return _amount; }
-    DamageType type() const { return _type; }
     uint32_t damager() const { return _damager; }
 
 private:
-    int _amount;
-    DamageType _type;
-    DamagePower _power;
+    DamagePacket _damage;
     uint32_t _damager;
 };
 

--- a/include/reone/game/effect/damageabsorption.h
+++ b/include/reone/game/effect/damageabsorption.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,31 +17,41 @@
 
 #pragma once
 
-#include "../effect.h"
+#include <algorithm>
 
 namespace reone {
 
 namespace game {
 
-class SavingThrowDecreaseEffect : public Effect {
+class DamageAbsorption {
 public:
-    SavingThrowDecreaseEffect(int save, int value, SavingThrowType savingThrowType) :
-        Effect(EffectType::SavingThrowDecrease),
-        _save(save),
-        _value(value),
-        _savingThrowType(savingThrowType) {
+    DamageAbsorption(int amount, int limit) :
+        _amount(amount),
+        _limit(limit),
+        _limited(limit > 0) {
     }
 
-    void applyTo(Object &object) override;
+    int amount() const { return _amount; }
 
-    int save() const { return _save; }
-    int value() const { return _value; }
-    SavingThrowType savingThrowType() const { return _savingThrowType; }
+    int absorb(int damage) {
+        if (damage <= 0 || _amount <= 0) {
+            return 0;
+        }
+        if (!_limited) {
+            return std::min(damage, _amount);
+        }
+
+        int remaining = _limit;
+        _limit = std::max(0, _limit - damage);
+        return std::min(damage, _limit == 0 ? remaining : _amount);
+    }
+
+    bool exhausted() const { return _limited && _limit == 0; }
 
 private:
-    int _save;
-    int _value;
-    SavingThrowType _savingThrowType;
+    int _amount;
+    int _limit;
+    bool _limited;
 };
 
 } // namespace game

--- a/include/reone/game/effect/damagedecrease.h
+++ b/include/reone/game/effect/damagedecrease.h
@@ -33,6 +33,9 @@ public:
 
     void applyTo(Object &object) override;
 
+    int penalty() const { return _penalty; }
+    DamageType damageType() const { return _damageType; }
+
 private:
     int _penalty;
     DamageType _damageType;

--- a/include/reone/game/effect/damageimmunitydecrease.h
+++ b/include/reone/game/effect/damageimmunitydecrease.h
@@ -31,8 +31,10 @@ public:
         _percentImmunity(percentImmunity) {
     }
 
-    void applyTo(Object &object) override {
-    }
+    bool onApply(Object &object) override;
+
+    DamageType damageType() const { return _damageType; }
+    int percentImmunity() const { return _percentImmunity; }
 
 private:
     DamageType _damageType;

--- a/include/reone/game/effect/damageimmunityincrease.h
+++ b/include/reone/game/effect/damageimmunityincrease.h
@@ -31,7 +31,10 @@ public:
         _percentImmunity(percentImmunity) {
     }
 
-    void applyTo(Object &object) override;
+    bool onApply(Object &object) override;
+
+    DamageType damageType() const { return _damageType; }
+    int percentImmunity() const { return _percentImmunity; }
 
 private:
     DamageType _damageType;

--- a/include/reone/game/effect/damageincrease.h
+++ b/include/reone/game/effect/damageincrease.h
@@ -33,6 +33,9 @@ public:
 
     void applyTo(Object &object) override;
 
+    int bonus() const { return _bonus; }
+    DamageType damageType() const { return _damageType; }
+
 private:
     int _bonus;
     DamageType _damageType;

--- a/include/reone/game/effect/damagereduction.h
+++ b/include/reone/game/effect/damagereduction.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "../effect.h"
+#include "damageabsorption.h"
 
 namespace reone {
 
@@ -27,18 +28,21 @@ class DamageReductionEffect : public Effect {
 public:
     DamageReductionEffect(int amount, DamagePower damagePower, int limit) :
         Effect(EffectType::DamageReduction),
-        _amount(amount),
-        _damagePower(damagePower),
-        _limit(limit) {
+        _absorption(amount, limit),
+        _damagePower(damagePower) {
     }
 
-    void applyTo(Object &object) override {
+    void applyTo(Object &) override {
     }
+
+    int amount() const { return _absorption.amount(); }
+    DamagePower damagePower() const { return _damagePower; }
+    int absorb(int damage) { return _absorption.absorb(damage); }
+    bool exhausted() const { return _absorption.exhausted(); }
 
 private:
-    int _amount;
+    DamageAbsorption _absorption;
     DamagePower _damagePower;
-    int _limit;
 };
 
 } // namespace game

--- a/include/reone/game/effect/damageresistance.h
+++ b/include/reone/game/effect/damageresistance.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "../effect.h"
+#include "damageabsorption.h"
 
 namespace reone {
 
@@ -28,16 +29,19 @@ public:
     DamageResistanceEffect(DamageType damageType, int amount, int limit) :
         Effect(EffectType::DamageResistance),
         _damageType(damageType),
-        _amount(amount),
-        _limit(limit) {
+        _absorption(amount, limit) {
     }
 
     void applyTo(Object &object) override;
 
+    DamageType damageType() const { return _damageType; }
+    int amount() const { return _absorption.amount(); }
+    int absorb(int damage) { return _absorption.absorb(damage); }
+    bool exhausted() const { return _absorption.exhausted(); }
+
 private:
     DamageType _damageType;
-    int _amount;
-    int _limit;
+    DamageAbsorption _absorption;
 };
 
 } // namespace game

--- a/include/reone/game/effect/immunity.h
+++ b/include/reone/game/effect/immunity.h
@@ -32,6 +32,8 @@ public:
 
     void applyTo(Object &object) override;
 
+    ImmunityType immunityType() const { return _immunityType; }
+
 private:
     ImmunityType _immunityType;
 };

--- a/include/reone/game/effect/modifyattacks.h
+++ b/include/reone/game/effect/modifyattacks.h
@@ -30,7 +30,8 @@ public:
         _attacks(attacks) {
     }
 
-    void applyTo(Object &object) override;
+    bool onApply(Object &object) override;
+    void onRemove(Object &object) override;
 
 private:
     int _attacks;

--- a/include/reone/game/effect/savingthrowincrease.h
+++ b/include/reone/game/effect/savingthrowincrease.h
@@ -34,6 +34,10 @@ public:
 
     void applyTo(Object &object) override;
 
+    int save() const { return _save; }
+    int value() const { return _value; }
+    SavingThrowType savingThrowType() const { return _savingThrowType; }
+
 private:
     int _save;
     int _value;

--- a/include/reone/game/effect/stunned.h
+++ b/include/reone/game/effect/stunned.h
@@ -30,6 +30,7 @@ public:
     }
 
     void applyTo(Object &object) override;
+    void onRemove(Object &object) override;
 };
 
 } // namespace game

--- a/include/reone/game/floatingtext.h
+++ b/include/reone/game/floatingtext.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace reone {
+
+namespace graphics {
+
+class Font;
+
+}
+
+namespace game {
+
+class Creature;
+class Game;
+class Object;
+struct ServicesView;
+
+/**
+ * Target-anchored floating feedback shown over objects in the active area.
+ */
+class FloatingText {
+public:
+    FloatingText(Game &game, ServicesView &services) :
+        _game(game),
+        _services(services) {
+    }
+
+    void addDamage(const Object &object, int amount, int adjustedAmount, uint32_t damager);
+    void addHeal(const Object &object, int amount);
+    void addMiss(const Creature &attacker, const Object &target);
+
+    void update(float dt);
+    void render();
+    void reset();
+
+private:
+    enum class Style {
+        Damage,
+        Heal,
+        Miss,
+    };
+
+    struct Entry {
+        uint32_t objectId;
+        std::string text;
+        Style style;
+        float remaining;
+        int stack;
+        std::optional<glm::vec2> anchorOffset;
+    };
+
+    Game &_game;
+    ServicesView &_services;
+
+    std::vector<Entry> _entries;
+    std::shared_ptr<graphics::Font> _font;
+    std::string _fontResRef;
+
+    void add(const Object &object, std::string text, Style style);
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -31,6 +31,7 @@
 #include "di/services.h"
 #include "effect.h"
 #include "event.h"
+#include "floatingtext.h"
 #include "gui/chargen.h"
 #include "gui/computer.h"
 #include "gui/container.h"
@@ -46,6 +47,7 @@
 #include "gui/saveload.h"
 #include "journal.h"
 #include "location.h"
+#include "messagelog.h"
 #include "object/area.h"
 #include "object/camera/animated.h"
 #include "object/camera/dialog.h"
@@ -65,8 +67,8 @@
 #include "party.h"
 #include "pazaaksession.h"
 #include "script/runner.h"
-#include "swooprace.h"
 #include "statussummary.h"
+#include "swooprace.h"
 #include "talent.h"
 
 #include <queue>
@@ -121,7 +123,8 @@ public:
         _party(*this),
         _combat(*this, services),
         _swoopRace(*this),
-        _journal(services.resource.gffs, services.resource.strings) {
+        _journal(services.resource.gffs, services.resource.strings),
+        _floatingText(*this, services) {
         initJournalNotifications();
     }
 
@@ -143,6 +146,8 @@ public:
     Party &party() { return _party; }
     Combat &combat() { return _combat; }
     Journal &journal() { return _journal; }
+    MessageLog &messageLog() { return _messageLog; }
+    FloatingText &floatingText() { return _floatingText; }
     ScriptRunner &scriptRunner() { return *_scriptRunner; }
     Map &map() { return *_map; }
     script::IRoutines &routines() { return *_routines; }
@@ -469,6 +474,8 @@ private:
     Combat _combat;
     SwoopRace _swoopRace;
     Journal _journal;
+    MessageLog _messageLog;
+    FloatingText _floatingText;
     StatusSummaryAccumulator _statusSummary;
 
     std::unique_ptr<script::IRoutines> _routines;

--- a/include/reone/game/gui/chargen.h
+++ b/include/reone/game/gui/chargen.h
@@ -99,6 +99,7 @@ public:
     const Character &character() const { return _character; }
 
     void setCharacter(Character character);
+    void setCharacterName(std::string name);
 
     const std::string &musicResRef() const {
         return _musicResRef;

--- a/include/reone/game/gui/ingame/messages.h
+++ b/include/reone/game/gui/ingame/messages.h
@@ -42,6 +42,8 @@ public:
 
     void onGUILoaded() override;
 
+    void refresh();
+
 private:
     struct Controls {
         std::shared_ptr<gui::Button> BTN_COMBAT;
@@ -68,6 +70,11 @@ private:
     };
 
     Controls _controls;
+    bool _showingFeedback {false};
+
+    void showDialogMessages();
+    void showFeedbackMessages();
+    void toggleMessages();
 
     void bindControls() {
         _controls.BTN_COMBAT = findControl<gui::Button>("BTN_COMBAT");

--- a/include/reone/game/messagelog.h
+++ b/include/reone/game/messagelog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,45 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "reone/game/effect/damageresistance.h"
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <string>
+#include <utility>
 
 namespace reone {
 
 namespace game {
 
-void DamageResistanceEffect::applyTo(Object &) {
-}
+/**
+ * Rolling in-game feedback history.
+ */
+class MessageLog {
+public:
+    enum class Style : uint8_t {
+        Normal = 0,
+        Combat = 1,
+    };
+
+    struct Entry {
+        uint32_t type;
+        Style style;
+        std::string text;
+    };
+
+    static constexpr std::size_t kMaxEntries = 64;
+    static constexpr uint32_t kFeedbackMessageType = 0x80;
+
+    void add(uint32_t type, Style style, std::string text);
+    void reset() { _entries.clear(); }
+
+    const std::deque<Entry> &entries() const { return _entries; }
+
+private:
+    std::deque<Entry> _entries;
+};
 
 } // namespace game
 

--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -21,6 +21,7 @@
 #include "reone/scene/graph.h"
 #include "reone/scene/node.h"
 #include "reone/scene/user.h"
+#include "reone/script/types.h"
 #include "reone/system/cast.h"
 #include "reone/system/timer.h"
 
@@ -98,6 +99,7 @@ public:
 
     void setTag(std::string tag) { _tag = std::move(tag); }
     void setConversation(std::string conversation) { _conversation = std::move(conversation); }
+    void setName(std::string name) { _name = std::move(name); }
     void setPlotFlag(bool plot) { _plot = plot; }
     void setCommandable(bool commandable) { _commandable = commandable; }
     void setIsInConversation(bool isInConversation) { _isInConversation = isInConversation; }
@@ -134,6 +136,7 @@ public:
     // Effects
 
     void clearAllEffects();
+    void removeEffect(const std::shared_ptr<Effect> &effect);
     void applyEffect(const std::shared_ptr<Effect> &effect, DurationType durationType, float duration = 0.0f);
 
     struct AppliedEffect {
@@ -143,6 +146,7 @@ public:
     };
 
     const std::deque<AppliedEffect> &effects() const { return _effects; }
+    bool hasEffect(EffectType type) const;
     std::shared_ptr<Effect> getFirstEffect();
     std::shared_ptr<Effect> getNextEffect();
 
@@ -189,13 +193,21 @@ public:
     void addActionOnTop(std::shared_ptr<Action> action);
     void delayAction(std::shared_ptr<Action> action, float seconds);
 
-    bool hasUserActionsPending() const;
+    bool hasUserActionsPending(const Action *excluded = nullptr) const;
 
     std::shared_ptr<Action> getCurrentAction() const;
 
     const std::deque<std::shared_ptr<Action>> &actions() const { return _actions; }
 
     // END Actions
+
+    // Combat
+
+    uint32_t getLastHostileActor() const { return _lastHostileActor; }
+
+    void setLastHostileActor(uint32_t actor) { _lastHostileActor = actor; }
+
+    // END Combat
 
     // Local variables
 
@@ -271,6 +283,8 @@ protected:
 
     // END Actions
 
+    uint32_t _lastHostileActor {script::kObjectInvalid};
+
     // Local variables
 
     std::map<int, bool> _localBooleans;
@@ -292,6 +306,7 @@ protected:
     }
 
     virtual void updateTransform();
+    virtual bool canExecuteActions() const { return true; }
 
     // Actions
 
@@ -306,7 +321,9 @@ protected:
     // Effects
 
     void updateEffects(float dt);
-    void applyInstantEffect(Effect &effect);
+    virtual void onEffectsCleared() {}
+
+    int applyDamageToHitPoints(int amount, int currentHitPoints);
 
     // END Effects
 };

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -46,6 +46,9 @@ namespace game {
 
 constexpr float kDefaultAttackRange = 2.0f;
 
+class DamagePacket;
+struct AttackBonusBreakdown;
+
 class Creature : public Object, public scene::IAnimationEventListener {
 public:
     enum class ModelType {
@@ -87,6 +90,9 @@ public:
         bool shouldDeactivate {false};
         bool debilitated {false};
         std::shared_ptr<Object> attackTarget;
+        uint32_t attemptedAttackTarget {script::kObjectInvalid};
+        ActionType attackAction {ActionType::QueueEmpty};
+        FeatType combatFeat {FeatType::Invalid};
         Timer deactivationTimer;
     };
 
@@ -119,7 +125,7 @@ public:
     void stopTalking();
 
     bool isSelectable() const override;
-    bool isMovementRestricted() const { return _movementRestricted; }
+    bool isMovementRestricted() const { return _movementRestricted || !canExecuteActions(); }
     bool isLevelUpPending() const;
 
     glm::vec3 getSelectablePosition() const override;
@@ -133,12 +139,14 @@ public:
     float walkSpeed() const { return _walkSpeed; }
     float runSpeed() const { return _runSpeed; }
     float creaturePersonalSpace() const { return _creaturePersonalSpace; }
+    CreatureSize size() const { return _size; }
     CreatureAttributes &attributes() { return _attributes; }
     const CreatureAttributes &attributes() const { return _attributes; }
     ItemAttributes &itemAttributes() { return _itemAttributes; }
     const ItemAttributes &itemAttributes() const { return _itemAttributes; }
     Faction faction() const { return _faction; }
     int xp() const { return _xp; }
+    Alignment alignment() const;
     RacialType racialType() const { return _race; }
     Subrace subrace() const { return _subrace; }
     NPCAIStyle aiStyle() const { return _aiStyle; }
@@ -218,19 +226,54 @@ public:
     void deactivateCombat(float delay);
 
     bool isInCombat() const { return _combatState.active; }
-    bool isDebilitated() const { return _combatState.debilitated; }
+    bool isDebilitated() const;
+    bool isTemporarilyDead() const;
     bool isTwoWeaponFighting() const;
+    std::shared_ptr<Item> getOffhandAttackWeapon() const;
 
-    std::shared_ptr<Object> getAttemptedAttackTarget() const;
+    uint32_t getAttemptedAttackTarget() const { return _combatState.attemptedAttackTarget; }
     std::shared_ptr<Object> getAttackTarget() const { return _combatState.attackTarget; }
+    uint32_t getLastHostileTarget() const { return _lastHostileTarget; }
+    ActionType getLastAttackAction() const { return _lastAttackAction; }
+    FeatType getLastCombatFeat() const { return _lastCombatFeat; }
+    AttackResultType getLastAttackResult() const { return _lastAttackResult; }
+    int modifiedAttacks() const { return _modifiedAttacks; }
+    bool hasAssuredHit() const { return _assuredHit; }
+    AttackBonusBreakdown getAttackBonusBreakdown(
+        const Creature *target,
+        const Item *weapon,
+        bool offHand) const;
     int getAttackBonus(bool offHand = false) const;
+    int getDefense(const Creature *attacker, int damageFlags) const;
     int getDefense() const;
+    int getFortitudeSave(SavingThrowType savingThrowType = SavingThrowType::All) const;
+    bool rollFortitudeSave(
+        int difficultyClass,
+        SavingThrowType savingThrowType = SavingThrowType::All) const;
+    int getPhysicalDamageBonus(const Item *weapon, bool offHand) const;
+    int getMassiveCriticalDamage(const Item *weapon, bool criticalHit) const;
+    int getItemDamageImmunity(DamageType type) const;
+    int getItemDamageResistance(DamageType type) const;
+    void getItemDamageReduction(int &amount, DamagePower &power) const;
+    int getDamageResistanceFeatBonus() const;
+    void addPhysicalDamageModifiers(
+        DamagePacket &damage,
+        const Creature *target,
+        const Item *weapon,
+        bool offHand,
+        int criticalMultiplier) const;
     void getMainHandDamage(int &min, int &max) const;
     void getOffhandDamage(int &min, int &max) const;
 
-    void setAttackTarget(std::shared_ptr<Object> target) {
-        _combatState.attackTarget = std::move(target);
+    void setAttemptedAttackTarget(uint32_t target) {
+        _combatState.attemptedAttackTarget = target;
     }
+    void beginCombatAttack(std::shared_ptr<Object> target, FeatType feat);
+    void finishCombatRound();
+    void setLastAttackResult(AttackResultType result) { _lastAttackResult = result; }
+    void adjustModifiedAttacks(int amount);
+    bool applyAssuredHit();
+    void removeAssuredHit() { _assuredHit = false; }
 
     // END Combat
 
@@ -277,6 +320,9 @@ public:
     void setIsListening(bool value) { _isListening = value; }
 
     // END Listeners
+
+protected:
+    bool canExecuteActions() const override;
 
 private:
     // Serializable
@@ -336,6 +382,7 @@ private:
     float _walkSpeed {0.0f};
     float _runSpeed {0.0f};
     float _creaturePersonalSpace {0.6f};
+    CreatureSize _size {CreatureSize::Invalid};
     MovementType _movementType {MovementType::None};
     bool _talking {false};
 
@@ -343,6 +390,12 @@ private:
 
     bool _movementRestricted {false};
     CombatState _combatState;
+    uint32_t _lastHostileTarget {script::kObjectInvalid};
+    ActionType _lastAttackAction {ActionType::QueueEmpty};
+    FeatType _lastCombatFeat {FeatType::Invalid};
+    AttackResultType _lastAttackResult {AttackResultType::Invalid};
+    int _modifiedAttacks {0};
+    bool _assuredHit {false};
     bool _immortal {false};
     std::shared_ptr<resource::SoundSet> _soundSet;
     BodyBag _bodyBag;
@@ -374,9 +427,10 @@ private:
 
     void loadTransformFromGIT(const resource::generated::GIT_Creature_List &git);
 
+    void onEffectsCleared() override;
     void updateModel();
 
-    // Refresh appearance-derived state (model type, speeds, footstep, envmap,
+    // Refresh appearance-derived state (model type, size, speeds, footstep, envmap,
     // portrait) for the current _appearance, without building a scene node.
     void loadAppearanceProperties();
 
@@ -429,7 +483,13 @@ private:
 
     bool getWeaponInfo(WeaponType &type, WeaponWield &wield) const;
     int getWeaponWieldNumber(WeaponWield wield) const;
-    void getWeaponDamage(int slot, int &min, int &max) const;
+    int getRelativeWeaponSize(const Item &weapon) const;
+    int getTwoWeaponAttackPenalty(
+        const Item *weapon,
+        bool offHand,
+        int *smallOffhandBonus = nullptr) const;
+    int getDuelingBonus() const;
+    void getWeaponDamage(const Item *weapon, int &min, int &max) const;
 
     // END Animation
 

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -92,14 +92,19 @@ public:
     bool isDropable() const { return _dropable; }
     bool isIdentified() const { return _identified; }
     bool isEquipped() const { return _equipped; }
+    bool isLightsaber() const { return _baseItem >= 8 && _baseItem <= 10; }
     bool isRanged() const { return _weaponType == WeaponType::Ranged; }
 
     const std::string &baseBodyVariation() const { return _baseBodyVariation; }
     const std::string &itemClass() const { return _itemClass; }
     const std::string &localizedName() const { return _localizedName.str(); }
-    float attackRange() const { return static_cast<float>(_attackRange); }
+    float attackRange() const { return _attackRange; }
     int bodyVariation() const { return _bodyVariation; }
-    int damageFlags() const { return _damageFlags; }
+    int damageFlags() const {
+        return _damageFlags != 0
+                   ? _damageFlags
+                   : static_cast<int>(DamageType::Universal);
+    }
     int dieToRoll() const { return _dieToRoll; }
     int modelVariation() const { return _modelVariation; }
     int numDice() const { return _numDice; }
@@ -109,11 +114,17 @@ public:
     std::shared_ptr<graphics::Texture> icon() const { return _icon; }
     WeaponType weaponType() const { return _weaponType; }
     WeaponWield weaponWield() const { return _weaponWield; }
+    CreatureSize weaponSize() const { return _weaponSize; }
     const std::string &description() const { return _description.str(); }
     const std::string &descIdentified() const { return _descIdentified.str(); }
     int baseItemType() const { return _baseItem; }
     int criticalThreat() const { return _criticalThreat; }
     int criticalHitMultiplier() const { return _criticalHitMultiplier; }
+    FeatType weaponFocusFeat() const { return _weaponFocusFeat; }
+    FeatType weaponSpecializationFeat() const { return _weaponSpecializationFeat; }
+    int baseDefense() const { return _baseDefense; }
+    int maxDexterityBonus() const { return _maxDexterityBonus; }
+    ACBonus acBonusType() const { return _acBonusType; }
     std::optional<SpellType> activateSpell() const { return _activateSpell; }
     const std::vector<PropertyEntry> &properties() const { return _properties; }
 
@@ -148,12 +159,13 @@ private:
 
     std::shared_ptr<graphics::Texture> _icon;
     uint32_t _equipableSlots {0};
-    int _attackRange {0};
+    float _attackRange {0.0f};
     int _numDice {0};
     int _dieToRoll {0};
     int _damageFlags {0};
     WeaponType _weaponType {WeaponType::None};
     WeaponWield _weaponWield {WeaponWield::None};
+    CreatureSize _weaponSize {CreatureSize::Invalid};
 
     bool _equipped {false};
     std::shared_ptr<AmmunitionType> _ammunitionType;
@@ -166,6 +178,11 @@ private:
 
     int _criticalThreat {0};
     int _criticalHitMultiplier {0};
+    FeatType _weaponFocusFeat {FeatType::Invalid};
+    FeatType _weaponSpecializationFeat {FeatType::Invalid};
+    int _baseDefense {0};
+    int _maxDexterityBonus {-1};
+    ACBonus _acBonusType {ACBonus::Invalid};
 
     std::optional<SpellType> _activateSpell;
     int _disguiseAppearance {-1};

--- a/include/reone/game/twodautil.h
+++ b/include/reone/game/twodautil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,28 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "reone/game/effect/damageresistance.h"
+#pragma once
+
+#include <memory>
+#include <string>
 
 namespace reone {
 
+namespace resource {
+class ITwoDAs;
+class TwoDA;
+} // namespace resource
+
 namespace game {
 
-void DamageResistanceEffect::applyTo(Object &) {
-}
+std::shared_ptr<resource::TwoDA> getRequiredTwoDA(
+    resource::ITwoDAs &twoDas,
+    const std::string &resRef);
+
+void validateTwoDARow(
+    const resource::TwoDA &table,
+    const std::string &resRef,
+    int row);
 
 } // namespace game
 

--- a/include/reone/game/types.h
+++ b/include/reone/game/types.h
@@ -558,6 +558,13 @@ enum class FeatType {
     ImprovedRapidShot = 92,
     ProficiencyAll = 93,
     BattleMeditation = 94,
+    WookieEndurance = 95,
+    ForceImmunityStun = 99,
+    ForceImmunityParalysis = 100,
+    Dueling = 113,
+    ImprovedDueling = 114,
+    MasterDueling = 115,
+    ImprovedToughness = 123,
 
     // TSL
 
@@ -1215,6 +1222,7 @@ enum class DamagePower {
 };
 
 enum class ACBonus {
+    Invalid = -1,
     Dodge = 0,
     Natural = 1,
     ArmourEnchantment = 2,

--- a/include/reone/graphics/font.h
+++ b/include/reone/graphics/font.h
@@ -54,6 +54,12 @@ public:
         const glm::vec3 &color = glm::vec3(1.0f, 1.0f, 1.0f),
         TextGravity align = TextGravity::CenterCenter);
 
+    void render(
+        std::string_view text,
+        const glm::vec3 &position,
+        const glm::vec4 &color,
+        TextGravity align = TextGravity::CenterCenter);
+
     float measure(std::string_view text) const;
 
     void renderLine(std::string_view line,

--- a/include/reone/gui/control/listbox.h
+++ b/include/reone/gui/control/listbox.h
@@ -19,6 +19,8 @@
 
 #include "../control.h"
 
+#include <optional>
+
 namespace reone {
 
 namespace gui {
@@ -38,6 +40,7 @@ public:
         std::string iconText;
         std::shared_ptr<graphics::Texture> iconTexture;
         std::shared_ptr<graphics::Texture> iconFrame;
+        std::optional<glm::vec3> textColor;
         bool invalid {false};
 
         std::vector<std::string> _textLines;
@@ -81,6 +84,7 @@ public:
     void setItemsInteractive(bool interactive);
     void setProtoMatchContent(bool match);
     void setRenderItemIconsForButtonProto(bool render);
+    void scrollToBottom();
 
     int getItemCount() const;
     const Item &getItemAt(int index) const;
@@ -105,7 +109,6 @@ private:
     int _slotCount {0};
     int _itemOffset {0};
     int _selectedItemIndex {-1};
-    int _itemMargin {0};
     bool _itemsInteractive {true};
     bool _protoMatchContent {false}; /**< proto item height must match its content */
     bool _renderItemIconsForButtonProto {false};
@@ -118,7 +121,11 @@ private:
     // END Event listeners
 
     void updateItemSlots();
+    void updateItemsLayout();
 
+    int getInnerHeight() const;
+    int getItemWidth() const;
+    int getItemHeight(const Item &item) const;
     int getItemTextWidth() const;
     int getItemIndex(int y) const;
     bool shouldRenderItemIconsForButtonProto() const;

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -112,10 +112,10 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/effect/cutsceneparalyze.h
     ${GAME_INCLUDE_DIR}/effect/cutscenestunned.h
     ${GAME_INCLUDE_DIR}/effect/damage.h
+    ${GAME_INCLUDE_DIR}/effect/damageabsorption.h
     ${GAME_INCLUDE_DIR}/effect/damagedecrease.h
     ${GAME_INCLUDE_DIR}/effect/damageforcepoints.h
     ${GAME_INCLUDE_DIR}/effect/damageimmunitydecrease.h
-    ${GAME_INCLUDE_DIR}/effect/damageimmunityincrease.h
     ${GAME_INCLUDE_DIR}/effect/damageimmunityincrease.h
     ${GAME_INCLUDE_DIR}/effect/damageincrease.h
     ${GAME_INCLUDE_DIR}/effect/damagereduction.h
@@ -183,6 +183,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/equipmentrules.h
     ${GAME_INCLUDE_DIR}/event.h
     ${GAME_INCLUDE_DIR}/footstepsounds.h
+    ${GAME_INCLUDE_DIR}/floatingtext.h
     ${GAME_INCLUDE_DIR}/game.h
     ${GAME_INCLUDE_DIR}/itemdescription.h
     ${GAME_INCLUDE_DIR}/gui.h
@@ -295,6 +296,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/statussummary.h
     ${GAME_INCLUDE_DIR}/location.h
     ${GAME_INCLUDE_DIR}/messagebus.h
+    ${GAME_INCLUDE_DIR}/messagelog.h
     ${GAME_INCLUDE_DIR}/minigame.h
     ${GAME_INCLUDE_DIR}/object.h
     ${GAME_INCLUDE_DIR}/object/area.h
@@ -336,6 +338,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/swooprace.h
     ${GAME_INCLUDE_DIR}/talent.h
     ${GAME_INCLUDE_DIR}/transitioncandidate.h
+    ${GAME_INCLUDE_DIR}/twodautil.h
     ${GAME_INCLUDE_DIR}/types.h
     ${GAME_INCLUDE_DIR}/visualeffects.h)
 
@@ -465,6 +468,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/effect.cpp
     ${GAME_SOURCE_DIR}/equipmentrules.cpp
     ${GAME_SOURCE_DIR}/footstepsounds.cpp
+    ${GAME_SOURCE_DIR}/floatingtext.cpp
     ${GAME_SOURCE_DIR}/game.cpp
     ${GAME_SOURCE_DIR}/itemdescription.cpp
     ${GAME_SOURCE_DIR}/gui/actionbar.cpp
@@ -511,6 +515,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/journal.cpp
     ${GAME_SOURCE_DIR}/statussummary.cpp
     ${GAME_SOURCE_DIR}/messagebus.cpp
+    ${GAME_SOURCE_DIR}/messagelog.cpp
     ${GAME_SOURCE_DIR}/object.cpp
     ${GAME_SOURCE_DIR}/object/area.cpp
     ${GAME_SOURCE_DIR}/object/camera/animated.cpp
@@ -547,6 +552,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/surfaces.cpp
     ${GAME_SOURCE_DIR}/swooprace.cpp
     ${GAME_SOURCE_DIR}/transitioncandidate.cpp
+    ${GAME_SOURCE_DIR}/twodautil.cpp
     ${GAME_SOURCE_DIR}/visualeffects.cpp)
 
 add_library(game STATIC ${GAME_HEADERS} ${GAME_SOURCES} ${CLANG_FORMAT_PATH})

--- a/src/libs/game/action.cpp
+++ b/src/libs/game/action.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/action.h"
 
+#include "reone/game/action/usefeat.h"
+#include "reone/game/attack.h"
 #include "reone/system/logutil.h"
 
 namespace reone {
@@ -29,10 +31,11 @@ void Action::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
 }
 
 bool isHostileAction(Action &action) {
-    // TODO: handle feats and spells
     switch (action.type()) {
     case ActionType::AttackObject:
         return true;
+    case ActionType::UseFeat:
+        return isPhysicalAttackFeat(static_cast<UseFeatAction &>(action).feat());
     default:
         break;
     }

--- a/src/libs/game/action/attackobject.cpp
+++ b/src/libs/game/action/attackobject.cpp
@@ -68,16 +68,7 @@ static std::string getStunBatonAttackAnim(int variant) {
 
 static void attack(const CombatRound &round, Creature &attacker, Object &target,
                    const IAnimations &anims, AttackBuffer &attacks) {
-
-    if (auto main = attacker.getEquippedItem(InventorySlots::rightWeapon)) {
-        attacks.addWeaponAttack(attacker, target, *main);
-
-        if (auto offhand = attacker.getEquippedItem(InventorySlots::leftWeapon)) {
-            attacks.addWeaponAttack(attacker, target, *offhand);
-        }
-    } else {
-        attacks.addUnarmedAttack(attacker, target);
-    }
+    attacks.addPhysicalAttacks(attacker, target);
 
     scene::AnimationProperties animProp =
         scene::AnimationProperties::fromFlags(scene::AnimationFlags::blend);
@@ -148,6 +139,7 @@ void AttackObjectAction::addProjectiles(const Creature &creature) {
 
 void AttackObjectAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     Creature &attacker = cast<Creature>(actor);
+    attacker.setAttemptedAttackTarget(_target->id());
 
     if (_target->isDead()) {
         finish(attacker);
@@ -171,16 +163,13 @@ void AttackObjectAction::execute(std::shared_ptr<Action> self, Object &actor, fl
         attacker.setMovementRestricted(true);
 
         attack(round, attacker, *_target, _services.game.animations, _attacks);
-
-        if (auto target = dyn_cast<Creature>(_target)) {
-            target->runAttackedScript(attacker.id());
-        }
+        _attacks.resolve(attacker, *_target);
 
         addProjectiles(attacker);
         return;
     }
     case AttackSchedule::Damage: {
-        _attacks.applyEffects(attacker, *_target, _game);
+        _attacks.signal(_game, _services, attacker, *_target);
         break;
     }
     case AttackSchedule::Finish: {

--- a/src/libs/game/action/usefeat.cpp
+++ b/src/libs/game/action/usefeat.cpp
@@ -25,7 +25,6 @@
 #include "reone/game/object.h"
 #include "reone/game/projectiles.h"
 #include "reone/scene/graphs.h"
-#include "reone/system/randomutil.h"
 
 namespace reone {
 
@@ -90,16 +89,6 @@ static std::optional<ProjectileAttackType> getProjectileType(FeatType feat) {
     }
 }
 
-static std::string getStunBatonAttackAnim(int variant) {
-    variant = variant % 2;
-    return str(boost::format("g1a%d") % variant);
-}
-
-static std::string getUnarmedAttackAnim(int variant) {
-    variant = variant % 2;
-    return str(boost::format("g8a%d") % variant);
-}
-
 static std::string getAttackAnim(FeatType feat, CreatureWieldType attackerWield) {
     const char *format = getAnimFormat(feat);
     if (!format) {
@@ -111,16 +100,7 @@ static std::string getAttackAnim(FeatType feat, CreatureWieldType attackerWield)
 static void attack(FeatType feat, const CombatRound &round,
                    Creature &attacker, Object &target,
                    const IAnimations &anims, AttackBuffer &attacks) {
-
-    if (auto main = attacker.getEquippedItem(InventorySlots::rightWeapon)) {
-        attacks.addWeaponAttack(attacker, target, *main);
-
-        if (auto offhand = attacker.getEquippedItem(InventorySlots::leftWeapon)) {
-            attacks.addWeaponAttack(attacker, target, *offhand);
-        }
-    } else {
-        // TODO: handle Unarmed
-    }
+    attacks.addPhysicalAttacks(attacker, target, feat);
 
     scene::AnimationProperties animProp =
         scene::AnimationProperties::fromFlags(scene::AnimationFlags::blend);
@@ -130,10 +110,7 @@ static void attack(FeatType feat, const CombatRound &round,
         targetWield = targetCreature->getWieldType();
     }
 
-    int variant = randomInt(1, 5);
-
     CreatureWieldType attackerWield = attacker.getWieldType();
-    bool isMelee = isMeleeWieldType(attacker.getWieldType());
 
     std::string attackAnim = getAttackAnim(feat, attackerWield);
     attacker.playAnimation(attackAnim, animProp);
@@ -166,6 +143,9 @@ void UseFeatAction::addProjectiles(const Creature &creature, FeatType feat) {
 
 void UseFeatAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     Creature &attacker = static_cast<Creature &>(actor);
+    if (isPhysicalAttackFeat(_feat)) {
+        attacker.setAttemptedAttackTarget(_target->id());
+    }
 
     if (_target->isDead()) {
         finish(attacker);
@@ -189,16 +169,14 @@ void UseFeatAction::execute(std::shared_ptr<Action> self, Object &actor, float d
         attacker.setMovementRestricted(true);
 
         attack(_feat, round, attacker, *_target, _services.game.animations, _attacks);
-
-        if (auto target = dyn_cast<Creature>(_target)) {
-            target->runAttackedScript(attacker.id());
-        }
+        _attacks.resolveMeleeSpecialAttack(_feat, attacker, *_target, _game);
+        _attacks.resolve(attacker, *_target);
 
         addProjectiles(attacker, _feat);
         return;
     }
     case AttackSchedule::Damage: {
-        _attacks.applyEffects(attacker, *_target, _game);
+        _attacks.signal(_game, _services, attacker, *_target);
         break;
     }
     case AttackSchedule::Finish: {

--- a/src/libs/game/attack.cpp
+++ b/src/libs/game/attack.cpp
@@ -17,7 +17,11 @@
 
 #include "reone/game/attack.h"
 
+#include "reone/game/d20/feats.h"
 #include "reone/game/di/services.h"
+#include "reone/game/effect/acdecrease.h"
+#include "reone/game/effect/immunity.h"
+#include "reone/game/effect/stunned.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/item.h"
@@ -28,6 +32,7 @@
 #include "reone/system/randomutil.h"
 
 #include <algorithm>
+#include <initializer_list>
 
 namespace reone {
 
@@ -35,6 +40,10 @@ namespace game {
 
 static constexpr char kModelEventDetonate[] = "detonate";
 static constexpr float kProjectileSpeed = 16.0f;
+static constexpr int kUnarmedCriticalThreat = 1;
+static constexpr int kCriticalHitImmunityPropertySubtype = 8;
+static constexpr float kSpecialAttackDefensePenaltyDuration = 3.0f;
+static constexpr float kCriticalStrikeStunDuration = 6.0f;
 
 bool isMeleeWieldType(CreatureWieldType type) {
     switch (type) {
@@ -70,196 +79,802 @@ bool isAttackSuccessful(AttackResultType result) {
     }
 }
 
-static const char *attackResultDesc(AttackResultType type) {
-    switch (type) {
-    case AttackResultType::Miss:
-        return "missed";
-    case AttackResultType::AttackResisted:
-        return "resisted";
-    case AttackResultType::AttackFailed:
-        return "failed";
-    case AttackResultType::Parried:
-        return "parried";
-    case AttackResultType::Deflected:
-        return "deflected";
-    case AttackResultType::HitSuccessful:
-        return "hit";
-    case AttackResultType::AutomaticHit:
-        return "automatic hit";
-    case AttackResultType::CriticalHit:
-        return "critical hit";
-    case AttackResultType::Invalid:
-        break;
+bool isPhysicalAttackFeat(FeatType feat) {
+    switch (feat) {
+    case FeatType::CriticalStrike:
+    case FeatType::ImprovedCriticalStrike:
+    case FeatType::MasterCriticalStrike:
+    case FeatType::Flurry:
+    case FeatType::ImprovedFlurry:
+    case FeatType::WhirlwindAttack:
+    case FeatType::PowerAttack:
+    case FeatType::ImprovedPowerAttack:
+    case FeatType::MasterPowerAttack:
+    case FeatType::RapidShot:
+    case FeatType::ImprovedRapidShot:
+    case FeatType::MultiShot:
+    case FeatType::SniperShot:
+    case FeatType::ImprovedSniperShot:
+    case FeatType::MasterSniperShot:
+    case FeatType::PowerBlast:
+    case FeatType::ImprovedPowerBlast:
+    case FeatType::MasterPowerBlast:
+        return true;
+    default:
+        return false;
     }
-    return "invalid";
 }
 
-static int getWeaponAttackBonus(const Creature &attacker, const Item &weapon) {
-    auto rightWeapon(attacker.getEquippedItem(InventorySlots::rightWeapon));
-    auto leftWeapon(attacker.getEquippedItem(InventorySlots::leftWeapon));
+static bool hasActiveItemProperty(
+    const Item &item,
+    ItemProperty type,
+    int subtype = -1) {
 
-    Ability ability = weapon.isRanged() ? Ability::Dexterity : Ability::Strength;
-    int modifier = attacker.attributes().getAbilityModifier(ability);
-
-    int penalty = 0;
-    if (rightWeapon && leftWeapon) {
-        // TODO: support Dueling and Two-Weapon Fighting feats
-        bool offHand = (&weapon != rightWeapon.get());
-        penalty = offHand ? 10 : 6;
+    for (const Item::PropertyEntry &property : item.properties()) {
+        if (property.upgradeType != 0 ||
+            property.propertyName != static_cast<uint16_t>(type) ||
+            (subtype >= 0 && property.subtype != subtype)) {
+            continue;
+        }
+        return true;
     }
-
-    int effects = attacker.attributes().getAggregateAttackBonus();
-
-    debug(str(boost::format("getWeaponAttackBonus: modifier(%d) + effects(%d) - penalty(%d)") % modifier % effects % penalty),
-          LogChannel::Combat);
-
-    return modifier + effects - penalty;
+    return false;
 }
 
-static bool hasAssuredHitEffect(const Creature &attacker) {
-    for (auto &effect : attacker.effects()) {
-        if (effect.effect->type() == EffectType::AssuredHit) {
+static bool hasEffectImmunity(
+    const Creature &target,
+    ImmunityType immunityType) {
+
+    for (const Object::AppliedEffect &applied : target.effects()) {
+        if (applied.effect->type() != EffectType::Immunity) {
+            continue;
+        }
+
+        const auto &effect = static_cast<const ImmunityEffect &>(*applied.effect);
+        if (effect.immunityType() == immunityType) {
             return true;
         }
     }
     return false;
 }
 
-static AttackResultType computeAttack(const Creature &attacker, const Object &target, int rollBonus, int threatBonus) {
-    if (hasAssuredHitEffect(attacker)) {
-        return AttackResultType::AutomaticHit;
+static bool hasStunImmunity(const Creature &target) {
+    return hasEffectImmunity(target, ImmunityType::Stun) ||
+           target.attributes().hasFeat(FeatType::ForceImmunityStun) ||
+           target.attributes().hasFeat(FeatType::ForceImmunityParalysis);
+}
+
+static bool hasCriticalHitImmunity(const Creature &target) {
+    if (hasEffectImmunity(target, ImmunityType::CriticalHit)) {
+        return true;
     }
+
+    for (const auto &[slot, item] : target.equipment()) {
+        if (!item ||
+            slot == InventorySlots::rightWeapon2 ||
+            slot == InventorySlots::leftWeapon2) {
+            continue;
+        }
+        if (hasActiveItemProperty(
+                *item,
+                ItemProperty::Immunity,
+                kCriticalHitImmunityPropertySubtype)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int getBaseCriticalThreat(const Item *weapon) {
+    return weapon ? weapon->criticalThreat() : kUnarmedCriticalThreat;
+}
+
+static int getCriticalThreat(const Item *weapon, int threatBonus) {
+    int threat = getBaseCriticalThreat(weapon);
+    if (weapon && hasActiveItemProperty(*weapon, ItemProperty::Keen)) {
+        threat *= 2;
+    }
+    return threat + threatBonus;
+}
+
+struct AttackResolution {
+    AttackResultType result {AttackResultType::Invalid};
+    int roll {0};
+    int defense {0};
+    bool assuredHit {false};
+};
+
+static AttackResolution computeAttack(
+    const Creature &attacker,
+    const Object &target,
+    int attackBonus,
+    int criticalThreat,
+    int damageFlags) {
+
+    AttackResolution resolution;
 
     // Determine defense of a target
-    int defense;
-    if (const auto *creature = dyn_cast<Creature>(&target)) {
-        defense = creature->getDefense();
-    } else {
-        defense = 10;
-    }
+    const auto *targetCreature = dyn_cast<Creature>(&target);
+    resolution.defense = targetCreature
+                             ? targetCreature->getDefense(&attacker, damageFlags)
+                             : 0;
 
     // Attack roll
-    int roll = randomInt(1, 20);
+    resolution.roll = randomInt(1, 20);
 
-    if (roll == 1) {
-        debug(str(boost::format("computeAttack: miss: roll(1)")), LogChannel::Combat);
-        return AttackResultType::Miss;
+    if (attacker.hasAssuredHit()) {
+        resolution.result = AttackResultType::HitSuccessful;
+        resolution.assuredHit = true;
+        debug(str(boost::format("computeAttack: assured hit: roll(%d)") % resolution.roll),
+              LogChannel::Combat);
+        return resolution;
     }
 
-    AttackResultType result;
-    if (roll == 20) {
-        result = AttackResultType::AutomaticHit;
-    } else if ((roll + rollBonus) >= defense) {
-        result = AttackResultType::HitSuccessful;
-    } else {
-        debug(str(boost::format("computeAttack: miss: roll(%d), bonus(%d), defense(%d)") % roll % rollBonus % defense), LogChannel::Combat);
-        return AttackResultType::Miss;
+    if (resolution.roll == 1) {
+        resolution.result = AttackResultType::Miss;
+        debug(str(boost::format("computeAttack: miss: roll(1)")), LogChannel::Combat);
+        return resolution;
+    }
+
+    if (resolution.roll != 20 &&
+        (resolution.roll + attackBonus) < resolution.defense) {
+        resolution.result = AttackResultType::Miss;
+        debug(str(boost::format("computeAttack: miss: roll(%d), bonus(%d), defense(%d)") %
+                  resolution.roll % attackBonus % resolution.defense),
+              LogChannel::Combat);
+        return resolution;
     }
 
     // Critical threat
-    if (roll > (20 - threatBonus)) {
-        // Critical hit roll
-        int criticalRoll = randomInt(1, 20);
-        if ((criticalRoll + rollBonus) >= defense) {
-            debug(str(boost::format("computeAttack: critical hit: roll(%d), critical roll(%d),"
-                                    " bonus(%d), defense(%d), critical threat(20 - %d)") %
-                      roll % criticalRoll % rollBonus % defense % threatBonus),
-                  LogChannel::Combat);
-            return AttackResultType::CriticalHit;
+    if (resolution.roll >= (21 - criticalThreat)) {
+        // Critical confirmation
+        int confirmationRoll = randomInt(1, 20);
+        if ((confirmationRoll + attackBonus) >= resolution.defense) {
+            bool criticalHitImmune =
+                targetCreature && hasCriticalHitImmunity(*targetCreature);
+            if (!criticalHitImmune) {
+                resolution.result = AttackResultType::CriticalHit;
+                debug(str(boost::format("computeAttack: critical hit: roll(%d), confirmation(%d),"
+                                        " bonus(%d), defense(%d), critical threat(%d)") %
+                          resolution.roll % confirmationRoll % attackBonus %
+                          resolution.defense % criticalThreat),
+                      LogChannel::Combat);
+                return resolution;
+            }
         }
     }
 
-    debug(str(boost::format("computeAttack: %s: roll(%d), bonus(%d), defense(%d), critical threat(20 - %d)") % attackResultDesc(result) % roll % rollBonus % defense % threatBonus));
+    resolution.result = AttackResultType::HitSuccessful;
+    debug(str(boost::format("computeAttack: hit: roll(%d), bonus(%d), defense(%d),"
+                            " critical threat(%d)") %
+              resolution.roll % attackBonus % resolution.defense % criticalThreat),
+          LogChannel::Combat);
 
+    return resolution;
+}
+
+static int rollDamageDice(int numDice, int die) {
+    int result = 0;
+    for (int i = 0; i < numDice; ++i) {
+        result += randomInt(1, die);
+    }
     return result;
 }
 
-/**
- * Calculate damage for an attack with a weapon.
- *
- * It adds a descriptor to \p damage based on \p weapon damage amount and
- * type. When \result is a critical hit, the amount is multiplied by the \p
- * weapon critical multiplier.
- */
 static void computeWeaponDamage(
     const Creature &attacker, const Object &target, const Item &weapon,
-    AttackResultType result, int damageBonus, ISmallVector<Damage> &damage) {
+    AttackBuffer::Source source, AttackResultType result,
+    int damageBonus, DamagePacket &damage) {
 
-    int criticalHitMultiplier = weapon.criticalHitMultiplier();
     int multiplier = result == AttackResultType::CriticalHit
-                         ? criticalHitMultiplier
+                         ? weapon.criticalHitMultiplier()
                          : 1;
+    bool offHand = source == AttackBuffer::Source::Offhand;
 
-    int amount = damageBonus;
-    for (int i = 0; i < weapon.numDice(); ++i) {
-        amount += randomInt(1, weapon.dieToRoll());
+    int amount = multiplier * (damageBonus + attacker.getPhysicalDamageBonus(&weapon, offHand));
+    if (!hasActiveItemProperty(weapon, ItemProperty::NoDamage)) {
+        for (int multiple = 0; multiple < multiplier; ++multiple) {
+            amount += rollDamageDice(weapon.numDice(), weapon.dieToRoll());
+        }
     }
 
-    DamageType type = static_cast<DamageType>(weapon.damageFlags());
+    amount += attacker.getMassiveCriticalDamage(
+        &weapon, result == AttackResultType::CriticalHit);
 
-    // FIXME: weapon damage may have multiple damage effects (1d8 energy + 1d4
-    // sonic, for example).
-    damage.push_back({multiplier * amount, type, DamagePower::Normal});
+    DamageType type = getPrimaryDamageType(weapon.damageFlags());
+    damage.add(std::max(amount, 1), type);
+    damage.setDamageFlags(weapon.damageFlags());
+    attacker.addPhysicalDamageModifiers(
+        damage,
+        dyn_cast<Creature>(&target),
+        &weapon,
+        offHand,
+        multiplier);
 
-    debug(str(boost::format("computeWeaponDamage: %s -> %s (%d)") % attacker.tag() % target.tag() % amount),
+    debug(str(boost::format("computeWeaponDamage: %s -> %s (%d)") % attacker.tag() % target.tag() % damage.total()),
           LogChannel::Combat);
+}
+
+static int getUnarmedDamageDie(const Creature &attacker) {
+    return attacker.size() <= CreatureSize::Small ? 2 : 1;
 }
 
 static void computeUnarmedDamage(
     const Creature &attacker, const Object &target,
-    AttackResultType result, int damageBonus, ISmallVector<Damage> &damage) {
+    AttackResultType result, int damageBonus, DamagePacket &damage) {
 
     int multiplier = (result == AttackResultType::CriticalHit) ? 2 : 1;
 
-    int amount = damageBonus + 1; // FIXME: fixed damage in K1?
+    int amount = multiplier * (damageBonus + attacker.getPhysicalDamageBonus(nullptr, false));
+    for (int multiple = 0; multiple < multiplier; ++multiple) {
+        amount += randomInt(1, getUnarmedDamageDie(attacker));
+    }
 
-    damage.push_back({multiplier * amount, DamageType::Bludgeoning, DamagePower::Normal});
+    amount += attacker.getMassiveCriticalDamage(
+        nullptr, result == AttackResultType::CriticalHit);
 
-    debug(str(boost::format("computeUnarmedDamage: %s -> %s (%d)") % attacker.tag() % target.tag() % amount),
+    damage.add(std::max(amount, 1), DamageType::Bludgeoning);
+    damage.setDamageFlags(static_cast<int>(DamageType::Bludgeoning));
+    attacker.addPhysicalDamageModifiers(
+        damage,
+        dyn_cast<Creature>(&target),
+        nullptr,
+        false,
+        multiplier);
+
+    debug(str(boost::format("computeUnarmedDamage: %s -> %s (%d)") % attacker.tag() % target.tag() % damage.total()),
           LogChannel::Combat);
 }
 
-void AttackBuffer::addWeaponAttack(
-    const Creature &attacker, const Object &target, const Item &weapon,
-    int attackRollBonus, int attackThreatBonus, int damageBonus) {
-
-    attackRollBonus += getWeaponAttackBonus(attacker, weapon);
-    attackThreatBonus += weapon.criticalThreat();
-
-    AttackResultType result = computeAttack(
-        attacker, target, attackRollBonus, attackThreatBonus);
-
-    _attacks.emplace_back(result);
-
-    if (!isAttackSuccessful(result)) {
-        return;
+static bool grantsExtraMainHandAttack(FeatType feat) {
+    switch (feat) {
+    case FeatType::Flurry:
+    case FeatType::ImprovedFlurry:
+    case FeatType::WhirlwindAttack:
+    case FeatType::RapidShot:
+    case FeatType::ImprovedRapidShot:
+    case FeatType::MultiShot:
+        return true;
+    default:
+        return false;
     }
-
-    computeWeaponDamage(attacker, target, weapon, result,
-                        damageBonus, _attacks.back().damage);
 }
 
-void AttackBuffer::addUnarmedAttack(const Creature &attacker, const Object &target,
-                                    int attackRollBonus, int attackThreatBonus, int damageBonus) {
-    AttackResultType result = computeAttack(
-        attacker, target, attackRollBonus, attackThreatBonus);
+static int getSpecialAttackRollBonus(FeatType feat) {
+    switch (feat) {
+    case FeatType::PowerAttack:
+    case FeatType::ImprovedPowerAttack:
+    case FeatType::MasterPowerAttack:
+        return -3;
+    case FeatType::Flurry:
+        return -4;
+    case FeatType::ImprovedFlurry:
+        return -2;
+    case FeatType::WhirlwindAttack:
+        return -1;
+    default:
+        return 0;
+    }
+}
 
-    _attacks.emplace_back(result);
+static int getSpecialAttackDamageBonus(FeatType feat) {
+    switch (feat) {
+    case FeatType::PowerAttack:
+        return 5;
+    case FeatType::ImprovedPowerAttack:
+        return 8;
+    case FeatType::MasterPowerAttack:
+        return 10;
+    default:
+        return 0;
+    }
+}
 
-    if (!isAttackSuccessful(result)) {
+static int getSpecialAttackThreatBonus(
+    FeatType feat,
+    const Item *weapon) {
+
+    int multiplier = 0;
+    switch (feat) {
+    case FeatType::CriticalStrike:
+        multiplier = 1;
+        break;
+    case FeatType::ImprovedCriticalStrike:
+        multiplier = 2;
+        break;
+    case FeatType::MasterCriticalStrike:
+        multiplier = 3;
+        break;
+    default:
+        break;
+    }
+    return multiplier * getBaseCriticalThreat(weapon);
+}
+
+static int getMeleeSpecialAttackDefensePenalty(FeatType feat) {
+    switch (feat) {
+    case FeatType::CriticalStrike:
+    case FeatType::ImprovedCriticalStrike:
+    case FeatType::MasterCriticalStrike:
+        return 5;
+    case FeatType::Flurry:
+        return 4;
+    case FeatType::ImprovedFlurry:
+        return 2;
+    case FeatType::WhirlwindAttack:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static bool isCriticalStrikeFeat(FeatType feat) {
+    switch (feat) {
+    case FeatType::CriticalStrike:
+    case FeatType::ImprovedCriticalStrike:
+    case FeatType::MasterCriticalStrike:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void AttackBuffer::addPhysicalAttacks(const Creature &attacker, const Object &target,
+                                      FeatType feat) {
+    _feat = feat;
+
+    int mainHandAttacks = 1 + attacker.modifiedAttacks();
+    if (grantsExtraMainHandAttack(feat)) {
+        ++mainHandAttacks;
+    }
+
+    int attackRollBonus = getSpecialAttackRollBonus(feat);
+    int damageBonus = getSpecialAttackDamageBonus(feat);
+
+    auto main = attacker.getEquippedItem(InventorySlots::rightWeapon);
+    if (!main) {
+        auto gloves = attacker.getEquippedItem(InventorySlots::hands);
+        int attackThreatBonus = getSpecialAttackThreatBonus(feat, gloves.get());
+        for (int i = 0; i < mainHandAttacks; ++i) {
+            addPhysicalAttack(
+                attacker,
+                target,
+                nullptr,
+                Source::Main,
+                attackRollBonus,
+                attackThreatBonus,
+                damageBonus);
+        }
         return;
     }
 
-    computeUnarmedDamage(attacker, target, result, damageBonus, _attacks.back().damage);
+    int mainThreatBonus = getSpecialAttackThreatBonus(feat, main.get());
+    for (int i = 0; i < mainHandAttacks; ++i) {
+        addPhysicalAttack(
+            attacker,
+            target,
+            main.get(),
+            Source::Main,
+            attackRollBonus,
+            mainThreatBonus,
+            damageBonus);
+    }
+
+    auto offhand = attacker.getOffhandAttackWeapon();
+    if (offhand) {
+        int offhandThreatBonus = getSpecialAttackThreatBonus(feat, offhand.get());
+        addPhysicalAttack(
+            attacker,
+            target,
+            offhand.get(),
+            Source::Offhand,
+            attackRollBonus,
+            offhandThreatBonus,
+            damageBonus);
+    }
+}
+
+void AttackBuffer::resolveMeleeSpecialAttack(
+    FeatType feat,
+    Creature &attacker,
+    Object &target,
+    Game &game) {
+
+    if (_attacks.empty() || _attacks.front().ranged) {
+        return;
+    }
+
+    int defensePenalty = getMeleeSpecialAttackDefensePenalty(feat);
+    if (defensePenalty != 0) {
+        auto effect = game.newEffect<ACDecreaseEffect>(
+            defensePenalty,
+            ACBonus::Dodge,
+            kAllDamageTypeFlags);
+        attacker.applyEffect(
+            std::move(effect),
+            DurationType::Temporary,
+            kSpecialAttackDefensePenaltyDuration);
+    }
+
+    if (!isCriticalStrikeFeat(feat) ||
+        !isAttackSuccessful(_attacks.front().result)) {
+        return;
+    }
+
+    auto *targetCreature = dyn_cast<Creature>(&target);
+    if (!targetCreature || hasStunImmunity(*targetCreature)) {
+        return;
+    }
+
+    int difficultyClass =
+        attacker.attributes().getAggregateLevel() +
+        attacker.attributes().getAbilityModifier(Ability::Strength);
+    if (!targetCreature->rollFortitudeSave(difficultyClass)) {
+        _attacks.front().stunTarget = true;
+    }
+}
+
+void AttackBuffer::addPhysicalAttack(
+    const Creature &attacker,
+    const Object &target,
+    const Item *weapon,
+    Source source,
+    int attackRollBonus,
+    int attackThreatBonus,
+    int damageBonus) {
+
+    bool offHand = source == Source::Offhand;
+    const auto *targetCreature = dyn_cast<Creature>(&target);
+    AttackBonusBreakdown attackBonusBreakdown = attacker.getAttackBonusBreakdown(
+        targetCreature,
+        weapon,
+        offHand);
+    attackBonusBreakdown.featBonus = attackRollBonus;
+    attackRollBonus = attackBonusBreakdown.total();
+
+    auto handItem = weapon
+                        ? std::shared_ptr<Item>()
+                        : attacker.getEquippedItem(InventorySlots::hands);
+    const Item *criticalWeapon = weapon ? weapon : handItem.get();
+    int criticalThreat = getCriticalThreat(criticalWeapon, attackThreatBonus);
+    int damageFlags = weapon
+                          ? weapon->damageFlags()
+                          : static_cast<int>(DamageType::Bludgeoning);
+
+    AttackResolution resolution = computeAttack(
+        attacker,
+        target,
+        attackRollBonus,
+        criticalThreat,
+        damageFlags);
+
+    _attacks.emplace_back(
+        source,
+        weapon && weapon->isRanged(),
+        resolution.result,
+        resolution.roll,
+        std::move(attackBonusBreakdown),
+        resolution.defense,
+        resolution.assuredHit);
+
+    if (!isAttackSuccessful(resolution.result)) {
+        return;
+    }
+
+    if (weapon) {
+        computeWeaponDamage(
+            attacker,
+            target,
+            *weapon,
+            source,
+            resolution.result,
+            damageBonus,
+            _attacks.back().damage);
+    } else {
+        computeUnarmedDamage(
+            attacker,
+            target,
+            resolution.result,
+            damageBonus,
+            _attacks.back().damage);
+    }
+}
+
+void AttackBuffer::resolveDamage(Object &target) {
+    for (Attack &attack : _attacks) {
+        if (attack.damage.empty()) {
+            continue;
+        }
+
+        attack.damage.resolve(target);
+    }
+}
+
+void AttackBuffer::resolve(Creature &attacker, Object &target) {
+    if (_attacks.empty()) {
+        throw std::logic_error("Physical attack buffer is empty");
+    }
+
+    resolveDamage(target);
+    attacker.setLastAttackResult(_attacks.back().result);
+
+    if (auto *targetCreature = dyn_cast<Creature>(&target)) {
+        targetCreature->runAttackedScript(attacker.id());
+    }
 }
 
 void AttackBuffer::applyEffects(Creature &attacker, Object &target, Game &game) {
     for (Attack &attack : _attacks) {
-        for (Damage &damage : attack.damage) {
+        // Failed ranged attacks do not produce floating miss text.
+        if (!attack.ranged && !isAttackSuccessful(attack.result)) {
+            game.floatingText().addMiss(attacker, target);
+        }
+        if (!attack.damage.empty()) {
             auto effect = game.newEffect<DamageEffect>(
-                damage.amount, damage.type, damage.power, attacker.id());
-
+                std::move(attack.damage), attacker.id());
             target.applyEffect(std::move(effect), DurationType::Instant);
+        }
+        if (attack.stunTarget) {
+            auto effect = game.newEffect<StunnedEffect>();
+            target.applyEffect(
+                std::move(effect),
+                DurationType::Temporary,
+                kCriticalStrikeStunDuration);
+        }
+    }
+}
+
+void AttackBuffer::signal(
+    Game &game,
+    ServicesView &services,
+    Creature &attacker,
+    Object &target) {
+
+    addCombatFeedback(game, services, attacker, target);
+    applyEffects(attacker, target, game);
+}
+
+static constexpr float kCombatFeedbackRange2 = 900.0f;
+
+static bool canReceiveCombatFeedback(
+    const Creature &player,
+    const Creature &subject) {
+
+    return player.faction() == subject.faction() &&
+           player.getSquareDistanceTo(subject) <= kCombatFeedbackRange2;
+}
+
+static constexpr int kStrRefAttackSummary = 42042;
+static constexpr int kStrRefAttackSuccessVerb = 42043;
+static constexpr int kStrRefAttackFailureVerb = 42044;
+static constexpr int kStrRefAttackFeat = 42046;
+static constexpr int kStrRefAttackRoll = 42119;
+static constexpr int kStrRefAttackRollSuccess = 42133;
+static constexpr int kStrRefAttackRollFailure = 42134;
+static constexpr int kStrRefAttackBreakdown = 42146;
+static constexpr int kStrRefStrengthModifier = 42154;
+static constexpr int kStrRefMainhand = 42314;
+static constexpr int kStrRefOffhand = 42315;
+static constexpr int kStrRefAttackRollComponent = 42316;
+static constexpr int kStrRefMeleeOnRangedBonus = 42317;
+static constexpr int kStrRefFeatAttackBonus = 42318;
+static constexpr int kStrRefCloseProximityRangedBonus = 42330;
+static constexpr int kStrRefWeaponFocusBonus = 42331;
+static constexpr int kStrRefEffectBonus = 42332;
+static constexpr int kStrRefDualWieldPenalty = 42333;
+static constexpr int kStrRefSmallOffhandBonus = 42334;
+static constexpr int kStrRefDexterityModifier = 42375;
+static constexpr int kStrRefAutomaticHit = 42390;
+static constexpr int kStrRefAutomaticMiss = 42391;
+static constexpr int kStrRefBaseAttackBonus = 42392;
+
+static std::string getFeedbackString(
+    Game &game,
+    ServicesView &services,
+    int strRef,
+    std::initializer_list<std::pair<int, std::string>> tokens) {
+
+    std::string text = services.resource.strings.getText(strRef);
+    for (const auto &[token, value] : tokens) {
+        text = game.substituteCustomToken(
+            std::move(text),
+            token,
+            value);
+    }
+    return text;
+}
+
+void AttackBuffer::addCombatFeedback(
+    Game &game,
+    ServicesView &services,
+    const Creature &attacker,
+    const Object &target) const {
+
+    if (game.isTSL()) {
+        return;
+    }
+
+    auto leader = game.party().getLeader();
+    if (!leader) {
+        return;
+    }
+
+    bool broadcastFromAttacker = canReceiveCombatFeedback(*leader, attacker);
+    const auto *targetCreature = dyn_cast<Creature>(&target);
+    bool broadcastFromTarget = targetCreature &&
+                               canReceiveCombatFeedback(*leader, *targetCreature);
+    int broadcasts = static_cast<int>(broadcastFromAttacker) +
+                     static_cast<int>(broadcastFromTarget);
+    if (broadcasts == 0) {
+        return;
+    }
+
+    const std::string &attackerName = attacker.name();
+    const std::string &targetName = target.name();
+
+    for (const Attack &attack : _attacks) {
+        bool successful = isAttackSuccessful(attack.result);
+        std::string feedback = getFeedbackString(
+            game,
+            services,
+            kStrRefAttackSummary,
+            {
+                {0, attackerName},
+                {1, services.resource.strings.getText(
+                        successful ? kStrRefAttackSuccessVerb : kStrRefAttackFailureVerb)},
+                {2, targetName},
+            });
+        feedback += ". ";
+
+        if (isPhysicalAttackFeat(_feat)) {
+            auto feat = services.game.feats.get(_feat);
+            feedback += getFeedbackString(
+                game,
+                services,
+                kStrRefAttackFeat,
+                {{0, feat->name}});
+            feedback += ". ";
+        }
+
+        feedback += getFeedbackString(
+            game,
+            services,
+            kStrRefAttackRoll,
+            {
+                {0, services.resource.strings.getText(
+                        successful ? kStrRefAttackRollSuccess : kStrRefAttackRollFailure)},
+                {1, std::to_string(
+                        attack.roll + attack.attackBonusBreakdown.total())},
+                {2, std::to_string(attack.defense)},
+                {3, std::to_string(
+                        attack.damage.empty()
+                            ? 0
+                            : attack.damage.resolvedDamage())},
+            });
+
+        for (int broadcast = 0; broadcast < broadcasts; ++broadcast) {
+            game.messageLog().add(
+                MessageLog::kFeedbackMessageType,
+                MessageLog::Style::Combat,
+                feedback);
+        }
+
+        const AttackBonusBreakdown &bonus = attack.attackBonusBreakdown;
+        std::string breakdown = getFeedbackString(
+            game,
+            services,
+            kStrRefAttackBreakdown,
+            {
+                {0, services.resource.strings.getText(
+                        attack.source == Source::Main
+                            ? kStrRefMainhand
+                            : kStrRefOffhand)},
+                {1, std::to_string(
+                        attack.roll + attack.attackBonusBreakdown.total())},
+            });
+        breakdown += getFeedbackString(
+            game,
+            services,
+            kStrRefAttackRollComponent,
+            {{0, std::to_string(attack.roll)}});
+
+        if (!attack.assuredHit && attack.roll == 20) {
+            breakdown += " ";
+            breakdown += services.resource.strings.getText(kStrRefAutomaticHit);
+        } else if (!attack.assuredHit && attack.roll == 1) {
+            breakdown += " ";
+            breakdown += services.resource.strings.getText(kStrRefAutomaticMiss);
+        } else {
+            breakdown += getFeedbackString(
+                game,
+                services,
+                kStrRefBaseAttackBonus,
+                {{0, std::to_string(bonus.baseAttackBonus)}});
+
+            if (bonus.dualWieldPenalty != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefDualWieldPenalty,
+                    {{0, std::to_string(bonus.dualWieldPenalty)}});
+            }
+            if (bonus.smallOffhandBonus != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefSmallOffhandBonus,
+                    {{0, std::to_string(bonus.smallOffhandBonus)}});
+            }
+            if (_feat != FeatType::Invalid && bonus.featBonus != 0) {
+                auto feat = services.game.feats.get(_feat);
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefFeatAttackBonus,
+                    {
+                        {0, feat->name},
+                        {1, std::to_string(bonus.featBonus)},
+                    });
+            }
+            if (bonus.duelingBonus != 0) {
+                auto feat = services.game.feats.get(bonus.duelingFeat);
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefFeatAttackBonus,
+                    {
+                        {0, feat->name},
+                        {1, std::to_string(bonus.duelingBonus)},
+                    });
+            }
+            if (bonus.closeProximityRangedBonus != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefCloseProximityRangedBonus,
+                    {{0, std::to_string(bonus.closeProximityRangedBonus)}});
+            }
+            if (bonus.meleeOnRangedBonus != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefMeleeOnRangedBonus,
+                    {{0, std::to_string(bonus.meleeOnRangedBonus)}});
+            }
+            if (bonus.dexterityModifier != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefDexterityModifier,
+                    {{0, std::to_string(bonus.dexterityModifier)}});
+            } else if (bonus.strengthModifier != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefStrengthModifier,
+                    {{0, std::to_string(bonus.strengthModifier)}});
+            }
+            if (bonus.weaponFocusBonus != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefWeaponFocusBonus,
+                    {{0, std::to_string(bonus.weaponFocusBonus)}});
+            }
+            if (bonus.effectBonus != 0) {
+                breakdown += getFeedbackString(
+                    game,
+                    services,
+                    kStrRefEffectBonus,
+                    {{0, std::to_string(bonus.effectBonus)}});
+            }
+        }
+
+        for (int broadcast = 0; broadcast < broadcasts; ++broadcast) {
+            game.messageLog().add(
+                MessageLog::kFeedbackMessageType,
+                MessageLog::Style::Normal,
+                breakdown);
         }
     }
 }

--- a/src/libs/game/combat.cpp
+++ b/src/libs/game/combat.cpp
@@ -21,6 +21,7 @@
 #include "reone/game/action/usefeat.h"
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
+#include "reone/game/reputes.h"
 #include "reone/scene/di/services.h"
 #include "reone/scene/graphs.h"
 #include "reone/system/logutil.h"
@@ -36,6 +37,12 @@ namespace game {
 
 static constexpr float kRoundDuration = 3.0f;
 static constexpr float kDeactivateDelay = 8.0f;
+static constexpr float kMaxAttackRange = 20.0f;
+static constexpr float kAttackTargetSearchPadding = 2.0f;
+
+static bool isUnavailableAttackTarget(const Creature &creature) {
+    return creature.isDead() || creature.isTemporarilyDead();
+}
 
 bool CombatRound::canExecute(Action &action) const {
     State requiredState[] = {CombatRound::FirstAction, CombatRound::SecondAction};
@@ -48,19 +55,86 @@ bool CombatRound::canExecute(Action &action) const {
     return false;
 }
 
-static Object *getTarget(Action &action) {
+static std::shared_ptr<Object> getTarget(Action &action) {
     if (auto *attack = dyn_cast<AttackObjectAction>(&action)) {
-        return attack->target().get();
+        return attack->target();
     }
     if (auto *feat = dyn_cast<UseFeatAction>(&action)) {
-        return feat->target().get();
+        return feat->target();
     }
 
     return nullptr;
 }
 
+static FeatType getCombatFeat(Action &action) {
+    if (auto *feat = dyn_cast<UseFeatAction>(&action)) {
+        return isPhysicalAttackFeat(feat->feat())
+                   ? feat->feat()
+                   : FeatType::Invalid;
+    }
+    return FeatType::Invalid;
+}
+
+static void recordCombatAction(
+    Object &actor,
+    const std::shared_ptr<Object> &target,
+    Action &action) {
+
+    if (!target || !isHostileAction(action)) {
+        return;
+    }
+
+    target->setLastHostileActor(actor.id());
+    if (auto *creature = dyn_cast<Creature>(&actor)) {
+        creature->beginCombatAttack(target, getCombatFeat(action));
+    }
+}
+
 static bool isRoundPastFirstAttack(float time) {
     return time >= 0.5f * kRoundDuration;
+}
+
+static float getAttackTargetSearchRange(const Creature &attacker) {
+    return std::min(attacker.getAttackRange(), kMaxAttackRange) + kAttackTargetSearchPadding;
+}
+
+static std::shared_ptr<Creature> findNearestEnemy(
+    Area &area,
+    const Creature &attacker,
+    const Creature &observer,
+    float maxDistance,
+    const IReputes &reputes) {
+
+    std::shared_ptr<Creature> nearest;
+    float nearestDistance = maxDistance;
+
+    for (const std::shared_ptr<Object> &object : area.getObjectsByType(ObjectType::Creature)) {
+        auto candidate = std::static_pointer_cast<Creature>(object);
+        if (candidate->id() == attacker.id() ||
+            candidate->id() == observer.id() ||
+            isUnavailableAttackTarget(*candidate)) {
+            continue;
+        }
+
+        bool isEnemy = observer.id() == attacker.id()
+                           ? reputes.getIsEnemy(attacker, *candidate)
+                           : reputes.getIsEnemy(*candidate, attacker);
+        if (!isEnemy || observer.perception().seen.count(candidate->id()) == 0) {
+            continue;
+        }
+
+        float distance = attacker.getDistanceTo(*candidate) -
+                         observer.creaturePersonalSpace() -
+                         candidate->creaturePersonalSpace();
+        if (distance >= nearestDistance || !area.isObjectSeen(observer, *candidate)) {
+            continue;
+        }
+
+        nearest = std::move(candidate);
+        nearestDistance = distance;
+    }
+
+    return nearest;
 }
 
 CombatRound *Combat::findRoundForAction(
@@ -116,9 +190,10 @@ const CombatRound &Combat::addAction(const std::shared_ptr<Action> &action, Obje
 
     // Find an existing round where target and attacker roles are reversed, and
     // append the action to this round.
-    Object *target = getTarget(*action);
+    std::shared_ptr<Object> target = getTarget(*action);
     if (target) {
         if (CombatRound *round = tryAppendAction(action, actor.id(), target->id())) {
+            recordCombatAction(actor, target, *action);
             debug(str(boost::format("Append attack: %s -> %s") % actor.tag() % target->tag()), LogChannel::Combat);
             return *round;
         }
@@ -130,6 +205,7 @@ const CombatRound &Combat::addAction(const std::shared_ptr<Action> &action, Obje
     CombatRound &newRound = *_rounds.back();
 
     if (target) {
+        recordCombatAction(actor, target, *action);
         debug(str(boost::format("Start round: %s -> %s") % actor.tag() % target->tag()), LogChannel::Combat);
     } else {
         debug(str(boost::format("Start round: %s") % actor.tag()), LogChannel::Combat);
@@ -150,7 +226,36 @@ void Combat::update(float dt) {
         updateRound(*round, dt);
     }
 
-    // TODO: clear history
+    retireCompletedRounds();
+}
+
+static bool isActionFinished(const CombatRound::RoundAction &action, const Game &game) {
+    return action.action->isCompleted() ||
+           action.action->isCancelled() ||
+           !game.getObjectById(action.attacker);
+}
+
+void Combat::retireCompletedRounds() {
+    for (auto it = _rounds.begin(); it != _rounds.end();) {
+        CombatRound &round = **it;
+        if (round.state != CombatRound::Finished) {
+            ++it;
+            continue;
+        }
+
+        bool actionsFinished = std::all_of(
+            round.actions.begin(),
+            round.actions.end(),
+            [this](const CombatRound::RoundAction &action) {
+                return isActionFinished(action, _game);
+            });
+
+        if (actionsFinished) {
+            it = _rounds.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 static void setMovement(CombatRound &round, bool enabled) {
@@ -186,22 +291,100 @@ void Combat::updateRound(CombatRound &round, float dt) {
 
 void Combat::finishRound(CombatRound &round) {
     SmallSet<uint32_t, 4> objects;
+    SmallSet<uint32_t, 2> attackers;
     for (CombatRound::RoundAction &action : round.actions) {
         objects.insert(action.attacker);
         objects.insert(action.target);
+        if (isHostileAction(*action.action)) {
+            attackers.insert(action.attacker);
+        }
 
         if (Logger::instance.isChannelEnabled(LogChannel::Combat)) {
-            auto attacker = _game.getObjectById<Creature>(action.attacker);
-            debug(str(boost::format("Finish round: %s") % attacker->tag()), LogChannel::Combat);
+            if (auto attacker = _game.getObjectById<Creature>(action.attacker)) {
+                debug(str(boost::format("Finish round: %s") % attacker->tag()), LogChannel::Combat);
+            }
         }
     }
 
+    for (uint32_t id : attackers) {
+        if (auto attacker = _game.getObjectById<Creature>(id)) {
+            attacker->finishCombatRound();
+        }
+    }
+
+    std::shared_ptr<Creature> leader = _game.party().getLeader();
     for (uint32_t id : objects) {
         std::shared_ptr<Object> object = _game.getObjectById(id);
         if (object && isa<Creature>(object)) {
             auto &participant = cast<Creature>(*object);
-            participant.runEndRoundScript();
+            if (!leader || participant.id() != leader->id()) {
+                participant.runEndRoundScript();
+            }
             participant.deactivateCombat(kDeactivateDelay);
+        }
+    }
+
+    if (!leader || isUnavailableAttackTarget(*leader)) {
+        return;
+    }
+
+    for (CombatRound::RoundAction &action : round.actions) {
+        if (action.attacker != leader->id()) {
+            continue;
+        }
+
+        if (leader->hasUserActionsPending(action.action.get())) {
+            continue;
+        }
+
+        std::shared_ptr<Module> module = _game.module();
+
+        std::shared_ptr<Object> target = _game.getObjectById(action.target);
+        auto targetCreature = target ? dyn_cast<Creature>(target) : nullptr;
+        bool targetUnavailable = !targetCreature || isUnavailableAttackTarget(*targetCreature);
+        if (!targetUnavailable) {
+            if (leader->getCurrentAction() != action.action) {
+                continue;
+            }
+            if (!module || !module->isHostileToPartyLeader(*targetCreature)) {
+                continue;
+            }
+
+            leader->addAction(_game.newAction<AttackObjectAction>(std::move(target)));
+            continue;
+        }
+
+        if (!isa<AttackObjectAction>(action.action.get()) &&
+            !isa<UseFeatAction>(action.action.get())) {
+            continue;
+        }
+
+        std::shared_ptr<Creature> enemy;
+        std::shared_ptr<Area> area = module ? module->area() : nullptr;
+        if (area) {
+            float searchRange = getAttackTargetSearchRange(*leader);
+            if (targetCreature) {
+                enemy = findNearestEnemy(
+                    *area,
+                    *leader,
+                    *targetCreature,
+                    searchRange,
+                    _services.game.reputes);
+            }
+            if (!enemy) {
+                enemy = findNearestEnemy(
+                    *area,
+                    *leader,
+                    *leader,
+                    searchRange,
+                    _services.game.reputes);
+            }
+        }
+
+        if (enemy) {
+            leader->addAction(_game.newAction<AttackObjectAction>(std::move(enemy)));
+        } else {
+            leader->deactivateCombat(0.0f);
         }
     }
 }

--- a/src/libs/game/d20/attributes.cpp
+++ b/src/libs/game/d20/attributes.cpp
@@ -27,7 +27,9 @@ static constexpr int kDefaultAbilityScore = 8;
 static constexpr int kDefaultSkillRank = 0;
 
 int CreatureAttributes::getDefense() const {
-    return 10 + getAbilityModifier(Ability::Dexterity);
+    return 10 +
+           getAggregateDefenseBonus() +
+           getAbilityModifier(Ability::Dexterity);
 }
 
 int CreatureAttributes::getAbilityScore(Ability ability) const {
@@ -37,7 +39,7 @@ int CreatureAttributes::getAbilityScore(Ability ability) const {
 
 int CreatureAttributes::getAbilityModifier(Ability ability) const {
     int score = getAbilityScore(ability);
-    return (score - 10) / 2;
+    return score >= 10 ? (score - 10) / 2 : (score - 11) / 2;
 }
 
 int CreatureAttributes::strength() const {
@@ -122,11 +124,19 @@ int CreatureAttributes::getAggregateAttackBonus() const {
     return result;
 }
 
+int CreatureAttributes::getAggregateDefenseBonus() const {
+    int result = 0;
+    for (auto &pair : _classLevels) {
+        result += pair.first->getDefenseBonus(pair.second);
+    }
+    return result;
+}
+
 SavingThrows CreatureAttributes::getAggregateSavingThrows() const {
     SavingThrows result;
-    result.fortitude = 1;
-    result.reflex = 1;
-    result.will = 1;
+    result.fortitude = 0;
+    result.reflex = 0;
+    result.will = 0;
     for (auto &pair : _classLevels) {
         auto classThrows = pair.first->getSavingThrows(pair.second);
         result.fortitude += classThrows.fortitude;

--- a/src/libs/game/d20/class.cpp
+++ b/src/libs/game/d20/class.cpp
@@ -22,6 +22,7 @@
 #include "reone/resource/strings.h"
 
 #include "reone/game/d20/classes.h"
+#include "reone/game/twodautil.h"
 
 using namespace reone::resource;
 
@@ -30,6 +31,7 @@ namespace reone {
 namespace game {
 
 static const char kSkillsTwoDAResRef[] = "skills";
+static const char kDefenseBonusTwoDAResRef[] = "acbonus";
 static const char kFeatTwoDAResRef[] = "feat";
 static const char kFeatGainTwoDAResRef[] = "featgain";
 static const char kPowerGainTwoDAResRef[] = "classpowergain";
@@ -62,11 +64,19 @@ void CreatureClass::load(const TwoDA &twoDa, int row) {
     std::string skillsTable(boost::to_lower_copy(twoDa.getString(row, "skillstable")));
     loadClassSkills(skillsTable);
 
-    std::string savingThrowTable(boost::to_lower_copy(twoDa.getString(row, "savingthrowtable")));
+    std::string savingThrowTable(boost::to_lower_copy(
+        twoDa.getString(row, "savingthrowtable")));
     loadSavingThrows(savingThrowTable);
 
-    std::string attackBonusTable(boost::to_lower_copy(twoDa.getString(row, "attackbonustable")));
+    std::string attackBonusTable(boost::to_lower_copy(
+        twoDa.getString(row, "attackbonustable")));
     loadAttackBonuses(attackBonusTable);
+
+    std::string defenseBonusColumn(boost::to_lower_copy(
+        twoDa.getString(row, "armorclasscolumn")));
+    if (!defenseBonusColumn.empty()) {
+        loadDefenseBonuses(defenseBonusColumn);
+    }
 
     std::string featsPrefix(boost::to_lower_copy(twoDa.getString(row, "featstable")));
     loadFeatListValues(featsPrefix);
@@ -88,7 +98,7 @@ void CreatureClass::loadClassSkills(const std::string &skillsTable) {
 }
 
 void CreatureClass::loadSavingThrows(const std::string &savingThrowTable) {
-    std::shared_ptr<TwoDA> twoDa(_twoDas.get(savingThrowTable));
+    auto twoDa = getRequiredTwoDA(_twoDas, savingThrowTable);
     for (int row = 0; row < twoDa->getRowCount(); ++row) {
         int level = twoDa->getInt(row, "level");
 
@@ -102,9 +112,16 @@ void CreatureClass::loadSavingThrows(const std::string &savingThrowTable) {
 }
 
 void CreatureClass::loadAttackBonuses(const std::string &attackBonusTable) {
-    std::shared_ptr<TwoDA> twoDa(_twoDas.get(attackBonusTable));
+    auto twoDa = getRequiredTwoDA(_twoDas, attackBonusTable);
     for (int row = 0; row < twoDa->getRowCount(); ++row) {
         _attackBonuses.push_back(twoDa->getInt(row, "bab"));
+    }
+}
+
+void CreatureClass::loadDefenseBonuses(const std::string &defenseBonusColumn) {
+    auto twoDa = getRequiredTwoDA(_twoDas, kDefenseBonusTwoDAResRef);
+    for (int row = 0; row < twoDa->getRowCount(); ++row) {
+        _defenseBonuses.push_back(twoDa->getInt(row, defenseBonusColumn));
     }
 }
 
@@ -179,6 +196,16 @@ int CreatureClass::getAttackBonus(int level) const {
         throw std::out_of_range(str(boost::format("Level out of range: %d/%d") % level % static_cast<int>(_attackBonuses.size())));
     }
     return _attackBonuses[level - 1];
+}
+
+int CreatureClass::getDefenseBonus(int level) const {
+    assert(level >= 0);
+    assert(!_defenseBonuses.empty());
+
+    if (level >= static_cast<int>(_defenseBonuses.size())) {
+        return _defenseBonuses.back();
+    }
+    return _defenseBonuses[level];
 }
 
 int CreatureClass::getFeatGain(int level) const {

--- a/src/libs/game/effect.cpp
+++ b/src/libs/game/effect.cpp
@@ -27,6 +27,14 @@ void Effect::applyTo(Object &object) {
     debug("Unsupported effect type: " + std::to_string(static_cast<int>(_type)));
 }
 
+bool Effect::onApply(Object &object) {
+    applyTo(object);
+    return true;
+}
+
+void Effect::onRemove(Object &object) {
+}
+
 } // namespace game
 
 } // namespace reone

--- a/src/libs/game/effect/assuredhit.cpp
+++ b/src/libs/game/effect/assuredhit.cpp
@@ -17,12 +17,21 @@
 
 #include "reone/game/effect/assuredhit.h"
 
+#include "reone/game/object/creature.h"
+
 namespace reone {
 
 namespace game {
 
-void AssuredHitEffect::applyTo(Object &object) {
-    // TODO: implement
+bool AssuredHitEffect::onApply(Object &object) {
+    auto *creature = dyn_cast<Creature>(&object);
+    return creature && creature->applyAssuredHit();
+}
+
+void AssuredHitEffect::onRemove(Object &object) {
+    if (auto *creature = dyn_cast<Creature>(&object)) {
+        creature->removeAssuredHit();
+    }
 }
 
 } // namespace game

--- a/src/libs/game/effect/damage.cpp
+++ b/src/libs/game/effect/damage.cpp
@@ -19,6 +19,10 @@
 
 #include "reone/system/logutil.h"
 
+#include "reone/game/effect/damageimmunitydecrease.h"
+#include "reone/game/effect/damageimmunityincrease.h"
+#include "reone/game/effect/damagereduction.h"
+#include "reone/game/effect/damageresistance.h"
 #include "reone/game/object.h"
 #include "reone/game/object/creature.h"
 
@@ -26,9 +30,287 @@ namespace reone {
 
 namespace game {
 
+static constexpr int kDamageTypeCount = 15;
+
+DamageType getPrimaryDamageType(int damageFlags) {
+    assert(damageFlags > 0);
+
+    int type = 1;
+    while (damageFlags > 1) {
+        damageFlags >>= 1;
+        type <<= 1;
+    }
+    return static_cast<DamageType>(type);
+}
+
+bool damageTypeMatches(int modifierFlags, int damageFlags) {
+    if (modifierFlags == kAllDamageTypeFlags) {
+        return true;
+    }
+    if (modifierFlags <= 0 || damageFlags == 0) {
+        return false;
+    }
+    if (modifierFlags == kPhysicalDamageTypeFlags) {
+        return (damageFlags & static_cast<int>(DamageType::Physical)) != 0;
+    }
+    return (modifierFlags & damageFlags) != 0;
+}
+
+static int getDamageImmunity(const Object &object, DamageType damageType) {
+    int damageFlags = static_cast<int>(damageType);
+    int result = 0;
+
+    for (int bit = 0; bit < kDamageTypeCount; ++bit) {
+        int typeFlag = 1 << bit;
+        if ((damageFlags & typeFlag) == 0) {
+            continue;
+        }
+
+        auto type = static_cast<DamageType>(typeFlag);
+        int immunity = 0;
+        if (const auto *creature = dyn_cast<Creature>(&object)) {
+            immunity = std::clamp(
+                creature->getItemDamageImmunity(type),
+                -100,
+                100);
+        }
+
+        for (const Object::AppliedEffect &applied : object.effects()) {
+            switch (applied.effect->type()) {
+            case EffectType::DamageImmunityIncrease: {
+                const auto &effect =
+                    static_cast<const DamageImmunityIncreaseEffect &>(*applied.effect);
+                if (damageTypeMatches(
+                        static_cast<int>(effect.damageType()),
+                        static_cast<int>(type))) {
+                    immunity = std::clamp(
+                        immunity + effect.percentImmunity(),
+                        -100,
+                        100);
+                }
+                break;
+            }
+            case EffectType::DamageImmunityDecrease: {
+                const auto &effect =
+                    static_cast<const DamageImmunityDecreaseEffect &>(*applied.effect);
+                if (damageTypeMatches(
+                        static_cast<int>(effect.damageType()),
+                        static_cast<int>(type))) {
+                    immunity = std::clamp(
+                        immunity - effect.percentImmunity(),
+                        -100,
+                        100);
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        }
+
+        if (result == 0 || immunity < result) {
+            result = immunity;
+        }
+    }
+
+    return std::clamp(result, -100, 100);
+}
+
+static int applyDamageImmunity(
+    const Object &object,
+    DamageType damageType,
+    int damage) {
+
+    if (damage <= 0) {
+        return 0;
+    }
+
+    int immunity = getDamageImmunity(object, damageType);
+    if (immunity > 0) {
+        int prevented = std::max(1, damage * immunity / 100);
+        return std::max(0, damage - prevented);
+    }
+    return damage - damage * immunity / 100;
+}
+
+static int applyDamageResistance(
+    Object &object,
+    DamageType damageType,
+    int damage) {
+
+    if (damage <= 0) {
+        return 0;
+    }
+
+    int resistance = 0;
+    int featBonus = 0;
+    if (const auto *creature = dyn_cast<Creature>(&object)) {
+        resistance = creature->getItemDamageResistance(damageType);
+        featBonus = creature->getDamageResistanceFeatBonus();
+    }
+
+    std::shared_ptr<DamageResistanceEffect> selectedEffect;
+    for (const Object::AppliedEffect &applied : object.effects()) {
+        if (applied.effect->type() != EffectType::DamageResistance) {
+            continue;
+        }
+
+        auto effect = std::static_pointer_cast<DamageResistanceEffect>(applied.effect);
+        if (!damageTypeMatches(
+                static_cast<int>(effect->damageType()),
+                static_cast<int>(damageType)) ||
+            effect->amount() <= resistance) {
+            continue;
+        }
+
+        resistance = effect->amount();
+        selectedEffect = std::move(effect);
+    }
+
+    int prevented = selectedEffect
+                        ? selectedEffect->absorb(damage)
+                        : std::min(damage, resistance);
+    if (selectedEffect && selectedEffect->exhausted()) {
+        object.removeEffect(selectedEffect);
+    }
+
+    return std::max(0, damage - prevented - featBonus);
+}
+
+static int applyDamageReduction(
+    Object &object,
+    DamageType damageType,
+    DamagePower damagePower,
+    int damage) {
+
+    if (damage <= 0) {
+        return 0;
+    }
+    if (!damageTypeMatches(
+            kPhysicalDamageTypeFlags,
+            static_cast<int>(damageType))) {
+        return damage;
+    }
+
+    int reduction = 0;
+    DamagePower requiredPower = DamagePower::Normal;
+    if (const auto *creature = dyn_cast<Creature>(&object)) {
+        creature->getItemDamageReduction(reduction, requiredPower);
+    }
+
+    std::shared_ptr<DamageReductionEffect> selectedEffect;
+    for (const Object::AppliedEffect &applied : object.effects()) {
+        if (applied.effect->type() != EffectType::DamageReduction) {
+            continue;
+        }
+
+        auto effect = std::static_pointer_cast<DamageReductionEffect>(applied.effect);
+        if (effect->amount() <= reduction) {
+            continue;
+        }
+
+        reduction = effect->amount();
+        requiredPower = effect->damagePower();
+        selectedEffect = std::move(effect);
+    }
+
+    int prevented = selectedEffect
+                        ? selectedEffect->absorb(damage)
+                        : std::min(damage, reduction);
+    if (selectedEffect && selectedEffect->exhausted()) {
+        object.removeEffect(selectedEffect);
+    }
+
+    if (static_cast<int>(damagePower) >= static_cast<int>(requiredPower)) {
+        return damage;
+    }
+    return std::max(0, damage - prevented);
+}
+
+void DamagePacket::requireUnresolved() const {
+    if (isResolved()) {
+        throw std::logic_error("Damage packet has already been resolved");
+    }
+}
+
+void DamagePacket::addResolved(int amount, DamageType type) {
+    for (Component &component : _components) {
+        if (component.type == type) {
+            component.amount = std::max(component.amount + amount, 1);
+            return;
+        }
+    }
+    if (amount > 0) {
+        _components.push_back({amount, type});
+    }
+}
+
+void DamagePacket::add(int amount, DamageType type) {
+    requireUnresolved();
+    if (amount == 0) {
+        return;
+    }
+
+    addResolved(amount, type);
+}
+
+void DamagePacket::setDamageFlags(int damageFlags) {
+    requireUnresolved();
+    if (damageFlags == 0) {
+        throw std::invalid_argument("Damage flags must not be zero");
+    }
+    _damageFlags = damageFlags;
+}
+
+void DamagePacket::setPower(DamagePower power) {
+    requireUnresolved();
+    if (static_cast<int>(power) > static_cast<int>(_power)) {
+        _power = power;
+    }
+}
+
+void DamagePacket::resolve(Object &object) {
+    requireUnresolved();
+    if (_damageFlags == 0) {
+        throw std::logic_error("Damage packet has no damage flags");
+    }
+
+    int amount = total();
+    if (object.plotFlag()) {
+        _resolvedDamage = 0;
+        return;
+    }
+
+    auto damageType = static_cast<DamageType>(_damageFlags);
+    amount = applyDamageImmunity(object, damageType, amount);
+    amount = applyDamageResistance(object, damageType, amount);
+    amount = applyDamageReduction(object, damageType, _power, amount);
+    _resolvedDamage = amount;
+}
+
+int DamagePacket::resolvedDamage() const {
+    if (!_resolvedDamage) {
+        throw std::logic_error("Damage packet has not been resolved");
+    }
+    return *_resolvedDamage;
+}
+
+int DamagePacket::total() const {
+    int result = 0;
+    for (const Component &component : _components) {
+        result += component.amount;
+    }
+    return result;
+}
+
 void DamageEffect::applyTo(Object &object) {
-    debug(str(boost::format("Damage taken: %s %d") % object.tag() % _amount));
-    object.damage(_amount, _damager);
+    if (!_damage.isResolved()) {
+        _damage.resolve(object);
+    }
+
+    int amount = _damage.resolvedDamage();
+    debug(str(boost::format("Damage taken: %s %d") % object.tag() % amount));
+    object.damage(amount, _damager);
 }
 
 } // namespace game

--- a/src/libs/game/effect/damageimmunityincrease.cpp
+++ b/src/libs/game/effect/damageimmunityincrease.cpp
@@ -17,12 +17,19 @@
 
 #include "reone/game/effect/damageimmunityincrease.h"
 
+#include "reone/game/effect/damageimmunitydecrease.h"
+#include "reone/game/object.h"
+
 namespace reone {
 
 namespace game {
 
-void DamageImmunityIncreaseEffect::applyTo(Object &object) {
-    // TODO: implement
+bool DamageImmunityIncreaseEffect::onApply(Object &) {
+    return _percentImmunity >= 0;
+}
+
+bool DamageImmunityDecreaseEffect::onApply(Object &object) {
+    return _percentImmunity >= 0 && !object.plotFlag();
 }
 
 } // namespace game

--- a/src/libs/game/effect/modifyattacks.cpp
+++ b/src/libs/game/effect/modifyattacks.cpp
@@ -17,12 +17,26 @@
 
 #include "reone/game/effect/modifyattacks.h"
 
+#include "reone/game/object/creature.h"
+
 namespace reone {
 
 namespace game {
 
-void ModifyAttacksEffect::applyTo(Object &object) {
-    // TODO: implement
+bool ModifyAttacksEffect::onApply(Object &object) {
+    auto *creature = dyn_cast<Creature>(&object);
+    if (!creature) {
+        return false;
+    }
+
+    creature->adjustModifiedAttacks(_attacks);
+    return true;
+}
+
+void ModifyAttacksEffect::onRemove(Object &object) {
+    if (auto *creature = dyn_cast<Creature>(&object)) {
+        creature->adjustModifiedAttacks(-_attacks);
+    }
 }
 
 } // namespace game

--- a/src/libs/game/effect/stunned.cpp
+++ b/src/libs/game/effect/stunned.cpp
@@ -17,12 +17,25 @@
 
 #include "reone/game/effect/stunned.h"
 
+#include "reone/game/object/creature.h"
+
 namespace reone {
 
 namespace game {
 
 void StunnedEffect::applyTo(Object &object) {
-    // TODO: implement
+    if (auto *creature = dyn_cast<Creature>(&object)) {
+        creature->setMovementType(Creature::MovementType::None);
+    }
+}
+
+void StunnedEffect::onRemove(Object &object) {
+    if (auto *creature = dyn_cast<Creature>(&object)) {
+        if (creature->hasEffect(EffectType::Stunned)) {
+            return;
+        }
+        creature->resumeStateDrivenAnimation();
+    }
 }
 
 } // namespace game

--- a/src/libs/game/floatingtext.cpp
+++ b/src/libs/game/floatingtext.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/floatingtext.h"
+
+#include <algorithm>
+
+#include "reone/game/game.h"
+#include "reone/game/object.h"
+#include "reone/game/object/camera.h"
+#include "reone/game/object/creature.h"
+#include "reone/graphics/camera.h"
+#include "reone/graphics/context.h"
+#include "reone/graphics/font.h"
+#include "reone/graphics/uniforms.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/provider/fonts.h"
+#include "reone/resource/strings.h"
+#include "reone/scene/node/camera.h"
+
+using namespace reone::graphics;
+
+namespace reone {
+
+namespace game {
+
+static constexpr float kFloatingTextOffsetY = 32.0f;
+static constexpr float kFloatingTextDuration = 1.5f;
+static constexpr int kMaxFloatingTextEntries = 5;
+static constexpr int kMissStrRef = 1373;
+
+static const glm::vec3 kDamageColor(0.74f, 0.11f, 0.0f);
+static const glm::vec3 kHealColor(0.28f, 0.92f, 0.11f);
+static const glm::vec3 kMissColor(1.0f);
+
+static glm::vec2 projectToScreen(
+    const glm::vec3 &position,
+    const glm::mat4 &view,
+    const glm::mat4 &projection,
+    int width,
+    int height) {
+
+    static const glm::vec4 viewport(0.0f, 0.0f, 1.0f, 1.0f);
+    glm::vec3 screen = glm::project(position, view, projection, viewport);
+    return glm::vec2(
+        width * screen.x,
+        height * (1.0f - screen.y));
+}
+
+void FloatingText::addDamage(
+    const Object &object, int amount, int adjustedAmount, uint32_t damager) {
+
+    if (_game.isTSL()) {
+        return;
+    }
+
+    auto leader = _game.party().getLeader();
+    if (!leader) {
+        return;
+    }
+
+    if (damager == leader->id()) {
+        add(object, std::to_string(amount), Style::Damage);
+    } else if (object.id() == leader->id()) {
+        add(object, std::to_string(adjustedAmount), Style::Damage);
+    }
+}
+
+void FloatingText::addHeal(const Object &object, int amount) {
+    if (_game.isTSL() || !_game.party().isMember(object)) {
+        return;
+    }
+
+    add(object, std::to_string(amount), Style::Heal);
+}
+
+void FloatingText::addMiss(const Creature &attacker, const Object &target) {
+    if (_game.isTSL()) {
+        return;
+    }
+
+    auto leader = _game.party().getLeader();
+    if (!leader || attacker.id() != leader->id()) {
+        return;
+    }
+
+    add(
+        target,
+        _services.resource.strings.getText(kMissStrRef),
+        Style::Miss);
+}
+
+void FloatingText::add(const Object &object, std::string text, Style style) {
+    for (Entry &entry : _entries) {
+        if (entry.objectId == object.id()) {
+            ++entry.stack;
+        }
+    }
+    _entries.erase(
+        std::remove_if(_entries.begin(), _entries.end(), [&object](const Entry &entry) {
+            return entry.objectId == object.id() && entry.stack > kMaxFloatingTextEntries;
+        }),
+        _entries.end());
+
+    std::optional<glm::vec2> anchorOffset;
+    auto model = object.sceneNode();
+    auto camera = _game.getActiveCamera();
+    auto cameraNode = camera ? camera->cameraSceneNode() : nullptr;
+    auto graphicsCamera = cameraNode ? cameraNode->camera() : nullptr;
+    if (model && graphicsCamera) {
+        const auto &options = _game.options().graphics;
+        const glm::mat4 &projection = graphicsCamera->projection();
+        const glm::mat4 &view = graphicsCamera->view();
+        glm::vec2 originScreen = projectToScreen(
+            model->origin(),
+            view,
+            projection,
+            options.width,
+            options.height);
+        glm::vec2 reticleScreen = projectToScreen(
+            object.getSelectablePosition(),
+            view,
+            projection,
+            options.width,
+            options.height);
+        anchorOffset = reticleScreen - originScreen;
+    }
+
+    _entries.push_back({object.id(),
+                        std::move(text),
+                        style,
+                        kFloatingTextDuration,
+                        1,
+                        std::move(anchorOffset)});
+}
+
+void FloatingText::update(float dt) {
+    for (Entry &entry : _entries) {
+        entry.remaining -= dt;
+    }
+    _entries.erase(
+        std::remove_if(_entries.begin(), _entries.end(), [](const Entry &entry) {
+            return entry.remaining <= 0.0f;
+        }),
+        _entries.end());
+}
+
+void FloatingText::render() {
+    if (_game.isTSL() || _entries.empty()) {
+        return;
+    }
+    const auto &options = _game.options().graphics;
+    const std::string fontResRef(
+        options.width > 1279 ? "fnt_d16x16b" : "fnt_d16x16a");
+    if (!_font || _fontResRef != fontResRef) {
+        _font = _services.resource.fonts.get(fontResRef);
+        _fontResRef = fontResRef;
+    }
+    if (!_font) {
+        throw resource::ResourceNotFoundException(
+            "Floating-text font not found: " + fontResRef);
+    }
+
+    auto camera = _game.getActiveCamera();
+    if (!camera) {
+        return;
+    }
+
+    auto cameraNode = camera->cameraSceneNode();
+    auto graphicsCamera = cameraNode ? cameraNode->camera() : nullptr;
+    if (!graphicsCamera) {
+        return;
+    }
+
+    const glm::mat4 &projection = graphicsCamera->projection();
+    const glm::mat4 &view = graphicsCamera->view();
+    const glm::vec3 cameraForward = graphicsCamera->forward();
+    const glm::vec3 cameraPosition = graphicsCamera->position();
+    const float lineHeight = _font->height();
+
+    _services.graphics.uniforms.setGlobals([&options](auto &globals) {
+        globals.reset();
+        globals.projection = glm::ortho(
+            0.0f,
+            static_cast<float>(options.width),
+            static_cast<float>(options.height),
+            0.0f,
+            0.0f,
+            100.0f);
+        globals.projectionInv = glm::inverse(globals.projection);
+    });
+
+    _services.graphics.context.withViewport(
+        {0, 0, options.width, options.height},
+        [this, &projection, &view, cameraForward, cameraPosition,
+         &options, lineHeight]() {
+            _services.graphics.context.withDepthTestMode(
+                DepthTestMode::None,
+                [this, &projection, &view, cameraForward, cameraPosition,
+                 &options, lineHeight]() {
+                    _services.graphics.context.withDepthMask(
+                        false,
+                        [this, &projection, &view, cameraForward, cameraPosition,
+                         &options, lineHeight]() {
+                            _services.graphics.context.withBlendMode(
+                                BlendMode::Normal,
+                                [this, &projection, &view, cameraForward, cameraPosition,
+                                 &options, lineHeight]() {
+                                    for (auto it = _entries.rbegin();
+                                         it != _entries.rend();
+                                         ++it) {
+                                        const Entry &entry = *it;
+                                        auto object = _game.getObjectById(entry.objectId);
+                                        if (!object) {
+                                            continue;
+                                        }
+
+                                        auto model = object->sceneNode();
+                                        if (!model) {
+                                            continue;
+                                        }
+
+                                        const glm::vec3 position = model->origin();
+                                        if (glm::dot(cameraForward, position) <=
+                                            glm::dot(cameraForward, cameraPosition)) {
+                                            continue;
+                                        }
+
+                                        if (!entry.anchorOffset) {
+                                            continue;
+                                        }
+
+                                        glm::vec2 screen = projectToScreen(
+                                            position,
+                                            view,
+                                            projection,
+                                            options.width,
+                                            options.height);
+
+                                        glm::vec3 color;
+                                        switch (entry.style) {
+                                        case Style::Damage:
+                                            color = kDamageColor;
+                                            break;
+                                        case Style::Heal:
+                                            color = kHealColor;
+                                            break;
+                                        case Style::Miss:
+                                            color = kMissColor;
+                                            break;
+                                        }
+
+                                        float x = screen.x + entry.anchorOffset->x;
+                                        float y = screen.y + entry.anchorOffset->y -
+                                                  kFloatingTextOffsetY -
+                                                  (entry.stack - 0.5f) * lineHeight;
+                                        float alpha = entry.remaining / kFloatingTextDuration;
+
+                                        _font->render(
+                                            entry.text,
+                                            glm::vec3(x, y, 0.0f),
+                                            glm::vec4(color, alpha),
+                                            TextGravity::CenterCenter);
+                                    }
+                                });
+                        });
+                });
+        });
+}
+
+void FloatingText::reset() {
+    _entries.clear();
+    _font.reset();
+    _fontResRef.clear();
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -603,6 +603,7 @@ void Game::update(float frameTime) {
 
     bool updModule = !_movie && _module && (_screen == Screen::InGame || _screen == Screen::Conversation);
     if (updModule && !_paused) {
+        _floatingText.update(dt);
         _module->update(dt);
         _combat.update(dt);
     }
@@ -777,6 +778,7 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
             // Do not carry a displayed or pending batch, indicator, or GUI
             // controls across module teardown. OnLoad events below start a new
             // batch for the destination module.
+            _floatingText.reset();
             _statusSummary.reset();
             if (_hud) {
                 _hud->resetStatusSummaryPresentation();
@@ -868,6 +870,8 @@ void Game::resetGame() {
     _party.reset();
     _combat.reset();
     _journal.reset();
+    _messageLog.reset();
+    _floatingText.reset();
     _statusSummary.reset();
     if (_hud) {
         _hud->resetStatusSummaryPresentation();

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -252,6 +252,7 @@ void CharacterGeneration::startLevelUp() {
     std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
 
     Character character;
+    character.name = partyLeader->name();
     character.appearance = partyLeader->appearance();
     character.gender = partyLeader->gender();
     character.attributes = partyLeader->attributes();
@@ -348,6 +349,7 @@ void CharacterGeneration::finish() {
     } else {
         std::shared_ptr<Creature> player = _game.newCreature();
         player->setTag(kObjectTagPlayer);
+        player->setName(_character.name);
         player->setGender(_character.gender);
         player->setAppearance(_character.appearance);
         player->loadAppearance();
@@ -378,6 +380,7 @@ void CharacterGeneration::setCharacter(Character character) {
     bool appearanceChanged = character.appearance != _character.appearance;
 
     _character = std::move(character);
+    _controls.LBL_NAME->setTextMessage(_character.name);
 
     if (appearanceChanged) {
         reloadCharacterModel();
@@ -386,6 +389,11 @@ void CharacterGeneration::setCharacter(Character character) {
     }
 
     updateAttributes();
+}
+
+void CharacterGeneration::setCharacterName(std::string name) {
+    _character.name = std::move(name);
+    _controls.LBL_NAME->setTextMessage(_character.name);
 }
 
 void CharacterGeneration::reloadCharacterModel() {

--- a/src/libs/game/gui/chargen/nameentry.cpp
+++ b/src/libs/game/gui/chargen/nameentry.cpp
@@ -39,7 +39,8 @@ static const ResRef kLastNameLtrResRef("humanl");
 void NameEntry::onGUILoaded() {
     bindControls();
 
-    _controls.NAME_BOX_EDIT->setTextMessage("");
+    _input.setText(_charGen.character().name);
+    _controls.NAME_BOX_EDIT->setTextMessage(_charGen.character().name);
 
     _controls.BTN_RANDOM->setOnClick([this]() {
         loadRandomName();
@@ -55,7 +56,9 @@ void NameEntry::onGUILoaded() {
 
 bool NameEntry::handle(const input::Event &event) {
     if (event.type == input::EventType::KeyDown && _input.handle(event)) {
-        _controls.NAME_BOX_EDIT->setTextMessage(std::string(_buffer.str()));
+        std::string name(_buffer.str());
+        _controls.NAME_BOX_EDIT->setTextMessage(name);
+        _charGen.setCharacterName(std::move(name));
         return true;
     }
     return _gui->handle(event);
@@ -67,7 +70,9 @@ void NameEntry::loadRandomName() {
     auto nameLtr = _services.resource.ltrs.get(nameLtrResRef);
     auto lastNameLtr = _services.resource.ltrs.get(kLastNameLtrResRef);
     auto generated = nameLtr->randomName(8) + " " + lastNameLtr->randomName(8);
+    _input.setText(generated);
     _controls.NAME_BOX_EDIT->setTextMessage(generated);
+    _charGen.setCharacterName(std::move(generated));
 }
 
 } // namespace game

--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -75,7 +75,6 @@ void HUD::preload(IGUI &gui) {
 
 void HUD::onGUILoaded() {
     bindControls();
-
     _actionBar.addDescription(
         findControl<gui::Label>("LBL_ACTIONDESC"),
         findControl<gui::Label>("LBL_ACTIONDESCBG"));
@@ -411,6 +410,7 @@ void HUD::render() {
     }
     _select.render();
     _actionBar.render();
+    _game.floatingText().render();
 
     if (_statusSummary && _statusSummary->isVisible()) {
         _statusSummary->render();

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -379,6 +379,7 @@ void InGameMenu::openPartySelection() {
 }
 
 void InGameMenu::openMessages() {
+    _messages->refresh();
     changeTab(InGameMenuTab::Messages);
 }
 

--- a/src/libs/game/gui/ingame/character.cpp
+++ b/src/libs/game/gui/ingame/character.cpp
@@ -131,7 +131,7 @@ void CharacterMenu::refreshControls() {
     }
 
     _controls.LBL_VITALITY_STAT->setTextMessage(str(boost::format("%d/%d") % partyLeader->currentHitPoints() % partyLeader->hitPoints()));
-    _controls.LBL_DEFENSE_STAT->setTextMessage(std::to_string(attributes.getDefense()));
+    _controls.LBL_DEFENSE_STAT->setTextMessage(std::to_string(partyLeader->getDefense()));
     _controls.LBL_FORCE_STAT->setTextMessage("");
 
     _controls.LBL_STR->setTextMessage(std::to_string(attributes.strength()));

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -481,13 +481,17 @@ void Equipment::updateEquipment() {
     partyLeader->getOffhandDamage(min, max);
     _controls.LBL_ATKL->setTextMessage(str(boost::format("%d-%d") % min % max));
 
-    int attackBonus = partyLeader->getAttackBonus();
-    std::string attackBonusString(std::to_string(attackBonus));
-    if (attackBonus > 0) {
-        attackBonusString.insert(0, "+");
-    }
-    _controls.LBL_TOHITL->setTextMessage(attackBonusString);
-    _controls.LBL_TOHITR->setTextMessage(attackBonusString);
+    auto formatAttackBonus = [](int attackBonus) {
+        std::string result(std::to_string(attackBonus));
+        if (attackBonus > 0) {
+            result.insert(0, "+");
+        }
+        return result;
+    };
+    _controls.LBL_TOHITL->setTextMessage(
+        formatAttackBonus(partyLeader->getAttackBonus(true)));
+    _controls.LBL_TOHITR->setTextMessage(
+        formatAttackBonus(partyLeader->getAttackBonus()));
 }
 
 std::shared_ptr<Texture> Equipment::getEmptySlotIcon(Slot slot) const {

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -18,7 +18,9 @@
 #include "reone/game/gui/ingame/messages.h"
 
 #include "reone/game/game.h"
+#include "reone/game/messagelog.h"
 #include "reone/gui/control/button.h"
+#include "reone/resource/strings.h"
 
 using namespace reone::audio;
 
@@ -29,6 +31,15 @@ using namespace reone::resource;
 namespace reone {
 
 namespace game {
+
+static constexpr int kStrRefMessages = 1563;
+static constexpr int kStrRefDialog = 371;
+static constexpr int kStrRefFeedback = 42167;
+static constexpr int kStrRefShowFeedback = 42142;
+static constexpr int kStrRefShowDialog = 42143;
+
+static const glm::vec3 kFeedbackColor(0.0f, 0.66f, 0.98f);
+static const glm::vec3 kCombatColor(0.74f, 0.11f, 0.0f);
 
 void MessagesMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
@@ -41,9 +52,70 @@ void MessagesMenu::onGUILoaded() {
             _game.openInGame();
         }
     });
-
     if (!_game.isTSL()) {
-        _controls.BTN_SHOW->setDisabled(true);
+        _controls.BTN_SHOW->setOnClick([this]() {
+            toggleMessages();
+        });
+        _controls.LB_MESSAGES->setItemsInteractive(false);
+        _controls.LB_MESSAGES->setProtoMatchContent(true);
+    }
+}
+
+void MessagesMenu::refresh() {
+    if (_game.isTSL()) {
+        return;
+    }
+
+    _controls.LB_MESSAGES->clearItems();
+
+    for (const MessageLog::Entry &entry : _game.messageLog().entries()) {
+        if ((entry.type & MessageLog::kFeedbackMessageType) == 0) {
+            continue;
+        }
+
+        gui::ListBox::Item item;
+        item.text = entry.text;
+        item.textColor = entry.style == MessageLog::Style::Combat
+                             ? kCombatColor
+                             : kFeedbackColor;
+        _controls.LB_MESSAGES->addItem(std::move(item));
+    }
+    _controls.LB_MESSAGES->scrollToBottom();
+
+    if (_showingFeedback) {
+        showFeedbackMessages();
+    } else {
+        showDialogMessages();
+    }
+}
+
+void MessagesMenu::showDialogMessages() {
+    _controls.LB_MESSAGES->setVisible(false);
+    _controls.LB_DIALOG->setVisible(true);
+    _controls.LBL_MESSAGES->setTextMessage(
+        _services.resource.strings.getText(kStrRefMessages) + " - " +
+        _services.resource.strings.getText(kStrRefDialog));
+    _controls.BTN_SHOW->setTextMessage(
+        _services.resource.strings.getText(kStrRefShowFeedback));
+    _showingFeedback = false;
+}
+
+void MessagesMenu::showFeedbackMessages() {
+    _controls.LB_DIALOG->setVisible(false);
+    _controls.LB_MESSAGES->setVisible(true);
+    _controls.LBL_MESSAGES->setTextMessage(
+        _services.resource.strings.getText(kStrRefMessages) + " - " +
+        _services.resource.strings.getText(kStrRefFeedback));
+    _controls.BTN_SHOW->setTextMessage(
+        _services.resource.strings.getText(kStrRefShowDialog));
+    _showingFeedback = true;
+}
+
+void MessagesMenu::toggleMessages() {
+    if (_showingFeedback) {
+        showDialogMessages();
+    } else {
+        showFeedbackMessages();
     }
 }
 

--- a/src/libs/game/messagelog.cpp
+++ b/src/libs/game/messagelog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The reone project contributors
+ * Copyright (c) 2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +15,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "reone/game/effect/damageresistance.h"
+#include "reone/game/messagelog.h"
 
 namespace reone {
 
 namespace game {
 
-void DamageResistanceEffect::applyTo(Object &) {
+void MessageLog::add(uint32_t type, Style style, std::string text) {
+    while (_entries.size() >= kMaxEntries) {
+        _entries.pop_front();
+    }
+    _entries.push_back({type, style, std::move(text)});
 }
 
 } // namespace game

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -83,7 +83,7 @@ void Object::deserialize(const resource::Gff &gff) {
 void Object::update(float dt) {
     updateActions(dt);
     updateEffects(dt);
-    if (!_dead) {
+    if (!_dead && canExecuteActions()) {
         executeActions(dt);
     }
     if (_sceneNode && _sceneNode->type() == SceneNodeType::Model) {
@@ -122,6 +122,7 @@ void Object::clearAllActions(bool force) {
                     break;
                 }
                 action->cancel(action, *this);
+                action->markCancelled();
                 _actions.pop_front();
             }
             if (!_actions.empty() && _actions.front() == executingAction) {
@@ -136,6 +137,7 @@ void Object::clearAllActions(bool force) {
             break;
         }
         _actions.back()->cancel(action, *this);
+        action->markCancelled();
         _actions.pop_back();
     }
 }
@@ -205,11 +207,12 @@ void Object::executeActions(float dt) {
     _executingAction.reset();
 }
 
-bool Object::hasUserActionsPending() const {
+bool Object::hasUserActionsPending(const Action *excluded) const {
     // TODO: must only work during combat
-    for (auto &action : _actions) {
-        if (action->isUserAction())
+    for (const auto &action : _actions) {
+        if (action.get() != excluded && action->isUserAction()) {
             return true;
+        }
     }
     return false;
 }
@@ -361,19 +364,19 @@ void Object::moveDropableItemsTo(Object &other) {
 
 void Object::applyEffect(const std::shared_ptr<Effect> &effect, DurationType durationType, float duration) {
     if (durationType == DurationType::Instant) {
-        applyInstantEffect(*effect);
+        if (effect->onApply(*this)) {
+            effect->onRemove(*this);
+        }
     } else {
         AppliedEffect appliedEffect;
         appliedEffect.effect = effect;
         appliedEffect.durationType = durationType;
         appliedEffect.duration = duration;
         _effects.push_back(std::move(appliedEffect));
-        applyInstantEffect(*_effects.back().effect);
+        if (!_effects.back().effect->onApply(*this)) {
+            _effects.pop_back();
+        }
     }
-}
-
-void Object::applyInstantEffect(Effect &effect) {
-    effect.applyTo(*this);
 }
 
 void Object::updateEffects(float dt) {
@@ -384,7 +387,9 @@ void Object::updateEffects(float dt) {
             effect.duration = glm::max(0.0f, effect.duration - dt);
         }
         if (temporary && effect.duration == 0.0f) {
+            std::shared_ptr<Effect> removed = effect.effect;
             it = _effects.erase(it);
+            removed->onRemove(*this);
         } else {
             ++it;
         }
@@ -466,7 +471,47 @@ std::shared_ptr<Item> Object::getItemByTag(const std::string &tag) {
 }
 
 void Object::clearAllEffects() {
+    std::vector<std::shared_ptr<Effect>> removed;
+    removed.reserve(_effects.size());
+    for (AppliedEffect &effect : _effects) {
+        removed.push_back(std::move(effect.effect));
+    }
     _effects.clear();
+
+    for (const std::shared_ptr<Effect> &effect : removed) {
+        effect->onRemove(*this);
+    }
+    onEffectsCleared();
+}
+
+void Object::removeEffect(const std::shared_ptr<Effect> &effect) {
+    for (auto it = _effects.begin(); it != _effects.end(); ++it) {
+        if (it->effect == effect) {
+            std::shared_ptr<Effect> removed = it->effect;
+            _effects.erase(it);
+            removed->onRemove(*this);
+            return;
+        }
+    }
+}
+
+bool Object::hasEffect(EffectType type) const {
+    return std::any_of(
+        _effects.begin(),
+        _effects.end(),
+        [type](const AppliedEffect &applied) {
+            return applied.effect->type() == type;
+        });
+}
+
+int Object::applyDamageToHitPoints(int amount, int currentHitPoints) {
+    bool minimumOne = isMinOneHP();
+    int minimumHitPoints = minimumOne ? 1 : 0;
+    int adjustedAmount = minimumOne
+                             ? std::min(amount, std::max(0, currentHitPoints - minimumHitPoints))
+                             : amount;
+    _currentHitPoints = std::max(minimumHitPoints, currentHitPoints - amount);
+    return adjustedAmount;
 }
 
 void Object::damage(int amount, uint32_t damager) {

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -17,18 +17,32 @@
 
 #include "reone/game/object/creature.h"
 
+#include <array>
+
 #include "reone/audio/di/services.h"
 #include "reone/audio/mixer.h"
 #include "reone/game/action.h"
 #include "reone/game/action/attackobject.h"
 #include "reone/game/animationutil.h"
+#include "reone/game/attack.h"
 #include "reone/game/d20/classes.h"
 #include "reone/game/di/services.h"
+#include "reone/game/effect/acdecrease.h"
+#include "reone/game/effect/acincrease.h"
+#include "reone/game/effect/attackdecrease.h"
+#include "reone/game/effect/attackincrease.h"
+#include "reone/game/effect/damage.h"
+#include "reone/game/effect/damagedecrease.h"
+#include "reone/game/effect/damageincrease.h"
+#include "reone/game/effect/immunity.h"
+#include "reone/game/effect/savingthrowdecrease.h"
+#include "reone/game/effect/savingthrowincrease.h"
 #include "reone/game/footstepsounds.h"
 #include "reone/game/game.h"
 #include "reone/game/portraits.h"
 #include "reone/game/script/runner.h"
 #include "reone/game/surfaces.h"
+#include "reone/game/twodautil.h"
 #include "reone/graphics/context.h"
 #include "reone/graphics/di/services.h"
 #include "reone/graphics/textureregistry.h"
@@ -64,7 +78,25 @@ namespace reone {
 namespace game {
 
 static constexpr int kStrRefRemains = 38151;
+static constexpr int kMaximumDodgeBonus = 10;
+static constexpr int kMaximumSavingThrowModifier = 20;
+static constexpr int kAllSavingThrows = 0;
+static constexpr int kFortitudeSavingThrow = 1;
+static constexpr int kSituationalAttackBonus = 10;
+static constexpr float kCloseRangeAttackDistance2 = 25.0f;
+static constexpr size_t kACBonusTypeCount = static_cast<size_t>(ACBonus::Deflection) + 1;
 static constexpr float kKeepPathDuration = 1000.0f;
+
+static constexpr char kItemPropertyCostTable[] = "iprp_costtable";
+static constexpr char kBonusCostTable[] = "iprp_bonuscost";
+static constexpr char kMeleeCostTable[] = "iprp_meleecost";
+static constexpr char kDecreaseCostTable[] = "iprp_neg5cost";
+static constexpr char kDamageCostTable[] = "iprp_damagecost";
+static constexpr char kResistanceCostTable[] = "iprp_resistcost";
+static constexpr char kReductionCostTable[] = "iprp_soakcost";
+static constexpr char kVulnerabilityCostTable[] = "iprp_damvulcost";
+static constexpr char kDamageTypeTable[] = "iprp_damagetype";
+static constexpr char kProtectionTable[] = "iprp_protection";
 
 static std::string g_talkDummyNode("talkdummy");
 
@@ -82,6 +114,404 @@ static int getEquipabilitySlot(int slot) {
     default:
         return slot;
     }
+}
+
+static bool attackModifierApplies(
+    AttackBonus modifierType,
+    const Item *weapon,
+    bool offHand) {
+
+    switch (modifierType) {
+    case AttackBonus::Misc:
+        return true;
+    case AttackBonus::Onhand:
+        return weapon && !offHand;
+    case AttackBonus::Offhand:
+        return weapon && offHand;
+    default:
+        return false;
+    }
+}
+
+static bool racialTypeMatches(uint16_t racialType, const Creature &target) {
+    auto type = static_cast<RacialType>(racialType);
+    return type == RacialType::All || type == target.racialType();
+}
+
+static bool attackAlignmentGroupMatches(uint16_t alignment, const Creature &target) {
+    auto group = static_cast<Alignment>(alignment);
+    // The native attack-property handler stores Neutral in the unused
+    // law/chaos qualifier, so it applies to every target.
+    return group == Alignment::All ||
+           group == Alignment::Neutral ||
+           group == target.alignment();
+}
+
+static bool defenseAlignmentGroupMatches(uint16_t alignment, const Creature &attacker) {
+    auto group = static_cast<Alignment>(alignment);
+    return group == Alignment::All || group == attacker.alignment();
+}
+
+static DamageType getItemPropertyDamageType(
+    ServicesView &services,
+    uint16_t subtype) {
+
+    auto table = getRequiredTwoDA(
+        services.resource.twoDas,
+        kDamageTypeTable);
+    validateTwoDARow(*table, kDamageTypeTable, subtype);
+    return static_cast<DamageType>(1 << subtype);
+}
+
+static DamagePower getDamageReductionPower(
+    ServicesView &services,
+    uint16_t subtype) {
+
+    auto table = getRequiredTwoDA(
+        services.resource.twoDas,
+        kProtectionTable);
+    validateTwoDARow(*table, kProtectionTable, subtype);
+    return static_cast<DamagePower>(subtype + 1);
+}
+
+static bool acDamageTypePropertyApplies(uint16_t subtype, int damageFlags) {
+    // KOTOR 1 stores the raw IPRP_COMBATDAM row in the effect qualifier, then
+    // compares it directly with runtime damage flags. Preserve that mismatch.
+    switch (subtype) {
+    case 1:
+        return damageFlags == 0;
+    case 2:
+        return damageFlags == static_cast<int>(DamageType::Bludgeoning);
+    case 4:
+        return damageFlags == static_cast<int>(DamageType::Piercing);
+    default:
+        return false;
+    }
+}
+
+static bool attackPropertyApplies(
+    ItemProperty property,
+    uint16_t subtype,
+    const Creature *target) {
+
+    switch (property) {
+    case ItemProperty::EnhancementBonus:
+    case ItemProperty::AttackBonus:
+        return true;
+    case ItemProperty::EnhancementBonusVsAlignmentGroup:
+    case ItemProperty::AttackBonusVsAlignmentGroup:
+        return target && attackAlignmentGroupMatches(subtype, *target);
+    case ItemProperty::EnhancementBonusVsRacialGroup:
+    case ItemProperty::AttackBonusVsRacialGroup:
+        return target && racialTypeMatches(subtype, *target);
+    default:
+        return false;
+    }
+}
+
+static bool defensePropertyApplies(
+    ItemProperty property,
+    uint16_t subtype,
+    const Creature *attacker,
+    int damageFlags) {
+
+    switch (property) {
+    case ItemProperty::AcBonus:
+        return true;
+    case ItemProperty::AcBonusVsAlignmentGroup:
+        return attacker && defenseAlignmentGroupMatches(subtype, *attacker);
+    case ItemProperty::AcBonusVsDamageType:
+        return acDamageTypePropertyApplies(subtype, damageFlags);
+    case ItemProperty::AcBonusVsRacialGroup:
+        return attacker && racialTypeMatches(subtype, *attacker);
+    default:
+        return false;
+    }
+}
+
+static void getSituationalAttackBonuses(
+    const Creature &attacker,
+    const Creature &target,
+    const Item *weapon,
+    int &closeProximityRangedBonus,
+    int &meleeOnRangedBonus) {
+
+    closeProximityRangedBonus = 0;
+    meleeOnRangedBonus = 0;
+
+    if (weapon && weapon->isRanged()) {
+        if (attacker.getSquareDistanceTo(target) <= kCloseRangeAttackDistance2) {
+            closeProximityRangedBonus = kSituationalAttackBonus;
+        }
+        return;
+    }
+
+    auto targetWeapon = target.getEquippedItem(InventorySlots::rightWeapon);
+    if (targetWeapon && targetWeapon->isRanged()) {
+        meleeOnRangedBonus = kSituationalAttackBonus;
+    }
+}
+
+static bool equippedItemAppliesToAttack(
+    int slot,
+    const Item &item,
+    const Item *weapon,
+    bool offHand) {
+
+    switch (slot) {
+    case InventorySlots::rightWeapon:
+        return weapon == &item &&
+               (!offHand || item.weaponWield() == WeaponWield::DoubleBladedSword);
+    case InventorySlots::leftWeapon:
+        return weapon == &item && offHand;
+    case InventorySlots::hands:
+        return !weapon && !offHand;
+    case InventorySlots::cWeaponL:
+    case InventorySlots::cWeaponR:
+    case InventorySlots::cWeaponB:
+    case InventorySlots::rightWeapon2:
+    case InventorySlots::leftWeapon2:
+        return false;
+    default:
+        return true;
+    }
+}
+
+static bool isHandSpecificAttackModifierSlot(int slot) {
+    switch (slot) {
+    case InventorySlots::rightWeapon:
+    case InventorySlots::leftWeapon:
+    case InventorySlots::hands:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void addAttackModifier(int modifier, int &bonus, int &penalty) {
+    if (modifier > 0) {
+        bonus += modifier;
+    } else if (modifier < 0) {
+        penalty -= modifier;
+    }
+}
+
+static int getCostTableValue(
+    ServicesView &services,
+    const std::string &resRef,
+    int row,
+    const std::string &column,
+    int blankValue) {
+
+    auto table = getRequiredTwoDA(services.resource.twoDas, resRef);
+    return table->getInt(row, column, blankValue);
+}
+
+struct NamedTwoDA {
+    std::string resRef;
+    std::shared_ptr<TwoDA> table;
+};
+
+static NamedTwoDA getItemPropertyCostTable(
+    ServicesView &services,
+    int index) {
+
+    auto costTables = getRequiredTwoDA(
+        services.resource.twoDas,
+        kItemPropertyCostTable);
+    std::string resRef = boost::to_lower_copy(
+        costTables->getString(index, "name"));
+    return {resRef, getRequiredTwoDA(services.resource.twoDas, resRef)};
+}
+
+static int getItemPropertyValue(
+    ServicesView &services,
+    const Item::PropertyEntry &property,
+    const std::string &column,
+    int blankValue) {
+
+    auto costTable = getItemPropertyCostTable(
+        services,
+        property.costTable);
+    return costTable.table->getInt(
+        property.costValue,
+        column,
+        blankValue);
+}
+
+static bool savingThrowModifierApplies(
+    int save,
+    SavingThrowType modifierType,
+    int requestedSave,
+    SavingThrowType requestedType) {
+
+    return (save == kAllSavingThrows || save == requestedSave) &&
+           (modifierType == SavingThrowType::All ||
+            modifierType == requestedType);
+}
+
+static bool savingThrowPropertyApplies(
+    ItemProperty property,
+    uint16_t subtype,
+    int requestedSave,
+    SavingThrowType requestedType) {
+
+    switch (property) {
+    case ItemProperty::ImprovedSavingThrow:
+    case ItemProperty::DecreasedSavingThrows:
+        return subtype == static_cast<uint16_t>(SavingThrowType::All) ||
+               subtype == static_cast<uint16_t>(requestedType);
+    case ItemProperty::ImprovedSavingThrowSpecific:
+    case ItemProperty::DecreasedSavingThrowsSpecific:
+        return subtype == kAllSavingThrows || subtype == requestedSave;
+    default:
+        return false;
+    }
+}
+
+struct DamageModifier {
+    int costValue;
+    int numDice;
+    int die;
+    int flat;
+    DamageType type;
+};
+
+static std::optional<DamageModifier> getDamageModifier(
+    ServicesView &services,
+    uint16_t costValue,
+    DamageType type) {
+
+    auto table = getRequiredTwoDA(services.resource.twoDas, kDamageCostTable);
+
+    DamageModifier result {costValue, 0, 0, 0, type};
+
+    auto numDice = table->getIntOpt(costValue, "numdice");
+    if (!numDice) {
+        result.flat = costValue;
+    } else {
+        auto die = table->getIntOpt(costValue, "die");
+        if (!die) {
+            throw ValidationException(
+                "Missing die in iprp_damagecost row " +
+                std::to_string(costValue));
+        }
+        result.numDice = *numDice;
+        result.die = *die;
+    }
+
+    if (result.numDice <= 0 && result.flat <= 0) {
+        return std::nullopt;
+    }
+    return result;
+}
+
+static std::optional<DamageModifier> getFlatDamageModifier(
+    ServicesView &services,
+    const std::string &resRef,
+    uint16_t costValue,
+    DamageType type) {
+
+    int value = getCostTableValue(
+        services,
+        resRef,
+        costValue,
+        "value",
+        0);
+    if (value == 0) {
+        return std::nullopt;
+    }
+
+    return DamageModifier {costValue, 0, 0, value, type};
+}
+
+static int rollDamageModifier(
+    const DamageModifier &modifier,
+    int multiplier) {
+
+    if (modifier.numDice <= 0 || modifier.die <= 0) {
+        return multiplier * modifier.flat;
+    }
+
+    int result = 0;
+    for (int multiple = 0; multiple < multiplier; ++multiple) {
+        for (int die = 0; die < modifier.numDice; ++die) {
+            result += randomInt(1, modifier.die);
+        }
+    }
+    return result;
+}
+
+static void selectDamageModifier(
+    std::map<int, DamageModifier> &modifiers,
+    DamageModifier modifier) {
+
+    int type = static_cast<int>(modifier.type);
+    auto it = modifiers.find(type);
+    if (it == modifiers.end() ||
+        modifier.costValue > it->second.costValue) {
+        modifiers.insert_or_assign(type, std::move(modifier));
+    }
+}
+
+static bool damagePropertyApplies(
+    ItemProperty property,
+    uint16_t subtype,
+    const Creature *target) {
+
+    switch (property) {
+    case ItemProperty::EnhancementBonus:
+    case ItemProperty::DamageBonus:
+    case ItemProperty::DecreasedDamage:
+        return true;
+    case ItemProperty::EnhancementBonusVsAlignmentGroup:
+    case ItemProperty::DamageBonusVsAlignmentGroup:
+        return target && attackAlignmentGroupMatches(subtype, *target);
+    case ItemProperty::EnhancementBonusVsRacialGroup:
+    case ItemProperty::DamageBonusVsRacialGroup:
+        return target && racialTypeMatches(subtype, *target);
+    default:
+        return false;
+    }
+}
+
+static bool equippedItemAppliesToDefense(int slot) {
+    return slot != InventorySlots::rightWeapon2 &&
+           slot != InventorySlots::leftWeapon2;
+}
+
+static void addDefenseModifier(
+    int value,
+    ACBonus modifierType,
+    std::array<int, kACBonusTypeCount> &modifiers) {
+
+    int index = static_cast<int>(modifierType);
+    if (value <= 0 || index < 0 || index >= static_cast<int>(modifiers.size())) {
+        return;
+    }
+
+    if (modifierType == ACBonus::Dodge) {
+        modifiers[index] += value;
+    } else {
+        modifiers[index] = std::max(modifiers[index], value);
+    }
+}
+
+static int getDefenseModifier(
+    const std::array<int, kACBonusTypeCount> &bonuses,
+    const std::array<int, kACBonusTypeCount> &penalties) {
+
+    int result = std::min(
+        bonuses[static_cast<int>(ACBonus::Dodge)] -
+            penalties[static_cast<int>(ACBonus::Dodge)],
+        kMaximumDodgeBonus);
+
+    for (int i = static_cast<int>(ACBonus::Natural);
+         i <= static_cast<int>(ACBonus::Deflection);
+         ++i) {
+        result += bonuses[i] - penalties[i];
+    }
+    return result;
 }
 
 Creature::Creature(
@@ -128,6 +558,10 @@ void Creature::loadAppearanceProperties() {
     _runSpeed = appearances->getFloat(_appearance, "rundist", 1.0f);
     float personalSpace = appearances->getFloat(_appearance, "perspace", 0.6f);
     _creaturePersonalSpace = appearances->getFloat(_appearance, "creperspace", personalSpace);
+    _size = static_cast<CreatureSize>(appearances->getInt(
+        _appearance,
+        "sizecategory",
+        static_cast<int>(CreatureSize::Invalid)));
     _footstepType = appearances->getInt(_appearance, "footsteptype", -1);
     _envmap = boost::to_lower_copy(appearances->getString(_appearance, "envmap"));
 
@@ -195,6 +629,18 @@ void Creature::loadTransformFromGIT(const resource::generated::GIT_Creature_List
     _orientation = glm::quat(glm::vec3(0.0f, 0.0f, -glm::atan(cosine, sine)));
 
     updateTransform();
+}
+
+bool Creature::isDebilitated() const {
+    return _combatState.debilitated || hasEffect(EffectType::Stunned);
+}
+
+bool Creature::isTemporarilyDead() const {
+    return _game.party().isMember(*this) && currentHitPoints() <= 0;
+}
+
+bool Creature::canExecuteActions() const {
+    return !hasEffect(EffectType::Stunned);
 }
 
 bool Creature::isSelectable() const {
@@ -280,14 +726,21 @@ void Creature::damage(int amount, uint32_t damager) {
 
     if (amount < 0) {
         // Heal instead of damage.
+        int previousHitPoints = _currentHitPoints;
         _currentHitPoints = std::min(maxHitPoints(), _currentHitPoints - amount);
+        _game.floatingText().addHeal(*this, _currentHitPoints - previousHitPoints);
         return;
     }
 
-    if (amount == std::numeric_limits<int>::max()) {
+    bool deathEffect = amount == std::numeric_limits<int>::max();
+    int previousHitPoints = _currentHitPoints;
+    if (deathEffect) {
         _currentHitPoints = 0; // special case for Death effect
     } else {
-        _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, _currentHitPoints - amount);
+        int adjustedAmount = applyDamageToHitPoints(amount, _currentHitPoints);
+        if (amount > 0) {
+            _game.floatingText().addDamage(*this, amount, adjustedAmount, damager);
+        }
     }
 
     damager = damager ? damager : script::kObjectInvalid;
@@ -318,8 +771,17 @@ void Creature::updateCombat(float dt) {
     }
     if (_combatState.shouldDeactivate && _combatState.deactivationTimer.elapsed()) {
         _combatState.active = false;
-        _combatState.debilitated = false;
         _combatState.shouldDeactivate = false;
+        _combatState.debilitated = false;
+        _combatState.attackTarget.reset();
+        _combatState.attemptedAttackTarget = script::kObjectInvalid;
+        _combatState.attackAction = ActionType::QueueEmpty;
+        _combatState.combatFeat = FeatType::Invalid;
+        _lastHostileTarget = script::kObjectInvalid;
+        _lastAttackAction = ActionType::QueueEmpty;
+        _lastCombatFeat = FeatType::Invalid;
+        setLastHostileActor(script::kObjectInvalid);
+
         _animDirty = true;
         setLightsabersPowered(false, true);
     }
@@ -821,59 +1283,858 @@ void Creature::deactivateCombat(float delay) {
 }
 
 bool Creature::isTwoWeaponFighting() const {
-    return static_cast<bool>(getEquippedItem(InventorySlots::leftWeapon));
+    return static_cast<bool>(getOffhandAttackWeapon());
 }
 
-std::shared_ptr<Object> Creature::getAttemptedAttackTarget() const {
-    auto action = getCurrentAction();
-    if (!action) {
+std::shared_ptr<Item> Creature::getOffhandAttackWeapon() const {
+    auto main = getEquippedItem(InventorySlots::rightWeapon);
+    if (!main) {
         return nullptr;
     }
-    std::shared_ptr<Object> target;
-    switch (action->type()) {
-    case ActionType::AttackObject:
-        target = cast<AttackObjectAction>(*action).target();
-        break;
-    default:
-        break;
+
+    int relativeSize = static_cast<int>(main->weaponSize()) -
+                       static_cast<int>(_size);
+    if (relativeSize > 0) {
+        return main->weaponWield() == WeaponWield::DoubleBladedSword
+                   ? main
+                   : nullptr;
     }
-    return target;
+
+    auto offhand = getEquippedItem(InventorySlots::leftWeapon);
+    if (!offhand ||
+        offhand->weaponType() == WeaponType::None ||
+        offhand->weaponWield() == WeaponWield::None) {
+        return nullptr;
+    }
+    return offhand;
+}
+
+void Creature::beginCombatAttack(std::shared_ptr<Object> target, FeatType feat) {
+    _combatState.attackTarget = std::move(target);
+    _combatState.attackAction = ActionType::AttackObject;
+    _combatState.combatFeat = feat;
+}
+
+void Creature::finishCombatRound() {
+    if (_combatState.attackTarget) {
+        _lastHostileTarget = _combatState.attackTarget->id();
+    } else {
+        _lastHostileTarget = script::kObjectInvalid;
+    }
+    _lastAttackAction = _combatState.attackAction;
+    if (_combatState.combatFeat != FeatType::Invalid) {
+        _lastCombatFeat = _combatState.combatFeat;
+    }
+}
+
+void Creature::adjustModifiedAttacks(int amount) {
+    _modifiedAttacks = std::clamp(_modifiedAttacks + amount, 0, 2);
+}
+
+void Creature::onEffectsCleared() {
+    _modifiedAttacks = 0;
+    _assuredHit = false;
+}
+
+bool Creature::applyAssuredHit() {
+    if (_assuredHit) {
+        return false;
+    }
+    _assuredHit = true;
+    return true;
+}
+
+Alignment Creature::alignment() const {
+    if (_goodEvil <= 40) {
+        return Alignment::DarkSide;
+    }
+    if (_goodEvil >= 60) {
+        return Alignment::LightSide;
+    }
+    return Alignment::Neutral;
+}
+
+AttackBonusBreakdown Creature::getAttackBonusBreakdown(
+    const Creature *target,
+    const Item *weapon,
+    bool offHand) const {
+
+    AttackBonusBreakdown result;
+
+    int strengthModifier = _attributes.getAbilityModifier(Ability::Strength);
+    int dexterityModifier = _attributes.getAbilityModifier(Ability::Dexterity);
+
+    if (weapon && weapon->isRanged()) {
+        result.dexterityModifier = dexterityModifier;
+    } else if (weapon && dexterityModifier > strengthModifier) {
+        bool finesse = !_game.isTSL() && weapon->isLightsaber();
+        if (weapon->isLightsaber() &&
+            _attributes.hasFeat(FeatType::FinesseLightsabers)) {
+            finesse = true;
+        }
+        switch (weapon->weaponWield()) {
+        case WeaponWield::StunBaton:
+        case WeaponWield::SingleSword:
+        case WeaponWield::DoubleBladedSword:
+            finesse = finesse ||
+                      _attributes.hasFeat(FeatType::FinesseMeleeWeapons);
+            break;
+        default:
+            break;
+        }
+
+        if (finesse) {
+            result.dexterityModifier = dexterityModifier;
+        } else {
+            result.strengthModifier = strengthModifier;
+        }
+    } else {
+        result.strengthModifier = strengthModifier;
+    }
+
+    int modifierBonus = 0;
+    int modifierPenalty = 0;
+
+    for (const auto &applied : effects()) {
+        switch (applied.effect->type()) {
+        case EffectType::AttackIncrease: {
+            const auto &effect = static_cast<const AttackIncreaseEffect &>(*applied.effect);
+            if (effect.bonus() > 0 &&
+                attackModifierApplies(effect.modifierType(), weapon, offHand)) {
+                modifierBonus += effect.bonus();
+            }
+            break;
+        }
+        case EffectType::AttackDecrease: {
+            const auto &effect = static_cast<const AttackDecreaseEffect &>(*applied.effect);
+            if (effect.penalty() > 0 &&
+                attackModifierApplies(effect.modifierType(), weapon, offHand)) {
+                modifierPenalty += effect.penalty();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToAttack(slot, *item, weapon, offHand)) {
+            continue;
+        }
+
+        int itemBonus = 0;
+        int itemPenalty = 0;
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0) {
+                continue;
+            }
+
+            int modifier = 0;
+            auto propertyType = static_cast<ItemProperty>(property.propertyName);
+            switch (propertyType) {
+            case ItemProperty::EnhancementBonus:
+            case ItemProperty::EnhancementBonusVsAlignmentGroup:
+            case ItemProperty::EnhancementBonusVsRacialGroup:
+            case ItemProperty::AttackBonus:
+            case ItemProperty::AttackBonusVsAlignmentGroup:
+            case ItemProperty::AttackBonusVsRacialGroup: {
+                if (!attackPropertyApplies(
+                        propertyType,
+                        property.subtype,
+                        target)) {
+                    continue;
+                }
+                int value = getCostTableValue(
+                    _services,
+                    kMeleeCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                if (value <= 0) {
+                    continue;
+                }
+                modifier = value;
+                break;
+            }
+            case ItemProperty::AttackPenalty:
+            case ItemProperty::DecreasedAttackModifier: {
+                int value = getCostTableValue(
+                    _services,
+                    kDecreaseCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                if (value >= 0) {
+                    continue;
+                }
+                modifier = value;
+                break;
+            }
+            default:
+                continue;
+            }
+
+            if (isHandSpecificAttackModifierSlot(slot)) {
+                addAttackModifier(modifier, modifierBonus, modifierPenalty);
+            } else if (modifier > 0) {
+                itemBonus = std::max(itemBonus, modifier);
+            } else {
+                itemPenalty = std::max(itemPenalty, -modifier);
+            }
+        }
+        modifierBonus += itemBonus;
+        modifierPenalty += itemPenalty;
+    }
+
+    result.effectBonus = std::min(modifierBonus, 20) -
+                         std::min(modifierPenalty, 20);
+
+    if (weapon &&
+        weapon->weaponFocusFeat() != FeatType::Invalid &&
+        _attributes.hasFeat(weapon->weaponFocusFeat())) {
+        result.weaponFocusBonus = 1;
+    }
+
+    if (target) {
+        getSituationalAttackBonuses(
+            *this,
+            *target,
+            weapon,
+            result.closeProximityRangedBonus,
+            result.meleeOnRangedBonus);
+    }
+
+    int twoWeaponPenalty = getTwoWeaponAttackPenalty(
+        weapon,
+        offHand,
+        &result.smallOffhandBonus);
+    result.dualWieldPenalty = -twoWeaponPenalty - result.smallOffhandBonus;
+
+    if (!offHand) {
+        result.duelingBonus = getDuelingBonus();
+        switch (result.duelingBonus) {
+        case 3:
+            result.duelingFeat = FeatType::MasterDueling;
+            break;
+        case 2:
+            result.duelingFeat = FeatType::ImprovedDueling;
+            break;
+        case 1:
+            result.duelingFeat = FeatType::Dueling;
+            break;
+        default:
+            break;
+        }
+    }
+
+    result.baseAttackBonus = _attributes.getAggregateAttackBonus();
+    return result;
 }
 
 int Creature::getAttackBonus(bool offHand) const {
-    auto rightWeapon(getEquippedItem(InventorySlots::rightWeapon));
-    auto leftWeapon(getEquippedItem(InventorySlots::leftWeapon));
-    auto &weapon = offHand ? leftWeapon : rightWeapon;
+    auto weapon = offHand
+                      ? getOffhandAttackWeapon()
+                      : getEquippedItem(InventorySlots::rightWeapon);
+    return getAttackBonusBreakdown(nullptr, weapon.get(), offHand).total();
+}
 
-    int modifier;
-    if (weapon && weapon->isRanged()) {
-        modifier = _attributes.getAbilityModifier(Ability::Dexterity);
-    } else {
-        modifier = _attributes.getAbilityModifier(Ability::Strength);
+int Creature::getDefense(const Creature *attacker, int damageFlags) const {
+    int dexterityModifier = _attributes.getAbilityModifier(Ability::Dexterity);
+    auto armor = getEquippedItem(InventorySlots::body);
+    int armorDefense = armor ? armor->baseDefense() : 0;
+
+    if (isDebilitated()) {
+        dexterityModifier = std::min(dexterityModifier, 0);
+    } else if (armorDefense > 0 && armor->maxDexterityBonus() >= 0) {
+        dexterityModifier = std::min(
+            dexterityModifier,
+            armor->maxDexterityBonus());
     }
 
-    int penalty;
-    if (rightWeapon && leftWeapon) {
-        // TODO: support Dueling and Two-Weapon Fighting feats
-        penalty = offHand ? 10 : 6;
-    } else {
-        penalty = 0;
+    std::array<int, kACBonusTypeCount> modifierBonuses {};
+    std::array<int, kACBonusTypeCount> modifierPenalties {};
+
+    for (const auto &applied : effects()) {
+        switch (applied.effect->type()) {
+        case EffectType::ACIncrease: {
+            const auto &effect = static_cast<const ACIncreaseEffect &>(*applied.effect);
+            if (damageTypeMatches(effect.damageType(), damageFlags)) {
+                addDefenseModifier(
+                    effect.bonus(),
+                    effect.modifierType(),
+                    modifierBonuses);
+            }
+            break;
+        }
+        case EffectType::ACDecrease: {
+            const auto &effect = static_cast<const ACDecreaseEffect &>(*applied.effect);
+            if (damageTypeMatches(effect.damageType(), damageFlags)) {
+                addDefenseModifier(
+                    effect.penalty(),
+                    effect.modifierType(),
+                    modifierPenalties);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
 
-    return _attributes.getAggregateAttackBonus() + modifier - penalty;
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToDefense(slot)) {
+            continue;
+        }
+
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0) {
+                continue;
+            }
+
+            auto propertyType = static_cast<ItemProperty>(property.propertyName);
+            switch (propertyType) {
+            case ItemProperty::AcBonus:
+            case ItemProperty::AcBonusVsAlignmentGroup:
+            case ItemProperty::AcBonusVsDamageType:
+            case ItemProperty::AcBonusVsRacialGroup: {
+                if (!defensePropertyApplies(
+                        propertyType,
+                        property.subtype,
+                        attacker,
+                        damageFlags)) {
+                    continue;
+                }
+                int value = getCostTableValue(
+                    _services,
+                    kBonusCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                addDefenseModifier(
+                    value,
+                    item->acBonusType(),
+                    modifierBonuses);
+                break;
+            }
+            case ItemProperty::DecreasedAc: {
+                int value = getCostTableValue(
+                    _services,
+                    kDecreaseCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                addDefenseModifier(
+                    -value,
+                    static_cast<ACBonus>(property.subtype),
+                    modifierPenalties);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+
+    int defense = 10 +
+                  _attributes.getAggregateDefenseBonus() +
+                  armorDefense +
+                  _naturalAC +
+                  dexterityModifier +
+                  getDefenseModifier(modifierBonuses, modifierPenalties) +
+                  getDuelingBonus();
+
+    return defense - (isDebilitated() ? 4 : 0);
 }
 
 int Creature::getDefense() const {
-    return _attributes.getDefense();
+    return getDefense(nullptr, 0);
+}
+
+int Creature::getFortitudeSave(SavingThrowType savingThrowType) const {
+    int modifier = 0;
+    for (const auto &applied : effects()) {
+        switch (applied.effect->type()) {
+        case EffectType::SavingThrowIncrease: {
+            const auto &effect =
+                static_cast<const SavingThrowIncreaseEffect &>(*applied.effect);
+            if (savingThrowModifierApplies(
+                    effect.save(),
+                    effect.savingThrowType(),
+                    kFortitudeSavingThrow,
+                    savingThrowType)) {
+                modifier += effect.value();
+            }
+            break;
+        }
+        case EffectType::SavingThrowDecrease: {
+            const auto &effect =
+                static_cast<const SavingThrowDecreaseEffect &>(*applied.effect);
+            if (savingThrowModifierApplies(
+                    effect.save(),
+                    effect.savingThrowType(),
+                    kFortitudeSavingThrow,
+                    savingThrowType)) {
+                modifier -= effect.value();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToDefense(slot)) {
+            continue;
+        }
+
+        int itemBonus = 0;
+        int itemPenalty = 0;
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0) {
+                continue;
+            }
+
+            auto propertyType = static_cast<ItemProperty>(property.propertyName);
+            if (!savingThrowPropertyApplies(
+                    propertyType,
+                    property.subtype,
+                    kFortitudeSavingThrow,
+                    savingThrowType)) {
+                continue;
+            }
+
+            switch (propertyType) {
+            case ItemProperty::ImprovedSavingThrow:
+            case ItemProperty::ImprovedSavingThrowSpecific: {
+                int value = getCostTableValue(
+                    _services,
+                    kBonusCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                itemBonus = std::max(itemBonus, value);
+                break;
+            }
+            case ItemProperty::DecreasedSavingThrows:
+            case ItemProperty::DecreasedSavingThrowsSpecific: {
+                int value = getCostTableValue(
+                    _services,
+                    kDecreaseCostTable,
+                    property.costValue,
+                    "value",
+                    0);
+                itemPenalty = std::max(itemPenalty, -value);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+        modifier += itemBonus - itemPenalty;
+    }
+    modifier = std::min(modifier, kMaximumSavingThrowModifier);
+
+    int conditioningBonus = 0;
+    if (_attributes.hasFeat(FeatType::LightningReflexes)) {
+        conditioningBonus = 3;
+    } else if (_attributes.hasFeat(FeatType::IronWill)) {
+        conditioningBonus = 2;
+    } else if (_attributes.hasFeat(FeatType::GreatFortitude)) {
+        conditioningBonus = 1;
+    }
+
+    return _attributes.getAggregateSavingThrows().fortitude +
+           _attributes.getAbilityModifier(Ability::Constitution) +
+           _fortBonus +
+           conditioningBonus +
+           modifier;
+}
+
+bool Creature::rollFortitudeSave(
+    int difficultyClass,
+    SavingThrowType savingThrowType) const {
+
+    return randomInt(1, 20) + getFortitudeSave(savingThrowType) >= difficultyClass;
+}
+
+int Creature::getPhysicalDamageBonus(
+    const Item *weapon,
+    bool offHand) const {
+
+    int strengthModifier = _attributes.getAbilityModifier(Ability::Strength);
+    int abilityModifier = strengthModifier;
+
+    if (weapon && weapon->isRanged()) {
+        if (strengthModifier > 0) {
+            int mighty = 0;
+            for (const auto &property : weapon->properties()) {
+                if (property.upgradeType != 0 ||
+                    property.propertyName != static_cast<uint16_t>(ItemProperty::Mighty)) {
+                    continue;
+                }
+                mighty = property.costValue;
+                break;
+            }
+            abilityModifier = std::min(strengthModifier, mighty);
+        }
+    } else if (strengthModifier > 0) {
+        if (offHand) {
+            abilityModifier = strengthModifier / 2;
+        } else if (weapon &&
+                   weapon->weaponWield() != WeaponWield::DoubleBladedSword &&
+                   static_cast<int>(weapon->weaponSize()) ==
+                       static_cast<int>(_size) + 1) {
+            abilityModifier = 3 * strengthModifier / 2;
+        }
+    }
+
+    int specialization = 0;
+    if (weapon &&
+        weapon->weaponSpecializationFeat() != FeatType::Invalid &&
+        _attributes.hasFeat(weapon->weaponSpecializationFeat())) {
+        specialization = 2;
+    }
+
+    return abilityModifier + specialization;
+}
+
+int Creature::getMassiveCriticalDamage(
+    const Item *weapon,
+    bool criticalHit) const {
+
+    if (!criticalHit) {
+        return 0;
+    }
+
+    auto handItem = weapon
+                        ? std::shared_ptr<Item>()
+                        : getEquippedItem(InventorySlots::hands);
+    const Item *sourceItem = weapon ? weapon : handItem.get();
+    if (!sourceItem) {
+        return 0;
+    }
+
+    for (const auto &property : sourceItem->properties()) {
+        if (property.upgradeType != 0 ||
+            property.propertyName != static_cast<uint16_t>(ItemProperty::MassiveCriticals)) {
+            continue;
+        }
+
+        auto modifier = getDamageModifier(
+            _services,
+            property.costValue,
+            weapon
+                ? getPrimaryDamageType(sourceItem->damageFlags())
+                : DamageType::Bludgeoning);
+        return modifier
+                   ? rollDamageModifier(*modifier, 1)
+                   : 0;
+    }
+
+    return 0;
+}
+
+int Creature::getItemDamageImmunity(DamageType type) const {
+    int result = 0;
+    int damageFlags = static_cast<int>(type);
+    bool immuneToDecrease = plotFlag();
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToDefense(slot)) {
+            continue;
+        }
+
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0) {
+                continue;
+            }
+
+            auto propertyType = static_cast<ItemProperty>(property.propertyName);
+            if (propertyType != ItemProperty::ImmunityDamageType &&
+                propertyType != ItemProperty::DamageVulnerability) {
+                continue;
+            }
+            if (propertyType == ItemProperty::DamageVulnerability &&
+                immuneToDecrease) {
+                continue;
+            }
+
+            DamageType propertyDamageType = getItemPropertyDamageType(
+                _services,
+                property.subtype);
+            if (!damageTypeMatches(
+                    static_cast<int>(propertyDamageType),
+                    damageFlags)) {
+                continue;
+            }
+
+            int value =
+                propertyType == ItemProperty::ImmunityDamageType
+                    ? getItemPropertyValue(
+                          _services,
+                          property,
+                          "value",
+                          0)
+                    : getCostTableValue(
+                          _services,
+                          kVulnerabilityCostTable,
+                          property.costValue,
+                          "value",
+                          0);
+            result = std::clamp(
+                result + (propertyType == ItemProperty::ImmunityDamageType
+                              ? value
+                              : -value),
+                -100,
+                100);
+        }
+    }
+    return result;
+}
+
+int Creature::getItemDamageResistance(DamageType type) const {
+    int result = 0;
+    int damageFlags = static_cast<int>(type);
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToDefense(slot)) {
+            continue;
+        }
+
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0 ||
+                property.propertyName != static_cast<uint16_t>(ItemProperty::DamageResistance)) {
+                continue;
+            }
+
+            DamageType propertyDamageType = getItemPropertyDamageType(
+                _services,
+                property.subtype);
+            if (!damageTypeMatches(
+                    static_cast<int>(propertyDamageType),
+                    damageFlags)) {
+                continue;
+            }
+
+            int value = getCostTableValue(
+                _services,
+                kResistanceCostTable,
+                property.costValue,
+                "amount",
+                0);
+            result = std::max(result, value);
+        }
+    }
+    return result;
+}
+
+void Creature::getItemDamageReduction(
+    int &amount,
+    DamagePower &power) const {
+
+    amount = 0;
+    power = DamagePower::Normal;
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToDefense(slot)) {
+            continue;
+        }
+
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0 ||
+                property.propertyName != static_cast<uint16_t>(ItemProperty::DamageReduction)) {
+                continue;
+            }
+
+            DamagePower propertyPower = getDamageReductionPower(
+                _services,
+                property.subtype);
+            int value = getCostTableValue(
+                _services,
+                kReductionCostTable,
+                property.costValue,
+                "amount",
+                0);
+            if (value > amount) {
+                amount = value;
+                power = propertyPower;
+            }
+        }
+    }
+}
+
+int Creature::getDamageResistanceFeatBonus() const {
+    int result = 0;
+    if (_attributes.hasFeat(FeatType::ImprovedToughness)) {
+        result += 2;
+    }
+    if (_attributes.hasFeat(FeatType::WookieEndurance)) {
+        result += 2;
+    }
+    return result;
+}
+
+void Creature::addPhysicalDamageModifiers(
+    DamagePacket &damage,
+    const Creature *target,
+    const Item *weapon,
+    bool offHand,
+    int criticalMultiplier) const {
+
+    std::vector<DamageModifier> itemBonuses;
+    std::vector<DamageModifier> itemPenalties;
+
+    auto handItem = weapon
+                        ? std::shared_ptr<Item>()
+                        : getEquippedItem(InventorySlots::hands);
+    const Item *sourceItem = weapon ? weapon : handItem.get();
+
+    for (const auto &[slot, item] : _equipment) {
+        if (!item || !equippedItemAppliesToAttack(slot, *item, weapon, offHand)) {
+            continue;
+        }
+
+        std::map<int, DamageModifier> bonuses;
+        std::map<int, DamageModifier> penalties;
+
+        for (const auto &property : item->properties()) {
+            if (property.upgradeType != 0) {
+                continue;
+            }
+
+            auto propertyType = static_cast<ItemProperty>(property.propertyName);
+            if (!damagePropertyApplies(
+                    propertyType,
+                    property.subtype,
+                    target)) {
+                continue;
+            }
+
+            switch (propertyType) {
+            case ItemProperty::EnhancementBonus:
+            case ItemProperty::EnhancementBonusVsAlignmentGroup:
+            case ItemProperty::EnhancementBonusVsRacialGroup: {
+                auto modifier = getFlatDamageModifier(
+                    _services,
+                    kMeleeCostTable,
+                    property.costValue,
+                    !weapon && item.get() == sourceItem
+                        ? DamageType::Bludgeoning
+                        : getPrimaryDamageType(item->damageFlags()));
+                if (!modifier || modifier->flat <= 0) {
+                    break;
+                }
+                selectDamageModifier(bonuses, *modifier);
+                damage.setPower(static_cast<DamagePower>(modifier->flat));
+                break;
+            }
+            case ItemProperty::DamageBonus: {
+                DamageType type = getItemPropertyDamageType(
+                    _services,
+                    property.subtype);
+                auto modifier = getDamageModifier(
+                    _services,
+                    property.costValue,
+                    type);
+                if (modifier) {
+                    selectDamageModifier(bonuses, *modifier);
+                }
+                break;
+            }
+            case ItemProperty::DamageBonusVsAlignmentGroup:
+            case ItemProperty::DamageBonusVsRacialGroup: {
+                DamageType type = getItemPropertyDamageType(
+                    _services,
+                    property.paramValue);
+                auto modifier = getDamageModifier(
+                    _services,
+                    property.costValue,
+                    type);
+                if (modifier) {
+                    selectDamageModifier(bonuses, *modifier);
+                }
+                break;
+            }
+            case ItemProperty::DecreasedDamage: {
+                auto modifier = getFlatDamageModifier(
+                    _services,
+                    kDecreaseCostTable,
+                    property.costValue,
+                    !weapon && item.get() == sourceItem
+                        ? DamageType::Bludgeoning
+                        : getPrimaryDamageType(item->damageFlags()));
+                if (!modifier) {
+                    break;
+                }
+                selectDamageModifier(penalties, *modifier);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+
+        for (const auto &entry : bonuses) {
+            itemBonuses.push_back(entry.second);
+        }
+        for (const auto &entry : penalties) {
+            itemPenalties.push_back(entry.second);
+        }
+    }
+
+    std::map<int, int> effectBonuses;
+    std::map<int, int> effectPenalties;
+    for (const auto &applied : effects()) {
+        switch (applied.effect->type()) {
+        case EffectType::DamageIncrease: {
+            const auto &effect = static_cast<const DamageIncreaseEffect &>(*applied.effect);
+            if (effect.bonus() > 0) {
+                effectBonuses[static_cast<int>(getPrimaryDamageType(
+                    static_cast<int>(effect.damageType())))] +=
+                    criticalMultiplier * effect.bonus();
+            }
+            break;
+        }
+        case EffectType::DamageDecrease: {
+            const auto &effect = static_cast<const DamageDecreaseEffect &>(*applied.effect);
+            if (effect.penalty() > 0) {
+                effectPenalties[static_cast<int>(getPrimaryDamageType(
+                    static_cast<int>(effect.damageType())))] +=
+                    criticalMultiplier * effect.penalty();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    for (const auto &[type, amount] : effectBonuses) {
+        damage.add(amount, static_cast<DamageType>(type));
+    }
+    for (const DamageModifier &modifier : itemBonuses) {
+        damage.add(
+            rollDamageModifier(modifier, criticalMultiplier),
+            modifier.type);
+    }
+    for (const auto &[type, amount] : effectPenalties) {
+        damage.add(-amount, static_cast<DamageType>(type));
+    }
+    for (const DamageModifier &modifier : itemPenalties) {
+        damage.add(
+            rollDamageModifier(modifier, criticalMultiplier),
+            modifier.type);
+    }
 }
 
 void Creature::getMainHandDamage(int &min, int &max) const {
-    getWeaponDamage(InventorySlots::rightWeapon, min, max);
+    auto weapon = getEquippedItem(InventorySlots::rightWeapon);
+    getWeaponDamage(weapon.get(), min, max);
 }
 
-void Creature::getWeaponDamage(int slot, int &min, int &max) const {
-    auto weapon = getEquippedItem(slot);
-
+void Creature::getWeaponDamage(const Item *weapon, int &min, int &max) const {
     if (!weapon) {
         min = 1;
         max = 1;
@@ -893,7 +2154,8 @@ void Creature::getWeaponDamage(int slot, int &min, int &max) const {
 }
 
 void Creature::getOffhandDamage(int &min, int &max) const {
-    getWeaponDamage(InventorySlots::leftWeapon, min, max);
+    auto weapon = getOffhandAttackWeapon();
+    getWeaponDamage(weapon.get(), min, max);
 }
 
 void Creature::onEventSignalled(const std::string &name) {
@@ -1193,11 +2455,11 @@ int Creature::getWeaponWieldNumber(WeaponWield wield) const {
     case WeaponWield::StunBaton:
         return 1;
     case WeaponWield::SingleSword:
-        return isSlotEquipped(InventorySlots::leftWeapon) ? 4 : 2;
+        return getOffhandAttackWeapon() ? 4 : 2;
     case WeaponWield::DoubleBladedSword:
         return 3;
     case WeaponWield::BlasterPistol:
-        return isSlotEquipped(InventorySlots::leftWeapon) ? 6 : 5;
+        return getOffhandAttackWeapon() ? 6 : 5;
     case WeaponWield::BlasterRifle:
         return 7;
     case WeaponWield::HeavyWeapon:
@@ -1205,6 +2467,97 @@ int Creature::getWeaponWieldNumber(WeaponWield wield) const {
     default:
         return 8;
     }
+}
+
+int Creature::getRelativeWeaponSize(const Item &weapon) const {
+    if (_size == CreatureSize::Invalid ||
+        weapon.weaponSize() == CreatureSize::Invalid) {
+        return -10;
+    }
+
+    int relativeSize = static_cast<int>(weapon.weaponSize()) -
+                       static_cast<int>(_size);
+    return relativeSize >= -2 && relativeSize <= 1 ? relativeSize : -10;
+}
+
+int Creature::getTwoWeaponAttackPenalty(
+    const Item *weapon,
+    bool offHand,
+    int *smallOffhandBonus) const {
+
+    if (smallOffhandBonus) {
+        *smallOffhandBonus = 0;
+    }
+
+    auto mainHand = getEquippedItem(InventorySlots::rightWeapon);
+    if (!mainHand || mainHand->weaponType() == WeaponType::None) {
+        return 0;
+    }
+
+    auto offHandWeapon = getOffhandAttackWeapon();
+    bool doubleBladed = offHandWeapon == mainHand &&
+                        mainHand->weaponWield() == WeaponWield::DoubleBladedSword;
+    if (!offHandWeapon || offHandWeapon->weaponType() == WeaponType::None) {
+        return 0;
+    }
+
+    if (offHand) {
+        if (weapon != offHandWeapon.get()) {
+            return 0;
+        }
+        if (_attributes.hasFeat(FeatType::AdvancedDoubleWeaponFighting)) {
+            return 2;
+        }
+        if (_attributes.hasFeat(FeatType::DoubleWeaponFighting)) {
+            return 4;
+        }
+        if (_attributes.hasFeat(FeatType::Ambidexterity)) {
+            return 6;
+        }
+        return 10;
+    }
+
+    if (weapon != mainHand.get()) {
+        return 0;
+    }
+
+    bool balanced = doubleBladed;
+    if (!balanced) {
+        int relativeSize = getRelativeWeaponSize(
+            mainHand->isRanged() ? *mainHand : *offHandWeapon);
+        balanced = mainHand->isRanged() ? relativeSize <= -1 : relativeSize == -1;
+    }
+
+    if (balanced && smallOffhandBonus) {
+        *smallOffhandBonus = 2;
+    }
+
+    int penalty = balanced ? 4 : 6;
+    if (_attributes.hasFeat(FeatType::AdvancedDoubleWeaponFighting)) {
+        penalty -= 4;
+    } else if (_attributes.hasFeat(FeatType::DoubleWeaponFighting)) {
+        penalty -= 2;
+    }
+    return penalty;
+}
+
+int Creature::getDuelingBonus() const {
+    auto mainHand = getEquippedItem(InventorySlots::rightWeapon);
+    if (!mainHand || getEquippedItem(InventorySlots::leftWeapon)) {
+        return 0;
+    }
+    if (mainHand->weaponWield() != WeaponWield::SingleSword &&
+        mainHand->weaponWield() != WeaponWield::BlasterPistol) {
+        return 0;
+    }
+
+    if (_attributes.hasFeat(FeatType::MasterDueling)) {
+        return 3;
+    }
+    if (_attributes.hasFeat(FeatType::ImprovedDueling)) {
+        return 2;
+    }
+    return _attributes.hasFeat(FeatType::Dueling) ? 1 : 0;
 }
 
 std::string Creature::getWalkAnimation() const {

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -212,7 +212,8 @@ void Door::damage(int amount, uint32_t damager) {
     if (amount == std::numeric_limits<int>::max()) {
         _currentHitPoints = isMinOneHP() ? 1 : 0;
     } else {
-        _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, currentHitPoints - amount);
+        int adjustedAmount = applyDamageToHitPoints(amount, currentHitPoints);
+        _game.floatingText().addDamage(*this, amount, adjustedAmount, damager);
     }
 
     damager = damager ? damager : script::kObjectInvalid;

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -21,6 +21,7 @@
 #include "reone/audio/mixer.h"
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
+#include "reone/game/twodautil.h"
 #include "reone/graphics/di/services.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/di/services.h"
@@ -130,20 +131,34 @@ void Item::deserializeBase(const resource::Gff &gff) {
         return;
     }
 
-    std::shared_ptr<TwoDA> baseItems(_services.resource.twoDas.get("baseitems"));
-    if (!baseItems) {
-        return;
-    }
-    _attackRange = baseItems->getInt(_baseItem, "maxattackrange");
-    _criticalHitMultiplier = baseItems->getInt(_baseItem, "crithitmult");
-    _criticalThreat = baseItems->getInt(_baseItem, "critthreat");
-    _damageFlags = baseItems->getInt(_baseItem, "damageflags");
-    _dieToRoll = baseItems->getInt(_baseItem, "dietoroll");
-    _equipableSlots = baseItems->getHexInt(_baseItem, "equipableslots", 0);
-    _itemClass = boost::to_lower_copy(baseItems->getString(_baseItem, "itemclass"));
-    _numDice = baseItems->getInt(_baseItem, "numdice");
-    _weaponType = static_cast<WeaponType>(baseItems->getInt(_baseItem, "weapontype"));
-    _weaponWield = static_cast<WeaponWield>(baseItems->getInt(_baseItem, "weaponwield"));
+    auto baseItems = getRequiredTwoDA(_services.resource.twoDas, "baseitems");
+    _attackRange = baseItems->getFloat(_baseItem, "maxattackrange", 0.0f);
+    _baseDefense = baseItems->getInt(_baseItem, "baseac", 0);
+    _criticalHitMultiplier = baseItems->getInt(_baseItem, "crithitmult", 0);
+    _criticalThreat = baseItems->getInt(_baseItem, "critthreat", 0);
+    _damageFlags = baseItems->getInt(_baseItem, "damageflags", 0);
+    _dieToRoll = baseItems->getInt(_baseItem, "dietoroll", 0);
+    _maxDexterityBonus = baseItems->getInt(_baseItem, "dexbonus", -1);
+    _equipableSlots = static_cast<uint32_t>(
+        baseItems->getInt(_baseItem, "equipableslots", 0));
+    _itemClass = boost::to_lower_copy(
+        baseItems->getString(_baseItem, "itemclass"));
+    _numDice = baseItems->getInt(_baseItem, "numdice", 0);
+    _acBonusType = static_cast<ACBonus>(baseItems->getInt(
+        _baseItem,
+        "ac_enchant",
+        static_cast<int>(ACBonus::Invalid)));
+    _weaponType = static_cast<WeaponType>(
+        baseItems->getInt(_baseItem, "weapontype", 0));
+    _weaponWield = static_cast<WeaponWield>(
+        baseItems->getInt(_baseItem, "weaponwield", 0));
+    _weaponSize = static_cast<CreatureSize>(
+        baseItems->getInt(_baseItem, "weaponsize", 0));
+    _weaponFocusFeat = static_cast<FeatType>(
+        baseItems->getInt(_baseItem, "focfeat", 0));
+    _weaponSpecializationFeat = static_cast<FeatType>(
+        baseItems->getInt(_baseItem, "specfeat", 0));
+
     _poweredItem = baseItems->getInt(_baseItem, "powereditem") != 0;
     if (_poweredItem) {
         auto loadSound = [this, &baseItems](const char *column) {
@@ -174,19 +189,21 @@ void Item::deserializeBase(const resource::Gff &gff) {
 }
 
 void Item::loadAmmunitionType() {
-    std::shared_ptr<TwoDA> baseItems(_services.resource.twoDas.get("baseitems"));
+    auto baseItems = getRequiredTwoDA(_services.resource.twoDas, "baseitems");
 
-    int ammunitionIdx = baseItems->getInt(_baseItem, "ammunitiontype", -1);
-    if (ammunitionIdx != -1) {
-        std::shared_ptr<TwoDA> twoDa(_services.resource.twoDas.get("ammunitiontypes"));
-        _ammunitionType = std::make_shared<Item::AmmunitionType>();
-        _ammunitionType->model = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "model")));
-        _ammunitionType->muzzleFlash = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "muzzleflash")));
-        _ammunitionType->shotSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound0")));
-        _ammunitionType->shotSound2 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound1")));
-        _ammunitionType->impactSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "impactsound0")));
-        _ammunitionType->impactSound2 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "impactsound1")));
+    int ammunitionIdx = baseItems->getInt(_baseItem, "ammunitiontype", 0);
+    if (ammunitionIdx < 1) {
+        return;
     }
+
+    auto twoDa = getRequiredTwoDA(_services.resource.twoDas, "ammunitiontypes");
+    _ammunitionType = std::make_shared<Item::AmmunitionType>();
+    _ammunitionType->model = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "model")));
+    _ammunitionType->muzzleFlash = _services.resource.models.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "muzzleflash")));
+    _ammunitionType->shotSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound0")));
+    _ammunitionType->shotSound2 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "shotsound1")));
+    _ammunitionType->impactSound1 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "impactsound0")));
+    _ammunitionType->impactSound2 = _services.resource.audioClips.get(boost::to_lower_copy(twoDa->getString(ammunitionIdx, "impactsound1")));
 }
 
 void Item::update(float dt) {

--- a/src/libs/game/object/placeable.cpp
+++ b/src/libs/game/object/placeable.cpp
@@ -186,7 +186,8 @@ void Placeable::damage(int amount, uint32_t damager) {
     if (amount == std::numeric_limits<int>::max()) {
         _currentHitPoints = isMinOneHP() ? 1 : 0;
     } else {
-        _currentHitPoints = std::max(isMinOneHP() ? 1 : 0, currentHitPoints - amount);
+        int adjustedAmount = applyDamageToHitPoints(amount, currentHitPoints);
+        _game.floatingText().addDamage(*this, amount, adjustedAmount, damager);
     }
 
     damager = damager ? damager : script::kObjectInvalid;

--- a/src/libs/game/script/routine/impl/effect.cpp
+++ b/src/libs/game/script/routine/impl/effect.cpp
@@ -199,14 +199,22 @@ static Variable EffectResurrection(const std::vector<Variable> &args, const Rout
     return Variable::ofEffect(std::move(effect));
 }
 
+static ACBonus getACBonus(int value) {
+    if (value < static_cast<int>(ACBonus::Dodge) ||
+        value > static_cast<int>(ACBonus::Deflection)) {
+        return ACBonus::Dodge;
+    }
+    return static_cast<ACBonus>(value);
+}
+
 static Variable EffectACIncrease(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto nValue = getInt(args, 0);
     auto nModifyType = getIntOrElse(args, 1, 0);
-    auto nDamageType = getIntOrElse(args, 2, 8199);
+    auto nDamageType = getIntOrElse(args, 2, kAllDamageTypeFlags);
 
     // Transform
-    auto modifyType = static_cast<ACBonus>(nModifyType);
+    auto modifyType = getACBonus(nModifyType);
 
     // Execute
     auto effect = ctx.game.newEffect<ACIncreaseEffect>(nValue, modifyType, nDamageType);
@@ -670,10 +678,10 @@ static Variable EffectACDecrease(const std::vector<Variable> &args, const Routin
     // Load
     auto nValue = getInt(args, 0);
     auto nModifyType = getIntOrElse(args, 1, 0);
-    auto nDamageType = getIntOrElse(args, 2, 8199);
+    auto nDamageType = getIntOrElse(args, 2, kAllDamageTypeFlags);
 
     // Transform
-    auto modifyType = static_cast<ACBonus>(nModifyType);
+    auto modifyType = getACBonus(nModifyType);
 
     // Execute
     auto effect = ctx.game.newEffect<ACDecreaseEffect>(nValue, modifyType, nDamageType);

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3498,8 +3498,7 @@ static Variable GetIsTalentValid(const std::vector<Variable> &args, const Routin
 static Variable GetAttemptedAttackTarget(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
     auto caller = checkCreature(getCaller(ctx));
-    auto target = caller->getAttemptedAttackTarget();
-    return Variable::ofObject(getObjectIdOrInvalid(target));
+    return Variable::ofObject(caller->getAttemptedAttackTarget());
 }
 
 static Variable GetTypeFromTalent(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5052,17 +5051,15 @@ static Variable GetLastHostileActor(const std::vector<Variable> &args, const Rou
     auto oVictim = getObjectOrCaller(args, 0, ctx);
 
     // Execute
-    const Combat::RoundQueue &rounds = ctx.game.combat().rounds();
-    for (auto it = rounds.rbegin(), end = rounds.rend(); it != end; ++it) {
-        for (const CombatRound::RoundAction &action : (*it)->actions) {
-            bool hostile = isHostileAction(*action.action);
-            if (action.target == oVictim->id() && hostile) {
-                return Variable::ofObject(action.attacker);
-            }
+    uint32_t actorId = oVictim->getLastHostileActor();
+    if (actorId != script::kObjectInvalid) {
+        auto actor = ctx.game.getObjectById<Creature>(actorId);
+        if (!actor || actor->isDead() || actor->isTemporarilyDead()) {
+            actorId = script::kObjectInvalid;
+            oVictim->setLastHostileActor(actorId);
         }
     }
-
-    return Variable::ofObject(kObjectInvalid);
+    return Variable::ofObject(actorId);
 }
 
 static Variable ExportAllCharacters(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5775,18 +5772,7 @@ static Variable GetLastHostileTarget(const std::vector<Variable> &args, const Ro
     auto attacker = checkCreature(oAttacker);
 
     // Execute
-    // TODO: rbegin/end pair for iteration on rounds
-    const Combat::RoundQueue &rounds = ctx.game.combat().rounds();
-    for (auto it = rounds.rbegin(), end = rounds.rend(); it != end; ++it) {
-        for (const CombatRound::RoundAction &action : (*it)->actions) {
-            bool hostile = isHostileAction(*action.action);
-            if (action.attacker == attacker->id() && hostile) {
-                return Variable::ofObject(action.target);
-            }
-        }
-    }
-
-    return Variable::ofObject(kObjectInvalid);
+    return Variable::ofObject(attacker->getLastHostileTarget());
 }
 
 static Variable GetLastAttackAction(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5797,17 +5783,7 @@ static Variable GetLastAttackAction(const std::vector<Variable> &args, const Rou
     auto attacker = checkCreature(oAttacker);
 
     // Execute
-    const Combat::RoundQueue &rounds = ctx.game.combat().rounds();
-    for (auto it = rounds.rbegin(), end = rounds.rend(); it != end; ++it) {
-        for (const CombatRound::RoundAction &action : (*it)->actions) {
-            bool hostile = isHostileAction(*action.action);
-            if (action.attacker == attacker->id() && hostile) {
-                return Variable::ofInt(static_cast<int>(action.action->type()));
-            }
-        }
-    }
-
-    return Variable::ofInt(static_cast<int>(ActionType::QueueEmpty));
+    return Variable::ofInt(static_cast<int>(attacker->getLastAttackAction()));
 }
 
 static Variable GetLastForcePowerUsed(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5823,9 +5799,10 @@ static Variable GetLastCombatFeatUsed(const std::vector<Variable> &args, const R
     auto oAttacker = getObjectOrCaller(args, 0, ctx);
 
     // Transform
+    auto attacker = checkCreature(oAttacker);
 
     // Execute
-    throw RoutineNotImplementedException("GetLastCombatFeatUsed");
+    return Variable::ofInt(static_cast<int>(attacker->getLastCombatFeat()));
 }
 
 static Variable GetLastAttackResult(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -5836,26 +5813,7 @@ static Variable GetLastAttackResult(const std::vector<Variable> &args, const Rou
     auto attacker = checkCreature(oAttacker);
 
     // Execute
-    const Combat::RoundQueue &rounds = ctx.game.combat().rounds();
-    for (auto it = rounds.rbegin(), end = rounds.rend(); it != end; ++it) {
-        for (const CombatRound::RoundAction &action : (*it)->actions) {
-
-            AttackResultType result = AttackResultType::Invalid;
-            switch (action.action->type()) {
-            case ActionType::AttackObject:
-                cast<AttackObjectAction>(*action.action).result();
-                break;
-            default:
-                break;
-            }
-
-            if (result != AttackResultType::Invalid) {
-                return Variable::ofInt(static_cast<int>(result));
-            }
-        }
-    }
-
-    return Variable::ofInt(static_cast<int>(AttackResultType::Invalid));
+    return Variable::ofInt(static_cast<int>(attacker->getLastAttackResult()));
 }
 
 static Variable GetWasForcePowerSuccessful(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/game/twodautil.cpp
+++ b/src/libs/game/twodautil.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/twodautil.h"
+
+#include "reone/resource/2da.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/provider/2das.h"
+#include "reone/system/exception/validation.h"
+
+using namespace reone::resource;
+
+namespace reone {
+
+namespace game {
+
+std::shared_ptr<TwoDA> getRequiredTwoDA(
+    ITwoDAs &twoDas,
+    const std::string &resRef) {
+
+    auto table = twoDas.get(resRef);
+    if (!table) {
+        throw ResourceNotFoundException("2DA not found: " + resRef);
+    }
+    return table;
+}
+
+void validateTwoDARow(
+    const TwoDA &table,
+    const std::string &resRef,
+    int row) {
+
+    if (row < 0 || row >= table.getRowCount()) {
+        throw ValidationException(str(boost::format(
+            "%s.2da row out of range: %d/%d") %
+            resRef % row % table.getRowCount()));
+    }
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/graphics/font.cpp
+++ b/src/libs/graphics/font.cpp
@@ -52,6 +52,10 @@ void Font::load(std::shared_ptr<Texture> texture) {
 }
 
 void Font::render(std::string_view text, const glm::vec3 &position, const glm::vec3 &color, TextGravity gravity) {
+    render(text, position, glm::vec4(color, 1.0f), gravity);
+}
+
+void Font::render(std::string_view text, const glm::vec3 &position, const glm::vec4 &color, TextGravity gravity) {
     if (text.empty()) {
         return;
     }
@@ -61,7 +65,7 @@ void Font::render(std::string_view text, const glm::vec3 &position, const glm::v
 
     _uniforms.setLocals([this, &color](auto &locals) {
         locals.reset();
-        locals.color = glm::vec4(color, 1.0f);
+        locals.color = color;
     });
 
     int numBlocks = static_cast<int>(text.size()) / kMaxTextChars;

--- a/src/libs/graphics/textutil.cpp
+++ b/src/libs/graphics/textutil.cpp
@@ -19,74 +19,86 @@
 
 #include "reone/graphics/font.h"
 
+#include <cctype>
+#include <string_view>
+
 namespace reone {
 
 namespace graphics {
 
+static float measureCharacter(Font &font, char ch) {
+    return font.measure(std::string_view(&ch, 1));
+}
+
+static bool isAlphabetic(char ch) {
+    return std::isalpha(static_cast<unsigned char>(ch)) != 0;
+}
+
 std::vector<std::string> breakText(const std::string &text, Font &font, int maxWidth) {
     std::vector<std::string> result;
-    std::string line;
-    std::ostringstream tokenBuffer;
+    if (text.empty()) {
+        return result;
+    }
 
-    for (char ch : text) {
-        switch (ch) {
-        case '\n': {
-            std::string token(tokenBuffer.str());
-            if (!token.empty()) {
-                tokenBuffer.str("");
-                if (!line.empty()) {
-                    line += " ";
-                }
-                line += token;
-            }
-            if (!line.empty()) {
-                result.push_back(line);
-                line = "";
-            }
-            break;
+    size_t lineStart = 0;
+    while (lineStart < text.size()) {
+        if (text[lineStart] == '\n') {
+            result.emplace_back();
+            ++lineStart;
+            continue;
         }
-        case ' ': {
-            std::string token(tokenBuffer.str());
-            if (!token.empty()) {
-                tokenBuffer.str("");
 
-                std::string test(line);
-                if (!test.empty()) {
-                    test += " ";
-                }
-                test += token;
+        float width = 0.0f;
+        size_t breakAt = std::string::npos;
+        size_t cursor = lineStart;
+        bool wrapped = false;
 
-                if (font.measure(test) <= maxWidth) {
-                    line = std::move(test);
+        while (cursor < text.size() && text[cursor] != '\n') {
+            char ch = text[cursor];
+            width += measureCharacter(font, ch);
+
+            if (ch == ' ' && cursor > lineStart) {
+                breakAt = cursor;
+            } else if (ch == '-' &&
+                       cursor > lineStart &&
+                       cursor + 1 < text.size() &&
+                       isAlphabetic(text[cursor - 1]) &&
+                       isAlphabetic(text[cursor + 1])) {
+                breakAt = cursor;
+            }
+
+            if (width >= static_cast<float>(maxWidth)) {
+                size_t lineEnd;
+                size_t nextLineStart;
+                if (breakAt != std::string::npos) {
+                    bool breakAfter = text[breakAt] == '-';
+                    lineEnd = breakAt + static_cast<size_t>(breakAfter);
+                    nextLineStart = breakAt + 1;
+                } else if (cursor > lineStart) {
+                    lineEnd = cursor;
+                    nextLineStart = cursor;
                 } else {
-                    result.push_back(line);
-                    line = std::move(token);
+                    lineEnd = cursor + 1;
+                    nextLineStart = cursor + 1;
                 }
-            }
-            break;
-        }
-        default:
-            tokenBuffer.put(ch);
-            break;
-        }
-    }
 
-    std::string token(tokenBuffer.str());
-    std::string test(line);
-    if (!token.empty()) {
-        if (!test.empty()) {
-            test += " ";
-        }
-        test += token;
-    }
-    if (!test.empty()) {
-        if (font.measure(test) <= maxWidth) {
-            result.push_back(test);
-        } else {
-            result.push_back(line);
-            if (!token.empty()) {
-                result.push_back(token);
+                result.emplace_back(text.substr(lineStart, lineEnd - lineStart));
+                lineStart = nextLineStart;
+                wrapped = true;
+                break;
             }
+            ++cursor;
+        }
+
+        if (wrapped) {
+            continue;
+        }
+
+        result.emplace_back(text.substr(lineStart, cursor - lineStart));
+        if (cursor == text.size()) {
+            lineStart = cursor;
+        } else {
+            lineStart = cursor + 1;
         }
     }
 

--- a/src/libs/gui/control/listbox.cpp
+++ b/src/libs/gui/control/listbox.cpp
@@ -31,6 +31,7 @@
 #include "reone/scene/render/pass.h"
 #include "reone/system/logutil.h"
 
+#include <algorithm>
 #include <sstream>
 
 using namespace reone::graphics;
@@ -41,7 +42,6 @@ namespace reone {
 
 namespace gui {
 
-static constexpr int kItemPadding = 3;
 static constexpr glm::vec3 kInvalidItemBorderColor {1.0f, 0.0f, 0.0f};
 
 void ListBox::clearItems() {
@@ -130,11 +130,7 @@ int ListBox::getItemIndex(int y) const {
 
     for (size_t i = _itemOffset; i < _items.size(); ++i) {
         const Item &item = _items[i];
-        if (_protoMatchContent) {
-            itemy += item._textLines.size() * _protoItem->text().font->height();
-        } else {
-            itemy += protoExtent.height;
-        }
+        itemy += getItemHeight(item);
         itemy += _padding;
         if (y < itemy)
             return static_cast<int>(i);
@@ -164,17 +160,16 @@ bool ListBox::handleMouseWheel(int x, int y) {
 void ListBox::updateItemSlots() {
     _slotCount = 0;
 
-    // Increase the number of slots until they no longer fit vertically
+    // Increase the number of slots until they no longer fit vertically.
+    // KOTOR lays out unequal rows inside the list border, with one padding
+    // interval accounted for by every visible row.
     float y = 0.0f;
+    int innerHeight = getInnerHeight();
     for (size_t i = _itemOffset; i < _items.size(); ++i) {
-        if (_protoMatchContent) {
-            y += _items[i]._textLines.size() * _protoItem->text().font->height();
-        } else {
-            y += _protoItem->extent().height;
-        }
+        y += getItemHeight(_items[i]);
         y += _padding;
 
-        if (y > _extent.height)
+        if (y > innerHeight)
             break;
 
         ++_slotCount;
@@ -217,8 +212,7 @@ void ListBox::render(const glm::ivec2 &screenSize,
     if (!_protoItem)
         return;
 
-    glm::vec2 itemOffset(offset);
-
+    glm::ivec2 itemOffset(offset);
     for (int i = 0; i < _slotCount; ++i) {
         int itemIdx = i + _itemOffset;
         if (itemIdx >= _items.size())
@@ -226,9 +220,14 @@ void ListBox::render(const glm::ivec2 &screenSize,
 
         const Item &item = _items[itemIdx];
         if (_protoMatchContent) {
-            _protoItem->setHeight(static_cast<int>(item._textLines.size() * (_protoItem->text().font->height() + _padding)));
+            _protoItem->setExtentHeight(getItemHeight(item));
         }
         _protoItem->setSelected(_selectedItemIndex == itemIdx);
+
+        glm::vec3 originalTextColor(_protoItem->text().color);
+        if (item.textColor) {
+            _protoItem->setTextColor(*item.textColor);
+        }
 
         auto imageButton = std::dynamic_pointer_cast<ImageButton>(_protoItem);
         if (imageButton) {
@@ -240,11 +239,9 @@ void ListBox::render(const glm::ivec2 &screenSize,
             _protoItem->render(screenSize, itemOffset, pass);
         }
 
-        if (_protoMatchContent) {
-            itemOffset.y += item._textLines.size() * (_protoItem->text().font->height() + _padding);
-        } else {
-            itemOffset.y += _protoItem->extent().height + _padding;
-        }
+        _protoItem->setTextColor(originalTextColor);
+
+        itemOffset.y += getItemHeight(item) + _padding;
     }
 
     if (_scrollBar) {
@@ -269,6 +266,7 @@ void ListBox::stretch(float x, float y, int mask) {
         // Do not change width of the scroll bar
         _scrollBar->stretch(x, y, mask & ~kStretchWidth);
     }
+    updateItemsLayout();
 }
 
 void ListBox::setSelected(bool selected) {
@@ -280,7 +278,7 @@ void ListBox::setSelected(bool selected) {
 
 void ListBox::setExtent(Extent extent) {
     Control::setExtent(extent);
-    updateItemSlots();
+    updateItemsLayout();
 }
 
 void ListBox::setExtentHeight(int height) {
@@ -326,25 +324,99 @@ void ListBox::setItemsInteractive(bool interactive) {
 
 void ListBox::setProtoMatchContent(bool match) {
     _protoMatchContent = match;
+    updateItemsLayout();
 }
 
 void ListBox::setRenderItemIconsForButtonProto(bool render) {
     _renderItemIconsForButtonProto = render;
+    updateItemsLayout();
+}
 
-    if (!_protoItem)
+void ListBox::scrollToBottom() {
+    if (!_protoItem || _items.empty()) {
+        _itemOffset = 0;
+        updateItemSlots();
         return;
+    }
 
+    float height = 0.0f;
+    size_t offset = _items.size();
+    while (offset > 0) {
+        const Item &item = _items[offset - 1];
+        float itemHeight = static_cast<float>(getItemHeight(item));
+        itemHeight += _padding;
+
+        if (height > 0.0f && height + itemHeight > getInnerHeight()) {
+            break;
+        }
+        height += itemHeight;
+        --offset;
+    }
+
+    _itemOffset = static_cast<int>(offset);
+    updateItemSlots();
+}
+
+void ListBox::updateItemsLayout() {
+    if (!_protoItem) {
+        return;
+    }
+
+    if (_protoMatchContent) {
+        auto extent = _protoItem->extent();
+        extent.width = getItemWidth();
+        _protoItem->setExtent(std::move(extent));
+    }
+
+    int textWidth = getItemTextWidth();
     for (auto &item : _items) {
-        item._textLines = breakText(item.text, *_protoItem->text().font, getItemTextWidth());
+        item._textLines = breakText(item.text, *_protoItem->text().font, textWidth);
     }
     updateItemSlots();
+}
+
+int ListBox::getInnerHeight() const {
+    int height = _extent.height;
+    if (_border) {
+        height -= 2 * _border->dimension;
+    }
+    return std::max(height, 0);
+}
+
+int ListBox::getItemWidth() const {
+    int width = _extent.width;
+    if (_scrollBar) {
+        width -= _scrollBar->extent().width;
+    }
+    if (_border) {
+        width -= 2 * _border->dimension;
+    }
+    width -= 2 * _padding;
+    return std::max(width, 0);
+}
+
+int ListBox::getItemHeight(const Item &item) const {
+    if (!_protoItem) {
+        return 0;
+    }
+    if (!_protoMatchContent) {
+        return _protoItem->extent().height;
+    }
+
+    float fontHeight = _protoItem->text().font->height();
+    int textHeight = static_cast<int>(item._textLines.size() * fontHeight + 0.5f);
+    if (static_cast<int>(fontHeight + 0.5f) <= 15) {
+        ++textHeight;
+    }
+    return textHeight + 2 * _protoItem->border().dimension;
 }
 
 int ListBox::getItemTextWidth() const {
     if (!_protoItem)
         return 0;
 
-    int width = _protoItem->extent().width;
+    int width = _protoItem->extent().width -
+                2 * _protoItem->border().dimension;
     if (shouldRenderItemIconsForButtonProto()) {
         // Button-proto item icons render in a square gutter sized from the row height.
         int itemIconWidth = _protoItem->extent().height;

--- a/src/libs/resource/2da.cpp
+++ b/src/libs/resource/2da.cpp
@@ -121,7 +121,10 @@ std::optional<int> TwoDA::getIntOpt(int row, const std::string &column) const {
     if (value.empty()) {
         return std::nullopt;
     }
-    return stoi(value);
+    bool hexadecimal = value.size() > 2 &&
+                       value[0] == '0' &&
+                       (value[1] == 'x' || value[1] == 'X');
+    return stoi(value, nullptr, hexadecimal ? 16 : 10);
 }
 
 uint32_t TwoDA::getHexInt(int row, const std::string &column, uint32_t defValue) const {


### PR DESCRIPTION
## Summary

This PR implements the core KOTOR 1 physical-combat loop. It covers combat-round scheduling, continuous attacks, per-swing attack resolution, damage calculation and mitigation, melee special attacks, script-visible combat state, combat feedback, and floating combat text.


## Combat rounds and auto-attack

- Continue the controlled character's basic attack across combat rounds.
- Give explicitly queued user actions precedence over generated attacks.
- Retain a valid hostile target between rounds.
- Select a replacement hostile target when the previous target is no longer valid.
- End the attack chain cleanly when no replacement target is available.
- Preserve existing end-of-round script handling for other combat participants.
- Retire completed combat rounds once their actions have finished or left their owners' queues.
- Keep combat history independently of retired scheduler state.

## Physical attack construction

Each physical combat action now owns an ordered set of subattacks rather than treating an entire round as one combined hit:

```text
main-hand attack
additional main-hand attacks
offhand attack
```

The construction path handles:

- main-hand and offhand weapon selection;
- double-bladed weapons;
- unarmed attacks;
- valid offhand weapon eligibility;
- shared extra-attack handling for combat feats and `ModifyAttacks` effects;
- separate result and damage state for every subattack.

## Attack and defense calculation

The attack calculation now includes:

- class base attack bonus;
- Strength or Dexterity selection based on attack type and weapon eligibility;
- Weapon Focus;
- attack-increase and attack-decrease effects;
- enhancement, attack-bonus, and attack-penalty item properties;
- main-hand and offhand penalties;
- balanced weapon handling;
- Two-Weapon Fighting progression;
- Dueling attack bonuses;
- alignment- and racial-group attack modifiers;
- close-range ranged and melee-versus-ranged situational modifiers.

Defense now includes:

- base defense;
- class defense progression;
- armor base defense;
- natural defense;
- armor-capped Dexterity;
- AC increase and decrease effects;
- equipped AC properties;
- AC modifier-category stacking;
- Dueling defense bonuses;
- alignment-, racial-, and damage-type-specific AC modifiers;
- debilitated-state penalties.

Target-independent values remain usable by character and equipment interfaces, while target-aware calculations are used during combat resolution.

## Attack results and critical hits

Physical subattacks now resolve:

- d20 attack rolls;
- natural 1 misses;
- natural 20 hits;
- assured hits;
- weapon threat ranges;
- Keen threat expansion;
- critical confirmation rolls;
- critical-hit immunity;
- independent outcomes for every main-hand and offhand subattack.

## Damage packets and mitigation

Every successful physical subattack produces one damage packet and one logical damage event.

Damage construction includes:

- weapon and unarmed base damage dice;
- Strength-based melee damage;
- offhand and two-handed Strength scaling;
- Mighty ranged damage;
- Weapon Specialization;
- enhancement damage;
- typed damage item properties;
- damage-increase and damage-decrease effects;
- No Damage;
- weapon critical multipliers;
- independent critical dice rerolls;
- Massive Criticals;
- damage power used by damage-reduction bypass rules.

The completed physical damage value is then resolved through:

```text
damage immunity or vulnerability
damage resistance
damage reduction
final applied damage
```

A physical subattack causes one HP change, one `OnDamaged` path, and one floating damage number, even when the attack contains multiple damage sources.

## Melee special attacks

Implemented the three melee special-attack families:

### Power Attack

- rank-specific attack penalty;
- rank-specific damage bonus;
- shared physical attack and critical-damage calculation.

### Flurry

- one additional main-hand attack through the shared attack-count path;
- rank-specific attack penalty;
- temporary rank-specific Dodge-defense penalty.

### Critical Strike

- rank-specific threat-range expansion;
- attack penalty;
- temporary defense penalty;
- Fortitude save and stun effect on a qualifying first subattack.

## Combat state and script interfaces

Creature combat state now retains:

- attempted attack target;
- current attack target;
- current attack action;
- current combat feat;
- last hostile actor;
- last hostile target;
- last attack action;
- last combat feat;
- last attack result.

The corresponding script routines read this persistent state instead of traversing retained combat-round objects.

Stateful effect admission and removal were also added for combat effects that maintain creature state, including `ModifyAttacks`, Assured Hit, and Stunned cleanup.

## Combat feedback

The Messages screen now provides the KOTOR 1 feedback view.

Physical subattacks produce:

- a red attack-result summary;
- a blue attack-breakdown entry;
- localized text assembled from the game's string resources;
- the controlled character's runtime display name;
- final resolved damage in the attack summary.

The attack breakdown includes the roll and applicable base attack, ability, weapon-style, feat, situational, focus, and effect components.

Feedback rows wrap to the available list width, use measured variable heights, and remain within the message-list bounds.

## Floating combat text

Added KOTOR 1 floating combat text for:

- damage values;
- healing values;
- failed melee attacks.


## Character-name handling

Character generation now writes the selected player name into the runtime creature name. 