### PR TITLE
[resource] Add module mount planning policy

### DIFF
--- a/include/reone/resource/modulepolicy.h
+++ b/include/reone/resource/modulepolicy.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "reone/resource/types.h"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace reone {
+namespace resource {
+
+/**
+ * Raw lookup bucket. Bucket order, and order within a bucket, decide which
+ * source wins an identical resref and resource type. Neither mount phase nor
+ * ownership takes part in that decision.
+ */
+enum class ResourceSourceBucket {
+    LooseDirectory,
+    EncapsulatedClass1,
+    ResourceImage,
+    EncapsulatedClass2,
+    KeyBif,
+};
+
+enum class EncapsulatedClass { Class1, Class2 };
+
+/**
+ * What causes a source to be removed. Ownership answers when a source goes
+ * away; it never answers where a source is searched.
+ *
+ * SaveSlot and ActiveModuleState are deliberately distinct: an outer save
+ * archive holds state for every module it has visited and survives a module
+ * transition, whereas the staged state of the module currently entered does
+ * not.
+ */
+enum class ResourceOwner {
+    Global,
+    SaveSlot,
+    ActiveModule,
+    ActiveModuleState,
+    TemporaryDiscovery,
+};
+
+enum class ModulePrimaryKind { SavedResourceImage, SavedArchive, Nwm, Mod, Rim };
+
+enum class ModulePrimaryOrigin {
+    GameInProgress,
+    NwmFiles,
+    Modules,
+    LivePackage,
+    ConfiguredModuleRoot,
+};
+
+/**
+ * Archive families the policy models. "_adrx" is absent on purpose: it has
+ * never been observed, is not a supported family, and must never be treated
+ * as "_adx".
+ *
+ * SavedResourceImage, SavedArchive and Nwm describe primary candidates rather
+ * than sources the module branch mounts. For the saved pair, mountMetadata
+ * describes the staged active table, not the discovery source it was found
+ * through.
+ */
+enum class ModuleArchiveFamily {
+    PrimaryMod,
+    PrimaryRim,
+    StaticRim,
+    AreaRim,
+    AdxRim,
+    Dialogue,
+    Localization,
+    PlayerSupport,
+    SavedResourceImage,
+    SavedArchive,
+    Nwm,
+};
+
+/// Phase of the module load a mount attempt belongs to.
+enum class ModuleMountPhase {
+    Support,
+    AdjunctImages,
+    ModuleBranch,
+    ActiveCurrentGame,
+};
+
+/// How many attempts of one family may end up mounted.
+enum class MountCardinality { ZeroOrOne, FirstSuccessful, AllSuccessful };
+
+/// What a failed attempt means for the module load as a whole.
+enum class MountFailureEffect { BestEffort, FailOrCurrentGameFallback, Required };
+
+/**
+ * One normalized source offered to the policy. Identifiers are opaque: the
+ * policy never reads them as filesystem paths and never manufactures one.
+ *
+ * packageOrder orders numbered packages; rootOrder orders configured module
+ * roots in their configured enumeration order. The two orderings are used
+ * differently by selection and by mount planning, so both are explicit.
+ */
+struct ModuleSourceCandidate {
+    std::string sourceId;
+    std::string rootId;
+    ModulePrimaryOrigin origin {ModulePrimaryOrigin::Modules};
+    ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
+    std::uint32_t packageOrder {0};
+    std::uint32_t rootOrder {0};
+};
+
+/**
+ * A source eligible to be the primary, with the kind that eligibility gives
+ * it. Origin and ordering are not repeated here: they belong to the source and
+ * duplicating them would allow the two copies to disagree.
+ */
+struct ModulePrimaryCandidate {
+    ModuleSourceCandidate source;
+    ModulePrimaryKind kind {ModulePrimaryKind::Rim};
+};
+
+/**
+ * The source chosen to enter or stage the module.
+ *
+ * This deliberately carries no bucket or class: the selected source is copied
+ * or staged, and the table eventually mounted for the active module can take a
+ * different form. Giving a selection object raw lookup metadata would conflate
+ * two separate decisions.
+ */
+struct ModulePrimarySelection {
+    ModulePrimaryCandidate candidate;
+    std::string canonicalModuleName;
+    bool fromSavedState {false};
+    bool isNwm {false};
+};
+
+/**
+ * Encapsulated class implied by a bucket, or nothing for a bucket that is not
+ * encapsulated. Class is derived rather than stored so that it cannot come to
+ * disagree with the bucket it describes.
+ */
+constexpr std::optional<EncapsulatedClass> encapsulatedClassOf(ResourceSourceBucket bucket) {
+    switch (bucket) {
+    case ResourceSourceBucket::EncapsulatedClass1: return EncapsulatedClass::Class1;
+    case ResourceSourceBucket::EncapsulatedClass2: return EncapsulatedClass::Class2;
+    default: return std::nullopt;
+    }
+}
+
+/// Bucket and ownership of a source once it is actually mounted.
+struct ModuleSourceMetadata {
+    ResourceSourceBucket bucket {ResourceSourceBucket::ResourceImage};
+    ResourceOwner owner {ResourceOwner::ActiveModule};
+};
+
+struct ResourceMountAttempt {
+    ModuleSourceCandidate source;
+    ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
+    ModuleMountPhase phase {ModuleMountPhase::ModuleBranch};
+    ModuleSourceMetadata metadata;
+    MountFailureEffect failureEffect {MountFailureEffect::BestEffort};
+    std::uint32_t attemptOrder {0};
+};
+
+/**
+ * Attempts for one family, in the order the loader tries them, together with
+ * how many of them may remain mounted. Cardinality is per family: a single
+ * rule covering every family is wrong in both directions.
+ */
+struct ModuleFamilyPlan {
+    ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
+    MountCardinality cardinality {MountCardinality::ZeroOrOne};
+    std::vector<ResourceMountAttempt> attempts;
+};
+
+/**
+ * The final active table for the module, staged under the current-game
+ * location. Both forms are described rather than resolved: which one applies
+ * depends on saved mode and on whether a required branch mount failed at run
+ * time, and neither is known to a pure policy. Performing the staging is not
+ * part of this policy.
+ *
+ * Meaningful only when the plan selected a primary. With no primary there is
+ * nothing to stage, and this is inert description rather than an instruction.
+ */
+struct ModuleActiveStatePlan {
+    std::string canonicalModuleName;
+    ModuleMountPhase phase {ModuleMountPhase::ActiveCurrentGame};
+    ResourceOwner owner {ResourceOwner::ActiveModuleState};
+    /// Used when saved mode was requested, or as the recovery route when a
+    /// required branch mount fails.
+    ModuleSourceMetadata encapsulatedArchive;
+    /// Used otherwise, when the module is present there as a resource image.
+    ModuleSourceMetadata resourceImage;
+    bool savedModeRequested {false};
+};
+
+/**
+ * Ordered plan for one module load. families holds the phases in loader order;
+ * the selected primary is not an entry in it, because selecting a source and
+ * mounting the module's tables are separate operations.
+ */
+struct ModuleLoadPlan {
+    std::optional<ModulePrimarySelection> primary;
+    std::vector<ModuleFamilyPlan> families;
+    ModuleActiveStatePlan activeState;
+};
+
+/**
+ * Inputs that are not properties of any single source.
+ *
+ * includeInSave mirrors the module-save table: when it is false, saved
+ * candidates are not eligible to be selected at all.
+ *
+ * savedMode reports that active saved state for this module was already
+ * detected under the current-game location, which is what makes the active
+ * table take its encapsulated form. It is an input to the policy, not
+ * something the policy discovers.
+ */
+struct ModulePolicyRequest {
+    GameID game {GameID::KotOR};
+    std::string moduleName;
+    bool includeInSave {true};
+    bool savedMode {false};
+};
+
+/// Raw lookup order. Independent of ownership and of mount phase.
+constexpr std::array<ResourceSourceBucket, 5> kRawResourceLookupOrder {
+    ResourceSourceBucket::LooseDirectory,
+    ResourceSourceBucket::EncapsulatedClass1,
+    ResourceSourceBucket::ResourceImage,
+    ResourceSourceBucket::EncapsulatedClass2,
+    ResourceSourceBucket::KeyBif,
+};
+
+/**
+ * Bucket, class and owner a family takes once mounted, or nothing when the
+ * family has no automatic mount route of its own. A packaged NWM module
+ * reaches its final form through staging, so its route is the caller's to
+ * choose; the policy assigns it no bucket rather than inventing one.
+ */
+std::optional<ModuleSourceMetadata> mountMetadata(ModuleArchiveFamily family);
+
+/**
+ * Choose the source used to enter or stage the module, or nothing when the
+ * inventory offers no eligible candidate. No path is invented on failure.
+ */
+std::optional<ModulePrimarySelection> selectModulePrimary(
+    const ModulePolicyRequest &request,
+    const std::vector<ModuleSourceCandidate> &inventory);
+
+/// Build the phased mount plan for the module.
+ModuleLoadPlan planModuleLoad(const ModulePolicyRequest &request,
+                              const std::vector<ModuleSourceCandidate> &inventory);
+
+} // namespace resource
+} // namespace reone

