### PR TITLE
[game] Fix creature interaction disposition and one-line actions

### DIFF
--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -77,6 +77,9 @@ protected:
 
     virtual void setReplyLines(std::vector<std::string> lines) = 0;
 
+    // How a one-liner presents its entry, alongside setMessage/setReplyLines.
+    virtual void setBarkText(std::string text, float duration);
+
     virtual void onStart();
     virtual void onFinish();
     virtual void onLoadEntry();

--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -97,6 +97,7 @@ public:
     std::shared_ptr<scene::SceneNode> sceneNode() const { return _sceneNode; }
 
     void setTag(std::string tag) { _tag = std::move(tag); }
+    void setConversation(std::string conversation) { _conversation = std::move(conversation); }
     void setPlotFlag(bool plot) { _plot = plot; }
     void setCommandable(bool commandable) { _commandable = commandable; }
     void setIsInConversation(bool isInConversation) { _isInConversation = isInConversation; }

--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -79,6 +79,12 @@ public:
 
     std::vector<ContextAction> getContextActions(const std::shared_ptr<Object> &object) const;
 
+    // Reputation is directed, so how the player may interact with a creature
+    // follows that creature's own view of the party leader, not the reverse
+    // relationship: an effect that lowers only the creature's hostility still
+    // has to open up conversation. A dead creature is never hostile.
+    bool isHostileToPartyLeader(const Creature &creature) const;
+
     const std::string &name() const { return _name; }
     const ModuleInfo &info() const { return _info; }
     std::shared_ptr<Area> area() const { return _area; }
@@ -112,6 +118,8 @@ private:
     bool handleKeyDown(const input::KeyEvent &event);
 
     // END User input
+
+    friend class TestGameModule;
 };
 
 } // namespace game

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -120,6 +120,10 @@ void Conversation::loadCameraModel() {
     _cameraModel = modelResRef.empty() ? nullptr : _services.resource.models.get(modelResRef);
 }
 
+void Conversation::setBarkText(std::string text, float duration) {
+    _game.setBarkBubbleText(std::move(text), duration);
+}
+
 void Conversation::onStart() {
 }
 
@@ -242,8 +246,15 @@ void Conversation::loadEntry(int index, bool start) {
     loadReplies();
     loadVoiceOver();
 
-    // Run entry scripts
+    // Run entry scripts. An entry action can start another conversation, which
+    // replaces this one outright. Holding the dialogue keeps this entry and its
+    // replies alive for the script to act on, and tells us to stop rather than
+    // carry on driving the new session with the old one's state.
+    auto dialog = _dialog;
     runScripts(*_currentEntry);
+    if (_dialog != dialog) {
+        return;
+    }
 
     // Conversation is a one-liner if there is exactly one empty reply that has no entries
     bool oneLiner = false;
@@ -260,9 +271,18 @@ void Conversation::loadEntry(int index, bool start) {
     onLoadEntry();
 
     if (oneLiner) {
-        _game.setBarkBubbleText(std::move(entryText), _entryDuration);
+        setBarkText(std::move(entryText), _entryDuration);
         debug("Dialog: finish (one-liner)");
-        finish();
+
+        // Barking the entry instead of opening the conversation GUI is a
+        // presentation choice, not a reason to drop the sole terminal reply's
+        // action. Resolving that reply through pickReply keeps the usual
+        // ordering and lets it terminate the conversation, so nothing here
+        // finishes it a second time. Ending the entry first stops the update
+        // timer from auto-picking the same reply again afterwards, and leaves
+        // a replacement conversation's own entry state untouched.
+        _entryEnded = true;
+        pickReply(0);
         return;
     }
 
@@ -367,7 +387,14 @@ void Conversation::pickReply(int index) {
     applyStatusSummaryEntries(reply);
 
     // Run reply scripts
+    auto dialog = _dialog;
     runScripts(reply);
+
+    // A reply action can start another conversation, replacing this one. Going
+    // on would advance or finish the new session in place of the old one.
+    if (_dialog != dialog) {
+        return;
+    }
 
     int entryIdx = indexOfFirstActive(reply.entries);
     if (entryIdx == -1) {

--- a/src/libs/game/gui/selectoverlay.cpp
+++ b/src/libs/game/gui/selectoverlay.cpp
@@ -36,7 +36,6 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/party.h"
-#include "reone/game/reputes.h"
 
 using namespace reone::graphics;
 using namespace reone::resource;
@@ -238,7 +237,7 @@ void SelectionOverlay::update() {
 
             auto hilightedCreature = std::dynamic_pointer_cast<Creature>(hilightedObject);
             if (hilightedCreature) {
-                _hilightedHostile = !hilightedCreature->isDead() && _services.game.reputes.getIsEnemy(*(_game.party().getLeader()), *hilightedCreature);
+                _hilightedHostile = module->isHostileToPartyLeader(*hilightedCreature);
             }
         }
     }
@@ -285,7 +284,7 @@ void SelectionOverlay::update() {
 
             auto selectedCreature = std::dynamic_pointer_cast<Creature>(selectedObject);
             if (selectedCreature) {
-                _selectedHostile = !selectedCreature->isDead() && _services.game.reputes.getIsEnemy(*_game.party().getLeader(), *selectedCreature);
+                _selectedHostile = module->isHostileToPartyLeader(*selectedCreature);
             }
         }
     }

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -216,8 +216,7 @@ bool Module::handleMouseMotion(const input::MouseMotionEvent &event) {
                 cursor = CursorType::Pickup;
             } else {
                 auto creature = static_cast<Creature *>(object);
-                bool isEnemy = _services.game.reputes.getIsEnemy(*creature, *_game.party().getLeader());
-                cursor = isEnemy ? CursorType::Attack : CursorType::Talk;
+                cursor = isHostileToPartyLeader(*creature) ? CursorType::Attack : CursorType::Talk;
             }
             break;
         }
@@ -274,6 +273,13 @@ void Module::onObjectClick(const std::shared_ptr<Object> &object) {
     }
 }
 
