### PR TITLE
[game] Match vanilla lightsaber activation behavior

### DIFF
--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -357,6 +357,8 @@ private:
 
     std::shared_ptr<audio::AudioSource> _audioSourceVoice;
     std::shared_ptr<audio::AudioSource> _audioSourceFootstep;
+    bool _lightsaberIdlePowerDownPending {false};
+    Timer _lightsaberIdlePowerDownTimer;
 
     // Animation
 
@@ -383,6 +385,8 @@ private:
     // appearance when none remains. Updates _appearance only; callers rebuild the model.
     void updateDisguise();
     void updateCombat(float dt);
+    void setLightsabersPowered(bool powered, bool animate);
+    void updateLightsaberSoundPositions();
 
     void runDeathScript(uint32_t damagerId);
     void runDamagedScript(uint32_t damagerId);

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -82,6 +82,9 @@ public:
 
     void playShotSound(int variant, glm::vec3 position);
     void playImpactSound(int variant, glm::vec3 position);
+    void powerUp(glm::vec3 position);
+    void powerDown(glm::vec3 position);
+    void updatePoweredSoundPosition(glm::vec3 position);
 
     bool isEquippable() const;
     bool isEquippable(int slot) const;
@@ -154,6 +157,12 @@ private:
 
     bool _equipped {false};
     std::shared_ptr<AmmunitionType> _ammunitionType;
+    bool _poweredItem {false};
+    bool _isPowered {false};
+    std::shared_ptr<audio::AudioClip> _powerUpSound;
+    std::shared_ptr<audio::AudioClip> _powerDownSound;
+    std::shared_ptr<audio::AudioClip> _poweredSound;
+    std::shared_ptr<audio::AudioSource> _poweredAudioSource;
 
     int _criticalThreat {0};
     int _criticalHitMultiplier {0};

--- a/include/reone/scene/node/model.h
+++ b/include/reone/scene/node/model.h
@@ -123,6 +123,7 @@ public:
     void setMainTexture(graphics::Texture *texture);
     void setEnvironmentMap(graphics::Texture *texture);
     void setPickable(bool pickable) { _pickable = pickable; }
