### PR TITLE
[game] Implement directed reputation adjustments

### DIFF
--- a/include/reone/game/reputes.h
+++ b/include/reone/game/reputes.h
@@ -35,10 +35,15 @@ class IReputes {
 public:
     virtual ~IReputes() = default;
 
-    virtual bool getIsEnemy(const Creature &left, const Creature &right) const = 0;
-    virtual bool getIsEnemy(Faction left, Faction right) const = 0;
-    virtual bool getIsFriend(const Creature &left, const Creature &right) const = 0;
-    virtual bool getIsNeutral(const Creature &left, const Creature &right) const = 0;
+    // Reputation is directed: it is the source faction's disposition toward the
+    // target faction, and the reverse relationship is independent of it.
+    virtual int getReputation(Faction sourceFaction, Faction targetFaction) const = 0;
+    virtual void adjustReputation(Faction sourceFaction, Faction targetFaction, int adjustment) = 0;
+
+    virtual bool getIsEnemy(const Creature &source, const Creature &target) const = 0;
+    virtual bool getIsEnemy(Faction sourceFaction, Faction targetFaction) const = 0;
+    virtual bool getIsFriend(const Creature &source, const Creature &target) const = 0;
+    virtual bool getIsNeutral(const Creature &source, const Creature &target) const = 0;
 };
 
 class Reputes : public IReputes, boost::noncopyable {
@@ -49,17 +54,18 @@ public:
 
     void init();
 
-    bool getIsEnemy(const Creature &left, const Creature &right) const override;
-    bool getIsEnemy(Faction left, Faction right) const override;
-    bool getIsFriend(const Creature &left, const Creature &right) const override;
-    bool getIsNeutral(const Creature &left, const Creature &right) const override;
+    int getReputation(Faction sourceFaction, Faction targetFaction) const override;
+    void adjustReputation(Faction sourceFaction, Faction targetFaction, int adjustment) override;
+
+    bool getIsEnemy(const Creature &source, const Creature &target) const override;
+    bool getIsEnemy(Faction sourceFaction, Faction targetFaction) const override;
+    bool getIsFriend(const Creature &source, const Creature &target) const override;
+    bool getIsNeutral(const Creature &source, const Creature &target) const override;
 
 private:
     resource::ITwoDAs &_twoDas;
     std::vector<std::string> _factionLabels;
     std::vector<std::vector<int>> _factionValues;
-
-    int getRepute(Faction left, Faction right) const;
 };
 
 } // namespace game

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -1460,24 +1460,26 @@ std::shared_ptr<Creature> Area::getNearestCreature(const std::shared_ptr<Object>
     return nth < candidates.size() ? candidates[nth].first : nullptr;
 }
 