+bool Module::isHostileToPartyLeader(const Creature &creature) const {
+    if (creature.isDead()) {
+        return false;
+    }
+    return _services.game.reputes.getIsEnemy(creature, *_game.party().getLeader());
+}
+
 void Module::onCreatureClick(const std::shared_ptr<Creature> &creature) {
     debug(str(boost::format("Module: click: creature '%s', faction %d") % creature->tag() % static_cast<int>(creature->faction())));
 
@@ -285,8 +291,7 @@ void Module::onCreatureClick(const std::shared_ptr<Creature> &creature) {
             partyLeader->addAction(_game.newAction<OpenContainerAction>(creature));
         }
     } else {
-        bool isEnemy = _services.game.reputes.getIsEnemy(*partyLeader, *creature);
-        if (isEnemy) {
+        if (isHostileToPartyLeader(*creature)) {
             partyLeader->clearAllActions();
             auto action = _game.newAction<AttackObjectAction>(creature);
             action->setUserAction(true);
@@ -353,7 +358,7 @@ std::vector<ContextAction> Module::getContextActions(const std::shared_ptr<Objec
     case ObjectType::Creature: {
         auto leader = _game.party().getLeader();
         auto creature = std::static_pointer_cast<Creature>(object);
-        if (!creature->isDead() && _services.game.reputes.getIsEnemy(*leader, *creature)) {
+        if (isHostileToPartyLeader(*creature)) {
             actions.push_back(ContextAction(ActionType::AttackObject));
             auto weapon = leader->getEquippedItem(InventorySlots::rightWeapon);
             if (weapon && weapon->isRanged()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/conversation.cpp
+    ${TESTS_SOURCE_DIR}/game/interaction.cpp
     ${TESTS_SOURCE_DIR}/game/journal.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/object.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -52,6 +52,7 @@ class Gff;
 namespace game {
 
 class Game;
+class Module;
 class Object;
 
 class MockCameraStyles : public ICameraStyles, boost::noncopyable {
@@ -170,6 +171,7 @@ public:
     static void finishPazaak(Game &game, PazaakCompletedResult result);
     static void serializePazaakPartyTable(const Game &game, resource::Gff &gff);
     static void deserializePartyTable(Game &game, resource::Gff &gff);
+    static void clickCreature(Module &module, const std::shared_ptr<Creature> &creature);
 
     void init() {
         _cameraStyles = std::make_unique<MockCameraStyles>();

--- a/test/game/conversation.cpp
+++ b/test/game/conversation.cpp
@@ -72,9 +72,26 @@ public:
         _pauseOnFirstEntryLoad = true;
     }
 
+    const std::string &barkText() const {
+        return _barkText;
+    }
+
+    int barkCount() const {
+        return _barkCount;
+    }
+
+    int finishCount() const {
+        return _finishCount;
+    }
+
 protected:
     void setReplyLines(std::vector<std::string> lines) override {}
     void setMessage(std::string message) override {}
+
+    void setBarkText(std::string text, float duration) override {
+        _barkText = std::move(text);
+        ++_barkCount;
+    }
 
     void onLoadEntry() override {
         ++_entryLoadCount;
@@ -87,10 +104,17 @@ protected:
         ++_entryEndCount;
     }
 
+    void onFinish() override {
+        ++_finishCount;
+    }
+
 private:
     int _entryLoadCount {0};
     int _entryEndCount {0};
     bool _pauseOnFirstEntryLoad {false};
+    std::string _barkText;
+    int _barkCount {0};
+    int _finishCount {0};
 };
 
 std::shared_ptr<Dialog> makeDialog(int firstEntryDelay = 1, bool voiced = false) {
@@ -128,6 +152,30 @@ std::shared_ptr<Dialog> makeDialog(int firstEntryDelay = 1, bool voiced = false)
     return dialog;
 }
 
+// A one-liner: a single start entry whose only eligible reply is empty and
+// terminal. Both nodes carry an authored action.
+std::shared_ptr<Dialog> makeOneLinerDialog(std::string entryScript, std::string replyScript) {
+    auto dialog = std::make_shared<Dialog>();
+    dialog->resRef = "one_liner_test";
+    Dialog::EntryReplyLink startLink;
+    startLink.index = 0;
+    dialog->startEntries.push_back(startLink);
+    dialog->entries.resize(1);
+    dialog->replies.resize(1);
+
+    auto &entry = dialog->entries[0];
+    entry.text = "bark";
+    entry.delay = 1;
+    entry.script = std::move(entryScript);
+    Dialog::EntryReplyLink terminalReplyLink;
+    terminalReplyLink.index = 0;
+    entry.replies.push_back(terminalReplyLink);
+
+    // Empty text and no child entries -- this is what makes it a one-liner.
+    dialog->replies[0].script = std::move(replyScript);
+    return dialog;
+}
+
 std::shared_ptr<AudioClip> makeOneSecondClip() {
     auto clip = std::make_shared<AudioClip>();
     AudioClip::Frame frame;
@@ -142,6 +190,9 @@ protected:
     void SetUp() override {
         _engine.init();
         _game = std::make_unique<Game>(GameID::KotOR, std::filesystem::path {}, _engine.options(), _engine.services(), _console);
+        // Gives the game a real script runner over MockScripts, so dialogue
+        // actions can be observed as requests for their script.
+        _game->initLocalServices();
         _conversation = std::make_unique<TestConversation>(*_game, _engine.services());
     }
 
@@ -383,6 +434,95 @@ TEST_F(ConversationTest, module_transition_cleanup_clears_pause_before_the_next_
     EXPECT_EQ("second", _conversation->currentText());
     EXPECT_EQ(3, _conversation->entryLoadCount());
     EXPECT_EQ(1, _conversation->entryEndCount());
+}
+
+TEST_F(ConversationTest, one_liner_runs_entry_then_terminal_reply_actions_exactly_once) {
+    auto &scripts = _engine.resourceModule().scripts();
+    InSequence seq;
+    EXPECT_CALL(scripts, get("one_entry")).WillOnce(Return(nullptr));
+    EXPECT_CALL(scripts, get("one_reply")).WillOnce(Return(nullptr));
+
+    _conversation->start(makeOneLinerDialog("one_entry", "one_reply"), nullptr);
+}
+
+TEST_F(ConversationTest, one_liner_with_no_entry_action_still_runs_the_terminal_reply_action) {
+    // The authored action commonly sits only on the terminal reply, so running
+    // the entry action alone would still drop it.
+    auto &scripts = _engine.resourceModule().scripts();
+    EXPECT_CALL(scripts, get("one_reply")).WillOnce(Return(nullptr));
+
+    _conversation->start(makeOneLinerDialog("", "one_reply"), nullptr);
+}
+
+TEST_F(ConversationTest, one_liner_presents_its_entry_and_completes_without_opening_the_gui) {
+    auto &scripts = _engine.resourceModule().scripts();
+    EXPECT_CALL(scripts, get(_)).WillRepeatedly(Return(nullptr));
+
+    _conversation->start(makeOneLinerDialog("one_entry", "one_reply"), nullptr);
+
+    // Barked, not presented through the conversation GUI, and already over.
+    EXPECT_EQ("bark", _conversation->barkText());
+    EXPECT_EQ(1, _conversation->barkCount());
+    EXPECT_EQ("bark", _conversation->currentText());
+    EXPECT_EQ(Game::Screen::None, _game->currentScreen());
+    EXPECT_EQ(1, _conversation->entryLoadCount());
+}
+
+TEST_F(ConversationTest, completed_one_liner_does_not_run_its_actions_a_second_time) {
+    auto &scripts = _engine.resourceModule().scripts();
+    EXPECT_CALL(scripts, get("one_entry")).WillOnce(Return(nullptr));
+    EXPECT_CALL(scripts, get("one_reply")).WillOnce(Return(nullptr));
+
+    _conversation->start(makeOneLinerDialog("one_entry", "one_reply"), nullptr);
+
+    // The one-liner is already resolved; further ticks must not re-pick it.
+    for (int i = 0; i < 5; ++i) {
+        _conversation->update(1.0f);
+    }
+    EXPECT_EQ(1, _conversation->barkCount());
+}
+
+TEST_F(ConversationTest, one_liner_entry_action_starting_a_conversation_keeps_the_new_session) {
+    auto &scripts = _engine.resourceModule().scripts();
+    auto replacement = makeDialog();
+
+    // Stand in for an action script that starts another conversation: the
+    // replacement happens at exactly the point the real script would run.
+    EXPECT_CALL(scripts, get("one_entry")).WillOnce(Invoke([&](const std::string &) {
+        _conversation->start(replacement, nullptr);
+        return nullptr;
+    }));
+    // The old reply belongs to a conversation that no longer exists.
+    EXPECT_CALL(scripts, get("one_reply")).Times(0);
+
+    _conversation->start(makeOneLinerDialog("one_entry", "one_reply"), nullptr);
+
+    // The new conversation is live and presented once by itself: the old one
+    // must not have gone on to bark, reload or otherwise drive it.
+    EXPECT_EQ("first", _conversation->currentText());
+    EXPECT_EQ(1, _conversation->entryLoadCount());
+    EXPECT_EQ(0, _conversation->barkCount());
+    _conversation->update(1.0f);
+    EXPECT_EQ("second", _conversation->currentText());
+}
+
+TEST_F(ConversationTest, one_liner_reply_action_starting_a_conversation_keeps_the_new_session) {
+    auto &scripts = _engine.resourceModule().scripts();
+    auto replacement = makeDialog();
+
+    EXPECT_CALL(scripts, get("one_reply")).WillOnce(Invoke([&](const std::string &) {
+        _conversation->start(replacement, nullptr);
+        return nullptr;
+    }));
+
+    _conversation->start(makeOneLinerDialog("", "one_reply"), nullptr);
+
+    // Only the replacement itself ended the one-liner. Had the old conversation
+    // carried on to finish, it would have ended the new session instead.
+    EXPECT_EQ(1, _conversation->finishCount());
+    EXPECT_EQ("first", _conversation->currentText());
+    _conversation->update(1.0f);
+    EXPECT_EQ("second", _conversation->currentText());
 }
 
 } // namespace

--- a/test/game/interaction.cpp
+++ b/test/game/interaction.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "../fixtures/engine.h"
+
+#include "reone/game/console.h"
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/object/module.h"
+#include "reone/game/party.h"
+#include "reone/game/reputes.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+void reone::game::TestGameModule::clickCreature(Module &module, const std::shared_ptr<Creature> &creature) {
+    module.onCreatureClick(creature);
+}
+
+namespace {
+
+class StubConsole : public IConsole, boost::noncopyable {
+public:
+    void registerCommand(std::string name, std::string description, CommandHandler handler) override {}
+    void printLine(const std::string &text) override {}
+};
+
+// Two synthetic factions standing in for "the party leader's" and "the other
+// creature's". Nothing here depends on which factions they are.
+constexpr Faction kLeaderFaction = Faction::Friendly1;
+constexpr Faction kOtherFaction = Faction::Hostile1;
+
+// How a creature is interacted with follows the creature's own view of the
+// party leader. These tests set the two directions to opposite values, so a
+// query that reverses source and target reads the other cell and fails.
+class CreatureInteractionTest : public Test {
+protected:
+    void SetUp() override {
+        _engine.init();
+        _game = std::make_unique<Game>(GameID::KotOR, std::filesystem::path {}, _engine.options(), _engine.services(), _console);
+        _module = _game->newModule();
+
+        _leader = _game->newCreature();
+        _leader->setFaction(kLeaderFaction);
+        _game->party().addMember(0, _leader);
+        _game->party().setPlayer(_leader);
+
+        _other = _game->newCreature();
+        _other->setFaction(kOtherFaction);
+        _other->setConversation("test_conversation");
+    }
+
+    // Installs a directed disposition: only `source` regarding `target` as an
+    // enemy answers true, so the reverse pairing answers false.
+    void hostileOnly(Faction source, Faction target) {
+        auto &reputes = static_cast<MockReputes &>(_engine.services().game.reputes);
+        EXPECT_CALL(reputes, getIsEnemy(An<const Creature &>(), An<const Creature &>()))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke([source, target](const Creature &from, const Creature &to) {
+                return from.faction() == source && to.faction() == target;
+            }));
+    }
+
+    std::vector<ActionType> contextActionTypes() {
+        std::vector<ActionType> types;
+        for (auto &action : _module->getContextActions(_other)) {
+            types.push_back(action.type);
+        }
+        return types;
+    }
+
+    ActionType queuedActionType() {
+        TestGameModule::clickCreature(*_module, _other);
+        EXPECT_EQ(1ll, _leader->actions().size());
+        return _leader->actions().front()->type();
+    }
+
+    TestEngine _engine;
+    StubConsole _console;
+    std::unique_ptr<Game> _game;
+    std::shared_ptr<Module> _module;
+    std::shared_ptr<Creature> _leader;
+    std::shared_ptr<Creature> _other;
+};
+
+} // namespace
+
+// The disguise shape: the party leader still regards the creature as an enemy,
+// but the creature has stopped regarding the leader as one.
+TEST_F(CreatureInteractionTest, creature_that_is_no_longer_hostile_is_presented_and_treated_as_such) {
+    hostileOnly(kLeaderFaction, kOtherFaction);
+
+    EXPECT_FALSE(_module->isHostileToPartyLeader(*_other));
+    EXPECT_EQ(ActionType::StartConversation, queuedActionType());
+    EXPECT_THAT(contextActionTypes(), Not(Contains(ActionType::AttackObject)));
+}
+
+// The reverse shape: the creature regards the leader as an enemy even though
+// the leader's own faction does not return the sentiment.
+TEST_F(CreatureInteractionTest, creature_that_is_hostile_to_the_leader_is_presented_and_treated_as_hostile) {
+    hostileOnly(kOtherFaction, kLeaderFaction);
+
+    EXPECT_TRUE(_module->isHostileToPartyLeader(*_other));
+    EXPECT_EQ(ActionType::AttackObject, queuedActionType());
+    EXPECT_THAT(contextActionTypes(), Contains(ActionType::AttackObject));
+}
+
+TEST_F(CreatureInteractionTest, dead_creatures_are_never_hostile_regardless_of_disposition) {
+    hostileOnly(kOtherFaction, kLeaderFaction);
+    // Dying renames the creature to its authored "remains" string.
+    EXPECT_CALL(_engine.resourceModule().strings(), getText(_))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(""));
+    _other->damage(std::numeric_limits<int>::max(), 0);
+    ASSERT_TRUE(_other->isDead());
+
+    EXPECT_FALSE(_module->isHostileToPartyLeader(*_other));
+    EXPECT_THAT(contextActionTypes(), Not(Contains(ActionType::AttackObject)));
+}
+
+TEST_F(CreatureInteractionTest, clicking_a_non_hostile_creature_without_a_conversation_queues_nothing) {
+    hostileOnly(kLeaderFaction, kOtherFaction);
+    _other->setConversation("");
+
+    TestGameModule::clickCreature(*_module, _other);
+
+    EXPECT_TRUE(_leader->actions().empty());
+}


### PR DESCRIPTION
## Summary

Directed reputation is asymmetric, but creature interaction and HUD presentation were querying the player's disposition toward the creature. This could make a creature appear hostile and turn interaction into an attack even when the creature no longer regarded the player as hostile.

One-line conversations were also presented as bark bubbles but completed before their sole terminal reply action ran.

This change:

- uses the creature's disposition toward the party leader for hostile presentation, context actions and click behavior;
- preserves conversations with non-hostile creatures;
- runs one-line entry and terminal reply actions exactly once;
- preserves bark presentation without opening the conversation GUI;
- prevents duplicate execution;
- preserves a replacement conversation started re-entrantly by an action.

Manual K1 smoke:

- equipping Sand People Clothing (`k17_sandperdis`) makes the Sand People non-hostile;
- removing clothing in front of Sand People or approaching without disguise triggers hostile;
- interacting triggers the recognition bark without opening the conversation GUI;
- the terminal reply action executes and makes them hostile;
- removing the disguise independently restores hostility.

## Scope

The separate issue where disposition script routines reject faction-bearing non-creature source objects is not included.