--- a/include/reone/resource/modulepolicy.h
+++ b/include/reone/resource/modulepolicy.h
@@ -63,9 +63,9 @@ enum class ModulePrimaryOrigin {
 };
 
 /**
- * Archive families the policy models. "_adrx" is absent on purpose: it has
- * never been observed, is not a supported family, and must never be treated
- * as "_adx".
+ * Archive families the policy models. The set is closed and matched exactly:
+ * a name that is not one of these does not become a member of the family it
+ * most resembles, and nothing catch-all stands in for one.
  *
  * SavedResourceImage, SavedArchive and Nwm describe primary candidates rather
  * than sources the module branch mounts. For the saved pair, mountMetadata

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -63,6 +63,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/id.h
     ${RESOURCE_INCLUDE_DIR}/layout.h
     ${RESOURCE_INCLUDE_DIR}/ltr.h
+    ${RESOURCE_INCLUDE_DIR}/modulepolicy.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/appearance.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/genericdoors.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/heads.h
@@ -142,6 +143,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/gameprobe.cpp
     ${RESOURCE_SOURCE_DIR}/gff.cpp
     ${RESOURCE_SOURCE_DIR}/ltr.cpp
+    ${RESOURCE_SOURCE_DIR}/modulepolicy.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/appearance.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/genericdoors.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/heads.cpp

--- a/src/libs/resource/modulepolicy.cpp
+++ b/src/libs/resource/modulepolicy.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "reone/resource/modulepolicy.h"
+
+#include <algorithm>
+#include <limits>
+#include <tuple>
+
+namespace reone {
+namespace resource {
+namespace {
+
+std::optional<ModulePrimaryKind> primaryKind(ModuleArchiveFamily family) {
+    switch (family) {
+    case ModuleArchiveFamily::SavedResourceImage: return ModulePrimaryKind::SavedResourceImage;
+    case ModuleArchiveFamily::SavedArchive: return ModulePrimaryKind::SavedArchive;
+    case ModuleArchiveFamily::Nwm: return ModulePrimaryKind::Nwm;
+    case ModuleArchiveFamily::PrimaryMod: return ModulePrimaryKind::Mod;
+    case ModuleArchiveFamily::PrimaryRim: return ModulePrimaryKind::Rim;
+    default: return std::nullopt;
+    }
+}
+
+bool isNormalModuleRoot(ModulePrimaryOrigin origin) {
+    return origin == ModulePrimaryOrigin::Modules ||
+           origin == ModulePrimaryOrigin::ConfiguredModuleRoot;
+}
+
+/**
+ * Source class of a candidate, or -1 when it is not eligible.
+ *
+ * The two games differ materially here: K1 consults the ordinary module
+ * location before numbered packages, K2 consults numbered packages first.
+ */
+int sourceClass(const ModulePolicyRequest &request, const ModuleSourceCandidate &candidate) {
+    switch (candidate.family) {
+    case ModuleArchiveFamily::SavedResourceImage:
+        if (!request.includeInSave) return -1;
+        return candidate.origin == ModulePrimaryOrigin::GameInProgress ? 0 : -1;
+    case ModuleArchiveFamily::SavedArchive:
+        if (!request.includeInSave) return -1;
+        return candidate.origin == ModulePrimaryOrigin::GameInProgress ? 1 : -1;
+    case ModuleArchiveFamily::Nwm:
+        return candidate.origin == ModulePrimaryOrigin::NwmFiles ? 2 : -1;
+    case ModuleArchiveFamily::PrimaryMod:
+    case ModuleArchiveFamily::PrimaryRim:
+        if (request.game == GameID::KotOR) {
+            if (candidate.origin == ModulePrimaryOrigin::Modules) return 3;
+            if (candidate.origin == ModulePrimaryOrigin::LivePackage) return 4;
+            return -1;
+        }
+        if (candidate.origin == ModulePrimaryOrigin::LivePackage) return 3;
+        if (isNormalModuleRoot(candidate.origin)) return 4;
+        return -1;
+    default:
+        return -1;
+    }
+}
+
+using SelectionRank = std::tuple<int, std::uint32_t, std::uint32_t, std::uint32_t, std::size_t>;
+
+/**
+ * Rank of an eligible candidate. Lower wins.
+ *
+ * Within a numbered package the engine probes one package at a time and stops
+ * at the first hit, so package order outranks archive type. Within the ordinary
+ * module location the engine exposes every root at once and tests MOD across
+ * all of them before RIM, so archive type outranks root order there. Root order
+ * is then consumed in selection-priority order, which runs opposite to the
+ * configured order used when mounting, and the base location is the fallback.
+ */
+SelectionRank selectionRank(int cls, const ModuleSourceCandidate &candidate, std::size_t index) {
+    constexpr auto kMaxRoot = std::numeric_limits<std::uint32_t>::max();
+    std::uint32_t typeRank = candidate.family == ModuleArchiveFamily::PrimaryMod ? 0 : 1;
+    if (candidate.origin == ModulePrimaryOrigin::LivePackage) {
+        return {cls, candidate.packageOrder, typeRank, 0, index};
+    }
+    if (isNormalModuleRoot(candidate.origin)) {
+        bool configured = candidate.origin == ModulePrimaryOrigin::ConfiguredModuleRoot;
+        return {cls,
+                typeRank,
+                configured ? 0u : 1u,
+                configured ? kMaxRoot - candidate.rootOrder : 0u,
+                index};
+    }
+    return {cls, 0, 0, 0, index};
+}
+
+/**
+ * Candidates of one family, in configured root order, base location last.
+ *
+ * Configured module roots are a K2 concept. K1 enumerates no such roots for
+ * any family, so it never sees them here either; letting them through would
+ * plan a mount K1 cannot reach, and would contradict the selection rules.
+ */
+std::vector<const ModuleSourceCandidate *> rootsThenBase(
+    const std::vector<ModuleSourceCandidate> &inventory,
+    ModuleArchiveFamily family,
+    bool allowConfiguredRoots) {
+    std::vector<const ModuleSourceCandidate *> configured;
+    std::vector<const ModuleSourceCandidate *> base;
+    for (const auto &candidate : inventory) {
+        if (candidate.family != family) continue;
+        if (candidate.origin == ModulePrimaryOrigin::ConfiguredModuleRoot) {
+            if (allowConfiguredRoots) configured.push_back(&candidate);
+        } else if (candidate.origin == ModulePrimaryOrigin::Modules) {
+            base.push_back(&candidate);
+        }
+    }
+    std::stable_sort(configured.begin(), configured.end(), [](const auto *a, const auto *b) {
+        return a->rootOrder < b->rootOrder;
+    });
+    configured.insert(configured.end(), base.begin(), base.end());
+    return configured;
+}
+
+/// Candidates of one family, base location first, then configured root order.
+std::vector<const ModuleSourceCandidate *> baseThenRoots(
+    const std::vector<ModuleSourceCandidate> &inventory,
+    ModuleArchiveFamily family,
+    bool allowConfiguredRoots) {
+    auto ordered = rootsThenBase(inventory, family, allowConfiguredRoots);
+    std::stable_partition(ordered.begin(), ordered.end(), [](const auto *candidate) {
+        return candidate->origin == ModulePrimaryOrigin::Modules;
+    });
+    return ordered;
+}
+
+/// The single exact adjunct image of a family, if the inventory offers one.
+const ModuleSourceCandidate *exactAdjunct(const std::vector<ModuleSourceCandidate> &inventory,
+                                          ModuleArchiveFamily family) {
+    auto it = std::find_if(inventory.begin(), inventory.end(), [&](const auto &candidate) {
+        return candidate.family == family;
+    });
+    return it != inventory.end() ? &*it : nullptr;
+}
+
+class PlanBuilder {
+public:
+    explicit PlanBuilder(ModuleLoadPlan &plan) :
+        _plan(plan) {
+    }
+
+    void add(ModuleArchiveFamily family,
+             MountCardinality cardinality,
+             ModuleMountPhase phase,
+             MountFailureEffect failureEffect,
+             const std::vector<const ModuleSourceCandidate *> &sources) {
+        auto metadata = mountMetadata(family);
+        if (sources.empty() || !metadata) return;
+        ModuleFamilyPlan familyPlan;
+        familyPlan.family = family;
+        familyPlan.cardinality = cardinality;
+        // A family that admits at most one mount is given at most one attempt,
+        // so that cardinality and attempt count cannot describe different plans.
+        auto count = cardinality == MountCardinality::ZeroOrOne ? 1u : sources.size();
+        for (std::size_t i = 0; i < std::min<std::size_t>(count, sources.size()); ++i) {
+            familyPlan.attempts.push_back(ResourceMountAttempt {
+                *sources[i], family, phase, *metadata, failureEffect, _order++});
+        }
+        _plan.families.push_back(std::move(familyPlan));
+    }
+
+private:
+    ModuleLoadPlan &_plan;
+    std::uint32_t _order {0};
+};
+
+} // namespace
+
+std::optional<ModuleSourceMetadata> mountMetadata(ModuleArchiveFamily family) {
+    switch (family) {
+    // Module archives, saved module state and the dialogue archive are all
+    // encapsulated class 2. Class 1 is evidence-backed and belongs to the
+    // global patch archive and package texture archives, none of which is a
+    // module source, so no module family may claim it.
+    case ModuleArchiveFamily::PrimaryMod:
+    case ModuleArchiveFamily::Dialogue:
+    case ModuleArchiveFamily::Localization:
+    case ModuleArchiveFamily::PlayerSupport:
+        return ModuleSourceMetadata {ResourceSourceBucket::EncapsulatedClass2,
+                                     ResourceOwner::ActiveModule};
+    case ModuleArchiveFamily::SavedArchive:
+        return ModuleSourceMetadata {ResourceSourceBucket::EncapsulatedClass2,
+                                     ResourceOwner::ActiveModuleState};
+    case ModuleArchiveFamily::SavedResourceImage:
+        return ModuleSourceMetadata {ResourceSourceBucket::ResourceImage,
+                                     ResourceOwner::ActiveModuleState};
+    // A packaged module reaches its final form through staging, so its mount
+    // route belongs to the caller. Assigning it a bucket here would invent one.
+    case ModuleArchiveFamily::Nwm:
+        return std::nullopt;
+    default:
+        return ModuleSourceMetadata {ResourceSourceBucket::ResourceImage,
+                                     ResourceOwner::ActiveModule};
+    }
+}
+
+std::optional<ModulePrimarySelection> selectModulePrimary(
+    const ModulePolicyRequest &request,
+    const std::vector<ModuleSourceCandidate> &inventory) {
+    const ModuleSourceCandidate *selected = nullptr;
+    ModulePrimaryKind selectedKind {ModulePrimaryKind::Rim};
+    SelectionRank selectedRank {std::numeric_limits<int>::max(),
+                                std::numeric_limits<std::uint32_t>::max(),
+                                std::numeric_limits<std::uint32_t>::max(),
+                                std::numeric_limits<std::uint32_t>::max(),
+                                std::numeric_limits<std::size_t>::max()};
+    for (std::size_t i = 0; i < inventory.size(); ++i) {
+        const auto &candidate = inventory[i];
+        auto kind = primaryKind(candidate.family);
+        auto cls = sourceClass(request, candidate);
+        if (!kind || cls < 0) continue;
+        auto rank = selectionRank(cls, candidate, i);
+        if (rank < selectedRank) {
+            selected = &candidate;
+            selectedKind = *kind;
+            selectedRank = rank;
+        }
+    }
+    if (!selected) return std::nullopt;
+
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {*selected, selectedKind};
+    selection.canonicalModuleName = request.moduleName;
+    selection.fromSavedState = selectedKind == ModulePrimaryKind::SavedResourceImage ||
+                               selectedKind == ModulePrimaryKind::SavedArchive;
+    selection.isNwm = selectedKind == ModulePrimaryKind::Nwm;
+    return selection;
+}
+
+ModuleLoadPlan planModuleLoad(const ModulePolicyRequest &request,
+                              const std::vector<ModuleSourceCandidate> &inventory) {
+    ModuleLoadPlan plan;
+    plan.primary = selectModulePrimary(request, inventory);
+
+    plan.activeState.canonicalModuleName = request.moduleName;
+    plan.activeState.encapsulatedArchive = *mountMetadata(ModuleArchiveFamily::SavedArchive);
+    plan.activeState.resourceImage = *mountMetadata(ModuleArchiveFamily::SavedResourceImage);
+    plan.activeState.savedModeRequested = request.savedMode;
+
+    const bool k1 = request.game == GameID::KotOR;
+    // Configured module roots are enumerated by K2 only, for every family.
+    const bool roots = !k1;
+    PlanBuilder builder(plan);
+
+    // Support archives. K1 mounts a player archive here; neither game lets a
+    // support failure fail the module load.
+    if (k1) {
+        builder.add(ModuleArchiveFamily::PlayerSupport,
+                    MountCardinality::ZeroOrOne,
+                    ModuleMountPhase::Support,
+                    MountFailureEffect::BestEffort,
+                    baseThenRoots(inventory, ModuleArchiveFamily::PlayerSupport, roots));
+    }
+    builder.add(ModuleArchiveFamily::Localization,
+                MountCardinality::AllSuccessful,
+                ModuleMountPhase::Support,
+                MountFailureEffect::BestEffort,
+                baseThenRoots(inventory, ModuleArchiveFamily::Localization, roots));
+
+    // Adjunct images, exact and singular, tried before the module's own
+    // packaging is resolved. An absent adjunct is not a failure.
+    for (auto family : {ModuleArchiveFamily::AreaRim, ModuleArchiveFamily::AdxRim}) {
+        if (const auto *adjunct = exactAdjunct(inventory, family)) {
+            builder.add(family,
+                        MountCardinality::ZeroOrOne,
+                        ModuleMountPhase::AdjunctImages,
+                        MountFailureEffect::BestEffort,
+                        {adjunct});
+        }
+    }
+
+    // The branch turns on a module archive being visible in the module
+    // locations, not on which source was selected as the primary.
+    auto moduleArchives = baseThenRoots(inventory, ModuleArchiveFamily::PrimaryMod, roots);
+    if (!moduleArchives.empty()) {
+        builder.add(ModuleArchiveFamily::PrimaryMod,
+                    k1 ? MountCardinality::ZeroOrOne : MountCardinality::AllSuccessful,
+                    ModuleMountPhase::ModuleBranch,
+                    MountFailureEffect::FailOrCurrentGameFallback,
+                    moduleArchives);
+        return plan;
+    }
+
+    // Split branch. The static image stops at the first root that supplies it
+    // and falls back to the base location, so its attempts run configured roots
+    // first. Dialogue attempts every location and never fails the load, and is
+    // absent from the K1 path entirely.
+    builder.add(ModuleArchiveFamily::StaticRim,
+                MountCardinality::FirstSuccessful,
+                ModuleMountPhase::ModuleBranch,
+                MountFailureEffect::FailOrCurrentGameFallback,
+                rootsThenBase(inventory, ModuleArchiveFamily::StaticRim, roots));
+    if (!k1) {
+        builder.add(ModuleArchiveFamily::Dialogue,
+                    MountCardinality::AllSuccessful,
+                    ModuleMountPhase::ModuleBranch,
+                    MountFailureEffect::BestEffort,
+                    baseThenRoots(inventory, ModuleArchiveFamily::Dialogue, roots));
+    }
+    return plan;
+}
+
+} // namespace resource
+} // namespace reone

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
+    ${TESTS_SOURCE_DIR}/resource/modulepolicy.cpp
     ${TESTS_SOURCE_DIR}/resource/replacements.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dawriter.cpp