-static bool matchesReputation(const Creature &creature, const Object *target,
+// The criteria describe the candidate's standing with the creature the search
+// is centred on, so that creature is the source of every disposition query.
+static bool matchesReputation(const Creature &candidate, const Object *target,
                               ReputationType reputation, IReputes &reputes) {
     if (!target || target->type() != ObjectType::Creature) {
         return false;
     }
-    const Creature &targetCreature = static_cast<const Creature &>(*target);
+    const Creature &searching = static_cast<const Creature &>(*target);
 
     switch (reputation) {
     case ReputationType::Friend:
-        return reputes.getIsFriend(creature, targetCreature);
+        return reputes.getIsFriend(searching, candidate);
     case ReputationType::Enemy: {
         // Do not consider dead enemies as enemies. Scripts use
         // GetNearestCreature to find a new target, and targeting dead bodies is
         // a poor tactic.
-        return !creature.isDead() && reputes.getIsEnemy(creature, targetCreature);
+        return !candidate.isDead() && reputes.getIsEnemy(searching, candidate);
     }
     case ReputationType::Neutral:
-        return reputes.getIsNeutral(creature, targetCreature);
+        return reputes.getIsNeutral(searching, candidate);
     }
     return false;
 }

--- a/src/libs/game/reputes.cpp
+++ b/src/libs/game/reputes.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/reputes.h"
 
+#include <algorithm>
+
 #include "reone/resource/2da.h"
 #include "reone/resource/provider/2das.h"
 
@@ -29,6 +31,8 @@ namespace reone {
 namespace game {
 
 static constexpr int kDefaultRepute = 50;
+static constexpr int kMinRepute = 0;
+static constexpr int kMaxRepute = 100;
 
 void Reputes::init() {
     std::shared_ptr<TwoDA> repute(_twoDas.get("repute"));
@@ -61,31 +65,48 @@ void Reputes::init() {
     }
 }
 
-bool Reputes::getIsEnemy(const Creature &left, const Creature &right) const {
-    return getIsEnemy(left.faction(), right.faction());
-}
+int Reputes::getReputation(Faction sourceFaction, Faction targetFaction) const {
+    int source = static_cast<int>(sourceFaction);
+    int target = static_cast<int>(targetFaction);
 
-bool Reputes::getIsEnemy(Faction left, Faction right) const {
-    return getRepute(left, right) < 50;
-}
-
-bool Reputes::getIsFriend(const Creature &left, const Creature &right) const {
-    return getRepute(left.faction(), right.faction()) > 50;
-}
-
-bool Reputes::getIsNeutral(const Creature &left, const Creature &right) const {
-    return getRepute(left.faction(), right.faction()) == 50;
-}
-
-int Reputes::getRepute(Faction left, Faction right) const {
-    int leftFaction = static_cast<int>(left);
-    int rightFaction = static_cast<int>(right);
-
-    if (leftFaction < 0 || leftFaction >= _factionValues.size() ||
-        rightFaction < 0 || rightFaction >= _factionValues[leftFaction].size())
+    if (source < 0 || source >= static_cast<int>(_factionValues.size()) ||
+        target < 0 || target >= static_cast<int>(_factionValues[source].size()))
         return kDefaultRepute;
 
-    return _factionValues[leftFaction][rightFaction];
+    return _factionValues[source][target];
+}
+
+void Reputes::adjustReputation(Faction sourceFaction, Faction targetFaction, int adjustment) {
+    int source = static_cast<int>(sourceFaction);
+    int target = static_cast<int>(targetFaction);
+
+    // Only the source faction's view of the target moves. A faction's view of
+    // itself is fixed, and out-of-range factions have no cell to adjust.
+    if (source < 0 || source >= static_cast<int>(_factionValues.size()) ||
+        target < 0 || target >= static_cast<int>(_factionValues[source].size()) ||
+        source == target) {
+        return;
+    }
+
+    int64_t adjusted = static_cast<int64_t>(_factionValues[source][target]) + adjustment;
+    _factionValues[source][target] = static_cast<int>(
+        std::clamp(adjusted, static_cast<int64_t>(kMinRepute), static_cast<int64_t>(kMaxRepute)));
+}
+
+bool Reputes::getIsEnemy(const Creature &source, const Creature &target) const {
+    return getIsEnemy(source.faction(), target.faction());
+}
+
+bool Reputes::getIsEnemy(Faction sourceFaction, Faction targetFaction) const {
+    return getReputation(sourceFaction, targetFaction) < 50;
+}
+
+bool Reputes::getIsFriend(const Creature &source, const Creature &target) const {
+    return getReputation(source.faction(), target.faction()) > 50;
+}
+
+bool Reputes::getIsNeutral(const Creature &source, const Creature &target) const {
+    return getReputation(source.faction(), target.faction()) == 50;
 }
 
 } // namespace game

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -23,6 +23,8 @@
 #include "reone/game/effect/visual.h"
 #include "reone/game/event.h"
 #include "reone/game/game.h"
+#include "reone/game/object/door.h"
+#include "reone/game/object/placeable.h"
 #include "reone/game/reputes.h"
 #include "reone/game/script/routine/argutil.h"
 #include "reone/game/script/routine/context.h"
@@ -2094,6 +2096,21 @@ static Variable GetReputation(const std::vector<Variable> &args, const RoutineCo
     throw RoutineNotImplementedException("GetReputation");
 }
 
+// The faction member naming a reputation source need not be a creature --
+// modules commonly place an inert object purely to stand in for its faction.
+static std::optional<Faction> getObjectFaction(const Object &object) {
+    switch (object.type()) {
+    case ObjectType::Creature:
+        return static_cast<const Creature &>(object).faction();
+    case ObjectType::Door:
+        return static_cast<const Door &>(object).faction();
+    case ObjectType::Placeable:
+        return static_cast<const Placeable &>(object).faction();
+    default:
+        return std::nullopt;
+    }
+}
+
 static Variable AdjustReputation(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
     auto oTarget = getObject(args, 0, ctx);
@@ -2101,9 +2118,18 @@ static Variable AdjustReputation(const std::vector<Variable> &args, const Routin
     auto nAdjustment = getInt(args, 2);
 
     // Transform
+    auto target = dyn_cast<Creature>(oTarget);
+    if (!target) {
+        return Variable::ofNull();
+    }
+    auto sourceFaction = getObjectFaction(*oSourceFactionMember);
+    if (!sourceFaction) {
+        return Variable::ofNull();
+    }
 
     // Execute
-    throw RoutineNotImplementedException("AdjustReputation");
+    ctx.services.game.reputes.adjustReputation(*sourceFaction, target->faction(), nAdjustment);
+    return Variable::ofNull();
 }
 
 static Variable GetModuleFileName(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -2383,7 +2409,8 @@ static Variable GetIsEnemy(const std::vector<Variable> &args, const RoutineConte
     auto source = checkCreature(oSource);
 
     // Execute
-    bool enemy = ctx.services.game.reputes.getIsEnemy(*target, *source);
+    // oTarget is an enemy of oSource when oSource's faction regards it as one.
+    bool enemy = ctx.services.game.reputes.getIsEnemy(*source, *target);
     return Variable::ofInt(static_cast<int>(enemy));
 }
 
@@ -2397,7 +2424,7 @@ static Variable GetIsFriend(const std::vector<Variable> &args, const RoutineCont
     auto source = checkCreature(oSource);
 
     // Execute
-    bool isFriend = ctx.services.game.reputes.getIsFriend(*target, *source);
+    bool isFriend = ctx.services.game.reputes.getIsFriend(*source, *target);
     return Variable::ofInt(static_cast<int>(isFriend));
 }
 
@@ -2411,7 +2438,7 @@ static Variable GetIsNeutral(const std::vector<Variable> &args, const RoutineCon
     auto source = checkCreature(oSource);
 
     // Execute
-    bool neutral = ctx.services.game.reputes.getIsNeutral(*target, *source);
+    bool neutral = ctx.services.game.reputes.getIsNeutral(*source, *target);
     return Variable::ofInt(static_cast<int>(neutral));
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/pazaakintegration.cpp
     ${TESTS_SOURCE_DIR}/game/pazaaksession.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
+    ${TESTS_SOURCE_DIR}/game/reputes.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -98,10 +98,12 @@ public:
 
 class MockReputes : public IReputes, boost::noncopyable {
 public:
-    MOCK_METHOD(bool, getIsEnemy, (const Creature &left, const Creature &right), (const override));
-    MOCK_METHOD(bool, getIsEnemy, (Faction left, Faction right), (const override));
-    MOCK_METHOD(bool, getIsFriend, (const Creature &left, const Creature &right), (const override));
-    MOCK_METHOD(bool, getIsNeutral, (const Creature &left, const Creature &right), (const override));
+    MOCK_METHOD(int, getReputation, (Faction sourceFaction, Faction targetFaction), (const override));
+    MOCK_METHOD(void, adjustReputation, (Faction sourceFaction, Faction targetFaction, int adjustment), (override));
+    MOCK_METHOD(bool, getIsEnemy, (const Creature &source, const Creature &target), (const override));
+    MOCK_METHOD(bool, getIsEnemy, (Faction sourceFaction, Faction targetFaction), (const override));
+    MOCK_METHOD(bool, getIsFriend, (const Creature &source, const Creature &target), (const override));
+    MOCK_METHOD(bool, getIsNeutral, (const Creature &source, const Creature &target), (const override));
 };
 
 class MockSkills : public ISkills, boost::noncopyable {

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -1967,3 +1967,27 @@ TEST(Reputes, should_use_authored_creature_faction_dispositions) {
     EXPECT_TRUE(reputes.getIsNeutral(*friendly1, *neutral));
     EXPECT_TRUE(reputes.getIsNeutral(*neutral, *friendly1));
 }
+
+TEST(AreaReputationSearch, treats_the_creature_being_searched_around_as_the_source) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    testSceneGraph(engine);
+    auto area = game.newArea();
+    auto searching = game.newCreature();
+    searching->setFaction(Faction::Hostile1);
+    auto candidate = game.newCreature();
+    candidate->setFaction(Faction::Friendly1);
+    area->add(candidate);
+    auto &reputes = static_cast<MockReputes &>(engine.services().game.reputes);
+
+    // The search is centred on `searching`, so a candidate's hostility is
+    // judged from that creature's point of view, not the other way round.
+    EXPECT_CALL(reputes, getIsEnemy(Ref(*searching), Ref(*candidate)))
+        .WillOnce(Return(true));
+
+    Area::SearchCriteriaList criterias {
+        {CreatureType::Reputation, static_cast<int>(ReputationType::Enemy)}};
+
+    EXPECT_EQ(candidate, area->getNearestCreature(searching, criterias));
+}

--- a/test/game/reputes.cpp
+++ b/test/game/reputes.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/reputes.h"
+#include "reone/game/script/routines.h"
+#include "reone/resource/2da.h"
+#include "reone/script/executioncontext.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+
+// Synthetic factions. The relationships below are deliberately asymmetric so a
+// query that reverses source and target reads a different cell.
+constexpr Faction kBeta = static_cast<Faction>(1);
+constexpr Faction kGamma = static_cast<Faction>(2);
+
+// beta regards gamma as hostile, while gamma regards beta as friendly.
+std::shared_ptr<TwoDA> makeReputeTable() {
+    std::vector<std::string> columns {"label", "alpha", "beta", "gamma", "delta"};
+    std::vector<TwoDA::Row> rows {
+        TwoDA::Row {{"alpha", "50", "50", "50", "50"}},
+        TwoDA::Row {{"beta", "50", "100", "0", "50"}},
+        TwoDA::Row {{"gamma", "50", "100", "100", "50"}},
+        TwoDA::Row {{"delta", "50", "50", "50", "50"}}};
+    return std::make_shared<TwoDA>(std::move(columns), std::move(rows));
+}
+
+std::unique_ptr<Reputes> makeReputes(TestEngine &engine) {
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("repute"))
+        .WillOnce(Return(makeReputeTable()));
+    auto reputes = std::make_unique<Reputes>(engine.services().resource.twoDas);
+    reputes->init();
+    return reputes;
+}
+
+} // namespace
+
+TEST(Reputes, authored_directed_values_are_retained_in_both_directions) {
+    TestEngine &engine = testEngine();
+
+    auto reputes = makeReputes(engine);
+
+    EXPECT_EQ(0, reputes->getReputation(kBeta, kGamma));
+    EXPECT_EQ(100, reputes->getReputation(kGamma, kBeta));
+}
+
+TEST(Reputes, adjustment_changes_only_the_source_view_of_the_target) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    reputes->adjustReputation(kBeta, kGamma, 50);
+
+    EXPECT_EQ(50, reputes->getReputation(kBeta, kGamma));
+    EXPECT_EQ(100, reputes->getReputation(kGamma, kBeta));
+}
+
+TEST(Reputes, repeated_adjustments_accumulate) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    reputes->adjustReputation(kBeta, kGamma, 20);
+    reputes->adjustReputation(kBeta, kGamma, 20);
+
+    EXPECT_EQ(40, reputes->getReputation(kBeta, kGamma));
+}
+
+TEST(Reputes, adjustments_clamp_to_the_representable_range) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    reputes->adjustReputation(kBeta, kGamma, 1000);
+    EXPECT_EQ(100, reputes->getReputation(kBeta, kGamma));
+
+    reputes->adjustReputation(kBeta, kGamma, -1000);
+    EXPECT_EQ(0, reputes->getReputation(kBeta, kGamma));
+}
+
+TEST(Reputes, a_positive_adjustment_lifts_hostility_and_a_negative_one_restores_it) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    // This is the disguise shape: the source faction stops treating the target
+    // as an enemy, then treats it as one again once the disguise is dropped.
+    EXPECT_TRUE(reputes->getIsEnemy(kBeta, kGamma));
+
+    reputes->adjustReputation(kBeta, kGamma, 50);
+    EXPECT_FALSE(reputes->getIsEnemy(kBeta, kGamma));
+
+    reputes->adjustReputation(kBeta, kGamma, -50);
+    EXPECT_TRUE(reputes->getIsEnemy(kBeta, kGamma));
+}
+
+TEST(Reputes, hostility_is_read_from_the_source_view_not_the_target_view) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    EXPECT_TRUE(reputes->getIsEnemy(kBeta, kGamma));
+    EXPECT_FALSE(reputes->getIsEnemy(kGamma, kBeta));
+}
+
+TEST(Reputes, out_of_range_and_identical_factions_leave_the_matrix_untouched) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    reputes->adjustReputation(static_cast<Faction>(-1), kGamma, 50);
+    reputes->adjustReputation(kBeta, static_cast<Faction>(99), 50);
+    reputes->adjustReputation(static_cast<Faction>(99), kGamma, 50);
+    reputes->adjustReputation(kBeta, kBeta, -50);
+
+    EXPECT_EQ(0, reputes->getReputation(kBeta, kGamma));
+    EXPECT_EQ(100, reputes->getReputation(kGamma, kBeta));
+    EXPECT_EQ(100, reputes->getReputation(kBeta, kBeta));
+}
+
+TEST(Reputes, unknown_factions_report_the_neutral_default) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+
+    EXPECT_EQ(50, reputes->getReputation(static_cast<Faction>(99), kGamma));
+    EXPECT_EQ(50, reputes->getReputation(kBeta, static_cast<Faction>(99)));
+}
+
+TEST(Reputes, reinitialization_restores_the_authored_matrix) {
+    TestEngine &engine = testEngine();
+    auto reputes = makeReputes(engine);
+    reputes->adjustReputation(kBeta, kGamma, 50);
+    ASSERT_EQ(50, reputes->getReputation(kBeta, kGamma));
+
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("repute"))
+        .WillOnce(Return(makeReputeTable()));
+    reputes->init();
+
+    EXPECT_EQ(0, reputes->getReputation(kBeta, kGamma));
+}
+
+TEST(AdjustReputationRoutine, adjusts_the_source_faction_view_of_the_target) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto target = game.newCreature();
+    target->setFaction(kGamma);
+    auto sourceFactionMember = game.newCreature();
+    sourceFactionMember->setFaction(kBeta);
+    Routines routines(GameID::KotOR, &game, &engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+
+    EXPECT_CALL(static_cast<MockReputes &>(engine.services().game.reputes),
+                adjustReputation(kBeta, kGamma, 50));
+
+    routines.get(209).invoke(
+        {script::Variable::ofObject(target->id()),
+         script::Variable::ofObject(sourceFactionMember->id()),
+         script::Variable::ofInt(50)},
+        execution);
+}
+
+TEST(AdjustReputationRoutine, a_non_creature_target_is_ignored) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto target = game.newPlaceable();
+    auto sourceFactionMember = game.newCreature();
+    sourceFactionMember->setFaction(kBeta);
+    Routines routines(GameID::KotOR, &game, &engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+
+    EXPECT_CALL(static_cast<MockReputes &>(engine.services().game.reputes),
+                adjustReputation(_, _, _))
+        .Times(0);
+
+    routines.get(209).invoke(
+        {script::Variable::ofObject(target->id()),
+         script::Variable::ofObject(sourceFactionMember->id()),
+         script::Variable::ofInt(50)},
+        execution);
+}
+
+TEST(DirectedDispositionRoutines, query_the_source_view_of_the_target) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto target = game.newCreature();
+    target->setFaction(kGamma);
+    auto source = game.newCreature();
+    source->setFaction(kBeta);
+    Routines routines(GameID::KotOR, &game, &engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    auto &reputes = static_cast<MockReputes &>(engine.services().game.reputes);
+
+    // GetIsEnemy(oTarget, oSource) asks whether oSource's faction regards
+    // oTarget as an enemy, so oSource is the source of the query.
+    EXPECT_CALL(reputes, getIsEnemy(Ref(*source), Ref(*target))).WillOnce(Return(true));
+    EXPECT_CALL(reputes, getIsFriend(Ref(*source), Ref(*target))).WillOnce(Return(false));
+    EXPECT_CALL(reputes, getIsNeutral(Ref(*source), Ref(*target))).WillOnce(Return(false));
+
+    std::vector<script::Variable> args {
+        script::Variable::ofObject(target->id()),
+        script::Variable::ofObject(source->id())};
+
+    EXPECT_EQ(1, routines.get(235).invoke(args, execution).intValue);
+    EXPECT_EQ(0, routines.get(236).invoke(args, execution).intValue);
+    EXPECT_EQ(0, routines.get(237).invoke(args, execution).intValue);
+}