+    void setAnimationEventListener(IAnimationEventListener &listener) { _animEventListener = &listener; }
 
     // Animation
 

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -877,6 +877,10 @@ void Area::loadPartyMember(const std::shared_ptr<Creature> &member, int index, b
 }
 
 void Area::unloadPartyMember(const std::shared_ptr<Creature> &member) {
+    // Party creatures persist across modules, but combat does not. Reset it
+    // before rebuilding their models in the destination area so powered
+    // weapons do not leak their active state through a transition.
+    member->deactivateCombat(0.0f);
     doDestroyObject(member->id());
 }
 

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -212,6 +212,7 @@ void Creature::update(float dt) {
     Object::update(dt);
     updateModelAnimation();
     updateCombat(dt);
+    updateLightsaberSoundPositions();
 }
 
 void Creature::updateModelAnimation() {
@@ -308,9 +309,19 @@ void Creature::damage(int amount, uint32_t damager) {
 
 void Creature::updateCombat(float dt) {
     _combatState.deactivationTimer.update(dt);
+    _lightsaberIdlePowerDownTimer.update(dt);
+    if (_lightsaberIdlePowerDownPending &&
+        !_combatState.active &&
+        _lightsaberIdlePowerDownTimer.elapsed()) {
+        _lightsaberIdlePowerDownPending = false;
+        setLightsabersPowered(false, true);
+    }
     if (_combatState.shouldDeactivate && _combatState.deactivationTimer.elapsed()) {
         _combatState.active = false;
         _combatState.debilitated = false;
+        _combatState.shouldDeactivate = false;
+        _animDirty = true;
+        setLightsabersPowered(false, true);
     }
 }
 
@@ -430,6 +441,11 @@ bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
         return false;
     }
 
+    auto previous = getEquippedItem(slot);
+    if (previous && previous != item) {
+        previous->powerDown(_position);
+        previous->setEquipped(false);
+    }
     _equipment[slot] = item;
     item->setEquipped(true);
 
@@ -445,12 +461,9 @@ bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
     if (_sceneNode) {
         updateModel();
 
-        if (slot == InventorySlots::rightWeapon) {
-            auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
-            auto weapon = static_cast<ModelSceneNode *>(model->getAttachment("rhand"));
-            if (weapon && weapon->model().classification() == MdlClassification::lightsaber) {
-                weapon->playAnimation("powerup");
-            }
+        if (_combatState.active &&
+            (slot == InventorySlots::rightWeapon || slot == InventorySlots::leftWeapon)) {
+            setLightsabersPowered(true, true);
         }
     }
 
@@ -462,6 +475,7 @@ void Creature::unequip(const std::shared_ptr<Item> &item) {
         if (equipped.second != item) {
             continue;
         }
+        item->powerDown(_position);
         item->setEquipped(false);
         _equipment.erase(equipped.first);
         uint32_t prevAppearance = _appearance;
@@ -737,15 +751,73 @@ void Creature::runOnNotice(const Object &object, bool heard, bool seen) {
 }
 
 void Creature::activateCombat() {
+    _lightsaberIdlePowerDownPending = false;
+    if (_combatState.active) {
+        _combatState.shouldDeactivate = false;
+        return;
+    }
     _combatState.active = true;
     _combatState.shouldDeactivate = false;
+    _animDirty = true;
+    setLightsabersPowered(true, true);
+}
+
+void Creature::setLightsabersPowered(bool powered, bool animate) {
+    auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
+    if (!model) {
+        return;
+    }
+
+    const std::array<std::pair<int, std::string>, 2> weaponSlots {{
+        {InventorySlots::rightWeapon, g_rightHandNode},
+        {InventorySlots::leftWeapon, g_leftHandNode},
+    }};
+    for (auto [slot, attachment] : weaponSlots) {
+        auto weapon = static_cast<ModelSceneNode *>(model->getAttachment(attachment));
+        if (!weapon || weapon->model().classification() != MdlClassification::lightsaber) {
+            continue;
+        }
+
+        const auto activeAnimation = weapon->activeAnimationName();
+        if ((powered && (activeAnimation == "powerup" || activeAnimation == "powered")) ||
+            (!powered && (activeAnimation == "powerdown" || activeAnimation == "off"))) {
+            continue;
+        }
+        weapon->playAnimation(animate ? (powered ? "powerup" : "powerdown") : (powered ? "powered" : "off"));
+        if (!animate) {
+            continue;
+        }
+        auto item = getEquippedItem(slot);
+        if (item) {
+            powered ? item->powerUp(_position) : item->powerDown(_position);
+        }
+    }
+}
+
+void Creature::updateLightsaberSoundPositions() {
+    for (int slot : {InventorySlots::rightWeapon, InventorySlots::leftWeapon}) {
+        auto item = getEquippedItem(slot);
+        if (item) {
+            item->updatePoweredSoundPosition(_position);
+        }
+    }
 }
 
 void Creature::deactivateCombat(float delay) {
-    if (_combatState.active) {
-        _combatState.shouldDeactivate = true;
-        _combatState.deactivationTimer.reset(delay);
+    if (delay <= 0.0f) {
+        _lightsaberIdlePowerDownPending = false;
+        _combatState.active = false;
+        _combatState.shouldDeactivate = false;
+        _combatState.debilitated = false;
+        _animDirty = true;
+        setLightsabersPowered(false, true);
+        return;
     }
+    if (!_combatState.active) {
+        return;
+    }
+    _combatState.shouldDeactivate = true;
+    _combatState.deactivationTimer.reset(delay);
 }
 
 bool Creature::isTwoWeaponFighting() const {
@@ -825,6 +897,14 @@ void Creature::getOffhandDamage(int &min, int &max) const {
 }
 
 void Creature::onEventSignalled(const std::string &name) {
+    if (name == "draw_weapon") {
+        setLightsabersPowered(true, true);
+        if (!_combatState.active) {
+            _lightsaberIdlePowerDownPending = true;
+            _lightsaberIdlePowerDownTimer.reset(8.0f);
+        }
+        return;
+    }
     if (_footstepType == -1 || _walkmeshMaterial == -1 || name != "snd_footstep") {
         return;
     }
@@ -1221,6 +1301,7 @@ std::shared_ptr<ModelSceneNode> Creature::buildModel() {
     auto &sceneGraph = _services.scene.graphs.get(_sceneName);
     auto sceneNode = sceneGraph.newModel(*model, ModelUsage::Creature);
     sceneNode->setDrawDistance(_game.options().graphics.drawDistance);
+    sceneNode->setAnimationEventListener(*this);
 
     return sceneNode;
 }
@@ -1276,6 +1357,9 @@ void Creature::finalizeModel(ModelSceneNode &body) {
         if (weaponModel) {
             std::shared_ptr<ModelSceneNode> weaponSceneNode(sceneGraph.newModel(*weaponModel, ModelUsage::Equipment));
             body.attach(g_rightHandNode, *weaponSceneNode);
+            if (weaponModel->classification() == MdlClassification::lightsaber) {
+                weaponSceneNode->playAnimation(_combatState.active ? "powered" : "off");
+            }
         }
     }
 
@@ -1287,6 +1371,9 @@ void Creature::finalizeModel(ModelSceneNode &body) {
         if (weaponModel) {
             std::shared_ptr<ModelSceneNode> weaponSceneNode(sceneGraph.newModel(*weaponModel, ModelUsage::Equipment));
             body.attach(g_leftHandNode, *weaponSceneNode);
+            if (weaponModel->classification() == MdlClassification::lightsaber) {
+                weaponSceneNode->playAnimation(_combatState.active ? "powered" : "off");
+            }
         }
     }
 }

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -144,6 +144,16 @@ void Item::deserializeBase(const resource::Gff &gff) {
     _numDice = baseItems->getInt(_baseItem, "numdice");
     _weaponType = static_cast<WeaponType>(baseItems->getInt(_baseItem, "weapontype"));
     _weaponWield = static_cast<WeaponWield>(baseItems->getInt(_baseItem, "weaponwield"));
+    _poweredItem = baseItems->getInt(_baseItem, "powereditem") != 0;
+    if (_poweredItem) {
+        auto loadSound = [this, &baseItems](const char *column) {
+            auto resRef = boost::to_lower_copy(baseItems->getString(_baseItem, column));
+            return resRef.empty() ? nullptr : _services.resource.audioClips.get(resRef);
+        };
+        _powerUpSound = loadSound("powerupsnd");
+        _powerDownSound = loadSound("powerdownsnd");
+        _poweredSound = loadSound("poweredsnd");
+    }
 
     std::string iconResRef;
     if (isEquippable(InventorySlots::body)) {
@@ -209,6 +219,42 @@ void Item::playImpactSound(int variant, glm::vec3 position) {
             1.0f,
             false,
             std::move(position));
+    }
+}
+
+void Item::powerUp(glm::vec3 position) {
+    if (!_poweredItem || _isPowered) {
+        return;
+    }
+    _isPowered = true;
+    if (_powerUpSound) {
+        _services.audio.mixer.play(_powerUpSound, AudioType::Sound, 1.0f, false, position);
+    }
+    if (_poweredAudioSource) {
+        _poweredAudioSource->stop();
+    }
+    if (_poweredSound) {
+        _poweredAudioSource = _services.audio.mixer.play(_poweredSound, AudioType::Sound, 1.0f, true, position);
+    }
+}
+
+void Item::powerDown(glm::vec3 position) {
+    if (!_poweredItem || !_isPowered) {
+        return;
+    }
+    _isPowered = false;
+    if (_poweredAudioSource) {
+        _poweredAudioSource->stop();
+        _poweredAudioSource.reset();
+    }
+    if (_powerDownSound) {
+        _services.audio.mixer.play(_powerDownSound, AudioType::Sound, 1.0f, false, position);
+    }
+}
+
+void Item::updatePoweredSoundPosition(glm::vec3 position) {
+    if (_poweredAudioSource) {
+        _poweredAudioSource->setPosition(position);
     }
 }
 

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -258,7 +258,10 @@ void ModelSceneNode::playAnimation(Animation &anim, std::shared_ptr<LipAnimation
     if (properties.flags & AnimationFlags::propagate) {
         for (auto &attachment : _attachments) {
             if (attachment.second->type() == SceneNodeType::Model) {
-                static_cast<ModelSceneNode *>(attachment.second)->playAnimation(anim, lipAnim, properties);
+                // Attachments have their own animation sets. Resolve by name so
+                // an unrelated body animation cannot replace a weapon's local
+                // state animation (for example, a lightsaber's "off" pose).
+                static_cast<ModelSceneNode *>(attachment.second)->playAnimation(anim.name(), lipAnim, properties);
             }
         }
     }

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -418,7 +418,9 @@ std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int st
     return item;
 }
 
-std::shared_ptr<graphics::Animation> makeAnimation(std::string name) {
+std::shared_ptr<graphics::Animation> makeAnimation(
+    std::string name,
+    std::vector<graphics::Animation::Event> events = {}) {
     auto root = std::make_shared<graphics::ModelNode>(
         0,
         "root_node",
@@ -434,12 +436,13 @@ std::shared_ptr<graphics::Animation> makeAnimation(std::string name) {
         0.0f,
         "root_node",
         std::move(root),
-        std::vector<graphics::Animation::Event>());
+        std::move(events));
 }
 
 std::shared_ptr<graphics::Model> makeModel(
     std::string name,
-    std::vector<std::shared_ptr<graphics::Animation>> animations) {
+    std::vector<std::shared_ptr<graphics::Animation>> animations,
+    int classification = graphics::MdlClassification::other) {
     auto root = std::make_shared<graphics::ModelNode>(
         0,
         "root_node",
@@ -449,7 +452,7 @@ std::shared_ptr<graphics::Model> makeModel(
         nullptr);
     return std::make_shared<graphics::Model>(
         std::move(name),
-        0,
+        classification,
         std::move(root),
         std::move(animations),
         "",
@@ -503,6 +506,96 @@ TEST(Conversation, should_finish_active_presentation_before_starting_replacement
 
     conversation.cleanupForModuleTransition();
     EXPECT_FALSE(secondOwner->isInConversation());
+}
+
+TEST(Creature, should_activate_and_deactivate_lightsabers_in_both_hands_with_combat) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto bodyRoot = std::make_shared<graphics::ModelNode>(
+        0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+    bodyRoot->addChild(std::make_shared<graphics::ModelNode>(
+        1, "rhand", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, bodyRoot.get()));
+    bodyRoot->addChild(std::make_shared<graphics::ModelNode>(
+        2, "lhand", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, bodyRoot.get()));
+    graphics::Model body(
+        "body",
+        graphics::MdlClassification::character,
+        bodyRoot,
+        {makeAnimation("pause1", {{0.5f, "draw_weapon"}})},
+        "",
+        1.0f);
+
+    auto saberAnimations = std::vector<std::shared_ptr<graphics::Animation>> {
+        makeAnimation("off"),
+        makeAnimation("powerup"),
+        makeAnimation("powered"),
+        makeAnimation("powerdown")};
+    auto rightSaber = makeModel("right_saber", saberAnimations, graphics::MdlClassification::lightsaber);
+    auto leftSaber = makeModel("left_saber", saberAnimations, graphics::MdlClassification::lightsaber);
+
+    graphics::GraphicsOptions graphicsOptions;
+    scene::SceneGraph graph(
+        "test",
+        engine.sceneModule().renderPipelineFactory(),
+        graphicsOptions,
+        engine.services().graphics,
+        engine.services().audio,
+        engine.services().resource);
+    auto bodyNode = graph.newModel(body, scene::ModelUsage::Creature);
+    auto rightSaberNode = graph.newModel(*rightSaber, scene::ModelUsage::Equipment);
+    auto leftSaberNode = graph.newModel(*leftSaber, scene::ModelUsage::Equipment);
+    bodyNode->attach("rhand", *rightSaberNode);
+    bodyNode->attach("lhand", *leftSaberNode);
+    ASSERT_EQ(bodyNode->getAttachment("rhand"), rightSaberNode.get());
+    ASSERT_EQ(bodyNode->getAttachment("lhand"), leftSaberNode.get());
+
+    rightSaberNode->playAnimation("off");
+    leftSaberNode->playAnimation("off");
+    bodyNode->playAnimation(
+        "pause1",
+        nullptr,
+        scene::AnimationProperties::fromFlags(scene::AnimationFlags::propagate));
+
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "off");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "off");
+
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(bodyNode);
+    bodyNode->setAnimationEventListener(creature);
+    bodyNode->update(0.6f);
+
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerup");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerup");
+
+    creature.update(7.9f);
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerup");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerup");
+
+    creature.update(0.2f);
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerdown");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerdown");
+
+    rightSaberNode->playAnimation("off");
+    leftSaberNode->playAnimation("off");
+    creature.activateCombat();
+
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerup");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerup");
+
+    creature.deactivateCombat(8.0f);
+    creature.update(8.1f);
+
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerdown");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerdown");
+
+    creature.activateCombat();
+    creature.deactivateCombat(0.0f);
+
+    EXPECT_FALSE(creature.isInCombat());
+    EXPECT_EQ(rightSaberNode->activeAnimationName(), "powerdown");
+    EXPECT_EQ(leftSaberNode->activeAnimationName(), "powerdown");
 }
 
 TEST(Conversation, should_advance_script_only_auto_routing_entry_without_presenting_it) {


### PR DESCRIPTION
## Summary

Lightsabers now stay retracted while characters are passive, ignite at the stock `draw_weapon` animation event, and retract after combat or an idle flourish. Both weapon hands use the model's native power-up and power-down animations, while powered-item sound metadata drives the ignition, shutdown, and looping hum.

This also keeps attachment animations local to their models, resets persistent party combat state during module transitions, and stops a powered weapon's loop when it is replaced or unequipped.

## Validation

- Built the engine successfully with Visual Studio 2022.
- Passed all 378 automated tests.
- Manually verified in KOTOR 1 that sabers remain off after warping, activate with the X flourish, activate in combat, and shut down automatically after the idle delay.