--- a/test/resource/modulepolicy.cpp
+++ b/test/resource/modulepolicy.cpp
@@ -519,8 +519,8 @@ TEST(ModulePolicy, attempt_order_is_deterministic_and_independent_of_inventory_o
 }
 
 TEST(ModulePolicy, never_synthesizes_a_family_the_inventory_did_not_offer) {
-    // There is no unsupported-adjunct family to synthesize, and a plan only
-    // ever contains families that were actually offered.
+    // Families are matched exactly, so a plan only ever contains the families
+    // the inventory actually offered.
     auto plan = planModuleLoad(request(GameID::TSL), {
         source("module.rim", ModuleArchiveFamily::PrimaryRim),
         source("module_adx.rim", ModuleArchiveFamily::AdxRim),

--- a/test/resource/modulepolicy.cpp
+++ b/test/resource/modulepolicy.cpp
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/modulepolicy.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+namespace {
+
+ModuleSourceCandidate source(std::string id,
+                             ModuleArchiveFamily family,
+                             ModulePrimaryOrigin origin = ModulePrimaryOrigin::Modules,
+                             std::string root = "modules",
+                             std::uint32_t packageOrder = 0,
+                             std::uint32_t rootOrder = 0) {
+    return {std::move(id), std::move(root), origin, family, packageOrder, rootOrder};
+}
+
+ModulePolicyRequest request(GameID game, bool includeInSave = true, bool savedMode = false) {
+    ModulePolicyRequest req;
+    req.game = game;
+    req.moduleName = "module";
+    req.includeInSave = includeInSave;
+    req.savedMode = savedMode;
+    return req;
+}
+
+const ModuleFamilyPlan *familyPlan(const ModuleLoadPlan &plan, ModuleArchiveFamily family) {
+    for (const auto &entry : plan.families) {
+        if (entry.family == family) return &entry;
+    }
+    return nullptr;
+}
+
+std::vector<std::string> attemptIds(const ModuleLoadPlan &plan, ModuleArchiveFamily family) {
+    std::vector<std::string> ids;
+    if (const auto *entry = familyPlan(plan, family)) {
+        for (const auto &attempt : entry->attempts) ids.push_back(attempt.source.sourceId);
+    }
+    return ids;
+}
+
+std::vector<ModuleArchiveFamily> plannedFamilies(const ModuleLoadPlan &plan) {
+    std::vector<ModuleArchiveFamily> families;
+    for (const auto &entry : plan.families) families.push_back(entry.family);
+    return families;
+}
+
+// 14.1 Lookup metadata
+
+TEST(ModulePolicy, exposes_the_five_raw_buckets_in_verified_order) {
+    const std::array expected {
+        ResourceSourceBucket::LooseDirectory,
+        ResourceSourceBucket::EncapsulatedClass1,
+        ResourceSourceBucket::ResourceImage,
+        ResourceSourceBucket::EncapsulatedClass2,
+        ResourceSourceBucket::KeyBif,
+    };
+    EXPECT_EQ(expected, kRawResourceLookupOrder);
+}
+
+TEST(ModulePolicy, assigns_module_saved_and_dialogue_archives_to_encapsulated_class_two) {
+    for (auto family : {ModuleArchiveFamily::PrimaryMod,
+                        ModuleArchiveFamily::SavedArchive,
+                        ModuleArchiveFamily::Dialogue}) {
+        auto metadata = mountMetadata(family);
+        ASSERT_TRUE(metadata);
+        EXPECT_EQ(ResourceSourceBucket::EncapsulatedClass2, metadata->bucket);
+        EXPECT_EQ(EncapsulatedClass::Class2, encapsulatedClassOf(metadata->bucket));
+    }
+}
+
+TEST(ModulePolicy, derives_encapsulated_class_from_the_bucket) {
+    EXPECT_EQ(EncapsulatedClass::Class1,
+              encapsulatedClassOf(ResourceSourceBucket::EncapsulatedClass1));
+    EXPECT_EQ(EncapsulatedClass::Class2,
+              encapsulatedClassOf(ResourceSourceBucket::EncapsulatedClass2));
+    for (auto bucket : {ResourceSourceBucket::LooseDirectory,
+                        ResourceSourceBucket::ResourceImage,
+                        ResourceSourceBucket::KeyBif}) {
+        EXPECT_FALSE(encapsulatedClassOf(bucket));
+    }
+}
+
+TEST(ModulePolicy, assigns_images_to_the_resource_image_bucket) {
+    for (auto family : {ModuleArchiveFamily::PrimaryRim,
+                        ModuleArchiveFamily::SavedResourceImage,
+                        ModuleArchiveFamily::StaticRim,
+                        ModuleArchiveFamily::AreaRim,
+                        ModuleArchiveFamily::AdxRim}) {
+        auto metadata = mountMetadata(family);
+        ASSERT_TRUE(metadata);
+        EXPECT_EQ(ResourceSourceBucket::ResourceImage, metadata->bucket);
+        EXPECT_FALSE(encapsulatedClassOf(metadata->bucket));
+    }
+}
+
+TEST(ModulePolicy, assigns_no_bucket_to_a_packaged_nwm_module) {
+    // Its final form comes from staging, so the mount route is the caller's.
+    EXPECT_FALSE(mountMetadata(ModuleArchiveFamily::Nwm));
+}
+
+TEST(ModulePolicy, ownership_does_not_determine_lookup_priority) {
+    auto adjunct = mountMetadata(ModuleArchiveFamily::AdxRim);
+    auto savedArchive = mountMetadata(ModuleArchiveFamily::SavedArchive);
+    ASSERT_TRUE(adjunct);
+    ASSERT_TRUE(savedArchive);
+    EXPECT_EQ(ResourceOwner::ActiveModule, adjunct->owner);
+    EXPECT_EQ(ResourceOwner::ActiveModuleState, savedArchive->owner);
+
+    // Despite the saved archive owning later-cleared state, the adjunct image
+    // sits in an earlier bucket and therefore wins an identical raw key.
+    auto position = [](ResourceSourceBucket bucket) {
+        return std::find(kRawResourceLookupOrder.begin(), kRawResourceLookupOrder.end(), bucket) -
+               kRawResourceLookupOrder.begin();
+    };
+    EXPECT_LT(position(adjunct->bucket), position(savedArchive->bucket));
+}
+
+// 14.2 Primary selection
+
+TEST(ModulePolicy, k1_selects_saved_image_then_archive_then_nwm_then_modules_then_live) {
+    const std::vector<ModuleSourceCandidate> all {
+        source("live-mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::LivePackage, "live1"),
+        source("modules-mod", ModuleArchiveFamily::PrimaryMod),
+        source("nwm", ModuleArchiveFamily::Nwm, ModulePrimaryOrigin::NwmFiles, "nwm"),
+        source("save-sav", ModuleArchiveFamily::SavedArchive, ModulePrimaryOrigin::GameInProgress, "save"),
+        source("save-rsv", ModuleArchiveFamily::SavedResourceImage,
+               ModulePrimaryOrigin::GameInProgress, "save"),
+    };
+    const std::vector<std::string> expected {"save-rsv", "save-sav", "nwm", "modules-mod", "live-mod"};
+    auto remaining = all;
+    for (const auto &next : expected) {
+        auto selection = selectModulePrimary(request(GameID::KotOR), remaining);
+        ASSERT_TRUE(selection) << next;
+        EXPECT_EQ(next, selection->candidate.source.sourceId);
+        remaining.erase(std::remove_if(remaining.begin(), remaining.end(),
+                                       [&](const auto &c) { return c.sourceId == next; }),
+                        remaining.end());
+    }
+    EXPECT_FALSE(selectModulePrimary(request(GameID::KotOR), remaining));
+}
+
+TEST(ModulePolicy, k2_selects_saved_image_then_archive_then_nwm_then_live_then_module_roots) {
+    const std::vector<ModuleSourceCandidate> all {
+        source("modules-mod", ModuleArchiveFamily::PrimaryMod),
+        source("live-mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::LivePackage, "live1"),
+        source("nwm", ModuleArchiveFamily::Nwm, ModulePrimaryOrigin::NwmFiles, "nwm"),
+        source("save-sav", ModuleArchiveFamily::SavedArchive, ModulePrimaryOrigin::GameInProgress, "save"),
+        source("save-rsv", ModuleArchiveFamily::SavedResourceImage,
+               ModulePrimaryOrigin::GameInProgress, "save"),
+    };
+    const std::vector<std::string> expected {"save-rsv", "save-sav", "nwm", "live-mod", "modules-mod"};
+    auto remaining = all;
+    for (const auto &next : expected) {
+        auto selection = selectModulePrimary(request(GameID::TSL), remaining);
+        ASSERT_TRUE(selection) << next;
+        EXPECT_EQ(next, selection->candidate.source.sourceId);
+        remaining.erase(std::remove_if(remaining.begin(), remaining.end(),
+                                       [&](const auto &c) { return c.sourceId == next; }),
+                        remaining.end());
+    }
+}
+
+TEST(ModulePolicy, prefers_a_module_archive_to_a_base_image_within_one_root) {
+    for (auto game : {GameID::KotOR, GameID::TSL}) {
+        auto selection = selectModulePrimary(request(game), {
+            source("module.rim", ModuleArchiveFamily::PrimaryRim),
+            source("module.mod", ModuleArchiveFamily::PrimaryMod),
+        });
+        ASSERT_TRUE(selection);
+        EXPECT_EQ("module.mod", selection->candidate.source.sourceId);
+        EXPECT_EQ(ModulePrimaryKind::Mod, selection->candidate.kind);
+    }
+}
+
+TEST(ModulePolicy, k2_tests_the_module_archive_across_every_root_before_the_image) {
+    // The ordinary class exposes all roots at once, so a MOD anywhere beats a
+    // RIM in a root that would otherwise be consulted first.
+    auto selection = selectModulePrimary(request(GameID::TSL), {
+        source("root-rim", ModuleArchiveFamily::PrimaryRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root", 0, 1),
+        source("base-mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+    });
+    ASSERT_TRUE(selection);
+    EXPECT_EQ("base-mod", selection->candidate.source.sourceId);
+}
+
+TEST(ModulePolicy, live_packages_are_probed_one_package_at_a_time) {
+    // Each package is probed alone and the loop stops on a hit, so the first
+    // package wins with an image even when a later package has an archive.
+    auto selection = selectModulePrimary(request(GameID::TSL), {
+        source("live2-mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::LivePackage, "live2", 2),
+        source("live1-rim", ModuleArchiveFamily::PrimaryRim,
+               ModulePrimaryOrigin::LivePackage, "live1", 1),
+    });
+    ASSERT_TRUE(selection);
+    EXPECT_EQ("live1-rim", selection->candidate.source.sourceId);
+}
+
+TEST(ModulePolicy, k2_prefers_configured_roots_in_selection_order_then_the_base_location) {
+    // Selection consumes configured roots in the reverse of their configured
+    // order, and the base location is the fallback.
+    auto selection = selectModulePrimary(request(GameID::TSL), {
+        source("base-mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+        source("root0-mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+        source("root1-mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root1", 0, 1),
+    });
+    ASSERT_TRUE(selection);
+    EXPECT_EQ("root1-mod", selection->candidate.source.sourceId);
+
+    auto baseOnly = selectModulePrimary(request(GameID::TSL), {
+        source("base-mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+    });
+    ASSERT_TRUE(baseOnly);
+    EXPECT_EQ("base-mod", baseOnly->candidate.source.sourceId);
+}
+
+TEST(ModulePolicy, excludes_saved_candidates_when_include_in_save_disallows_them) {
+    const std::vector<ModuleSourceCandidate> inventory {
+        source("save-rsv", ModuleArchiveFamily::SavedResourceImage,
+               ModulePrimaryOrigin::GameInProgress, "save"),
+        source("save-sav", ModuleArchiveFamily::SavedArchive,
+               ModulePrimaryOrigin::GameInProgress, "save"),
+        source("modules-rim", ModuleArchiveFamily::PrimaryRim),
+    };
+    auto included = selectModulePrimary(request(GameID::TSL, true), inventory);
+    ASSERT_TRUE(included);
+    EXPECT_EQ("save-rsv", included->candidate.source.sourceId);
+    EXPECT_TRUE(included->fromSavedState);
+
+    auto excluded = selectModulePrimary(request(GameID::TSL, false), inventory);
+    ASSERT_TRUE(excluded);
+    EXPECT_EQ("modules-rim", excluded->candidate.source.sourceId);
+    EXPECT_FALSE(excluded->fromSavedState);
+}
+
+TEST(ModulePolicy, selects_nothing_from_an_empty_or_sidecar_only_inventory) {
+    EXPECT_FALSE(selectModulePrimary(request(GameID::TSL), {}));
+    EXPECT_FALSE(selectModulePrimary(request(GameID::TSL), {
+                                                               source("module_s.rim", ModuleArchiveFamily::StaticRim),
+                                                               source("module_a.rim", ModuleArchiveFamily::AreaRim),
+                                                               source("module_dlg.erf", ModuleArchiveFamily::Dialogue),
+                                                           }));
+}
+
+TEST(ModulePolicy, records_provenance_without_giving_the_selection_a_bucket) {
+    auto selection = selectModulePrimary(request(GameID::TSL), {
+        source("nwm", ModuleArchiveFamily::Nwm, ModulePrimaryOrigin::NwmFiles, "nwm"),
+    });
+    ASSERT_TRUE(selection);
+    EXPECT_TRUE(selection->isNwm);
+    EXPECT_EQ(ModulePrimaryOrigin::NwmFiles, selection->candidate.source.origin);
+    EXPECT_EQ("module", selection->canonicalModuleName);
+}
+
+TEST(ModulePolicy, k1_ignores_configured_module_roots_when_planning) {
+    // Configured roots are a K2 concept. K1 must neither select nor plan one,
+    // and a root archive must not take the branch that suppresses the static
+    // image.
+    const std::vector<ModuleSourceCandidate> inventory {
+        source("root.mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root", 0, 0),
+        source("base_s.rim", ModuleArchiveFamily::StaticRim, ModulePrimaryOrigin::Modules),
+        source("root_s.rim", ModuleArchiveFamily::StaticRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root", 0, 0),
+        source("base.rim", ModuleArchiveFamily::PrimaryRim, ModulePrimaryOrigin::Modules),
+    };
+    auto plan = planModuleLoad(request(GameID::KotOR), inventory);
+
+    ASSERT_TRUE(plan.primary);
+    EXPECT_EQ("base.rim", plan.primary->candidate.source.sourceId);
+    EXPECT_FALSE(familyPlan(plan, ModuleArchiveFamily::PrimaryMod));
+    EXPECT_EQ((std::vector<std::string> {"base_s.rim"}),
+              attemptIds(plan, ModuleArchiveFamily::StaticRim));
+
+    // K2 reaches both.
+    auto k2 = planModuleLoad(request(GameID::TSL), inventory);
+    EXPECT_EQ((std::vector<std::string> {"root.mod"}),
+              attemptIds(k2, ModuleArchiveFamily::PrimaryMod));
+}
+
+TEST(ModulePolicy, a_zero_or_one_family_is_never_given_more_than_one_attempt) {
+    auto plan = planModuleLoad(request(GameID::KotOR), {
+        source("base.rim", ModuleArchiveFamily::PrimaryRim),
+        source("base.mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+        source("other.mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+    });
+    const auto *archives = familyPlan(plan, ModuleArchiveFamily::PrimaryMod);
+    ASSERT_TRUE(archives);
+    EXPECT_EQ(MountCardinality::ZeroOrOne, archives->cardinality);
+    EXPECT_EQ(1u, archives->attempts.size());
+}
+
+// 14.3 Phased mount planning
+
+TEST(ModulePolicy, plans_the_area_image_before_the_adx_image_in_both_games) {
+    for (auto game : {GameID::KotOR, GameID::TSL}) {
+        auto plan = planModuleLoad(request(game), {
+            source("module.rim", ModuleArchiveFamily::PrimaryRim),
+            source("module_adx.rim", ModuleArchiveFamily::AdxRim),
+            source("module_a.rim", ModuleArchiveFamily::AreaRim),
+        });
+        const auto *area = familyPlan(plan, ModuleArchiveFamily::AreaRim);
+        const auto *adx = familyPlan(plan, ModuleArchiveFamily::AdxRim);
+        ASSERT_TRUE(area);
+        ASSERT_TRUE(adx);
+        EXPECT_EQ(MountCardinality::ZeroOrOne, area->cardinality);
+        EXPECT_EQ(MountCardinality::ZeroOrOne, adx->cardinality);
+        EXPECT_EQ(ModuleMountPhase::AdjunctImages, area->attempts[0].phase);
+        EXPECT_LT(area->attempts[0].attemptOrder, adx->attempts[0].attemptOrder);
+    }
+}
+
+TEST(ModulePolicy, a_module_archive_suppresses_the_static_image_in_both_games) {
+    for (auto game : {GameID::KotOR, GameID::TSL}) {
+        auto plan = planModuleLoad(request(game), {
+            source("module.mod", ModuleArchiveFamily::PrimaryMod),
+            source("module_s.rim", ModuleArchiveFamily::StaticRim),
+            source("module_a.rim", ModuleArchiveFamily::AreaRim),
+        });
+        EXPECT_TRUE(familyPlan(plan, ModuleArchiveFamily::PrimaryMod));
+        EXPECT_FALSE(familyPlan(plan, ModuleArchiveFamily::StaticRim));
+        // The adjunct is unaffected by the module's packaging.
+        EXPECT_TRUE(familyPlan(plan, ModuleArchiveFamily::AreaRim));
+    }
+}
+
+TEST(ModulePolicy, k2_module_archive_suppresses_dialogue) {
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.mod", ModuleArchiveFamily::PrimaryMod),
+        source("module_dlg.erf", ModuleArchiveFamily::Dialogue),
+    });
+    EXPECT_FALSE(familyPlan(plan, ModuleArchiveFamily::Dialogue));
+}
+
+TEST(ModulePolicy, k1_never_plans_dialogue) {
+    auto plan = planModuleLoad(request(GameID::KotOR), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("module_s.rim", ModuleArchiveFamily::StaticRim),
+        source("module_dlg.erf", ModuleArchiveFamily::Dialogue),
+    });
+    EXPECT_TRUE(familyPlan(plan, ModuleArchiveFamily::StaticRim));
+    EXPECT_FALSE(familyPlan(plan, ModuleArchiveFamily::Dialogue));
+}
+
+TEST(ModulePolicy, k1_plans_the_module_archive_as_a_single_base_attempt) {
+    auto plan = planModuleLoad(request(GameID::KotOR), {
+        source("base.mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+        source("root.mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root", 0, 0),
+    });
+    const auto *archives = familyPlan(plan, ModuleArchiveFamily::PrimaryMod);
+    ASSERT_TRUE(archives);
+    EXPECT_EQ(MountCardinality::ZeroOrOne, archives->cardinality);
+    EXPECT_EQ((std::vector<std::string> {"base.mod"}),
+              attemptIds(plan, ModuleArchiveFamily::PrimaryMod));
+}
+
+TEST(ModulePolicy, k2_plans_the_module_archive_across_base_and_every_configured_root) {
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("root1.mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root1", 0, 1),
+        source("base.mod", ModuleArchiveFamily::PrimaryMod, ModulePrimaryOrigin::Modules),
+        source("root0.mod", ModuleArchiveFamily::PrimaryMod,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+    });
+    const auto *archives = familyPlan(plan, ModuleArchiveFamily::PrimaryMod);
+    ASSERT_TRUE(archives);
+    EXPECT_EQ(MountCardinality::AllSuccessful, archives->cardinality);
+    EXPECT_EQ(MountFailureEffect::FailOrCurrentGameFallback, archives->attempts[0].failureEffect);
+    // Base first, then configured roots in configured order regardless of the
+    // order the inventory happened to list them in.
+    EXPECT_EQ((std::vector<std::string> {"base.mod", "root0.mod", "root1.mod"}),
+              attemptIds(plan, ModuleArchiveFamily::PrimaryMod));
+}
+
+TEST(ModulePolicy, k2_plans_the_static_image_first_successful_across_roots_then_base) {
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("base_s.rim", ModuleArchiveFamily::StaticRim, ModulePrimaryOrigin::Modules),
+        source("root1_s.rim", ModuleArchiveFamily::StaticRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root1", 0, 1),
+        source("root0_s.rim", ModuleArchiveFamily::StaticRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+    });
+    const auto *statics = familyPlan(plan, ModuleArchiveFamily::StaticRim);
+    ASSERT_TRUE(statics);
+    EXPECT_EQ(MountCardinality::FirstSuccessful, statics->cardinality);
+    EXPECT_EQ((std::vector<std::string> {"root0_s.rim", "root1_s.rim", "base_s.rim"}),
+              attemptIds(plan, ModuleArchiveFamily::StaticRim));
+}
+
+TEST(ModulePolicy, k2_plans_dialogue_across_base_and_every_root_as_best_effort) {
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("root0_dlg.erf", ModuleArchiveFamily::Dialogue,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+        source("base_dlg.erf", ModuleArchiveFamily::Dialogue, ModulePrimaryOrigin::Modules),
+    });
+    const auto *dialogue = familyPlan(plan, ModuleArchiveFamily::Dialogue);
+    ASSERT_TRUE(dialogue);
+    EXPECT_EQ(MountCardinality::AllSuccessful, dialogue->cardinality);
+    EXPECT_EQ(MountFailureEffect::BestEffort, dialogue->attempts[0].failureEffect);
+    EXPECT_EQ((std::vector<std::string> {"base_dlg.erf", "root0_dlg.erf"}),
+              attemptIds(plan, ModuleArchiveFamily::Dialogue));
+}
+
+TEST(ModulePolicy, plans_support_archives_before_the_adjunct_phase) {
+    auto k1 = planModuleLoad(request(GameID::KotOR), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("players", ModuleArchiveFamily::PlayerSupport),
+        source("lips_loc", ModuleArchiveFamily::Localization),
+        source("module_a.rim", ModuleArchiveFamily::AreaRim),
+    });
+    EXPECT_EQ((std::vector<ModuleArchiveFamily> {ModuleArchiveFamily::PlayerSupport,
+                                                 ModuleArchiveFamily::Localization,
+                                                 ModuleArchiveFamily::AreaRim}),
+              plannedFamilies(k1));
+
+    // The player archive is a K1 support mount and has no K2 counterpart.
+    auto k2 = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("players", ModuleArchiveFamily::PlayerSupport),
+    });
+    EXPECT_FALSE(familyPlan(k2, ModuleArchiveFamily::PlayerSupport));
+}
+
+TEST(ModulePolicy, k1_keeps_localization_to_the_base_locations) {
+    const std::vector<ModuleSourceCandidate> inventory {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("base_loc", ModuleArchiveFamily::Localization, ModulePrimaryOrigin::Modules),
+        source("root_loc", ModuleArchiveFamily::Localization,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+    };
+    EXPECT_EQ((std::vector<std::string> {"base_loc"}),
+              attemptIds(planModuleLoad(request(GameID::KotOR), inventory),
+                         ModuleArchiveFamily::Localization));
+    EXPECT_EQ((std::vector<std::string> {"base_loc", "root_loc"}),
+              attemptIds(planModuleLoad(request(GameID::TSL), inventory),
+                         ModuleArchiveFamily::Localization));
+}
+
+TEST(ModulePolicy, represents_the_active_state_separately_from_primary_selection) {
+    auto plan = planModuleLoad(request(GameID::TSL, true, true), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("module_s.rim", ModuleArchiveFamily::StaticRim),
+    });
+    ASSERT_TRUE(plan.primary);
+    EXPECT_EQ("module.rim", plan.primary->candidate.source.sourceId);
+
+    // The selected base image is not itself an entry in the mount sequence.
+    for (const auto &family : plan.families) {
+        for (const auto &attempt : family.attempts) {
+            EXPECT_NE("module.rim", attempt.source.sourceId);
+        }
+    }
+
+    EXPECT_EQ("module", plan.activeState.canonicalModuleName);
+    EXPECT_TRUE(plan.activeState.savedModeRequested);
+    EXPECT_EQ(ModuleMountPhase::ActiveCurrentGame, plan.activeState.phase);
+    EXPECT_EQ(ResourceOwner::ActiveModuleState, plan.activeState.owner);
+}
+
+TEST(ModulePolicy, active_state_offers_both_an_archive_and_an_image_form) {
+    // The archive form also serves as the recovery route when a required
+    // branch mount fails, so both forms are described rather than resolved.
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+    });
+    EXPECT_FALSE(plan.activeState.savedModeRequested);
+    EXPECT_EQ(ResourceSourceBucket::EncapsulatedClass2, plan.activeState.encapsulatedArchive.bucket);
+    EXPECT_EQ(EncapsulatedClass::Class2,
+              encapsulatedClassOf(plan.activeState.encapsulatedArchive.bucket));
+    EXPECT_EQ(ResourceSourceBucket::ResourceImage, plan.activeState.resourceImage.bucket);
+    EXPECT_EQ(ResourceOwner::ActiveModuleState, plan.activeState.encapsulatedArchive.owner);
+}
+
+TEST(ModulePolicy, attempt_order_is_deterministic_and_independent_of_inventory_order) {
+    const std::vector<ModuleSourceCandidate> forward {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("root0_s.rim", ModuleArchiveFamily::StaticRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root0", 0, 0),
+        source("root1_s.rim", ModuleArchiveFamily::StaticRim,
+               ModulePrimaryOrigin::ConfiguredModuleRoot, "root1", 0, 1),
+    };
+    std::vector<ModuleSourceCandidate> reversed(forward.rbegin(), forward.rend());
+
+    auto forwardIds = attemptIds(planModuleLoad(request(GameID::TSL), forward),
+                                 ModuleArchiveFamily::StaticRim);
+    auto reversedIds = attemptIds(planModuleLoad(request(GameID::TSL), reversed),
+                                  ModuleArchiveFamily::StaticRim);
+    EXPECT_EQ((std::vector<std::string> {"root0_s.rim", "root1_s.rim"}), forwardIds);
+    EXPECT_EQ(forwardIds, reversedIds);
+
+    // Attempt order is strictly increasing across the whole plan.
+    auto plan = planModuleLoad(request(GameID::TSL), forward);
+    std::uint32_t previous = 0;
+    bool first = true;
+    for (const auto &family : plan.families) {
+        for (const auto &attempt : family.attempts) {
+            if (!first) EXPECT_LT(previous, attempt.attemptOrder);
+            previous = attempt.attemptOrder;
+            first = false;
+        }
+    }
+}
+
+TEST(ModulePolicy, never_synthesizes_a_family_the_inventory_did_not_offer) {
+    // There is no unsupported-adjunct family to synthesize, and a plan only
+    // ever contains families that were actually offered.
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("module_adx.rim", ModuleArchiveFamily::AdxRim),
+    });
+    EXPECT_EQ((std::vector<ModuleArchiveFamily> {ModuleArchiveFamily::AdxRim}),
+              plannedFamilies(plan));
+}
+
+// 14.4 Evidence restraint
+
+TEST(ModulePolicy, split_layout_asserts_invariants_rather_than_a_total_image_order) {
+    auto plan = planModuleLoad(request(GameID::TSL), {
+        source("module.rim", ModuleArchiveFamily::PrimaryRim),
+        source("module_a.rim", ModuleArchiveFamily::AreaRim),
+        source("module_adx.rim", ModuleArchiveFamily::AdxRim),
+        source("module_s.rim", ModuleArchiveFamily::StaticRim),
+        source("module_dlg.erf", ModuleArchiveFamily::Dialogue),
+    });
+    const auto *area = familyPlan(plan, ModuleArchiveFamily::AreaRim);
+    const auto *adx = familyPlan(plan, ModuleArchiveFamily::AdxRim);
+    const auto *statics = familyPlan(plan, ModuleArchiveFamily::StaticRim);
+    const auto *dialogue = familyPlan(plan, ModuleArchiveFamily::Dialogue);
+    ASSERT_TRUE(area && adx && statics && dialogue);
+
+    // Established: the adx image is attempted after the area image, and every
+    // image family sits in a bucket above the class-2 dialogue archive. The
+    // total image order also depends on the active current-game mount, so it
+    // is deliberately not asserted here.
+    EXPECT_LT(area->attempts[0].attemptOrder, adx->attempts[0].attemptOrder);
+    for (const auto *images : {area, adx, statics}) {
+        EXPECT_EQ(ResourceSourceBucket::ResourceImage, images->attempts[0].metadata.bucket);
+    }
+    EXPECT_EQ(ResourceSourceBucket::EncapsulatedClass2, dialogue->attempts[0].metadata.bucket);
+}
+
+} // namespace


### PR DESCRIPTION
> **Resource-loader migration: L0**

## Summary

Adds a pure policy model for Odyssey module loading.

The current loader treats module resources as a flat newest-first list. That cannot correctly represent primary selection, related archive mounting, raw lookup priority and source lifetime as separate decisions.

This PR models those decisions without changing any runtime behaviour.

## What it adds

* K1 and K2 primary-source selection rules
* phased planning for support archives, `_a`/`_adx`, the MOD-or-split branch, and active staged state
* family-specific handling for MOD, `_s` and K2 `_dlg`
* explicit resource buckets and source ownership
* class-2 metadata for module, save and dialogue archives
* separate treatment of NWM, whose runtime form depends on staging
* K1/K2 differences in package order, configured roots and dialogue handling
* exact matching of known archive families, with no fallback to a near match

The model is pure, deterministic and filesystem-independent. Discovery and runtime integration will follow separately.

## Scope

No production path calls this code yet. This PR does not change mounting, save staging, current-game extraction or resource lookup.

## Testing

* `ModulePolicy.*`: 32/32
* full Release suite: 538/538
* focused Debug policy suite passed
* `git diff --check` passed