### PR DESCRIPTION
## Summary

- Implements directed runtime reputation adjustments.
- Implements the `AdjustReputation` script routine for creature targets and supported faction-bearing source objects.
- Corrects disposition queries to consistently use the source faction's view of the target.
- Corrects reputation-based creature searches to use the creature being searched around as the source.
- Adds focused asymmetric tests for directed reputation, adjustment, script routines and Area search behaviour.

## Problem

`AdjustReputation` was unimplemented, so authored scripts could not temporarily change faction relationships at runtime.

Reputation is directional: the source faction's view of the target faction is stored separately from the reverse relationship. Several consumers queried those operands in reverse, meaning a correctly adjusted source→target relationship could still be ignored by perception and AI searches.

This affected the K1 Sand People disguise flow: equipping the disguise should temporarily change the Tusken faction's disposition toward the player from hostile to neutral.

## Behaviour

- Reputation adjustments affect only the directed source→target cell.
- Repeated adjustments accumulate.
- Values clamp safely to the supported 0–100 range.
- Reverse target→source reputation remains unchanged.
- Invalid, unsupported and same-faction adjustments are inert.
- Existing disposition thresholds and authored matrix-loading behaviour remain unchanged.

## Testing

- Manual K1 smoke:
  - To test:  warp to `tat_m18aa`, `additem tat17_sandperdis`, approach the sand people behind the sandcrawler.
  - Tuskens begin hostile.
  - Equipping Sand People Clothing makes them neutral under perception and AI targeting.
  - Removing the disguise restores hostility and engagement.


## Known issues / Omissions

This PR fixes the reputation and AI-perception portion of the disguise flow.

The separate close-range recognition bark currently has an independent one-line conversation-action defect: the bark displays, but its terminal reply action is not executed. That issue is intentionally excluded from this PR and will be submitted separately.
