### PR TITLE
[resource] Resource loader

### DIFF
--- a/include/reone/extract/capsule.h
+++ b/include/reone/extract/capsule.h
@@ -29,6 +29,17 @@ public:
     explicit LazyCapsule(std::filesystem::path path);
 
     const std::filesystem::path &path() const { return _path; }
+
+    /**
+     * Read the container's index now rather than on the first lookup.
+     *
+     * Only the signature and the table of what the container holds are read;
+     * payloads stay on disk until a resource is asked for. A caller that has to
+     * know whether an archive is usable at the moment it takes it on uses this.
+     * A caller that only ever reads through it need not.
+     */
+    void load() const { ensureLoaded(); }
+
     const std::vector<FileResource> &resources() const;
 
     std::optional<FileResource> find(const resource::ResourceId &id) const;

--- a/include/reone/extract/installation.h
+++ b/include/reone/extract/installation.h
@@ -22,11 +22,37 @@
 #include "finder.h"
 #include "lookupcontext.h"
 
+#include "reone/resource/modulediscovery.h"
+#include "reone/resource/modulepolicy.h"
 #include "reone/resource/types.h"
 
 namespace reone {
 
 namespace extract {
+
+/**
+ * One module archive present in the installation, with the role and lookup
+ * position the shared discovery and policy layers give it.
+ *
+ * family is the canonical role, resolved from the filename by shared
+ * classification rather than read off the extension here. bucket is where the
+ * source sits in raw lookup once mounted, and resourceImage is what the
+ * container physically is; the two are separate facts, and an extension
+ * decides neither of them on its own.
+ */
+struct ModuleArchive {
+    /// Module the archive belongs to. A support archive resolves to the module
+    /// it supports, never to its own stem.
+    std::string moduleRoot;
+    resource::ModuleArchiveFamily family {resource::ModuleArchiveFamily::PrimaryRim};
+    /// Location the archive was found in, e.g. "modules" or "lips".
+    std::string rootId;
+    std::filesystem::path path;
+    /// Raw lookup bucket once mounted, or nothing for a family whose mount
+    /// route is the caller's to choose rather than the policy's to assign.
+    std::optional<resource::ResourceSourceBucket> bucket;
+    bool resourceImage {false};
+};
 
 /// Game installation indexer and resolver (PyKotor Installation).
 class Installation {
@@ -72,12 +98,28 @@ public:
     const std::vector<std::filesystem::path> &customFolders() const { return _customFolders; }
     const std::vector<std::filesystem::path> &customCapsules() const { return _customCapsules; }
 
-    /// Module root of a module archive filename, e.g. "foo" for "foo_s.rim".
-    static std::string getModuleRoot(std::string_view capsuleFilename);
+    /**
+     * Modules the installation can actually enter, sorted and independent of
+     * directory enumeration order.
+     *
+     * Only the module location is enumerated, and only a primary-eligible
+     * archive introduces a name. A location holding nothing but support
+     * archives contributes none, and the global archives kept alongside a
+     * module's own support archives in the lips location are not modules.
+     */
+    std::vector<std::string> moduleNames();
 
-    /// Relative paths under the game root at which archives of the given
-    /// module root may reside.
-    static std::vector<std::string> moduleArchiveRelPaths(std::string_view moduleRoot);
+    /**
+     * Every archive belonging to the current module root, whatever family, in
+     * canonical raw lookup order.
+     *
+     * This is the complete inventory rather than the set a running game would
+     * mount: nothing is suppressed here, because which support families a game
+     * uses is policy and this answers what physically exists. The order is the
+     * lookup order, so the first entry serving a resource is the one a lookup
+     * would return and the rest are the other places it also lives.
+     */
+    const std::vector<ModuleArchive> &moduleArchives();
 
     std::optional<std::filesystem::path> moviePath(std::string_view name);
 
@@ -105,7 +147,7 @@ private:
     bool _executableLoaded {false};
 
     std::vector<FileResource> _chitin;
-    std::unordered_map<std::string, std::filesystem::path> _moduleCapsulePaths;
+    std::vector<ModuleArchive> _moduleArchives;
     std::unordered_map<std::string, std::vector<FileResource>> _override;
     std::unordered_map<resource::ResourceId, FileResource> _overrideIndex;
     std::unordered_map<std::string, std::vector<FileResource>> _texturePacks;
@@ -157,6 +199,10 @@ private:
                        std::vector<LocationResult> &out);
 
     void checkModules(const resource::ResourceId &id, std::vector<LocationResult> &out);
+
+    /// Locations searched for a known module's archives, in the order their
+    /// mounts are attempted.
+    std::vector<resource::ModuleSearchRoot> moduleSearchRoots() const;
 
     void checkTexturePack(const char *packName,
                           const resource::ResourceId &id,

--- a/include/reone/extract/installation.h
+++ b/include/reone/extract/installation.h
@@ -24,6 +24,7 @@
 
 #include "reone/resource/modulediscovery.h"
 #include "reone/resource/modulepolicy.h"
+#include "reone/resource/odysseyroots.h"
 #include "reone/resource/types.h"
 
 namespace reone {
@@ -57,7 +58,9 @@ struct ModuleArchive {
 /// Game installation indexer and resolver (PyKotor Installation).
 class Installation {
 public:
-    Installation(resource::GameID game, std::filesystem::path root);
+    Installation(resource::GameID game,
+                 std::filesystem::path root,
+                 resource::OdysseyResourceRoots odysseyRoots = {});
 
     resource::GameID game() const { return _game; }
     const std::filesystem::path &root() const { return _root; }
@@ -102,10 +105,9 @@ public:
      * Modules the installation can actually enter, sorted and independent of
      * directory enumeration order.
      *
-     * Only the module location is enumerated, and only a primary-eligible
-     * archive introduces a name. A location holding nothing but support
-     * archives contributes none, and the global archives kept alongside a
-     * module's own support archives in the lips location are not modules.
+     * Shared primary roots are enumerated, and only a primary-eligible archive
+     * introduces a name. Support-only LIPS locations are excluded, so their
+     * global and per-module archives never become module names.
      */
     std::vector<std::string> moduleNames();
 
@@ -134,6 +136,7 @@ public:
 private:
     resource::GameID _game;
     std::filesystem::path _root;
+    resource::OdysseyResourceRoots _odysseyRoots;
 
     bool _chitinLoaded {false};
     bool _modulesLoaded {false};

--- a/include/reone/resource/2da.h
+++ b/include/reone/resource/2da.h
@@ -27,7 +27,16 @@ class TwoDAReader;
 
 class TwoDA : boost::noncopyable {
 public:
+    /**
+     * A data row together with the label that names it.
+     *
+     * The label is the first token of a row and is a key in its own right:
+     * some tables are addressed by it rather than by a cell value, and it is
+     * not always the row ordinal. It is therefore retained rather than
+     * discarded, and is not part of the column data.
+     */
     struct Row {
+        std::string label;
         std::vector<std::string> values;
     };
 
@@ -38,8 +47,14 @@ public:
             return *this;
         }
 
+        /// Append a row labelled by its ordinal, as an unlabelled table is
+        /// written out.
         Builder &row(std::vector<std::string> values) {
-            _rows.push_back({std::move(values)});
+            return row(std::to_string(_rows.size()), std::move(values));
+        }
+
+        Builder &row(std::string label, std::vector<std::string> values) {
+            _rows.push_back({std::move(label), std::move(values)});
             return *this;
         }
 
@@ -63,6 +78,15 @@ public:
             }
         }
     }
+
+    /**
+     * Find a row by its label, folding ASCII case as the original lookup does.
+     * Distinct from a cell lookup: a table may be keyed by label alone, and a
+     * label is not a column.
+     *
+     * @return row index or -1 when not found
+     */
+    int indexByLabel(const std::string &label) const;
 
     /**
      * @return row index or -1 when not found
@@ -92,8 +116,9 @@ public:
     const std::vector<std::string> &columns() const { return _columns; }
     const std::vector<Row> &rows() const { return _rows; }
 
-    static Row newRow(std::vector<std::string> values) {
+    static Row newRow(std::string label, std::vector<std::string> values) {
         auto row = Row();
+        row.label = std::move(label);
         row.values = std::move(values);
         return row;
     }

--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -82,7 +82,8 @@ public:
                    graphics::GraphicsModule &graphics,
                    audio::AudioModule &audio,
                    script::ScriptModule &script,
-                   ResourcesBackend resourcesBackend = ResourcesBackend::Legacy) :
+                   ResourcesBackend resourcesBackend = ResourcesBackend::Legacy,
+                   OdysseyResourceRoots odysseyRoots = {}) :
         _gameId(gameId),
         _gamePath(std::move(gamePath)),
         _graphicsOpt(graphicsOpt),
@@ -90,7 +91,11 @@ public:
         _graphics(graphics),
         _audio(audio),
         _script(script),
-        _resourcesBackend(resourcesBackend) {
+        _resourcesBackend(resourcesBackend),
+        _odysseyRoots(std::move(odysseyRoots)) {
+        if (!_odysseyRoots.nwmFiles) {
+            _odysseyRoots.nwmFiles = defaultOdysseyResourceRoots(_gamePath).nwmFiles;
+        }
     }
 
     ~ResourceModule() { deinit(); }
@@ -117,6 +122,7 @@ public:
     ResourceDirector &director() { return *_director; }
 
     ResourceServices &services() { return *_services; }
+    const OdysseyResourceRoots &odysseyRoots() const { return _odysseyRoots; }
 
     void setGameID(GameID id) {
         _gameId = id;
@@ -136,6 +142,7 @@ private:
     script::ScriptModule &_script;
     ResourcesBackend _resourcesBackend {ResourcesBackend::Legacy};
 
+    OdysseyResourceRoots _odysseyRoots;
     std::unique_ptr<Gffs> _gffs;
     std::unique_ptr<IResourceReplacements> _replacements;
     std::unique_ptr<IResources> _resources;

--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -92,6 +92,7 @@ public:
         _audio(audio),
         _script(script),
         _resourcesBackend(resourcesBackend),
+        _nwmFilesDerived(!odysseyRoots.nwmFiles),
         _odysseyRoots(std::move(odysseyRoots)) {
         if (!_odysseyRoots.nwmFiles) {
             _odysseyRoots.nwmFiles = defaultOdysseyResourceRoots(_gamePath).nwmFiles;
@@ -130,6 +131,9 @@ public:
 
     void setGamePath(std::filesystem::path path) {
         _gamePath = std::move(path);
+        if (_nwmFilesDerived) {
+            _odysseyRoots.nwmFiles = defaultOdysseyResourceRoots(_gamePath).nwmFiles;
+        }
     }
 
 private:
@@ -142,6 +146,7 @@ private:
     script::ScriptModule &_script;
     ResourcesBackend _resourcesBackend {ResourcesBackend::Legacy};
 
+    bool _nwmFilesDerived {false};
     OdysseyResourceRoots _odysseyRoots;
     std::unique_ptr<Gffs> _gffs;
     std::unique_ptr<IResourceReplacements> _replacements;

--- a/include/reone/resource/di/module.h
+++ b/include/reone/resource/di/module.h
@@ -139,6 +139,9 @@ private:
     std::unique_ptr<Gffs> _gffs;
     std::unique_ptr<IResourceReplacements> _replacements;
     std::unique_ptr<IResources> _resources;
+    /// Sources outside the Odyssey raw lookup model: the shader pack, the
+    /// executable, and streamed audio for an activated game.
+    std::unique_ptr<IResources> _auxResources;
     std::unique_ptr<Strings> _strings;
     std::unique_ptr<TwoDAs> _twoDas;
     std::unique_ptr<Scripts> _scripts;

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "modulediscovery.h"
+#include "modulemount.h"
 #include "resources.h"
 #include "types.h"
 
@@ -43,6 +45,17 @@ class ILips;
 class IPaths;
 class IResources;
 class IScripts;
+class ITwoDAs;
+
+/**
+ * Whether a game's Odyssey sources are placed in the raw lookup order.
+ *
+ * A source list is homogeneous, so anything mounting into the game's resource
+ * list has to agree with the director about this. K2 is activated; K1 keeps the
+ * insertion-ordered stack it has always used until its own global startup
+ * precedence is established.
+ */
+bool usesBucketedLookup(GameID game);
 
 class IResourceDirector {
 public:
@@ -68,7 +81,9 @@ public:
                      ILips &lips,
                      IPaths &paths,
                      IResources &resources,
-                     IScripts &scripts) :
+                     IResources &auxResources,
+                     IScripts &scripts,
+                     ITwoDAs &twoDas) :
         _gameId(gameId),
         _gamePath(gamePath),
         _graphicsOpt(graphicsOpt),
@@ -79,7 +94,9 @@ public:
         _lips(lips),
         _paths(paths),
         _resources(resources),
-        _scripts(scripts) {
+        _auxResources(auxResources),
+        _scripts(scripts),
+        _twoDas(twoDas) {
     }
 
     void init() override;
@@ -100,14 +117,32 @@ private:
     ILips &_lips;
     IPaths &_paths;
     IResources &_resources;
+    IResources &_auxResources;
     IScripts &_scripts;
+    ITwoDAs &_twoDas;
 
     // Set when a savegame is loaded.
     std::optional<std::filesystem::path> _savegamePath;
 
+    bool bucketed() const { return usesBucketedLookup(_gameId); }
+
+    /// The given bucket, or nothing when this game is not activated. A list is
+    /// homogeneous, so a game either places every source or places none.
+    std::optional<ResourceSourceBucket> bucketOf(ResourceSourceBucket bucket) const;
+
     void loadGlobalResources();
-    void loadModuleResources(const std::string &name);
+    void loadAuxiliaryResources();
+    void loadStreamResources();
     void loadSaveGameResources(std::string_view name);
+
+    void loadModuleResources(const std::string &name);
+    void loadModuleResourcesLegacy(const std::string &name);
+    void loadModuleResourcesFromPolicy(const std::string &name);
+
+    ModuleSearchRoot modulesSearchRoot();
+    std::vector<ModuleSearchRoot> moduleSearchRoots();
+    void addStagedModuleSources(const std::string &moduleRoot, RuntimeModuleSourceIndex &index);
+    bool includeModuleInSave(const std::string &moduleRoot);
 
     void loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
     void loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind);

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -100,6 +100,9 @@ public:
         _auxResources(auxResources),
         _scripts(scripts),
         _twoDas(twoDas) {
+        if (!_odysseyRoots.nwmFiles) {
+            _odysseyRoots.nwmFiles = defaultOdysseyResourceRoots(_gamePath).nwmFiles;
+        }
     }
 
     void init() override;

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -133,10 +133,16 @@ private:
     void loadGlobalResources();
     void loadAuxiliaryResources();
     void loadStreamResources();
+    void loadK1StreamResources();
+    void loadRimsDirectory();
+    void loadGlobalRimResource();
+    void loadOverrideTexturesResource();
+    void loadTexturePackResources();
+    void loadPlayerSupportResource();
+    void loadK1GlobalResources();
     void loadSaveGameResources(std::string_view name);
 
     void loadModuleResources(const std::string &name);
-    void loadModuleResourcesLegacy(const std::string &name);
     void loadModuleResourcesFromPolicy(const std::string &name);
 
     ModuleSearchRoot modulesSearchRoot();
@@ -144,8 +150,6 @@ private:
     void addStagedModuleSources(const std::string &moduleRoot, RuntimeModuleSourceIndex &index);
     bool includeModuleInSave(const std::string &moduleRoot);
 
-    void loadRIM(const std::filesystem::path &path, const std::string &name, ResourceOwner owner);
-    void loadERF(const std::filesystem::path &path, const std::string &name, ResourceOwner owner);
 };
 
 } // namespace resource

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -53,7 +53,7 @@ class ITwoDAs;
  *
  * A source list is homogeneous, so anything mounting into the game's resource
  * list has to agree with the director about this. K2 is activated; K1 keeps the
- * insertion-ordered stack it has always used until its own global startup
+ * shared bucketed stack established by its global startup
  * precedence is established.
  */
 bool usesBucketedLookup(GameID game);
@@ -153,7 +153,6 @@ private:
     void loadModuleResources(const std::string &name);
     void loadModuleResourcesFromPolicy(const std::string &name);
 
-    ModuleSearchRoot modulesSearchRoot();
     std::vector<ModuleSearchRoot> moduleSearchRoots();
     void addStagedModuleSources(const std::string &moduleRoot, RuntimeModuleSourceIndex &index);
     bool includeModuleInSave(const std::string &moduleRoot);

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -144,8 +144,8 @@ private:
     void addStagedModuleSources(const std::string &moduleRoot, RuntimeModuleSourceIndex &index);
     bool includeModuleInSave(const std::string &moduleRoot);
 
-    void loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
-    void loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind);
+    void loadRIM(const std::filesystem::path &path, const std::string &name, ResourceOwner owner);
+    void loadERF(const std::filesystem::path &path, const std::string &name, ResourceOwner owner);
 };
 
 } // namespace resource

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "modulediscovery.h"
+#include "odysseyroots.h"
 #include "modulemount.h"
 #include "resources.h"
 #include "types.h"
@@ -83,9 +84,11 @@ public:
                      IResources &resources,
                      IResources &auxResources,
                      IScripts &scripts,
-                     ITwoDAs &twoDas) :
+                     ITwoDAs &twoDas,
+                     OdysseyResourceRoots odysseyRoots = {}) :
         _gameId(gameId),
         _gamePath(gamePath),
+        _odysseyRoots(std::move(odysseyRoots)),
         _graphicsOpt(graphicsOpt),
         _graphicsSvc(graphicsSvc),
         _scriptSvc(scriptSvc),
@@ -109,6 +112,7 @@ public:
 private:
     GameID _gameId;
     const std::filesystem::path &_gamePath;
+    OdysseyResourceRoots _odysseyRoots;
     const graphics::GraphicsOptions &_graphicsOpt;
     graphics::GraphicsServices &_graphicsSvc;
     script::ScriptServices &_scriptSvc;
@@ -140,6 +144,7 @@ private:
     void loadTexturePackResources();
     void loadPlayerSupportResource();
     void loadK1GlobalResources();
+    void loadLiveResources();
     void loadSaveGameResources(std::string_view name);
 
     void loadModuleResources(const std::string &name);

--- a/include/reone/resource/extractresources.h
+++ b/include/reone/resource/extractresources.h
@@ -39,12 +39,16 @@ public:
         _sources.clear();
     }
 
-    void clearLocal() override {
-        _sources.clearKind(ContainerKind::Local);
+    void clearOwner(ResourceOwner owner) override {
+        _sources.clearOwner(owner);
     }
 
-    void clearSave() override {
-        _sources.clearKind(ContainerKind::Save);
+    ResourceMountToken mountToken() const override {
+        return _sources.mountToken();
+    }
+
+    void rollbackTo(ResourceMountToken token) override {
+        _sources.rollbackTo(token);
     }
 
     void addEXE(const std::filesystem::path &path,
@@ -52,19 +56,19 @@ public:
     void addKEY(const std::filesystem::path &path,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addERF(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemERF(ByteBuffer buffer,
-                   ContainerKind kind,
+                   ResourceOwner owner,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addRIM(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemRIM(ByteBuffer buffer,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addFolder(const std::filesystem::path &path,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;
@@ -74,20 +78,21 @@ public:
 
 private:
     struct Source {
-        ContainerKind kind;
+        ResourceOwner owner;
         std::optional<ResourceSourceBucket> bucket;
+        ResourceMountToken sequence {0};
         std::function<std::optional<ByteBuffer>(const ResourceId &)> find;
     };
 
     ResourceSourceList<Source> _sources;
 
-    void addSource(ContainerKind kind,
+    void addSource(ResourceOwner owner,
                    std::optional<ResourceSourceBucket> bucket,
                    std::function<std::optional<ByteBuffer>(const ResourceId &)> find) {
-        _sources.add(Source {kind, bucket, std::move(find)});
+        _sources.add(Source {owner, bucket, 0, std::move(find)});
     }
 
-    void addMemArchive(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket, bool rim);
+    void addMemArchive(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket, bool rim);
 };
 
 } // namespace resource

--- a/include/reone/resource/extractresources.h
+++ b/include/reone/resource/extractresources.h
@@ -40,20 +40,32 @@ public:
     }
 
     void clearLocal() override {
-        clearSome(ContainerKind::Local);
+        _sources.clearKind(ContainerKind::Local);
     }
 
     void clearSave() override {
-        clearSome(ContainerKind::Save);
+        _sources.clearKind(ContainerKind::Save);
     }
 
-    void addEXE(const std::filesystem::path &path) override;
-    void addKEY(const std::filesystem::path &path) override;
-    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
-    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
-    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addEXE(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addKEY(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addERF(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemERF(ByteBuffer buffer,
+                   ContainerKind kind,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addRIM(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemRIM(ByteBuffer buffer,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addFolder(const std::filesystem::path &path,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;
     std::optional<Resource> find(const ResourceId &id) override;
@@ -63,23 +75,19 @@ public:
 private:
     struct Source {
         ContainerKind kind;
+        std::optional<ResourceSourceBucket> bucket;
         std::function<std::optional<ByteBuffer>(const ResourceId &)> find;
     };
 
-    std::list<Source> _sources;
+    ResourceSourceList<Source> _sources;
 
-    void clearSome(ContainerKind kind) {
-        auto toErase = std::remove_if(_sources.begin(), _sources.end(), [kind](auto &source) {
-            return source.kind == kind;
-        });
-        _sources.erase(toErase, _sources.end());
+    void addSource(ContainerKind kind,
+                   std::optional<ResourceSourceBucket> bucket,
+                   std::function<std::optional<ByteBuffer>(const ResourceId &)> find) {
+        _sources.add(Source {kind, bucket, std::move(find)});
     }
 
-    void addSource(ContainerKind kind, std::function<std::optional<ByteBuffer>(const ResourceId &)> find) {
-        _sources.push_front(Source {kind, std::move(find)});
-    }
-
-    void addMemArchive(ByteBuffer buffer, ContainerKind kind, bool rim);
+    void addMemArchive(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket, bool rim);
 };
 
 } // namespace resource

--- a/include/reone/resource/format/2dareader.h
+++ b/include/reone/resource/format/2dareader.h
@@ -43,6 +43,7 @@ private:
     int _dataSize {0};
 
     std::vector<std::string> _columns;
+    std::vector<std::string> _labels;
     std::vector<TwoDA::Row> _rows;
 
     std::shared_ptr<TwoDA> _twoDa;

--- a/include/reone/resource/modulediscovery.h
+++ b/include/reone/resource/modulediscovery.h
@@ -190,6 +190,14 @@ ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
                                             const std::vector<ModuleSearchRoot> &roots);
 
 /**
+ * Construct the two exact module adjunct images from the installation RIMS
+ * location. These names are probed directly and RIMS is never enumerated.
+ */
+std::vector<DiscoveredModuleSource> discoverRimsModuleAdjuncts(
+    std::string_view moduleRoot,
+    const std::filesystem::path &gamePath);
+
+/**
  * Extensions the generic encapsulated opener probes for an exact basename, in
  * the order it probes them.
  *

--- a/include/reone/resource/modulediscovery.h
+++ b/include/reone/resource/modulediscovery.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/resource/modulepolicy.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace reone {
+namespace resource {
+
+/**
+ * Why a name was not accepted. Unsupported and ambiguous names are reported
+ * rather than reduced onto a supported family.
+ */
+enum class ModuleNameRejection {
+    Empty,
+    UnsupportedExtension,
+    UnsupportedSuffix,
+    SuffixExtensionMismatch,
+};
+
+/**
+ * A filename resolved against the archive-family contract.
+ *
+ * moduleRoot is the module the file belongs to, never the file's own stem: a
+ * sidecar resolves to the module it supports, so a sidecar can never introduce
+ * a module name of its own.
+ */
+struct ClassifiedModuleArchive {
+    std::string moduleRoot;
+    ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
+};
+
+/**
+ * Outcome of resolving a filename.
+ *
+ * At most one field is ever set. Both being empty is a third outcome, and only
+ * classifyForModuleRoot produces it: the file belongs to a different module,
+ * which is neither a result nor an error. Resolving without a root always
+ * yields an archive or a rejection.
+ */
+struct ModuleArchiveClassification {
+    std::optional<ClassifiedModuleArchive> archive;
+    std::optional<ModuleNameRejection> rejection;
+};
+
+/// Outcome of normalizing a requested module name. Exactly one field is set.
+struct ModuleNameNormalization {
+    std::optional<std::string> root;
+    std::optional<ModuleNameRejection> rejection;
+};
+
+/**
+ * A location searched for module archives.
+ *
+ * origin says what kind of location it is. packageOrder orders numbered
+ * packages and rootOrder orders configured roots in their configured
+ * enumeration order; the policy consumes the two differently, so discovery
+ * carries both rather than collapsing them into list position.
+ */
+struct ModuleSearchRoot {
+    std::string rootId;
+    std::filesystem::path path;
+    ModulePrimaryOrigin origin {ModulePrimaryOrigin::Modules};
+    std::uint32_t packageOrder {0};
+    std::uint32_t rootOrder {0};
+};
+
+/**
+ * One discovered archive.
+ *
+ * candidate is exactly what the policy consumes. The remaining fields are the
+ * physical facts the policy must not see: where the file is, what it was
+ * called, and which module it resolved to.
+ */
+struct DiscoveredModuleSource {
+    ModuleSourceCandidate candidate;
+    std::filesystem::path path;
+    std::string filename;
+    std::string moduleRoot;
+
+    /**
+     * Internal ARE/GIT module identity, where the architecture can supply it
+     * naturally. Discovery does not open archives to obtain it, so it is unset
+     * here. The field exists so callers that do know the identity are not
+     * forced to conflate it with the outer filename.
+     */
+    std::optional<std::string> internalModuleId;
+};
+
+/// A file in a module's name space that belongs to no supported family.
+struct RejectedModuleFile {
+    std::string rootId;
+    std::filesystem::path path;
+    std::string filename;
+    ModuleNameRejection reason {ModuleNameRejection::UnsupportedSuffix};
+};
+
+struct ModuleDiscoveryResult {
+    /// Empty when the request itself was rejected.
+    std::string moduleRoot;
+    std::optional<ModuleNameRejection> nameRejection;
+    std::vector<DiscoveredModuleSource> sources;
+    std::vector<RejectedModuleFile> rejected;
+};
+
+/**
+ * Whether a family can be the source a module is entered or staged from.
+ * Sidecar and support families never can, which is what stops them from
+ * introducing module names.
+ */
+bool isPrimaryEligible(ModuleArchiveFamily family);
+
+/**
+ * Whether a family is active saved state, and so selectable only when the
+ * module-save policy admits it. The gate itself is an input to the policy;
+ * discovery only reports which candidates it applies to.
+ */
+bool isActiveSavedState(ModuleArchiveFamily family);
+
+/**
+ * Resolve a filename to the module it belongs to, with no requested root for
+ * context. Used when enumerating an installation, where the module a file
+ * belongs to has to be inferred from the name alone.
+ *
+ * Suffixes are matched exactly, longest first, so a sidecar resolves to the
+ * module it supports. A suffix outside the recognized set is not resolved to
+ * the one it most resembles.
+ */
+ModuleArchiveClassification classifyModuleArchive(std::string_view filename);
+
+/**
+ * Resolve a filename against a module root that is already known.
+ *
+ * Knowing the root removes the ambiguity that inference cannot: relative to
+ * the root "foo_s", "foo_s.rim" is that module's own primary and
+ * "foo_s_s.rim" is its static sidecar. Returns neither an archive nor a
+ * rejection for a file belonging to some other module.
+ */
+ModuleArchiveClassification classifyForModuleRoot(std::string_view filename,
+                                                  std::string_view moduleRoot);
+
+/**
+ * Normalize a requested module name to its canonical root.
+ *
+ * The caller has already identified the request as a module, so the name is
+ * preserved apart from case and a supported archive extension. A root that
+ * happens to end in something resembling a family suffix is kept: only
+ * enumeration, which must infer ownership, treats such a name as a sidecar.
+ */
+ModuleNameNormalization normalizeModuleName(std::string_view requested);
+
+/**
+ * Module names that are actually playable across the search roots, sorted and
+ * independent of directory enumeration order. Only a primary-eligible archive
+ * introduces a name, so a location holding nothing but sidecars yields none.
+ */
+std::vector<std::string> discoverModuleRoots(const std::vector<ModuleSearchRoot> &roots);
+
+/**
+ * Discover every source belonging to the requested module, in root order.
+ *
+ * Classification derives nothing from a filename but family and module root.
+ * Which family applies to a game, in which order sources are consulted, how
+ * many may mount and how long they live are all policy.
+ */
+ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
+                                            const std::vector<ModuleSearchRoot> &roots);
+
+/// Candidate inventory for the policy, in discovery order.
+std::vector<ModuleSourceCandidate> plannerInventory(const ModuleDiscoveryResult &discovered);
+
+} // namespace resource
+} // namespace reone

--- a/include/reone/resource/modulediscovery.h
+++ b/include/reone/resource/modulediscovery.h
@@ -19,6 +19,7 @@
 
 #include "reone/resource/modulepolicy.h"
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -187,6 +188,27 @@ std::vector<std::string> discoverModuleRoots(const std::vector<ModuleSearchRoot>
  */
 ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
                                             const std::vector<ModuleSearchRoot> &roots);
+
+/**
+ * Extensions the generic encapsulated opener probes for an exact basename, in
+ * the order it probes them.
+ *
+ * A caller that mounts a basename rather than a filename gets whichever of
+ * these exists first. This is the opener's own order, not a preference of the
+ * caller's, so every such mount shares it.
+ */
+extern const std::array<std::string_view, 5> kEncapsulatedProbeOrder;
+
+/**
+ * The first encapsulated container matching an exact basename in a location,
+ * or nothing when the location holds none of them.
+ *
+ * Nothing is opened or validated here; this only answers which file the
+ * basename resolves to. An absent basename is a normal answer, not an error.
+ */
+std::optional<std::filesystem::path> findEncapsulatedByBasename(
+    const std::filesystem::path &directory,
+    std::string_view basename);
 
 /// Candidate inventory for the policy, in discovery order.
 std::vector<ModuleSourceCandidate> plannerInventory(const ModuleDiscoveryResult &discovered);

--- a/include/reone/resource/modulemount.h
+++ b/include/reone/resource/modulemount.h
@@ -122,14 +122,6 @@ private:
                          ModuleMountReport &report);
 };
 
-/// Lifetime scope a mounted source is held under. Ownership answers when a
-/// source goes away; it never answers where a source is searched.
-///
-/// ActiveModule and ActiveModuleState both map to Local: the two are one
-/// lifetime until owner-scoped clearing exists, which is deliberately not part
-/// of this stage.
-ContainerKind containerKindOf(ResourceOwner owner);
-
 /// Whether a family's mounted table is a resource image rather than an
 /// encapsulated archive. Derived from the family, not from the bucket, so that
 /// container form and lookup order stay separate decisions.

--- a/include/reone/resource/modulemount.h
+++ b/include/reone/resource/modulemount.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "id.h"
+#include "modulepolicy.h"
+#include "resources.h"
+
+#include <filesystem>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace reone {
+
+namespace resource {
+
+/**
+ * A planning candidate together with where its bytes actually come from.
+ *
+ * The policy consumes only the candidate; the locator is the physical fact it
+ * must not see. A discovered archive carries its path, and a module staged
+ * inside an archive already in scope carries the id it is read back by. No
+ * filesystem path is invented for the latter.
+ */
+struct RuntimeModuleSource {
+    ModuleSourceCandidate candidate;
+    std::variant<std::filesystem::path, ResourceId> locator;
+};
+
+/**
+ * Every source offered for one module load, whatever supplied it.
+ *
+ * Sources found on disk and sources staged inside a mounted archive enter one
+ * inventory, so the policy ranks them against each other without knowing they
+ * were found differently. Lookup is by source id, which stays opaque: it is
+ * minted by the supplier and never parsed.
+ */
+class RuntimeModuleSourceIndex {
+public:
+    void add(RuntimeModuleSource source) {
+        _sources.push_back(std::move(source));
+    }
+
+    const RuntimeModuleSource *find(const std::string &sourceId) const;
+
+    /// Candidates in supply order, as the policy consumes them.
+    std::vector<ModuleSourceCandidate> inventory() const;
+
+    const std::vector<RuntimeModuleSource> &sources() const { return _sources; }
+    bool empty() const { return _sources.empty(); }
+
+private:
+    std::vector<RuntimeModuleSource> _sources;
+};
+
+struct ModuleMountOutcome {
+    std::string sourceId;
+    ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
+    ModuleMountPhase phase {ModuleMountPhase::ModuleBranch};
+    bool mounted {false};
+};
+
+/**
+ * What the executor did, in the order it did it.
+ *
+ * requiredFailure reports that a family whose failure is not best-effort
+ * produced no successful mount, which is what makes the class-2 recovery route
+ * eligible. It is not by itself a failed module load.
+ */
+struct ModuleMountReport {
+    std::vector<ModuleMountOutcome> outcomes;
+    bool requiredFailure {false};
+
+    bool mounted(const std::string &sourceId) const;
+    std::size_t mountedCount() const;
+};
+
+/**
+ * Mounts a module load plan.
+ *
+ * There is one mode. Every mount carries the bucket the policy assigned to it,
+ * because a source that has not been placed has no position in the raw lookup
+ * order to be ranked at. Phases are mounted in order, so the active table is
+ * mounted last and wins its bucket.
+ */
+class ModuleMountExecutor {
+public:
+    ModuleMountExecutor(IResources &resources, const RuntimeModuleSourceIndex &sources) :
+        _resources(resources),
+        _sources(sources) {
+    }
+
+    ModuleMountReport run(const ModuleLoadPlan &plan);
+
+private:
+    IResources &_resources;
+    const RuntimeModuleSourceIndex &_sources;
+
+    bool mount(const RuntimeModuleSource &source, const ModuleSourceMetadata &metadata);
+    void runFamily(const ModuleFamilyPlan &family, ModuleMountReport &report);
+    void runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report);
+    bool mountBySourceId(const std::string &sourceId,
+                         ModuleArchiveFamily family,
+                         ModuleMountPhase phase,
+                         const ModuleSourceMetadata &metadata,
+                         ModuleMountReport &report);
+};
+
+/// Lifetime scope a mounted source is held under. Ownership answers when a
+/// source goes away; it never answers where a source is searched.
+///
+/// ActiveModule and ActiveModuleState both map to Local: the two are one
+/// lifetime until owner-scoped clearing exists, which is deliberately not part
+/// of this stage.
+ContainerKind containerKindOf(ResourceOwner owner);
+
+/// Whether a family's mounted table is a resource image rather than an
+/// encapsulated archive. Derived from the family, not from the bucket, so that
+/// container form and lookup order stay separate decisions.
+bool isResourceImageFamily(ModuleArchiveFamily family);
+
+} // namespace resource
+
+} // namespace reone

--- a/include/reone/resource/modulemount.h
+++ b/include/reone/resource/modulemount.h
@@ -69,6 +69,12 @@ private:
     std::vector<RuntimeModuleSource> _sources;
 };
 
+enum class ModuleLoadOutcome {
+    Succeeded,
+    RecoveredThroughActiveState,
+    Failed,
+};
+
 struct ModuleMountOutcome {
     std::string sourceId;
     ModuleArchiveFamily family {ModuleArchiveFamily::PrimaryRim};
@@ -86,6 +92,7 @@ struct ModuleMountOutcome {
 struct ModuleMountReport {
     std::vector<ModuleMountOutcome> outcomes;
     bool requiredFailure {false};
+    ModuleLoadOutcome outcome {ModuleLoadOutcome::Failed};
 
     bool mounted(const std::string &sourceId) const;
     std::size_t mountedCount() const;
@@ -114,7 +121,7 @@ private:
 
     bool mount(const RuntimeModuleSource &source, const ModuleSourceMetadata &metadata);
     void runFamily(const ModuleFamilyPlan &family, ModuleMountReport &report);
-    void runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report);
+    bool runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report);
     bool mountBySourceId(const std::string &sourceId,
                          ModuleArchiveFamily family,
                          ModuleMountPhase phase,

--- a/include/reone/resource/mounttransaction.h
+++ b/include/reone/resource/mounttransaction.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "resources.h"
+
+namespace reone {
+
+namespace resource {
+
+/**
+ * Undoes the mounts of an operation that does not reach its end.
+ *
+ * An operation that mounts more than one source can fail after some of them
+ * are already in place. What is left behind then is neither the old source set
+ * nor the new one, and because a half-mounted module still answers lookups it
+ * can supplement the next one. Scoping the operation removes exactly the
+ * sources it added, in every owner and bucket it touched.
+ *
+ * This restores the resource manager to a defined state; it does not restore
+ * the module that was there before. Whether the previous module is still valid
+ * is the caller's question, not this one's: the sources it needs were already
+ * retired before the new ones were mounted, and bringing them back would be a
+ * new operation rather than an undo.
+ *
+ * Rolls back unless commit() is called, so an exception on the way out is
+ * covered without the caller catching it.
+ */
+class ResourceMountTransaction : boost::noncopyable {
+public:
+    explicit ResourceMountTransaction(IResources &resources) :
+        _resources(resources),
+        _token(resources.mountToken()) {
+    }
+
+    ~ResourceMountTransaction() {
+        if (!_committed) {
+            _resources.rollbackTo(_token);
+        }
+    }
+
+    void commit() { _committed = true; }
+
+    ResourceMountToken token() const { return _token; }
+
+private:
+    IResources &_resources;
+    ResourceMountToken _token;
+    bool _committed {false};
+};
+
+} // namespace resource
+
+} // namespace reone

--- a/include/reone/resource/odysseyroots.h
+++ b/include/reone/resource/odysseyroots.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modulediscovery.h"
+#include "types.h"
+
+#include <array>
+
+namespace reone::resource {
+
+class Strings;
+
+struct OdysseyResourceRoots {
+    static constexpr std::size_t kLivePackageCount = 6;
+
+    std::optional<std::filesystem::path> nwmFiles;
+    std::array<std::optional<std::filesystem::path>, kLivePackageCount> livePackages;
+    std::vector<std::filesystem::path> k2OverrideRoots;
+};
+
+OdysseyResourceRoots defaultOdysseyResourceRoots(const std::filesystem::path &gamePath);
+
+/// Load every bound package TLK into its stable observable slot.
+void loadLiveTalkTables(Strings &strings, const OdysseyResourceRoots &roots);
+
+std::vector<std::filesystem::path> looseOverrideRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots);
+
+std::vector<std::filesystem::path> lipsRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots);
+
+std::vector<ModuleSearchRoot> primaryModuleSearchRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots);
+
+std::vector<ModuleSearchRoot> moduleSearchRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots);
+
+} // namespace reone::resource

--- a/include/reone/resource/provider/audioclips.h
+++ b/include/reone/resource/provider/audioclips.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "../resource.h"
+#include "../types.h"
+
 namespace reone {
 
 namespace audio {
@@ -38,10 +41,20 @@ public:
     virtual std::shared_ptr<audio::AudioClip> get(const std::string &key) = 0;
 };
 
+/**
+ * Audio clips, read from the streamed audio directories first and from
+ * ordinary resources second.
+ *
+ * The streaming directories are not part of the Odyssey raw lookup order, so
+ * they are held separately and consulted explicitly rather than being given a
+ * bucket they have no evidence for. Format preference is unchanged: MP3 is
+ * still preferred over WAV across both, not within each.
+ */
 class AudioClips : public IAudioClips {
 public:
-    AudioClips(IResources &resources) :
-        _resources(resources) {
+    AudioClips(IResources &resources, IResources &streamResources) :
+        _resources(resources),
+        _streamResources(streamResources) {
     }
 
     void clear() override {
@@ -59,10 +72,12 @@ public:
 
 private:
     IResources &_resources;
+    IResources &_streamResources;
 
     std::unordered_map<std::string, std::shared_ptr<audio::AudioClip>> _objects;
 
     std::shared_ptr<audio::AudioClip> doGet(std::string resRef);
+    std::optional<Resource> findClipData(const std::string &resRef, ResType type);
 };
 
 } // namespace resource

--- a/include/reone/resource/replacementresources.h
+++ b/include/reone/resource/replacementresources.h
@@ -33,27 +33,28 @@ public:
     }
 
     void clear() override;
-    void clearLocal() override;
-    void clearSave() override;
+    void clearOwner(ResourceOwner owner) override;
+    ResourceMountToken mountToken() const override;
+    void rollbackTo(ResourceMountToken token) override;
 
     void addEXE(const std::filesystem::path &path,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addKEY(const std::filesystem::path &path,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addERF(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemERF(ByteBuffer buffer,
-                   ContainerKind kind,
+                   ResourceOwner owner,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addRIM(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemRIM(ByteBuffer buffer,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addFolder(const std::filesystem::path &path,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;

--- a/include/reone/resource/replacementresources.h
+++ b/include/reone/resource/replacementresources.h
@@ -36,13 +36,25 @@ public:
     void clearLocal() override;
     void clearSave() override;
 
-    void addEXE(const std::filesystem::path &path) override;
-    void addKEY(const std::filesystem::path &path) override;
-    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
-    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
-    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addEXE(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addKEY(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addERF(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemERF(ByteBuffer buffer,
+                   ContainerKind kind,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addRIM(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemRIM(ByteBuffer buffer,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addFolder(const std::filesystem::path &path,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;
     std::optional<Resource> find(const ResourceId &id) override;

--- a/include/reone/resource/resources.h
+++ b/include/reone/resource/resources.h
@@ -22,24 +22,35 @@
 #include "container.h"
 #include "id.h"
 #include "resource.h"
+#include "sourcelist.h"
 
 namespace reone {
 
 namespace resource {
 
-enum class ContainerKind {
-    Global,
-    Local,
-    Save,
-};
-
 struct ResourceContainerPair {
     std::unique_ptr<IResourceContainer> provider;
     ContainerKind kind;
+    std::optional<ResourceSourceBucket> bucket;
 };
 
-using ResourceContainerList = std::list<ResourceContainerPair>;
+using ResourceContainerList = ResourceSourceList<ResourceContainerPair>;
 
+/**
+ * Facade over the sources game data is read from.
+ *
+ * Every mount takes an optional bucket. Passing none keeps the source in the
+ * insertion order the engine has always used, which is what all current
+ * callers do; passing one places the source in the raw lookup order instead.
+ * Which sources belong in which bucket is a decision for the callers, not for
+ * this layer.
+ *
+ * The two are not mixed: whichever a backend is given first fixes how it
+ * orders sources until it is emptied, and mounting across that choice throws
+ * ValidationException. A caller migrating to buckets migrates every mount it
+ * makes, because an unbucketed source has no position in the raw lookup order
+ * to be ranked at.
+ */
 class IResources {
 public:
     virtual ~IResources() = default;
@@ -48,13 +59,25 @@ public:
     virtual void clearLocal() = 0;
     virtual void clearSave() = 0;
 
-    virtual void addEXE(const std::filesystem::path &path) = 0;
-    virtual void addKEY(const std::filesystem::path &path) = 0;
-    virtual void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
-    virtual void addMemERF(ByteBuffer buffer, ContainerKind kind) = 0;
-    virtual void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
-    virtual void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) = 0;
-    virtual void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) = 0;
+    virtual void addEXE(const std::filesystem::path &path,
+                        std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addKEY(const std::filesystem::path &path,
+                        std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addERF(const std::filesystem::path &path,
+                        ContainerKind kind = ContainerKind::Global,
+                        std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addMemERF(ByteBuffer buffer,
+                           ContainerKind kind,
+                           std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addRIM(const std::filesystem::path &path,
+                        ContainerKind kind = ContainerKind::Global,
+                        std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addMemRIM(ByteBuffer buffer,
+                           ContainerKind kind = ContainerKind::Global,
+                           std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
+    virtual void addFolder(const std::filesystem::path &path,
+                           ContainerKind kind = ContainerKind::Global,
+                           std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
 
     virtual Resource get(const ResourceId &id) = 0;
     virtual std::optional<Resource> find(const ResourceId &id) = 0;
@@ -67,31 +90,38 @@ public:
     }
 
     void clearLocal() override {
-        clearSome(ContainerKind::Local);
+        _containers.clearKind(ContainerKind::Local);
     }
 
     void clearSave() override {
-        clearSome(ContainerKind::Save);
+        _containers.clearKind(ContainerKind::Save);
     }
 
-    void clearSome(ContainerKind kind) {
-        auto toErase = std::remove_if(_containers.begin(), _containers.end(), [kind](auto &pair) {
-            return pair.kind == kind;
-        });
-        _containers.erase(toErase, _containers.end());
+    void add(std::unique_ptr<IResourceContainer> provider,
+             ContainerKind kind = ContainerKind::Global,
+             std::optional<ResourceSourceBucket> bucket = std::nullopt) {
+        _containers.add(ResourceContainerPair {std::move(provider), kind, bucket});
     }
 
-    void add(std::unique_ptr<IResourceContainer> provider, ContainerKind kind = ContainerKind::Global) {
-        _containers.push_front(ResourceContainerPair {std::move(provider), kind});
-    }
-
-    void addEXE(const std::filesystem::path &path) override;
-    void addKEY(const std::filesystem::path &path) override;
-    void addERF(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemERF(ByteBuffer buffer, ContainerKind kind) override;
-    void addRIM(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
-    void addMemRIM(ByteBuffer buffer, ContainerKind kind = ContainerKind::Global) override;
-    void addFolder(const std::filesystem::path &path, ContainerKind kind = ContainerKind::Global) override;
+    void addEXE(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addKEY(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addERF(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemERF(ByteBuffer buffer,
+                   ContainerKind kind,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addRIM(const std::filesystem::path &path,
+                ContainerKind kind = ContainerKind::Global,
+                std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addMemRIM(ByteBuffer buffer,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
+    void addFolder(const std::filesystem::path &path,
+                   ContainerKind kind = ContainerKind::Global,
+                   std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;
     std::optional<Resource> find(const ResourceId &id) override;

--- a/include/reone/resource/resources.h
+++ b/include/reone/resource/resources.h
@@ -30,8 +30,9 @@ namespace resource {
 
 struct ResourceContainerPair {
     std::unique_ptr<IResourceContainer> provider;
-    ContainerKind kind;
+    ResourceOwner owner;
     std::optional<ResourceSourceBucket> bucket;
+    ResourceMountToken sequence {0};
 };
 
 using ResourceContainerList = ResourceSourceList<ResourceContainerPair>;
@@ -50,33 +51,47 @@ using ResourceContainerList = ResourceSourceList<ResourceContainerPair>;
  * ValidationException. A caller migrating to buckets migrates every mount it
  * makes, because an unbucketed source has no position in the raw lookup order
  * to be ranked at.
+ *
+ * Every mount also takes an owner, which says what retires the source. Owner
+ * and bucket are independent: clearing an owner never reorders what remains,
+ * and a bucket never implies a lifetime.
  */
 class IResources {
 public:
     virtual ~IResources() = default;
 
     virtual void clear() = 0;
-    virtual void clearLocal() = 0;
-    virtual void clearSave() = 0;
+
+    /// Retire every source of one owner. The other owners are untouched, and
+    /// the order of what remains does not change.
+    virtual void clearOwner(ResourceOwner owner) = 0;
+
+    /// The token a mount would take next, for undoing an operation that fails
+    /// partway through. Prefer ResourceMountTransaction over calling this and
+    /// rollbackTo by hand.
+    virtual ResourceMountToken mountToken() const = 0;
+
+    /// Retire every source mounted at or after the token, whatever its owner.
+    virtual void rollbackTo(ResourceMountToken token) = 0;
 
     virtual void addEXE(const std::filesystem::path &path,
                         std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addKEY(const std::filesystem::path &path,
                         std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addERF(const std::filesystem::path &path,
-                        ContainerKind kind = ContainerKind::Global,
+                        ResourceOwner owner = ResourceOwner::Global,
                         std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addMemERF(ByteBuffer buffer,
-                           ContainerKind kind,
+                           ResourceOwner owner,
                            std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addRIM(const std::filesystem::path &path,
-                        ContainerKind kind = ContainerKind::Global,
+                        ResourceOwner owner = ResourceOwner::Global,
                         std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addMemRIM(ByteBuffer buffer,
-                           ContainerKind kind = ContainerKind::Global,
+                           ResourceOwner owner = ResourceOwner::Global,
                            std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
     virtual void addFolder(const std::filesystem::path &path,
-                           ContainerKind kind = ContainerKind::Global,
+                           ResourceOwner owner = ResourceOwner::Global,
                            std::optional<ResourceSourceBucket> bucket = std::nullopt) = 0;
 
     virtual Resource get(const ResourceId &id) = 0;
@@ -89,18 +104,22 @@ public:
         _containers.clear();
     }
 
-    void clearLocal() override {
-        _containers.clearKind(ContainerKind::Local);
+    void clearOwner(ResourceOwner owner) override {
+        _containers.clearOwner(owner);
     }
 
-    void clearSave() override {
-        _containers.clearKind(ContainerKind::Save);
+    ResourceMountToken mountToken() const override {
+        return _containers.mountToken();
+    }
+
+    void rollbackTo(ResourceMountToken token) override {
+        _containers.rollbackTo(token);
     }
 
     void add(std::unique_ptr<IResourceContainer> provider,
-             ContainerKind kind = ContainerKind::Global,
+             ResourceOwner owner = ResourceOwner::Global,
              std::optional<ResourceSourceBucket> bucket = std::nullopt) {
-        _containers.add(ResourceContainerPair {std::move(provider), kind, bucket});
+        _containers.add(ResourceContainerPair {std::move(provider), owner, bucket});
     }
 
     void addEXE(const std::filesystem::path &path,
@@ -108,19 +127,19 @@ public:
     void addKEY(const std::filesystem::path &path,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addERF(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemERF(ByteBuffer buffer,
-                   ContainerKind kind,
+                   ResourceOwner owner,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addRIM(const std::filesystem::path &path,
-                ContainerKind kind = ContainerKind::Global,
+                ResourceOwner owner = ResourceOwner::Global,
                 std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addMemRIM(ByteBuffer buffer,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
     void addFolder(const std::filesystem::path &path,
-                   ContainerKind kind = ContainerKind::Global,
+                   ResourceOwner owner = ResourceOwner::Global,
                    std::optional<ResourceSourceBucket> bucket = std::nullopt) override;
 
     Resource get(const ResourceId &id) override;

--- a/include/reone/resource/sourcelist.h
+++ b/include/reone/resource/sourcelist.h
@@ -30,13 +30,14 @@ namespace reone {
 
 namespace resource {
 
-/// Lifetime scope of a mounted source. Independent of the bucket it is
-/// searched in.
-enum class ContainerKind {
-    Global,
-    Local,
-    Save,
-};
+/**
+ * A point in the mount sequence.
+ *
+ * Every mount takes the next value, so a token read before an operation names
+ * exactly the sources that operation went on to add. This is what makes a
+ * failed operation removable without knowing what it tried to mount.
+ */
+using ResourceMountToken = std::uint64_t;
 
 /**
  * How a source list orders what it holds.
@@ -71,11 +72,17 @@ constexpr std::size_t bucketRank(ResourceSourceBucket bucket) {
  * backend. Entries are held in lookup order, so a backend resolves an id by
  * walking the list and taking the first hit.
  *
- * Entry must expose a ContainerKind kind and an
- * std::optional<ResourceSourceBucket> bucket. Everything else about an entry,
- * including how the source is actually read, belongs to the backend: what is
- * shared here is which source wins and when a source goes away, which is
- * exactly what the two backends have to agree on.
+ * Entry must expose a ResourceOwner owner, an
+ * std::optional<ResourceSourceBucket> bucket, and a ResourceMountToken
+ * sequence this list assigns. Everything else about an entry, including how
+ * the source is actually read, belongs to the backend: what is shared here is
+ * which source wins and when a source goes away, which is exactly what the two
+ * backends have to agree on.
+ *
+ * Owner and bucket answer different questions and are never derived from each
+ * other. The bucket says where a source is searched; the owner says what makes
+ * it go away. A source is not searched earlier for being shorter-lived, and it
+ * does not live longer for being searched first.
  *
  * A list is homogeneous. In insertion mode, which is what every caller uses
  * today, the source added last wins and the list behaves exactly like the
@@ -114,17 +121,17 @@ public:
         auto required = entry.bucket ? ResourceSourceOrder::Bucketed
                                      : ResourceSourceOrder::Insertion;
         auto current = order();
-        if (current == ResourceSourceOrder::Empty) {
-            _entries.push_front(std::move(entry));
-            return;
-        }
-        if (current != required) {
+        // The mode is checked before the sequence is spent, so a rejected mount
+        // leaves the list exactly as it was, token included.
+        if (current != ResourceSourceOrder::Empty && current != required) {
             throw ValidationException(
                 required == ResourceSourceOrder::Bucketed
                     ? "Cannot mount a bucketed source into an insertion-ordered resource source list"
                     : "Cannot mount an unbucketed source into a bucketed resource source list");
         }
-        if (current == ResourceSourceOrder::Insertion) {
+        entry.sequence = _nextSequence++;
+        if (current == ResourceSourceOrder::Empty ||
+            current == ResourceSourceOrder::Insertion) {
             _entries.push_front(std::move(entry));
             return;
         }
@@ -137,15 +144,40 @@ public:
         _entries.insert(position, std::move(entry));
     }
 
+    /**
+     * Drop every source.
+     *
+     * The mount sequence deliberately keeps counting. Reusing a spent token
+     * would let a rollback taken before the clear match sources mounted after
+     * it, which is the one way a token could name something it never covered.
+     */
     void clear() {
         _entries.clear();
     }
 
-    /// Drop every source of one scope, in every bucket. Scope answers when a
-    /// source goes away; it never answers where a source is searched.
-    void clearKind(ContainerKind kind) {
-        _entries.remove_if([kind](const Entry &entry) {
-            return entry.kind == kind;
+    /// Drop every source of one owner, in every bucket. Ownership answers when
+    /// a source goes away; it never answers where a source is searched.
+    void clearOwner(ResourceOwner owner) {
+        _entries.remove_if([owner](const Entry &entry) {
+            return entry.owner == owner;
+        });
+    }
+
+    /// The token a mount would take next. Read it before an operation to be
+    /// able to undo exactly that operation.
+    ResourceMountToken mountToken() const { return _nextSequence; }
+
+    /**
+     * Drop every source mounted at or after the token, whatever its owner.
+     *
+     * This undoes an operation rather than retiring a lifetime, which is why it
+     * is expressed in mount order and not in ownership: a failed operation has
+     * to take back what it added, including sources whose owner still has other
+     * members that must survive.
+     */
+    void rollbackTo(ResourceMountToken token) {
+        _entries.remove_if([token](const Entry &entry) {
+            return entry.sequence >= token;
         });
     }
 
@@ -159,6 +191,7 @@ public:
 
 private:
     Entries _entries;
+    ResourceMountToken _nextSequence {0};
 };
 
 } // namespace resource

--- a/include/reone/resource/sourcelist.h
+++ b/include/reone/resource/sourcelist.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modulepolicy.h"
+
+#include "reone/system/exception/validation.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <list>
+#include <optional>
+
+namespace reone {
+
+namespace resource {
+
+/// Lifetime scope of a mounted source. Independent of the bucket it is
+/// searched in.
+enum class ContainerKind {
+    Global,
+    Local,
+    Save,
+};
+
+/**
+ * How a source list orders what it holds.
+ *
+ * A list has no mode until something is mounted, takes its mode from the first
+ * source registered, and releases it once it is empty again. There is no third
+ * mode: bucketed and unbucketed sources never coexist.
+ */
+enum class ResourceSourceOrder {
+    Empty,
+    Insertion,
+    Bucketed,
+};
+
+/// Position of a bucket in the raw lookup order. Derived from
+/// kRawResourceLookupOrder rather than restated, so the two cannot come to
+/// disagree. Only a bucketed source has a rank; an unbucketed one has none,
+/// which is why the two cannot be ordered against each other.
+constexpr std::size_t bucketRank(ResourceSourceBucket bucket) {
+    std::size_t rank = 0;
+    for (auto candidate : kRawResourceLookupOrder) {
+        if (candidate == bucket) {
+            break;
+        }
+        ++rank;
+    }
+    return rank;
+}
+
+/**
+ * Ordered list of mounted resource sources, shared by every IResources
+ * backend. Entries are held in lookup order, so a backend resolves an id by
+ * walking the list and taking the first hit.
+ *
+ * Entry must expose a ContainerKind kind and an
+ * std::optional<ResourceSourceBucket> bucket. Everything else about an entry,
+ * including how the source is actually read, belongs to the backend: what is
+ * shared here is which source wins and when a source goes away, which is
+ * exactly what the two backends have to agree on.
+ *
+ * A list is homogeneous. In insertion mode, which is what every caller uses
+ * today, the source added last wins and the list behaves exactly like the
+ * insertion-ordered list it replaces. In bucketed mode sources follow
+ * kRawResourceLookupOrder, and within one bucket the source added last wins.
+ *
+ * The two modes are never mixed. Ranking an unbucketed source against a
+ * bucketed one would require inventing a position for it in the raw lookup
+ * order, and any position invented would be wrong: a source that has not been
+ * placed has no place. Mounting across modes is therefore rejected rather than
+ * resolved, so that migrating a call site is a complete change or no change.
+ */
+template <class Entry>
+class ResourceSourceList {
+public:
+    using Entries = std::list<Entry>;
+    using iterator = typename Entries::iterator;
+    using const_iterator = typename Entries::const_iterator;
+
+    ResourceSourceOrder order() const {
+        if (_entries.empty()) {
+            return ResourceSourceOrder::Empty;
+        }
+        return _entries.front().bucket ? ResourceSourceOrder::Bucketed
+                                       : ResourceSourceOrder::Insertion;
+    }
+
+    /**
+     * Mount a source at the front of its rank, or at the front of the list in
+     * insertion mode.
+     *
+     * Throws ValidationException when the source does not match the mode the
+     * list is already in.
+     */
+    void add(Entry entry) {
+        auto required = entry.bucket ? ResourceSourceOrder::Bucketed
+                                     : ResourceSourceOrder::Insertion;
+        auto current = order();
+        if (current == ResourceSourceOrder::Empty) {
+            _entries.push_front(std::move(entry));
+            return;
+        }
+        if (current != required) {
+            throw ValidationException(
+                required == ResourceSourceOrder::Bucketed
+                    ? "Cannot mount a bucketed source into an insertion-ordered resource source list"
+                    : "Cannot mount an unbucketed source into a bucketed resource source list");
+        }
+        if (current == ResourceSourceOrder::Insertion) {
+            _entries.push_front(std::move(entry));
+            return;
+        }
+        // Every entry carries a bucket in this mode, which is what the check
+        // above maintains, so neither dereference here needs a guard.
+        auto rank = bucketRank(*entry.bucket);
+        auto position = std::find_if(_entries.begin(), _entries.end(), [rank](const Entry &other) {
+            return bucketRank(*other.bucket) >= rank;
+        });
+        _entries.insert(position, std::move(entry));
+    }
+
+    void clear() {
+        _entries.clear();
+    }
+
+    /// Drop every source of one scope, in every bucket. Scope answers when a
+    /// source goes away; it never answers where a source is searched.
+    void clearKind(ContainerKind kind) {
+        _entries.remove_if([kind](const Entry &entry) {
+            return entry.kind == kind;
+        });
+    }
+
+    iterator begin() { return _entries.begin(); }
+    iterator end() { return _entries.end(); }
+    const_iterator begin() const { return _entries.begin(); }
+    const_iterator end() const { return _entries.end(); }
+
+    bool empty() const { return _entries.empty(); }
+    std::size_t size() const { return _entries.size(); }
+
+private:
+    Entries _entries;
+};
+
+} // namespace resource
+
+} // namespace reone

--- a/include/reone/resource/strings.h
+++ b/include/reone/resource/strings.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
-#include "format/tlkreader.h"
+#include "talktable.h"
 
 #include "types.h"
+
+#include <array>
 
 namespace reone {
 
@@ -35,19 +37,22 @@ public:
 
 class Strings : public IStrings {
 public:
+    static constexpr std::size_t kTalkTableSlotCount = 7;
+
     Strings() = default;
 
     void init(const std::filesystem::path &gameDir);
 
+    void setTalkTable(std::size_t slot, std::shared_ptr<TalkTable> table);
+    bool loadTalkTable(std::size_t slot, const std::filesystem::path &path);
+
     std::string getText(int strRef) override;
     std::string getSound(int strRef) override;
 
-    void setTalkTable(std::shared_ptr<TalkTable> table) {
-        _table = std::move(table);
-    }
-
 private:
-    std::shared_ptr<TalkTable> _table;
+    std::array<std::shared_ptr<TalkTable>, kTalkTableSlotCount> _tables;
+
+    const TalkTable::String *findString(int strRef) const;
 
     void process(std::string &str);
     void stripDeveloperNotes(std::string &str);

--- a/include/reone/resource/types.h
+++ b/include/reone/resource/types.h
@@ -38,6 +38,7 @@ enum class ResType : uint16_t {
     Mdl = 2002,
     Nss = 2009,
     Ncs = 2010,
+    Mod = 2011,
     Are = 2012,
     Set = 2013,
     Ifo = 2014,
@@ -69,7 +70,9 @@ enum class ResType : uint16_t {
     Dwk = 2052,
     Pwk = 2053,
     Jrl = 2056,
-    Mod = 2057,
+    // 0x0809 is the saved module archive. The name Mod was historically bound
+    // to this value, which is why the nested saved module resolves through it.
+    Sav = 2057,
     Utw = 2058,
     Ssf = 2060,
     Ndb = 2064,
@@ -81,6 +84,7 @@ enum class ResType : uint16_t {
     Lip = 3004,
     Tpc = 3007,
     Mdx = 3008,
+    Rsv = 3009,
 
     // Mods and engine-specific
     Mp3 = 0x1000,

--- a/src/apps/dataminer/models.cpp
+++ b/src/apps/dataminer/models.cpp
@@ -277,7 +277,7 @@ static ModelStats analyzeModels(const std::filesystem::path &gameDir) {
     ModelStats stats;
     Resources resources;
     resources.addKEY(gameDir / std::string("chitin.key"));
-    for (const auto &[container, kind, bucket] : resources.containers()) {
+    for (const auto &[container, owner, bucket, sequence] : resources.containers()) {
         const auto &resIds = container->resourceIds();
         for (const auto &resId : resIds) {
             if (resId.type != ResType::Mdl) {

--- a/src/apps/dataminer/models.cpp
+++ b/src/apps/dataminer/models.cpp
@@ -277,7 +277,7 @@ static ModelStats analyzeModels(const std::filesystem::path &gameDir) {
     ModelStats stats;
     Resources resources;
     resources.addKEY(gameDir / std::string("chitin.key"));
-    for (const auto &[container, local] : resources.containers()) {
+    for (const auto &[container, kind, bucket] : resources.containers()) {
         const auto &resIds = container->resourceIds();
         for (const auto &resId : resIds) {
             if (resId.type != ResType::Mdl) {

--- a/src/apps/toolkit/viewmodel/resource/explorer.cpp
+++ b/src/apps/toolkit/viewmodel/resource/explorer.cpp
@@ -442,7 +442,7 @@ void ResourceExplorerViewModel::loadEngine() {
         if (usesBucketedLookup(_gameId)) {
             bucket = ResourceSourceBucket::LooseDirectory;
         }
-        _resourceModule->resources().addFolder(_resourcesPath, ContainerKind::Global, bucket);
+        _resourceModule->resources().addFolder(_resourcesPath, ResourceOwner::Global, bucket);
     }
 
     _modelResViewModel->initScene();

--- a/src/apps/toolkit/viewmodel/resource/explorer.cpp
+++ b/src/apps/toolkit/viewmodel/resource/explorer.cpp
@@ -435,7 +435,14 @@ void ResourceExplorerViewModel::loadEngine() {
 
     auto keyPath = findFileIgnoreCase(_resourcesPath, "chitin.key");
     if (!keyPath) {
-        _resourceModule->resources().addFolder(_resourcesPath);
+        // This mounts into the same list the director just filled, so it has to
+        // place the source exactly as the director would. Leaving it unplaced
+        // for a game whose sources are bucketed would be rejected outright.
+        std::optional<ResourceSourceBucket> bucket;
+        if (usesBucketedLookup(_gameId)) {
+            bucket = ResourceSourceBucket::LooseDirectory;
+        }
+        _resourceModule->resources().addFolder(_resourcesPath, ContainerKind::Global, bucket);
     }
 
     _modelResViewModel->initScene();
@@ -718,7 +725,9 @@ void ResourceExplorerViewModel::saveFile(Page &page, const std::filesystem::path
                 columns.emplace_back(column.name);
             }
             for (const auto &row : table.rows) {
-                rows.push_back({row});
+                // The table view does not carry row labels, so rows are
+                // relabelled by ordinal, which is what was written before.
+                rows.push_back(TwoDA::newRow(std::to_string(rows.size()), row));
             }
             TwoDA twoDa {std::move(columns), std::move(rows)};
             TwoDAWriter writer {twoDa};

--- a/src/libs/resource/2da.cpp
+++ b/src/libs/resource/2da.cpp
@@ -25,6 +25,37 @@ namespace resource {
 
 static constexpr char kCellValueDeleted[] = "****";
 
+/**
+ * ASCII case folding.
+ *
+ * Table keys are ASCII, and the original lookup folds case. A locale-aware
+ * conversion is deliberately avoided: it would make which row a table resolves
+ * to depend on the environment the game happens to run in.
+ */
+static char asciiLower(char ch) {
+    return ch >= 'A' && ch <= 'Z' ? static_cast<char>(ch - 'A' + 'a') : ch;
+}
+
+static bool asciiEqualsIgnoreCase(const std::string &lhs, const std::string &rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (asciiLower(lhs[i]) != asciiLower(rhs[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int TwoDA::indexByLabel(const std::string &label) const {
+    for (size_t i = 0; i < _rows.size(); ++i) {
+        if (asciiEqualsIgnoreCase(_rows[i].label, label))
+            return static_cast<int>(i);
+    }
+    return -1;
+}
+
 int TwoDA::indexByCellValue(const std::string &column, const std::string &value) const {
     int columnIdx = getColumnIndex(column);
     if (columnIdx == -1) {

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -63,6 +63,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/id.h
     ${RESOURCE_INCLUDE_DIR}/layout.h
     ${RESOURCE_INCLUDE_DIR}/ltr.h
+    ${RESOURCE_INCLUDE_DIR}/modulediscovery.h
     ${RESOURCE_INCLUDE_DIR}/modulepolicy.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/appearance.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/genericdoors.h
@@ -143,6 +144,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/gameprobe.cpp
     ${RESOURCE_SOURCE_DIR}/gff.cpp
     ${RESOURCE_SOURCE_DIR}/ltr.cpp
+    ${RESOURCE_SOURCE_DIR}/modulediscovery.cpp
     ${RESOURCE_SOURCE_DIR}/modulepolicy.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/appearance.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/genericdoors.cpp

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -64,6 +64,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/layout.h
     ${RESOURCE_INCLUDE_DIR}/ltr.h
     ${RESOURCE_INCLUDE_DIR}/modulediscovery.h
+    ${RESOURCE_INCLUDE_DIR}/modulemount.h
     ${RESOURCE_INCLUDE_DIR}/modulepolicy.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/appearance.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/genericdoors.h
@@ -146,6 +147,7 @@ set(RESOURCE_SOURCES
     ${RESOURCE_SOURCE_DIR}/gff.cpp
     ${RESOURCE_SOURCE_DIR}/ltr.cpp
     ${RESOURCE_SOURCE_DIR}/modulediscovery.cpp
+    ${RESOURCE_SOURCE_DIR}/modulemount.cpp
     ${RESOURCE_SOURCE_DIR}/modulepolicy.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/appearance.cpp
     ${RESOURCE_SOURCE_DIR}/parser/2da/genericdoors.cpp

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -101,6 +101,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/resource.h
     ${RESOURCE_INCLUDE_DIR}/resources.h
     ${RESOURCE_INCLUDE_DIR}/resref.h
+    ${RESOURCE_INCLUDE_DIR}/sourcelist.h
     ${RESOURCE_INCLUDE_DIR}/strings.h
     ${RESOURCE_INCLUDE_DIR}/talktable.h
     ${RESOURCE_INCLUDE_DIR}/types.h

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -66,6 +66,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/modulediscovery.h
     ${RESOURCE_INCLUDE_DIR}/modulemount.h
     ${RESOURCE_INCLUDE_DIR}/modulepolicy.h
+    ${RESOURCE_INCLUDE_DIR}/mounttransaction.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/appearance.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/genericdoors.h
     ${RESOURCE_INCLUDE_DIR}/parser/2da/heads.h

--- a/src/libs/resource/CMakeLists.txt
+++ b/src/libs/resource/CMakeLists.txt
@@ -17,6 +17,7 @@ set(RESOURCE_INCLUDE_DIR ${REONE_INCLUDE_DIR}/reone/resource)
 set(RESOURCE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/libs/resource)
 
 set(RESOURCE_HEADERS
+    ${RESOURCE_INCLUDE_DIR}/odysseyroots.h
     ${RESOURCE_INCLUDE_DIR}/2da.h
     ${RESOURCE_INCLUDE_DIR}/container.h
     ${RESOURCE_INCLUDE_DIR}/container/erf.h
@@ -110,6 +111,7 @@ set(RESOURCE_HEADERS
     ${RESOURCE_INCLUDE_DIR}/typeutil.h)
 
 set(RESOURCE_SOURCES
+    ${RESOURCE_SOURCE_DIR}/odysseyroots.cpp
     ${RESOURCE_SOURCE_DIR}/2da.cpp
     ${RESOURCE_SOURCE_DIR}/extract/capsule.cpp
     ${RESOURCE_SOURCE_DIR}/extract/chitin.cpp

--- a/src/libs/resource/di/module.cpp
+++ b/src/libs/resource/di/module.cpp
@@ -92,10 +92,12 @@ void ResourceModule::init() {
         *_resources,
         *_auxResources,
         *_scripts,
-        *_twoDas);
+        *_twoDas,
+        _odysseyRoots);
 
-    _director->init();
     _strings->init(_gamePath);
+    loadLiveTalkTables(*_strings, _odysseyRoots);
+    _director->init();
     _shaders->init();
     _textures->init();
 

--- a/src/libs/resource/di/module.cpp
+++ b/src/libs/resource/di/module.cpp
@@ -31,17 +31,26 @@ namespace resource {
 
 void ResourceModule::init() {
     std::unique_ptr<IResources> backend;
+    std::unique_ptr<IResources> auxBackend;
     if (_resourcesBackend == ResourcesBackend::Extract) {
         backend = std::make_unique<ExtractResources>();
+        auxBackend = std::make_unique<ExtractResources>();
     } else {
         backend = std::make_unique<Resources>();
+        auxBackend = std::make_unique<Resources>();
     }
     _replacements = std::make_unique<ResourceReplacements>();
     _resources = std::make_unique<ReplacementResources>(std::move(backend), *_replacements);
+    // Auxiliary sources are read through the same replacement store, so a
+    // replacement still sits above them. A second store would silently make
+    // shader and cursor resources unreplaceable. The backend mirrors the
+    // selected one because the two index folders differently, and streamed
+    // audio lives here for an activated game.
+    _auxResources = std::make_unique<ReplacementResources>(std::move(auxBackend), *_replacements);
     _strings = std::make_unique<Strings>();
     _twoDas = std::make_unique<TwoDAs>(*_resources);
     _gffs = std::make_unique<Gffs>(*_resources);
-    _shaders = std::make_unique<Shaders>(_graphicsOpt, _graphics.shaderRegistry(), *_resources);
+    _shaders = std::make_unique<Shaders>(_graphicsOpt, _graphics.shaderRegistry(), *_auxResources);
     _textures = std::make_unique<Textures>(_graphicsOpt, *_resources);
     _models = std::make_unique<Models>(*_textures, *_resources, _graphics.statistic());
     _walkmeshes = std::make_unique<Walkmeshes>(*_resources);
@@ -60,8 +69,8 @@ void ResourceModule::init() {
         *_textures,
         _graphics.uniforms(),
         _graphics.statistic(),
-        *_resources);
-    _audioClips = std::make_unique<AudioClips>(*_resources);
+        *_auxResources);
+    _audioClips = std::make_unique<AudioClips>(*_resources, *_auxResources);
     _movies = std::make_unique<Movies>(_gamePath, _graphics.services(), _audio.mixer());
     _scripts = std::make_unique<Scripts>(*_resources, *_replacements);
     _dialogs = std::make_unique<Dialogs>(*_gffs, *_strings);
@@ -81,7 +90,9 @@ void ResourceModule::init() {
         *_lips,
         *_paths,
         *_resources,
-        *_scripts);
+        *_auxResources,
+        *_scripts,
+        *_twoDas);
 
     _director->init();
     _strings->init(_gamePath);
@@ -136,6 +147,7 @@ void ResourceModule::deinit() {
     _gffs.reset();
     _twoDas.reset();
     _strings.reset();
+    _auxResources.reset();
     _resources.reset();
     _replacements.reset();
 }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -606,6 +606,10 @@ void ResourceDirector::loadModuleResourcesFromPolicy(const std::string &name) {
     }
 
     RuntimeModuleSourceIndex index;
+    for (auto &source : discoverRimsModuleAdjuncts(discovered.moduleRoot, _gamePath)) {
+        index.add(RuntimeModuleSource {source.candidate, source.path});
+    }
+
     for (const auto &source : discovered.sources) {
         index.add(RuntimeModuleSource {source.candidate, source.path});
     }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -496,8 +496,6 @@ void ResourceDirector::loadGlobalResources() {
         _resources.addKEY(*keyPath, bucketOf(ResourceSourceBucket::KeyBif));
     }
 
-    loadRimsDirectory();
-
     loadTexturePackResources();
     loadStreamResources();
 
@@ -524,6 +522,7 @@ void ResourceDirector::loadGlobalResources() {
                              ResourceOwner::Global,
                              bucketOf(ResourceSourceBucket::LooseDirectory));
     }
+    loadRimsDirectory();
     loadGlobalRimResource();
     loadLiveResources();
 }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -278,12 +278,11 @@ void ResourceDirector::loadK1StreamResources() {
  * images when something asks for them, so mounting them here because the files
  * exist would invent sources the engine never registers.
  *
- * K2 startup is not traced here, so this stays K1's.
+ * Both games register this source. Their startup routines use the same
+ * RIMS: logical directory even though the other global sources around it
+ * differ by game.
  */
 void ResourceDirector::loadRimsDirectory() {
-    if (_gameId != GameID::KotOR) {
-        return;
-    }
     if (auto rimsPath = findFileIgnoreCase(_gamePath, kRimsDirectoryName)) {
         _resources.addFolder(*rimsPath,
                              ResourceOwner::Global,
@@ -300,9 +299,6 @@ void ResourceDirector::loadRimsDirectory() {
  * invent sources the engine never registers.
  */
 void ResourceDirector::loadGlobalRimResource() {
-    if (_gameId != GameID::KotOR) {
-        return;
-    }
     auto rimsPath = findFileIgnoreCase(_gamePath, kRimsDirectoryName);
     if (!rimsPath) {
         return;
@@ -447,6 +443,8 @@ void ResourceDirector::loadGlobalResources() {
         _resources.addKEY(*keyPath, bucketOf(ResourceSourceBucket::KeyBif));
     }
 
+    loadRimsDirectory();
+
     loadTexturePackResources();
     loadStreamResources();
 
@@ -474,6 +472,7 @@ void ResourceDirector::loadGlobalResources() {
                              ResourceOwner::Global,
                              bucketOf(ResourceSourceBucket::LooseDirectory));
     }
+    loadGlobalRimResource();
 }
 
 void ResourceDirector::loadModuleResources(const std::string &name) {

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -608,7 +608,9 @@ void ResourceDirector::loadModuleResourcesFromPolicy(const std::string &name) {
     ModuleMountExecutor executor(_resources, index);
     auto report = executor.run(plan);
 
-    transaction.commit();
+    if (report.outcome != ModuleLoadOutcome::Failed) {
+        transaction.commit();
+    }
 
     if (!plan.primary) {
         warn("No primary source found for module '" + discovered.moduleRoot + "'");

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -57,6 +57,10 @@ static constexpr char kModulesDirectoryName[] = "modules";
 static constexpr char kSavesDirectoryName[] = "saves";
 static constexpr char kLipsDirectoryName[] = "lips";
 static constexpr char kOverrideDirectoryName[] = "override";
+static constexpr char kRimsDirectoryName[] = "rims";
+static constexpr char kGlobalRimFilename[] = "global.rim";
+static constexpr char kPlayersBasename[] = "players";
+static constexpr char kOverrideTexturesBasename[] = "textures";
 
 static constexpr char kTexturePackFilenameGUI[] = "swpc_tex_gui.erf";
 static constexpr char kTexturePackFilenameHigh[] = "swpc_tex_tpa.erf";
@@ -70,6 +74,8 @@ static constexpr char kShaderPackFilename[] = "shaderpack.erf";
 
 static constexpr char kModulesRootId[] = "modules";
 static constexpr char kLipsRootId[] = "lips";
+/// Root fixed-name installation support archives are offered under.
+static constexpr char kRootRootId[] = "hd0";
 /// Root the staged active module is offered under. reone has no current-game
 /// directory; the equivalent is the save archive already in scope.
 static constexpr char kStagedRootId[] = "currentgame";
@@ -151,8 +157,16 @@ std::set<std::string> ResourceDirector::saveNames() {
     return names;
 }
 
+/**
+ * Whether a game's sources are placed in the Odyssey raw lookup order.
+ *
+ * Both games are, and the answer no longer varies. It stays a named question
+ * because a source list is homogeneous: anything mounting into a game's list
+ * has to agree with the director about how that list is ordered, and the
+ * toolkit asks the same question when it mounts after startup.
+ */
 bool usesBucketedLookup(GameID game) {
-    return game == GameID::TSL;
+    return game == GameID::KotOR || game == GameID::TSL;
 }
 
 std::optional<ResourceSourceBucket> ResourceDirector::bucketOf(ResourceSourceBucket bucket) const {
@@ -197,62 +211,249 @@ void ResourceDirector::loadAuxiliaryResources() {
  * stay exactly where they have always been.
  */
 void ResourceDirector::loadStreamResources() {
-    auto &target = bucketed() ? _auxResources : _resources;
-
+    if (_gameId == GameID::KotOR) {
+        loadK1StreamResources();
+        return;
+    }
+    // K2 keeps its streamed audio out of the raw lookup order. Its own startup
+    // is not traced here, so this is left exactly as it was.
     auto musicPath = findFileIgnoreCase(_gamePath, kMusicDirectoryName);
     if (musicPath) {
-        target.addFolder(*musicPath);
+        _auxResources.addFolder(*musicPath);
     }
     auto soundsPath = findFileIgnoreCase(_gamePath, kSoundsDirectoryName);
     if (soundsPath) {
-        target.addFolder(*soundsPath);
+        _auxResources.addFolder(*soundsPath);
     }
+    auto voicePath = findFileIgnoreCase(_gamePath, kVoiceDirectoryName);
+    if (voicePath) {
+        _auxResources.addFolder(*voicePath);
+    }
+}
 
-    if (_gameId == GameID::TSL) {
-        auto voicePath = findFileIgnoreCase(_gamePath, kVoiceDirectoryName);
-        if (voicePath) {
-            target.addFolder(*voicePath);
-        }
-    } else {
-        auto wavesPath = findFileIgnoreCase(_gamePath, kWavesDirectoryName);
-        if (wavesPath) {
-            target.addFolder(*wavesPath);
-        }
+/**
+ * K1 streamed audio, as its startup registers it.
+ *
+ * K1 is not uniform about this and the difference is evidenced, not a
+ * simplification. Startup registers HD0:STREAMMUSIC and HD0:STREAMWAVES as
+ * ordinary resource directories, so both sit in the loose bucket and can answer
+ * an ordinary lookup. HD0:STREAMSOUNDS has no bare alias and is never
+ * registered: the only string for it is the path template HD0:STREAMSOUNDS\%s,
+ * so it is reached by constructed path and stays out of raw lookup entirely.
+ *
+ * The sounds directory therefore goes to the auxiliary list, where the audio
+ * provider still finds it and no ordinary lookup can.
+ */
+void ResourceDirector::loadK1StreamResources() {
+    // Waves first, then music: that is the order startup registers them in,
+    // and within the loose bucket the later one wins.
+    auto wavesPath = findFileIgnoreCase(_gamePath, kWavesDirectoryName);
+    if (wavesPath) {
+        _resources.addFolder(*wavesPath,
+                             ResourceOwner::Global,
+                             bucketOf(ResourceSourceBucket::LooseDirectory));
     }
+    auto musicPath = findFileIgnoreCase(_gamePath, kMusicDirectoryName);
+    if (musicPath) {
+        _resources.addFolder(*musicPath,
+                             ResourceOwner::Global,
+                             bucketOf(ResourceSourceBucket::LooseDirectory));
+    }
+    auto soundsPath = findFileIgnoreCase(_gamePath, kSoundsDirectoryName);
+    if (soundsPath) {
+        _auxResources.addFolder(*soundsPath);
+    }
+}
+
+/**
+ * The K1 rims location and its global image.
+ *
+ * These are two sources with two roles, and K1 startup registers them
+ * separately. The directory itself is a resource directory, so a loose file
+ * dropped there answers like any other loose file. GLOBAL.rim is registered on
+ * its own as a resource image.
+ *
+ * Only that one image is mounted. The directory holds several other images,
+ * and startup names none of them: the rest are reached as module or menu
+ * images when something asks for them, so mounting them here because the files
+ * exist would invent sources the engine never registers.
+ *
+ * K2 startup is not traced here, so this stays K1's.
+ */
+void ResourceDirector::loadRimsDirectory() {
+    if (_gameId != GameID::KotOR) {
+        return;
+    }
+    if (auto rimsPath = findFileIgnoreCase(_gamePath, kRimsDirectoryName)) {
+        _resources.addFolder(*rimsPath,
+                             ResourceOwner::Global,
+                             bucketOf(ResourceSourceBucket::LooseDirectory));
+    }
+}
+
+/**
+ * The global resource image, registered last of the startup sources.
+ *
+ * Only this one image is mounted. The rims location holds several others and
+ * startup names none of them: the rest are reached as module or menu images
+ * when something asks for them, so mounting them because the files exist would
+ * invent sources the engine never registers.
+ */
+void ResourceDirector::loadGlobalRimResource() {
+    if (_gameId != GameID::KotOR) {
+        return;
+    }
+    auto rimsPath = findFileIgnoreCase(_gamePath, kRimsDirectoryName);
+    if (!rimsPath) {
+        return;
+    }
+    if (auto globalRimPath = findFileIgnoreCase(*rimsPath, kGlobalRimFilename)) {
+        _resources.addRIM(*globalRimPath,
+                          ResourceOwner::Global,
+                          bucketOf(ResourceSourceBucket::ResourceImage));
+    }
+}
+
+/**
+ * The K1 override texture archive.
+ *
+ * Startup mounts the exact basename OVERRIDE:textures as an encapsulated
+ * source with source id 1, which is class 1: above every image and class-2
+ * archive, below the loose directories. It is a resource-manager source in its
+ * own right and has nothing to do with the texture packs, which are class 2 and
+ * mounted by the texture subsystem.
+ *
+ * K1 mounts exactly this one base location. It enumerates no configured roots
+ * for it, so neither does this.
+ *
+ * It is registered immediately before the patch archive because that is the
+ * order startup registers them in, and the two share a bucket: within class 1
+ * the later mount wins, so the order is the behaviour. Stock installations ship
+ * no such archive, and its absence is normal.
+ */
+void ResourceDirector::loadOverrideTexturesResource() {
+    if (_gameId != GameID::KotOR) {
+        return;
+    }
+    auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName);
+    if (!overridePath) {
+        return;
+    }
+    auto texturesPath = findEncapsulatedByBasename(*overridePath, kOverrideTexturesBasename);
+    if (!texturesPath) {
+        return;
+    }
+    _resources.addERF(*texturesPath,
+                      ResourceOwner::Global,
+                      bucketOf(ResourceSourceBucket::EncapsulatedClass1));
+}
+
+/**
+ * The GUI and quality-selected texture packs.
+ *
+ * Both games mount these as encapsulated class-2 sources. K1 does it from its
+ * own LoadTexturePack, which builds the path under the TEXTUREPACKS: alias and
+ * hands it to AddEncapsulatedResourceFile with source id 2 into a four-slot
+ * table; K2 does the same. They are not startup-table sources in either game,
+ * but they are ordinary resource-manager sources.
+ */
+void ResourceDirector::loadTexturePackResources() {
+    auto texPacksPath = findFileIgnoreCase(_gamePath, kTexturePackDirectoryName);
+    if (!texPacksPath) {
+        return;
+    }
+    if (auto guiPackPath = findFileIgnoreCase(*texPacksPath, kTexturePackFilenameGUI)) {
+        _resources.addERF(*guiPackPath,
+                          ResourceOwner::Global,
+                          bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+    }
+    auto &texPack = kTexQualityToTexPack.at(_graphicsOpt.textureQuality);
+    if (auto texPackPath = findFileIgnoreCase(*texPacksPath, texPack)) {
+        _resources.addERF(*texPackPath,
+                          ResourceOwner::Global,
+                          bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+    }
+}
+
+/**
+ * The K1 player archive.
+ *
+ * K1 mounts this from its module support phase but never removes it: that path
+ * removes only temporary directories, and re-adding the same exact filename
+ * rebuilds the existing table in place rather than inserting another. Its
+ * observable lifetime is therefore the whole session at a fixed position, which
+ * is what mounting it once here reproduces. Module ownership would retire and
+ * re-mount it on every transition, moving it to the newest position in its
+ * bucket each time, which the original never does.
+ *
+ * The engine mounts an exact basename, so the container extension is probed
+ * rather than assumed.
+ */
+void ResourceDirector::loadPlayerSupportResource() {
+    auto playersPath = findEncapsulatedByBasename(_gamePath, kPlayersBasename);
+    if (!playersPath) {
+        return;
+    }
+    _resources.addERF(*playersPath,
+                      ResourceOwner::Global,
+                      bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+}
+
+/**
+ * K1 startup sources, in the order K1 registers them.
+ *
+ * The order is the behaviour. Four of these share the loose bucket and two
+ * share class 1, and within a bucket the source registered later wins, so
+ * reproducing the chronology is what reproduces the winners. K1 registers the
+ * override directory early and the streaming directories late, which means a
+ * streamed asset outranks an override file of the same resref and type: the
+ * opposite of what mounting override last would give.
+ *
+ * Only sources reone reads through are mounted. The original also registers
+ * TEMPCLIENT:, ERRORTEX:, SERVERVAULT: and PORTRAITS:, which reone has no
+ * consumer for, and HD0:MOVIES, which reone plays by direct path.
+ */
+void ResourceDirector::loadK1GlobalResources() {
+    if (auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName)) {
+        _resources.addFolder(*overridePath,
+                             ResourceOwner::Global,
+                             bucketOf(ResourceSourceBucket::LooseDirectory));
+    }
+    if (auto keyPath = findFileIgnoreCase(_gamePath, kKeyFilename)) {
+        _resources.addKEY(*keyPath, bucketOf(ResourceSourceBucket::KeyBif));
+    }
+    loadRimsDirectory();
+    loadOverrideTexturesResource();
+    if (auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename)) {
+        _resources.addERF(*patchPath,
+                          ResourceOwner::Global,
+                          bucketOf(ResourceSourceBucket::EncapsulatedClass1));
+    }
+    loadK1StreamResources();
+    loadGlobalRimResource();
+    loadTexturePackResources();
+    loadPlayerSupportResource();
 }
 
 void ResourceDirector::loadGlobalResources() {
     loadAuxiliaryResources();
+    if (_gameId == GameID::KotOR) {
+        loadK1GlobalResources();
+        return;
+    }
 
     auto keyPath = findFileIgnoreCase(_gamePath, kKeyFilename);
     if (keyPath) {
         _resources.addKEY(*keyPath, bucketOf(ResourceSourceBucket::KeyBif));
     }
 
-    auto texPacksPath = findFileIgnoreCase(_gamePath, kTexturePackDirectoryName);
-    if (texPacksPath) {
-        auto guiPackPath = findFileIgnoreCase(*texPacksPath, kTexturePackFilenameGUI);
-        if (guiPackPath) {
-            _resources.addERF(*guiPackPath,
-                              ResourceOwner::Global,
-                              bucketOf(ResourceSourceBucket::EncapsulatedClass2));
-        }
-        auto &texPack = kTexQualityToTexPack.at(_graphicsOpt.textureQuality);
-        auto texPackPath = findFileIgnoreCase(*texPacksPath, texPack);
-        if (texPackPath) {
-            _resources.addERF(*texPackPath,
-                              ResourceOwner::Global,
-                              bucketOf(ResourceSourceBucket::EncapsulatedClass2));
-        }
-    }
-
+    loadTexturePackResources();
     loadStreamResources();
 
     auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName);
     if (lipsPath) {
         for (auto &filename : g_globalLipFiles) {
-            auto globalLipPath = findFileIgnoreCase(*lipsPath, filename);
-            if (globalLipPath) {
+            if (auto globalLipPath = findFileIgnoreCase(*lipsPath, filename)) {
                 // A global LIP archive is a caller-selected encapsulated
                 // source. Class 2 keeps it where it has always sat relative to
                 // the texture packs it is mounted after.
@@ -263,14 +464,12 @@ void ResourceDirector::loadGlobalResources() {
         }
     }
 
-    auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename);
-    if (patchPath) {
+    if (auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename)) {
         _resources.addERF(*patchPath,
                           ResourceOwner::Global,
                           bucketOf(ResourceSourceBucket::EncapsulatedClass1));
     }
-    auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName);
-    if (overridePath) {
+    if (auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName)) {
         _resources.addFolder(*overridePath,
                              ResourceOwner::Global,
                              bucketOf(ResourceSourceBucket::LooseDirectory));
@@ -278,45 +477,7 @@ void ResourceDirector::loadGlobalResources() {
 }
 
 void ResourceDirector::loadModuleResources(const std::string &name) {
-    if (bucketed()) {
-        loadModuleResourcesFromPolicy(name);
-    } else {
-        loadModuleResourcesLegacy(name);
-    }
-}
-
-/**
- * Module loading for a game that is not yet activated.
- *
- * This is the flat insertion-ordered stack the engine has always used. It is
- * retained unchanged rather than reimplemented, so that activating one game
- * cannot change the other.
- */
-void ResourceDirector::loadModuleResourcesLegacy(const std::string &name) {
-    std::optional<std::filesystem::path> modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
-    if (!modulesPath) {
-        throw ResourceNotFoundException("Modules directory not found");
-    }
-
-    // Scoped for the same reason the activated path is: an archive that fails
-    // to open partway down this list must not leave the ones above it mounted.
-    // The stack itself, and the order it is built in, are unchanged.
-    ResourceMountTransaction transaction(_resources);
-
-    loadRIM(*modulesPath, name, ResourceOwner::ActiveModule);
-    loadRIM(*modulesPath, name + "_s", ResourceOwner::ActiveModule);
-    loadERF(*modulesPath, name, ResourceOwner::ActiveModule);
-    loadERF(*modulesPath, name + "_loc", ResourceOwner::ActiveModule);
-
-    if (auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName)) {
-        loadERF(*lipsPath, name + "_loc", ResourceOwner::ActiveModule);
-    }
-
-    if (_gameId == GameID::TSL) {
-        loadERF(*modulesPath, name + "_dlg", ResourceOwner::ActiveModule);
-    }
-
-    transaction.commit();
+    loadModuleResourcesFromPolicy(name);
 }
 
 ModuleSearchRoot ResourceDirector::modulesSearchRoot() {
@@ -521,46 +682,6 @@ void ResourceDirector::loadSaveGameResources(std::string_view name) {
 
     transaction.commit();
     _savegamePath = std::move(savegamePath);
-}
-
-void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ResourceOwner owner) {
-    // Try to find a module with the same name in already loaded resources.
-    // Same idea as in loadERF.
-    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Res));
-    if (res) {
-        _resources.addMemRIM(res->data, owner);
-        return;
-    }
-
-    if (auto rimPath = findFileIgnoreCase(path, name + ".rim")) {
-        _resources.addRIM(*rimPath, owner);
-    }
-}
-
-void ResourceDirector::loadERF(const std::filesystem::path &path, const std::string &name, ResourceOwner owner) {
-    // Try to find a module with the same name in already loaded resources.
-    //
-    // This allows us to support savegame archives: savegame.sav is an ERF
-    // archive that contains ERF modules. When loading from a save game we add
-    // savegame.sav ERF container. Module lookups resolve to modules from this
-    // container, and fall back to filesystem search if the module is not in the
-    // save archive.
-    // Type 0x0809 is the saved module archive, which is what a nested module
-    // in savegame.sav is stored as. This probe is unchanged; only the name it
-    // is spelled with was wrong before.
-    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Sav));
-    if (res) {
-        _resources.addMemERF(res->data, owner);
-        return;
-    }
-
-    if (auto modPath = findFileIgnoreCase(path, name + ".mod")) {
-        _resources.addERF(*modPath, owner);
-    }
-
-    if (auto erfPath = findFileIgnoreCase(path, name + ".erf")) {
-        _resources.addERF(*erfPath, owner);
-    }
 }
 
 } // namespace resource

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -25,6 +25,7 @@
 #include "reone/resource/modulediscovery.h"
 #include "reone/resource/modulemount.h"
 #include "reone/resource/modulepolicy.h"
+#include "reone/resource/mounttransaction.h"
 #include "reone/resource/provider/2das.h"
 #include "reone/resource/provider/dialogs.h"
 #include "reone/resource/provider/gffs.h"
@@ -87,19 +88,42 @@ void ResourceDirector::init() {
     loadGlobalResources();
 }
 
+/**
+ * Retire the module that was here and put the next one in its place.
+ *
+ * Both module owners go: the support sources of the old module, and the state
+ * of the old module. They are retired separately even though they happen to be
+ * retired together here, because they are two lifetimes; collapsing them would
+ * make it impossible to replace one without the other later.
+ *
+ * Global and save-slot sources are untouched. A module transition is no reason
+ * to rebuild the installation or to leave the save that is loaded.
+ */
 void ResourceDirector::onModuleLoad(const std::string &name) {
     _dialogs.clear();
     _paths.clear();
     _scripts.clear();
     _lips.clear();
     _gffs.clear();
-    _resources.clearLocal();
+    _resources.clearOwner(ResourceOwner::ActiveModule);
+    _resources.clearOwner(ResourceOwner::ActiveModuleState);
 
     loadModuleResources(name);
 }
 
+/**
+ * Replace the loaded save.
+ *
+ * The GFF cache is cleared here rather than left to the module load that
+ * follows, because the caller reads the save's own records in between. Those
+ * records are keyed by resref and type alone, so the previous save's copy would
+ * be served from the cache whatever is mounted: retiring a source does not
+ * reach a result already parsed out of it. No other provider cache is read
+ * before the module load clears it, so no other one is cleared here.
+ */
 void ResourceDirector::onGameLoad(std::string_view name) {
-    _resources.clearSave();
+    _gffs.clear();
+    _resources.clearOwner(ResourceOwner::SaveSlot);
     loadSaveGameResources(name);
 }
 
@@ -210,14 +234,14 @@ void ResourceDirector::loadGlobalResources() {
         auto guiPackPath = findFileIgnoreCase(*texPacksPath, kTexturePackFilenameGUI);
         if (guiPackPath) {
             _resources.addERF(*guiPackPath,
-                              ContainerKind::Global,
+                              ResourceOwner::Global,
                               bucketOf(ResourceSourceBucket::EncapsulatedClass2));
         }
         auto &texPack = kTexQualityToTexPack.at(_graphicsOpt.textureQuality);
         auto texPackPath = findFileIgnoreCase(*texPacksPath, texPack);
         if (texPackPath) {
             _resources.addERF(*texPackPath,
-                              ContainerKind::Global,
+                              ResourceOwner::Global,
                               bucketOf(ResourceSourceBucket::EncapsulatedClass2));
         }
     }
@@ -233,7 +257,7 @@ void ResourceDirector::loadGlobalResources() {
                 // source. Class 2 keeps it where it has always sat relative to
                 // the texture packs it is mounted after.
                 _resources.addERF(*globalLipPath,
-                                  ContainerKind::Global,
+                                  ResourceOwner::Global,
                                   bucketOf(ResourceSourceBucket::EncapsulatedClass2));
             }
         }
@@ -242,13 +266,13 @@ void ResourceDirector::loadGlobalResources() {
     auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename);
     if (patchPath) {
         _resources.addERF(*patchPath,
-                          ContainerKind::Global,
+                          ResourceOwner::Global,
                           bucketOf(ResourceSourceBucket::EncapsulatedClass1));
     }
     auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName);
     if (overridePath) {
         _resources.addFolder(*overridePath,
-                             ContainerKind::Global,
+                             ResourceOwner::Global,
                              bucketOf(ResourceSourceBucket::LooseDirectory));
     }
 }
@@ -274,18 +298,25 @@ void ResourceDirector::loadModuleResourcesLegacy(const std::string &name) {
         throw ResourceNotFoundException("Modules directory not found");
     }
 
-    loadRIM(*modulesPath, name, ContainerKind::Local);
-    loadRIM(*modulesPath, name + "_s", ContainerKind::Local);
-    loadERF(*modulesPath, name, ContainerKind::Local);
-    loadERF(*modulesPath, name + "_loc", ContainerKind::Local);
+    // Scoped for the same reason the activated path is: an archive that fails
+    // to open partway down this list must not leave the ones above it mounted.
+    // The stack itself, and the order it is built in, are unchanged.
+    ResourceMountTransaction transaction(_resources);
+
+    loadRIM(*modulesPath, name, ResourceOwner::ActiveModule);
+    loadRIM(*modulesPath, name + "_s", ResourceOwner::ActiveModule);
+    loadERF(*modulesPath, name, ResourceOwner::ActiveModule);
+    loadERF(*modulesPath, name + "_loc", ResourceOwner::ActiveModule);
 
     if (auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName)) {
-        loadERF(*lipsPath, name + "_loc", ContainerKind::Local);
+        loadERF(*lipsPath, name + "_loc", ResourceOwner::ActiveModule);
     }
 
     if (_gameId == GameID::TSL) {
-        loadERF(*modulesPath, name + "_dlg", ContainerKind::Local);
+        loadERF(*modulesPath, name + "_dlg", ResourceOwner::ActiveModule);
     }
+
+    transaction.commit();
 }
 
 ModuleSearchRoot ResourceDirector::modulesSearchRoot() {
@@ -402,8 +433,22 @@ void ResourceDirector::loadModuleResourcesFromPolicy(const std::string &name) {
 
     auto plan = planModuleLoad(request, inventory);
 
+    // Mounting the module is one operation. Sources are mounted in phases and a
+    // later one can throw, which would otherwise leave the earlier phases in
+    // place: a module that is neither the old one nor the new one, still
+    // answering lookups. Whatever is mounted from here on goes away together if
+    // the load does not finish.
+    //
+    // This does not put the previous module back. Its sources were retired
+    // before this ran, and reinstating them would be a new load rather than an
+    // undo of this one; whether the caller can still use the module it had is
+    // its own question.
+    ResourceMountTransaction transaction(_resources);
+
     ModuleMountExecutor executor(_resources, index);
     auto report = executor.run(plan);
+
+    transaction.commit();
 
     if (!plan.primary) {
         warn("No primary source found for module '" + discovered.moduleRoot + "'");
@@ -422,6 +467,30 @@ void ResourceDirector::loadModuleResourcesFromPolicy(const std::string &name) {
     }
 }
 
+/**
+ * Put a save slot's sources in scope.
+ *
+ * Both sources are owned by the save slot, so loading another save retires
+ * them. They were global before, which meant no save was ever unloaded and the
+ * resources of every save visited stayed resolvable for the rest of the
+ * process; a resource held only by the previous save could then answer a lookup
+ * made under the current one.
+ *
+ * Mounting the outer archive directly is a compatibility path, not the Odyssey
+ * architecture: the original unpacks the container into the live working state
+ * and reads the loose results, so the container is never a source in its own
+ * right. Replacing the direct mount with that unpack step belongs to the save
+ * architecture work; giving it the right lifetime does not depend on it and is
+ * done here.
+ *
+ * Class 2 remains a compatibility placement for that direct mount rather than
+ * an evidenced bucket for the container: it is the least privileged position
+ * that still lets the save supply resources held nowhere else, and it cannot
+ * shadow a live module source.
+ *
+ * The whole setup is one operation. A slot whose archive is missing leaves no
+ * loose directory mounted behind it, so a failed load cannot half-load a save.
+ */
 void ResourceDirector::loadSaveGameResources(std::string_view name) {
     auto allSavesPath = findFileIgnoreCase(_gamePath, kSavesDirectoryName);
     if (!allSavesPath) {
@@ -433,55 +502,42 @@ void ResourceDirector::loadSaveGameResources(std::string_view name) {
         throw ResourceNotFoundException(str(boost::format("Save directory not found: %s") % name));
     }
 
+    ResourceMountTransaction transaction(_resources);
+
     // Add savegame directory itself, so we can load globalvars.res
     // partytable.res and savenfo.res.
     _resources.addFolder(*savePath,
-                         ContainerKind::Global,
+                         ResourceOwner::SaveSlot,
                          bucketOf(ResourceSourceBucket::LooseDirectory));
 
-    _savegamePath = findFileIgnoreCase(*savePath, "savegame.sav");
-    if (!_savegamePath) {
+    auto savegamePath = findFileIgnoreCase(*savePath, "savegame.sav");
+    if (!savegamePath) {
         throw ResourceNotFoundException("savegame.sav not found");
     }
 
-    // Add savegame resource archive.
-    //
-    // The archive itself is genuine: a save slot really does hold a MOD V1.0
-    // container packed from the game-in-progress directory. What differs is
-    // what is done with it. The original engine unpacks the container back out
-    // into the game-in-progress directory and reads the loose results, so the
-    // container is never a source in its own right; reone instead mounts it
-    // directly and reads through it.
-    //
-    // Class 2 is therefore a compatibility placement for that direct mount
-    // rather than an evidenced bucket for the container: it is the least
-    // privileged position that still lets the save supply resources held
-    // nowhere else, and it cannot shadow a live module source. Replacing the
-    // direct mount with an unpack step belongs to the save architecture work.
-    //
-    // The ownership here is known to be wrong: these are save-slot sources
-    // mounted as global, so clearSave does not retire them. That is left
-    // untouched, exactly as it is today.
-    _resources.addERF(*_savegamePath,
-                      ContainerKind::Global,
+    _resources.addERF(*savegamePath,
+                      ResourceOwner::SaveSlot,
                       bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+
+    transaction.commit();
+    _savegamePath = std::move(savegamePath);
 }
 
-void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {
+void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ResourceOwner owner) {
     // Try to find a module with the same name in already loaded resources.
     // Same idea as in loadERF.
     std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Res));
     if (res) {
-        _resources.addMemRIM(res->data, kind);
+        _resources.addMemRIM(res->data, owner);
         return;
     }
 
     if (auto rimPath = findFileIgnoreCase(path, name + ".rim")) {
-        _resources.addRIM(*rimPath, kind);
+        _resources.addRIM(*rimPath, owner);
     }
 }
 
-void ResourceDirector::loadERF(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {
+void ResourceDirector::loadERF(const std::filesystem::path &path, const std::string &name, ResourceOwner owner) {
     // Try to find a module with the same name in already loaded resources.
     //
     // This allows us to support savegame archives: savegame.sav is an ERF
@@ -494,16 +550,16 @@ void ResourceDirector::loadERF(const std::filesystem::path &path, const std::str
     // is spelled with was wrong before.
     std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Sav));
     if (res) {
-        _resources.addMemERF(res->data, kind);
+        _resources.addMemERF(res->data, owner);
         return;
     }
 
     if (auto modPath = findFileIgnoreCase(path, name + ".mod")) {
-        _resources.addERF(*modPath, kind);
+        _resources.addERF(*modPath, owner);
     }
 
     if (auto erfPath = findFileIgnoreCase(path, name + ".erf")) {
-        _resources.addERF(*erfPath, kind);
+        _resources.addERF(*erfPath, owner);
     }
 }
 

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -531,14 +531,6 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     loadModuleResourcesFromPolicy(name);
 }
 
-ModuleSearchRoot ResourceDirector::modulesSearchRoot() {
-    auto roots = primaryModuleSearchRoots(_gameId, _gamePath, _odysseyRoots);
-    if (roots.empty()) {
-        throw ResourceNotFoundException("Modules directory not found");
-    }
-    return roots.front();
-}
-
 std::vector<ModuleSearchRoot> ResourceDirector::moduleSearchRoots() {
     return resource::moduleSearchRoots(_gameId, _gamePath, _odysseyRoots);
 }

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -22,6 +22,9 @@
 #include "reone/graphics/types.h"
 #include "reone/resource/di/services.h"
 #include "reone/resource/exception/notfound.h"
+#include "reone/resource/modulediscovery.h"
+#include "reone/resource/modulemount.h"
+#include "reone/resource/modulepolicy.h"
 #include "reone/resource/provider/2das.h"
 #include "reone/resource/provider/dialogs.h"
 #include "reone/resource/provider/gffs.h"
@@ -31,6 +34,9 @@
 #include "reone/resource/resources.h"
 #include "reone/script/di/services.h"
 #include "reone/system/fileutil.h"
+#include "reone/system/logutil.h"
+
+#include <array>
 
 using namespace reone::graphics;
 using namespace reone::resource;
@@ -61,6 +67,15 @@ static constexpr char kExeFilenameTsl[] = "swkotor2.exe";
 
 static constexpr char kShaderPackFilename[] = "shaderpack.erf";
 
+static constexpr char kModulesRootId[] = "modules";
+static constexpr char kLipsRootId[] = "lips";
+/// Root the staged active module is offered under. reone has no current-game
+/// directory; the equivalent is the save archive already in scope.
+static constexpr char kStagedRootId[] = "currentgame";
+
+static constexpr char kModuleSaveTableName[] = "modulesave";
+static constexpr char kIncludeInSaveColumn[] = "includeinsave";
+
 static const std::vector<std::string> g_globalLipFiles {"global.mod", "localization.mod"};
 
 static const std::unordered_map<TextureQuality, std::string> kTexQualityToTexPack {
@@ -89,19 +104,15 @@ void ResourceDirector::onGameLoad(std::string_view name) {
 }
 
 std::set<std::string> ResourceDirector::moduleNames() {
-    auto moduleNames = std::set<std::string>();
-    auto modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
-    if (!modulesPath) {
-        throw ResourceNotFoundException("Modules directory not found");
-    }
-    for (auto &entry : std::filesystem::directory_iterator(*modulesPath)) {
-        auto filename = boost::to_lower_copy(entry.path().filename().string());
-        if (boost::ends_with(filename, ".mod") || (boost::ends_with(filename, ".rim") && !boost::ends_with(filename, "_s.rim"))) {
-            auto moduleName = boost::to_lower_copy(filename.substr(0, filename.size() - 4));
-            moduleNames.insert(moduleName);
-        }
-    }
-    return moduleNames;
+    // Only a primary-eligible archive introduces a module name. Excluding just
+    // "_s.rim" would expose _a and _adx as modules of their own, which they
+    // never are.
+    //
+    // Only the module location is enumerated. The lips location is searched for
+    // a known module's support archives, but the global archives it also holds
+    // are not modules and must not be offered as ones.
+    auto roots = discoverModuleRoots({modulesSearchRoot()});
+    return std::set<std::string>(roots.begin(), roots.end());
 }
 
 std::set<std::string> ResourceDirector::saveNames() {
@@ -116,66 +127,29 @@ std::set<std::string> ResourceDirector::saveNames() {
     return names;
 }
 
-void ResourceDirector::loadGlobalResources() {
-    _resources.addERF(getFileIgnoreCase(std::filesystem::current_path(), kShaderPackFilename));
+bool usesBucketedLookup(GameID game) {
+    return game == GameID::TSL;
+}
 
-    auto keyPath = findFileIgnoreCase(_gamePath, kKeyFilename);
-    if (keyPath) {
-        _resources.addKEY(*keyPath);
+std::optional<ResourceSourceBucket> ResourceDirector::bucketOf(ResourceSourceBucket bucket) const {
+    if (!bucketed()) {
+        return std::nullopt;
     }
+    return bucket;
+}
 
-    auto texPacksPath = findFileIgnoreCase(_gamePath, kTexturePackDirectoryName);
-    if (texPacksPath) {
-        auto guiPackPath = findFileIgnoreCase(*texPacksPath, kTexturePackFilenameGUI);
-        if (guiPackPath) {
-            _resources.addERF(*guiPackPath);
-        }
-        auto &texPack = kTexQualityToTexPack.at(_graphicsOpt.textureQuality);
-        auto texPackPath = findFileIgnoreCase(*texPacksPath, texPack);
-        if (texPackPath) {
-            _resources.addERF(*texPackPath);
-        }
-    }
-
-    auto musicPath = findFileIgnoreCase(_gamePath, kMusicDirectoryName);
-    if (musicPath) {
-        _resources.addFolder(*musicPath);
-    }
-    auto soundsPath = findFileIgnoreCase(_gamePath, kSoundsDirectoryName);
-    if (soundsPath) {
-        _resources.addFolder(*soundsPath);
-    }
-
-    if (_gameId == GameID::TSL) {
-        auto voicePath = findFileIgnoreCase(_gamePath, kVoiceDirectoryName);
-        if (voicePath) {
-            _resources.addFolder(*voicePath);
-        }
-    } else {
-        auto wavesPath = findFileIgnoreCase(_gamePath, kWavesDirectoryName);
-        if (wavesPath) {
-            _resources.addFolder(*wavesPath);
-        }
-    }
-
-    auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName);
-    if (lipsPath) {
-        for (auto &filename : g_globalLipFiles) {
-            auto globalLipPath = findFileIgnoreCase(*lipsPath, filename);
-            if (globalLipPath) {
-                _resources.addERF(*globalLipPath);
-            }
-        }
-    }
-
-    auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename);
-    if (patchPath) {
-        _resources.addERF(*patchPath);
-    }
-    auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName);
-    if (overridePath) {
-        _resources.addFolder(*overridePath);
-    }
+/**
+ * Sources that are not Odyssey game data.
+ *
+ * The shader pack is generated by this project and holds only GLSL; the
+ * executable holds only cursors. Neither serves a resource type that any other
+ * source serves, so neither has a place in the raw lookup order, and inventing
+ * one for them would be wrong in a way no bucket could express. They are kept
+ * in a separate insertion-ordered list instead, which also keeps the Odyssey
+ * list homogeneous once buckets are in use.
+ */
+void ResourceDirector::loadAuxiliaryResources() {
+    _auxResources.addERF(getFileIgnoreCase(std::filesystem::current_path(), kShaderPackFilename));
 
     std::optional<std::filesystem::path> exePath;
     if (_gameId == GameID::TSL) {
@@ -184,11 +158,117 @@ void ResourceDirector::loadGlobalResources() {
         exePath = findFileIgnoreCase(_gamePath, kExeFilenameKotor);
     }
     if (exePath) {
-        _resources.addEXE(*exePath);
+        _auxResources.addEXE(*exePath);
+    }
+}
+
+/**
+ * Streamed audio directories.
+ *
+ * The traced engine reaches these through its path and streaming systems
+ * rather than through ordinary raw lookup, so they are not given a bucket. For
+ * an activated game they leave the Odyssey list entirely, and which of the two
+ * lists a clip is read from becomes the streaming subsystem's decision rather
+ * than a question of source priority. For a game that is not activated they
+ * stay exactly where they have always been.
+ */
+void ResourceDirector::loadStreamResources() {
+    auto &target = bucketed() ? _auxResources : _resources;
+
+    auto musicPath = findFileIgnoreCase(_gamePath, kMusicDirectoryName);
+    if (musicPath) {
+        target.addFolder(*musicPath);
+    }
+    auto soundsPath = findFileIgnoreCase(_gamePath, kSoundsDirectoryName);
+    if (soundsPath) {
+        target.addFolder(*soundsPath);
+    }
+
+    if (_gameId == GameID::TSL) {
+        auto voicePath = findFileIgnoreCase(_gamePath, kVoiceDirectoryName);
+        if (voicePath) {
+            target.addFolder(*voicePath);
+        }
+    } else {
+        auto wavesPath = findFileIgnoreCase(_gamePath, kWavesDirectoryName);
+        if (wavesPath) {
+            target.addFolder(*wavesPath);
+        }
+    }
+}
+
+void ResourceDirector::loadGlobalResources() {
+    loadAuxiliaryResources();
+
+    auto keyPath = findFileIgnoreCase(_gamePath, kKeyFilename);
+    if (keyPath) {
+        _resources.addKEY(*keyPath, bucketOf(ResourceSourceBucket::KeyBif));
+    }
+
+    auto texPacksPath = findFileIgnoreCase(_gamePath, kTexturePackDirectoryName);
+    if (texPacksPath) {
+        auto guiPackPath = findFileIgnoreCase(*texPacksPath, kTexturePackFilenameGUI);
+        if (guiPackPath) {
+            _resources.addERF(*guiPackPath,
+                              ContainerKind::Global,
+                              bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+        }
+        auto &texPack = kTexQualityToTexPack.at(_graphicsOpt.textureQuality);
+        auto texPackPath = findFileIgnoreCase(*texPacksPath, texPack);
+        if (texPackPath) {
+            _resources.addERF(*texPackPath,
+                              ContainerKind::Global,
+                              bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+        }
+    }
+
+    loadStreamResources();
+
+    auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName);
+    if (lipsPath) {
+        for (auto &filename : g_globalLipFiles) {
+            auto globalLipPath = findFileIgnoreCase(*lipsPath, filename);
+            if (globalLipPath) {
+                // A global LIP archive is a caller-selected encapsulated
+                // source. Class 2 keeps it where it has always sat relative to
+                // the texture packs it is mounted after.
+                _resources.addERF(*globalLipPath,
+                                  ContainerKind::Global,
+                                  bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+            }
+        }
+    }
+
+    auto patchPath = findFileIgnoreCase(_gamePath, kPatchFilename);
+    if (patchPath) {
+        _resources.addERF(*patchPath,
+                          ContainerKind::Global,
+                          bucketOf(ResourceSourceBucket::EncapsulatedClass1));
+    }
+    auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName);
+    if (overridePath) {
+        _resources.addFolder(*overridePath,
+                             ContainerKind::Global,
+                             bucketOf(ResourceSourceBucket::LooseDirectory));
     }
 }
 
 void ResourceDirector::loadModuleResources(const std::string &name) {
+    if (bucketed()) {
+        loadModuleResourcesFromPolicy(name);
+    } else {
+        loadModuleResourcesLegacy(name);
+    }
+}
+
+/**
+ * Module loading for a game that is not yet activated.
+ *
+ * This is the flat insertion-ordered stack the engine has always used. It is
+ * retained unchanged rather than reimplemented, so that activating one game
+ * cannot change the other.
+ */
+void ResourceDirector::loadModuleResourcesLegacy(const std::string &name) {
     std::optional<std::filesystem::path> modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
     if (!modulesPath) {
         throw ResourceNotFoundException("Modules directory not found");
@@ -208,6 +288,140 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
     }
 }
 
+ModuleSearchRoot ResourceDirector::modulesSearchRoot() {
+    auto modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
+    if (!modulesPath) {
+        throw ResourceNotFoundException("Modules directory not found");
+    }
+    return ModuleSearchRoot {kModulesRootId, *modulesPath, ModulePrimaryOrigin::Modules, 0, 0};
+}
+
+std::vector<ModuleSearchRoot> ResourceDirector::moduleSearchRoots() {
+    std::vector<ModuleSearchRoot> roots;
+    roots.push_back(modulesSearchRoot());
+    // The lips location supplies a module's own support archives. It is
+    // searched after the module location, which is the order their mounts are
+    // attempted in.
+    if (auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName)) {
+        roots.push_back(ModuleSearchRoot {kLipsRootId, *lipsPath, ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    return roots;
+}
+
+/**
+ * Offer the module's staged active state, when a save archive in scope holds
+ * it.
+ *
+ * This is the explicit nested-source route, not discovery: exactly two ids are
+ * probed, and the container is never walked into. The saved image is checked
+ * before the saved archive because the policy ranks it first.
+ */
+void ResourceDirector::addStagedModuleSources(const std::string &moduleRoot,
+                                              RuntimeModuleSourceIndex &index) {
+    struct Probe {
+        ResType type;
+        ModuleArchiveFamily family;
+        const char *extension;
+    };
+    static const std::array<Probe, 2> kProbes {{
+        {ResType::Rsv, ModuleArchiveFamily::SavedResourceImage, ".rsv"},
+        {ResType::Sav, ModuleArchiveFamily::SavedArchive, ".sav"},
+    }};
+
+    for (const auto &probe : kProbes) {
+        auto id = ResourceId(moduleRoot, probe.type);
+        if (!_resources.find(id)) {
+            continue;
+        }
+        ModuleSourceCandidate candidate;
+        candidate.sourceId = std::string(kStagedRootId) + ":" + moduleRoot + probe.extension;
+        candidate.rootId = kStagedRootId;
+        candidate.origin = ModulePrimaryOrigin::GameInProgress;
+        candidate.family = probe.family;
+        index.add(RuntimeModuleSource {std::move(candidate), id});
+    }
+}
+
+/**
+ * Whether saved state for this module may be selected at all.
+ *
+ * The table is keyed by row label, which is the module root. Every way of
+ * failing to find an exclusion means include: no table, no row, or no cell.
+ */
+bool ResourceDirector::includeModuleInSave(const std::string &moduleRoot) {
+    auto table = _twoDas.get(kModuleSaveTableName);
+    if (!table) {
+        return true;
+    }
+    int row = table->indexByLabel(moduleRoot);
+    if (row == -1) {
+        return true;
+    }
+    auto include = table->getIntOpt(row, kIncludeInSaveColumn);
+    if (!include) {
+        return true;
+    }
+    return *include != 0;
+}
+
+void ResourceDirector::loadModuleResourcesFromPolicy(const std::string &name) {
+    auto discovered = discoverModuleSources(name, moduleSearchRoots());
+    if (discovered.nameRejection) {
+        throw ResourceNotFoundException("Not a supported module name: " + name);
+    }
+
+    RuntimeModuleSourceIndex index;
+    for (const auto &source : discovered.sources) {
+        index.add(RuntimeModuleSource {source.candidate, source.path});
+    }
+    addStagedModuleSources(discovered.moduleRoot, index);
+
+    ModulePolicyRequest request;
+    request.game = _gameId;
+    request.moduleName = discovered.moduleRoot;
+    request.includeInSave = includeModuleInSave(discovered.moduleRoot);
+
+    auto inventory = index.inventory();
+    // Saved mode is a property of the form the active table takes, not of the
+    // mere presence of saved state.
+    //
+    // The original sequence is: wipe the current-game location, select exactly
+    // one primary with the image checked before the archive, stage that one
+    // artifact, then ask whether the current-game location now holds an
+    // archive. Because the wipe leaves nothing behind and exactly one artifact
+    // is staged, that question can only answer yes when the selected primary
+    // was the archive. Deriving it from the selection is therefore the same
+    // answer, not an approximation, and it is why the presence of an archive
+    // alongside a winning image must not set saved mode.
+    //
+    // Selection does not read savedMode, so asking for it first cannot change
+    // the answer.
+    auto selection = selectModulePrimary(request, inventory);
+    request.savedMode = selection &&
+                        selection->candidate.kind == ModulePrimaryKind::SavedArchive;
+
+    auto plan = planModuleLoad(request, inventory);
+
+    ModuleMountExecutor executor(_resources, index);
+    auto report = executor.run(plan);
+
+    if (!plan.primary) {
+        warn("No primary source found for module '" + discovered.moduleRoot + "'");
+    }
+    if (report.requiredFailure) {
+        warn("Module '" + discovered.moduleRoot + "' had a required source fail to mount");
+    }
+    for (const auto &file : discovered.rejected) {
+        debug("Ignoring unsupported module file: " + file.filename);
+    }
+    // Which source supplied a resource is not recoverable from the payload, so
+    // record the sequence that was actually mounted.
+    for (const auto &outcome : report.outcomes) {
+        debug(str(boost::format("Module source %s: %s") %
+                  (outcome.mounted ? "mounted" : "skipped") % outcome.sourceId));
+    }
+}
+
 void ResourceDirector::loadSaveGameResources(std::string_view name) {
     auto allSavesPath = findFileIgnoreCase(_gamePath, kSavesDirectoryName);
     if (!allSavesPath) {
@@ -221,7 +435,9 @@ void ResourceDirector::loadSaveGameResources(std::string_view name) {
 
     // Add savegame directory itself, so we can load globalvars.res
     // partytable.res and savenfo.res.
-    _resources.addFolder(*savePath);
+    _resources.addFolder(*savePath,
+                         ContainerKind::Global,
+                         bucketOf(ResourceSourceBucket::LooseDirectory));
 
     _savegamePath = findFileIgnoreCase(*savePath, "savegame.sav");
     if (!_savegamePath) {
@@ -229,7 +445,26 @@ void ResourceDirector::loadSaveGameResources(std::string_view name) {
     }
 
     // Add savegame resource archive.
-    _resources.addERF(*_savegamePath);
+    //
+    // The archive itself is genuine: a save slot really does hold a MOD V1.0
+    // container packed from the game-in-progress directory. What differs is
+    // what is done with it. The original engine unpacks the container back out
+    // into the game-in-progress directory and reads the loose results, so the
+    // container is never a source in its own right; reone instead mounts it
+    // directly and reads through it.
+    //
+    // Class 2 is therefore a compatibility placement for that direct mount
+    // rather than an evidenced bucket for the container: it is the least
+    // privileged position that still lets the save supply resources held
+    // nowhere else, and it cannot shadow a live module source. Replacing the
+    // direct mount with an unpack step belongs to the save architecture work.
+    //
+    // The ownership here is known to be wrong: these are save-slot sources
+    // mounted as global, so clearSave does not retire them. That is left
+    // untouched, exactly as it is today.
+    _resources.addERF(*_savegamePath,
+                      ContainerKind::Global,
+                      bucketOf(ResourceSourceBucket::EncapsulatedClass2));
 }
 
 void ResourceDirector::loadRIM(const std::filesystem::path &path, const std::string &name, ContainerKind kind) {
@@ -254,7 +489,10 @@ void ResourceDirector::loadERF(const std::filesystem::path &path, const std::str
     // savegame.sav ERF container. Module lookups resolve to modules from this
     // container, and fall back to filesystem search if the module is not in the
     // save archive.
-    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Mod));
+    // Type 0x0809 is the saved module archive, which is what a nested module
+    // in savegame.sav is stored as. This probe is unchanged; only the name it
+    // is spelled with was wrong before.
+    std::optional<Resource> res = _resources.find(ResourceId(name, ResType::Sav));
     if (res) {
         _resources.addMemERF(res->data, kind);
         return;

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -53,9 +53,7 @@ static constexpr char kMusicDirectoryName[] = "streammusic";
 static constexpr char kSoundsDirectoryName[] = "streamsounds";
 static constexpr char kWavesDirectoryName[] = "streamwaves";
 static constexpr char kVoiceDirectoryName[] = "streamvoice";
-static constexpr char kModulesDirectoryName[] = "modules";
 static constexpr char kSavesDirectoryName[] = "saves";
-static constexpr char kLipsDirectoryName[] = "lips";
 static constexpr char kOverrideDirectoryName[] = "override";
 static constexpr char kRimsDirectoryName[] = "rims";
 static constexpr char kGlobalRimFilename[] = "global.rim";
@@ -72,8 +70,6 @@ static constexpr char kExeFilenameTsl[] = "swkotor2.exe";
 
 static constexpr char kShaderPackFilename[] = "shaderpack.erf";
 
-static constexpr char kModulesRootId[] = "modules";
-static constexpr char kLipsRootId[] = "lips";
 /// Root fixed-name installation support archives are offered under.
 static constexpr char kRootRootId[] = "hd0";
 /// Root the staged active module is offered under. reone has no current-game
@@ -138,10 +134,9 @@ std::set<std::string> ResourceDirector::moduleNames() {
     // "_s.rim" would expose _a and _adx as modules of their own, which they
     // never are.
     //
-    // Only the module location is enumerated. The lips location is searched for
-    // a known module's support archives, but the global archives it also holds
-    // are not modules and must not be offered as ones.
-    auto roots = discoverModuleRoots({modulesSearchRoot()});
+    // Enumerate shared primary roots only. LIPS roots remain support-only.
+    auto roots = discoverModuleRoots(
+        primaryModuleSearchRoots(_gameId, _gamePath, _odysseyRoots));
     return std::set<std::string>(roots.begin(), roots.end());
 }
 
@@ -431,10 +426,68 @@ void ResourceDirector::loadK1GlobalResources() {
     loadPlayerSupportResource();
 }
 
+void ResourceDirector::loadLiveResources() {
+    for (std::size_t i = 0; i < _odysseyRoots.livePackages.size(); ++i) {
+        if (!_odysseyRoots.livePackages[i]) {
+            continue;
+        }
+        const auto &root = *_odysseyRoots.livePackages[i];
+        auto basename = "live" + std::to_string(i + 1);
+        auto attempt = [](const auto &mount) {
+            try {
+                mount();
+            } catch (const std::exception &) {
+                // Every package member is best-effort and independent.
+            }
+        };
+
+        if (auto key = findFileIgnoreCase(root, basename + ".key")) {
+            attempt([&] {
+                _resources.addKEY(*key, bucketOf(ResourceSourceBucket::KeyBif));
+            });
+        }
+        if (auto rims = findFileIgnoreCase(root, "rimsxbox")) {
+            if (auto baseRim = findFileIgnoreCase(*rims, basename + ".rim")) {
+                attempt([&] {
+                    _resources.addRIM(*baseRim,
+                                      ResourceOwner::Global,
+                                      bucketOf(ResourceSourceBucket::ResourceImage));
+                });
+            }
+        }
+        if (auto mod = findFileIgnoreCase(root, basename + ".mod")) {
+            attempt([&] {
+                _resources.addERF(*mod,
+                                  ResourceOwner::Global,
+                                  bucketOf(ResourceSourceBucket::EncapsulatedClass2));
+            });
+        }
+        if (auto rims = findFileIgnoreCase(root, "rimsxbox")) {
+            if (auto dxRim = findFileIgnoreCase(*rims, basename + "dx.rim")) {
+                attempt([&] {
+                    _resources.addRIM(*dxRim,
+                                      ResourceOwner::Global,
+                                      bucketOf(ResourceSourceBucket::ResourceImage));
+                });
+            }
+        }
+        if (auto overridePath = findFileIgnoreCase(root, "override")) {
+            if (auto textures = findEncapsulatedByBasename(*overridePath, "textures")) {
+                attempt([&] {
+                    _resources.addERF(*textures,
+                                      ResourceOwner::Global,
+                                      bucketOf(ResourceSourceBucket::EncapsulatedClass1));
+                });
+            }
+        }
+    }
+}
+
 void ResourceDirector::loadGlobalResources() {
     loadAuxiliaryResources();
     if (_gameId == GameID::KotOR) {
         loadK1GlobalResources();
+        loadLiveResources();
         return;
     }
 
@@ -448,10 +501,9 @@ void ResourceDirector::loadGlobalResources() {
     loadTexturePackResources();
     loadStreamResources();
 
-    auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName);
-    if (lipsPath) {
+    for (const auto &lipsPath : lipsRoots(_gameId, _gamePath, _odysseyRoots)) {
         for (auto &filename : g_globalLipFiles) {
-            if (auto globalLipPath = findFileIgnoreCase(*lipsPath, filename)) {
+            if (auto globalLipPath = findFileIgnoreCase(lipsPath, filename)) {
                 // A global LIP archive is a caller-selected encapsulated
                 // source. Class 2 keeps it where it has always sat relative to
                 // the texture packs it is mounted after.
@@ -467,12 +519,13 @@ void ResourceDirector::loadGlobalResources() {
                           ResourceOwner::Global,
                           bucketOf(ResourceSourceBucket::EncapsulatedClass1));
     }
-    if (auto overridePath = findFileIgnoreCase(_gamePath, kOverrideDirectoryName)) {
-        _resources.addFolder(*overridePath,
+    for (const auto &overridePath : looseOverrideRoots(_gameId, _gamePath, _odysseyRoots)) {
+        _resources.addFolder(overridePath,
                              ResourceOwner::Global,
                              bucketOf(ResourceSourceBucket::LooseDirectory));
     }
     loadGlobalRimResource();
+    loadLiveResources();
 }
 
 void ResourceDirector::loadModuleResources(const std::string &name) {
@@ -480,23 +533,15 @@ void ResourceDirector::loadModuleResources(const std::string &name) {
 }
 
 ModuleSearchRoot ResourceDirector::modulesSearchRoot() {
-    auto modulesPath = findFileIgnoreCase(_gamePath, kModulesDirectoryName);
-    if (!modulesPath) {
+    auto roots = primaryModuleSearchRoots(_gameId, _gamePath, _odysseyRoots);
+    if (roots.empty()) {
         throw ResourceNotFoundException("Modules directory not found");
     }
-    return ModuleSearchRoot {kModulesRootId, *modulesPath, ModulePrimaryOrigin::Modules, 0, 0};
+    return roots.front();
 }
 
 std::vector<ModuleSearchRoot> ResourceDirector::moduleSearchRoots() {
-    std::vector<ModuleSearchRoot> roots;
-    roots.push_back(modulesSearchRoot());
-    // The lips location supplies a module's own support archives. It is
-    // searched after the module location, which is the order their mounts are
-    // attempted in.
-    if (auto lipsPath = findFileIgnoreCase(_gamePath, kLipsDirectoryName)) {
-        roots.push_back(ModuleSearchRoot {kLipsRootId, *lipsPath, ModulePrimaryOrigin::Modules, 0, 0});
-    }
-    return roots;
+    return resource::moduleSearchRoots(_gameId, _gamePath, _odysseyRoots);
 }
 
 /**

--- a/src/libs/resource/extract/installation.cpp
+++ b/src/libs/resource/extract/installation.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/extract/chitin.h"
 #include "reone/resource/format/pereader.h"
+#include "reone/resource/modulemount.h"
 #include "reone/system/fileutil.h"
 #include "reone/system/stream/gameinput.h"
 
@@ -36,11 +37,15 @@ static constexpr char kSoundsDirectoryName[] = "streamsounds";
 static constexpr char kWavesDirectoryName[] = "streamwaves";
 static constexpr char kVoiceDirectoryName[] = "streamvoice";
 static constexpr char kLipsDirectoryName[] = "lips";
+static constexpr char kModulesDirectoryName[] = "modules";
 static constexpr char kOverrideDirectoryName[] = "override";
 static constexpr char kRimsDirectoryName[] = "rims";
 static constexpr char kMoviesDirectoryName[] = "movies";
 static constexpr char kExeFilenameKotor[] = "swkotor.exe";
 static constexpr char kExeFilenameTsl[] = "swkotor2.exe";
+
+static constexpr char kModulesRootId[] = "modules";
+static constexpr char kLipsRootId[] = "lips";
 
 static constexpr char kTexturePackTpa[] = "swpc_tex_tpa.erf";
 static constexpr char kTexturePackTpb[] = "swpc_tex_tpb.erf";
@@ -104,22 +109,156 @@ void Installation::loadChitin() {
     clearLocationCaches();
 }
 
+std::vector<resource::ModuleSearchRoot> Installation::moduleSearchRoots() const {
+    std::vector<resource::ModuleSearchRoot> roots;
+    if (auto modulesPath = findFileIgnoreCase(_root, kModulesDirectoryName)) {
+        roots.push_back(resource::ModuleSearchRoot {
+            kModulesRootId, *modulesPath, resource::ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    // The lips location supplies a module's own support archives. It is
+    // searched after the module location, which is the order their mounts are
+    // attempted in.
+    if (auto lipsPath = findFileIgnoreCase(_root, kLipsDirectoryName)) {
+        roots.push_back(resource::ModuleSearchRoot {
+            kLipsRootId, *lipsPath, resource::ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    return roots;
+}
+
+/// Position of a bucket in the raw lookup order. A family the policy assigns no
+/// bucket has no position in that order, and is ranked after every source that
+/// does rather than being given an invented one.
+static std::size_t bucketRank(const std::optional<resource::ResourceSourceBucket> &bucket) {
+    if (!bucket) {
+        return resource::kRawResourceLookupOrder.size();
+    }
+    for (std::size_t i = 0; i < resource::kRawResourceLookupOrder.size(); ++i) {
+        if (resource::kRawResourceLookupOrder[i] == *bucket) {
+            return i;
+        }
+    }
+    return resource::kRawResourceLookupOrder.size();
+}
+
+/**
+ * Index the current module root's archives, in canonical raw lookup order.
+ *
+ * The set comes from shared discovery, so which files belong to the module and
+ * what family each one has are answered exactly as the runtime answers them.
+ * The order comes from the raw lookup contract: bucket first, and within a
+ * bucket the source a running game would have mounted latest. Mount timing
+ * therefore orders sources inside a bucket and never across buckets, which is
+ * what stops the old ".mod beats _s.rim beats .rim" ladder from reappearing.
+ *
+ * Nothing is suppressed. A game whose policy would not mount a family still
+ * has the file on disk, and answering where a resource lives is not the same
+ * question as which source a running game would read it from; an unmounted
+ * archive simply ranks below every mounted one in its bucket.
+ */
 void Installation::loadModules() {
     if (_modulesLoaded) {
         return;
     }
     _modulesLoaded = true;
-    _moduleCapsulePaths.clear();
+    _moduleArchives.clear();
+    clearLocationCaches();
     if (!_moduleRoot) {
         return;
     }
-    for (auto &rel : moduleArchiveRelPaths(*_moduleRoot)) {
-        if (auto path = findFileIgnoreCase(_root, rel)) {
-            auto filename = boost::to_lower_copy(path->filename().string());
-            _moduleCapsulePaths.emplace(filename, *path);
+
+    auto discovered = resource::discoverModuleSources(*_moduleRoot, moduleSearchRoots());
+    if (discovered.nameRejection) {
+        return;
+    }
+    auto inventory = resource::plannerInventory(discovered);
+
+    resource::ModulePolicyRequest request;
+    request.game = _game;
+    request.moduleName = discovered.moduleRoot;
+    // No module-save table is consulted. The gate excludes saved candidates
+    // only, and an installation's module locations offer none for it to
+    // exclude, so reading the table could not change the plan.
+    request.includeInSave = true;
+    auto selection = resource::selectModulePrimary(request, inventory);
+    request.savedMode = selection &&
+                        selection->candidate.kind == resource::ModulePrimaryKind::SavedArchive;
+    auto plan = resource::planModuleLoad(request, inventory);
+
+    std::unordered_map<std::string, std::uint32_t> mountSequence;
+    std::uint32_t nextSequence = 0;
+    for (const auto &family : plan.families) {
+        for (const auto &attempt : family.attempts) {
+            mountSequence[attempt.source.sourceId] = attempt.attemptOrder;
+            nextSequence = std::max(nextSequence, attempt.attemptOrder + 1);
         }
     }
-    clearLocationCaches();
+    // The selected primary is staged and mounted as the active table after
+    // every other phase, so it is the newest source of its bucket.
+    if (plan.primary) {
+        mountSequence[plan.primary->candidate.source.sourceId] = nextSequence;
+    }
+
+    struct Ranked {
+        ModuleArchive archive;
+        std::size_t bucket {0};
+        int unmounted {0};
+        std::uint32_t sequence {0};
+        std::size_t discovered {0};
+    };
+    std::vector<Ranked> ranked;
+    ranked.reserve(discovered.sources.size());
+    for (std::size_t i = 0; i < discovered.sources.size(); ++i) {
+        const auto &source = discovered.sources[i];
+        Ranked entry;
+        entry.archive.moduleRoot = source.moduleRoot;
+        entry.archive.family = source.candidate.family;
+        entry.archive.rootId = source.candidate.rootId;
+        entry.archive.path = source.path;
+        if (auto metadata = resource::mountMetadata(source.candidate.family)) {
+            entry.archive.bucket = metadata->bucket;
+        }
+        entry.archive.resourceImage = resource::isResourceImageFamily(source.candidate.family);
+        auto mounted = mountSequence.find(source.candidate.sourceId);
+        entry.bucket = bucketRank(entry.archive.bucket);
+        entry.unmounted = mounted == mountSequence.end() ? 1 : 0;
+        entry.sequence = mounted == mountSequence.end() ? 0 : mounted->second;
+        entry.discovered = i;
+        ranked.push_back(std::move(entry));
+    }
+    std::sort(ranked.begin(), ranked.end(), [](const Ranked &lhs, const Ranked &rhs) {
+        if (lhs.bucket != rhs.bucket) {
+            return lhs.bucket < rhs.bucket;
+        }
+        if (lhs.unmounted != rhs.unmounted) {
+            return lhs.unmounted < rhs.unmounted;
+        }
+        if (lhs.sequence != rhs.sequence) {
+            return lhs.sequence > rhs.sequence;
+        }
+        return lhs.discovered < rhs.discovered;
+    });
+
+    _moduleArchives.reserve(ranked.size());
+    for (auto &entry : ranked) {
+        _moduleArchives.push_back(std::move(entry.archive));
+    }
+}
+
+std::vector<std::string> Installation::moduleNames() {
+    auto modulesPath = findFileIgnoreCase(_root, kModulesDirectoryName);
+    if (!modulesPath) {
+        return {};
+    }
+    // Only the module location is enumerated. The lips location is searched for
+    // a known module's support archives, but the global archives it also holds
+    // are not modules and must not be offered as ones.
+    return resource::discoverModuleRoots({resource::ModuleSearchRoot {
+        kModulesRootId, *modulesPath, resource::ModulePrimaryOrigin::Modules, 0, 0}});
+}
+
+const std::vector<ModuleArchive> &Installation::moduleArchives() {
+    loadModules();
+    return _moduleArchives;
 }
 
 const std::vector<FileResource> &Installation::chitinResources() {
@@ -385,13 +524,25 @@ void Installation::loadExecutable() {
     clearLocationCaches();
 }
 
+/**
+ * Scope module lookups to one module.
+ *
+ * The name is normalized by the shared rule, which removes a supported archive
+ * extension and nothing else. A root that ends in something resembling a family
+ * suffix stays whole: the caller has said which module it wants, so "foo_adxx"
+ * is that module and "foo_adxx.rim" is its own primary. Only enumeration, which
+ * has to infer ownership from a name alone, reads a trailing suffix at all.
+ *
+ * A name no supported archive could carry leaves the scope unset rather than
+ * being reduced to something that is.
+ */
 void Installation::setModuleRoot(std::optional<std::string> root) {
+    _moduleRoot.reset();
     if (root) {
-        boost::to_lower(*root);
+        _moduleRoot = resource::normalizeModuleName(*root).root;
     }
-    _moduleRoot = std::move(root);
     _modulesLoaded = false;
-    _moduleCapsulePaths.clear();
+    _moduleArchives.clear();
     clearLocationCaches();
 }
 
@@ -429,7 +580,7 @@ void Installation::appendSaveScope(std::filesystem::path saveDir, std::filesyste
 void Installation::clearModuleScope() {
     _moduleRoot.reset();
     _modulesLoaded = false;
-    _moduleCapsulePaths.clear();
+    _moduleArchives.clear();
     clearLocationCaches();
 }
 
@@ -438,37 +589,6 @@ void Installation::clearSaveScope() {
     _customCapsules = _globalCustomCapsules;
     _capsuleCache.clear();
     clearLocationCaches();
-}
-
-std::string Installation::getModuleRoot(std::string_view capsuleFilename) {
-    auto stem = std::filesystem::path(capsuleFilename).stem().string();
-    boost::to_lower(stem);
-    if (boost::ends_with(stem, "_s")) {
-        stem.resize(stem.size() - 2);
-    }
-    if (boost::ends_with(stem, "_dlg")) {
-        stem.resize(stem.size() - 4);
-    }
-    if (boost::ends_with(stem, "_loc")) {
-        stem.resize(stem.size() - 4);
-    }
-    return stem;
-}
-
-std::vector<std::string> Installation::moduleArchiveRelPaths(std::string_view moduleRoot) {
-    auto low = boost::to_lower_copy(std::string(moduleRoot));
-    return {
-        "modules/" + low + ".mod",
-        "modules/" + low + "_s.rim",
-        "modules/" + low + ".rim",
-        "modules/" + low + ".erf",
-        "modules/" + low + "_loc.mod",
-        "modules/" + low + "_loc.erf",
-        "modules/" + low + "_dlg.mod",
-        "modules/" + low + "_dlg.erf",
-        "lips/" + low + "_loc.mod",
-        "lips/" + low + "_loc.erf",
-    };
 }
 
 static std::string normalizeRelativePath(std::string_view relativePath) {
@@ -628,14 +748,9 @@ void Installation::checkModules(const resource::ResourceId &id, std::vector<Loca
         return;
     }
     loadModules();
-    for (const auto &rel : moduleArchiveRelPaths(*_moduleRoot)) {
-        auto filename = boost::to_lower_copy(std::filesystem::path(rel).filename().string());
-        auto it = _moduleCapsulePaths.find(filename);
-        if (it != _moduleCapsulePaths.end()) {
-            auto res = cachedCapsule(it->second).find(id);
-            if (res) {
-                appendLocation(*res, out);
-            }
+    for (const auto &archive : _moduleArchives) {
+        if (auto res = cachedCapsule(archive.path).find(id)) {
+            appendLocation(*res, out);
         }
     }
 }

--- a/src/libs/resource/extract/installation.cpp
+++ b/src/libs/resource/extract/installation.cpp
@@ -36,16 +36,10 @@ static constexpr char kMusicDirectoryName[] = "streammusic";
 static constexpr char kSoundsDirectoryName[] = "streamsounds";
 static constexpr char kWavesDirectoryName[] = "streamwaves";
 static constexpr char kVoiceDirectoryName[] = "streamvoice";
-static constexpr char kLipsDirectoryName[] = "lips";
-static constexpr char kModulesDirectoryName[] = "modules";
-static constexpr char kOverrideDirectoryName[] = "override";
 static constexpr char kRimsDirectoryName[] = "rims";
 static constexpr char kMoviesDirectoryName[] = "movies";
 static constexpr char kExeFilenameKotor[] = "swkotor.exe";
 static constexpr char kExeFilenameTsl[] = "swkotor2.exe";
-
-static constexpr char kModulesRootId[] = "modules";
-static constexpr char kLipsRootId[] = "lips";
 
 static constexpr char kTexturePackTpa[] = "swpc_tex_tpa.erf";
 static constexpr char kTexturePackTpb[] = "swpc_tex_tpb.erf";
@@ -87,9 +81,12 @@ static std::vector<std::string> sortedKeys(const std::unordered_map<std::string,
     return keys;
 }
 
-Installation::Installation(resource::GameID game, std::filesystem::path root) :
+Installation::Installation(resource::GameID game,
+                           std::filesystem::path root,
+                           resource::OdysseyResourceRoots odysseyRoots) :
     _game(game),
-    _root(std::move(root)) {
+    _root(std::move(root)),
+    _odysseyRoots(std::move(odysseyRoots)) {
 }
 
 void Installation::clearLocationCaches() {
@@ -110,19 +107,7 @@ void Installation::loadChitin() {
 }
 
 std::vector<resource::ModuleSearchRoot> Installation::moduleSearchRoots() const {
-    std::vector<resource::ModuleSearchRoot> roots;
-    if (auto modulesPath = findFileIgnoreCase(_root, kModulesDirectoryName)) {
-        roots.push_back(resource::ModuleSearchRoot {
-            kModulesRootId, *modulesPath, resource::ModulePrimaryOrigin::Modules, 0, 0});
-    }
-    // The lips location supplies a module's own support archives. It is
-    // searched after the module location, which is the order their mounts are
-    // attempted in.
-    if (auto lipsPath = findFileIgnoreCase(_root, kLipsDirectoryName)) {
-        roots.push_back(resource::ModuleSearchRoot {
-            kLipsRootId, *lipsPath, resource::ModulePrimaryOrigin::Modules, 0, 0});
-    }
-    return roots;
+    return resource::moduleSearchRoots(_game, _root, _odysseyRoots);
 }
 
 /// Position of a bucket in the raw lookup order. A family the policy assigns no
@@ -245,15 +230,8 @@ void Installation::loadModules() {
 }
 
 std::vector<std::string> Installation::moduleNames() {
-    auto modulesPath = findFileIgnoreCase(_root, kModulesDirectoryName);
-    if (!modulesPath) {
-        return {};
-    }
-    // Only the module location is enumerated. The lips location is searched for
-    // a known module's support archives, but the global archives it also holds
-    // are not modules and must not be offered as ones.
-    return resource::discoverModuleRoots({resource::ModuleSearchRoot {
-        kModulesRootId, *modulesPath, resource::ModulePrimaryOrigin::Modules, 0, 0}});
+    return resource::discoverModuleRoots(
+        resource::primaryModuleSearchRoots(_game, _root, _odysseyRoots));
 }
 
 const std::vector<ModuleArchive> &Installation::moduleArchives() {
@@ -308,46 +286,24 @@ void Installation::loadOverride() {
     if (_overrideLoaded) {
         return;
     }
-    auto overridePath = findFileIgnoreCase(_root, kOverrideDirectoryName);
-    if (!overridePath) {
-        _overrideIndex.clear();
-        _overrideLoaded = true;
-        return;
-    }
-
-    std::vector<FileResource> loose;
-    for (auto &entry : std::filesystem::directory_iterator(*overridePath)) {
-        if (entry.is_regular_file()) {
-            auto id = resourceIdFromPath(entry.path());
-            if (id) {
-                loose.emplace_back(
-                    id->resRef.value(),
-                    id->type,
-                    static_cast<uint32_t>(entry.file_size()),
-                    0,
-                    entry.path());
-            }
-            continue;
-        }
-        if (!entry.is_directory()) {
-            continue;
-        }
-        auto relKey = entry.path().filename().string();
-        std::vector<FileResource> subdir;
-        indexLooseFiles(entry.path(), subdir);
-        if (!subdir.empty()) {
-            _override[relKey] = std::move(subdir);
-        }
-    }
-    if (!loose.empty()) {
-        sortResources(loose);
-        _override["."] = std::move(loose);
-    }
     _overrideIndex.clear();
-    for (const auto &key : sortedKeys(_override)) {
-        auto &list = _override.at(key);
-        for (auto &res : list) {
-            _overrideIndex.emplace(res.id(), res);
+    _override.clear();
+    auto roots = resource::looseOverrideRoots(_game, _root, _odysseyRoots);
+    for (std::size_t i = 0; i < roots.size(); ++i) {
+        std::vector<FileResource> files;
+        indexLooseFiles(roots[i], files);
+        auto key = "root" + std::to_string(i);
+        _override[key] = files;
+        std::unordered_map<resource::ResourceId, FileResource> rootIndex;
+        for (const auto &file : files) {
+            // Files are path-sorted, so first insertion preserves the existing
+            // deterministic winner among duplicate subdirectories in one root.
+            rootIndex.emplace(file.id(), file);
+        }
+        // Natural registration order is oldest to newest, so assignment makes
+        // the later configured root the lookup winner just as runtime does.
+        for (const auto &[id, file] : rootIndex) {
+            _overrideIndex.insert_or_assign(id, file);
         }
     }
     _overrideLoaded = true;
@@ -406,9 +362,13 @@ void Installation::loadLips() {
     if (_lipsLoaded) {
         return;
     }
-    auto lipsPath = findFileIgnoreCase(_root, kLipsDirectoryName);
-    if (lipsPath) {
-        indexCapsuleDict(*lipsPath, isCapsuleFile, _lips);
+    auto roots = resource::lipsRoots(_game, _root, _odysseyRoots);
+    for (std::size_t i = 0; i < roots.size(); ++i) {
+        std::unordered_map<std::string, std::vector<FileResource>> indexed;
+        indexCapsuleDict(roots[i], isCapsuleFile, indexed);
+        for (auto &[name, files] : indexed) {
+            _lips["root" + std::to_string(i) + ":" + name] = std::move(files);
+        }
     }
     _lipsLoaded = true;
     clearLocationCaches();

--- a/src/libs/resource/extract/installation.cpp
+++ b/src/libs/resource/extract/installation.cpp
@@ -158,6 +158,10 @@ void Installation::loadModules() {
     if (discovered.nameRejection) {
         return;
     }
+    auto rimsAdjuncts = resource::discoverRimsModuleAdjuncts(discovered.moduleRoot, _root);
+    discovered.sources.insert(discovered.sources.end(),
+                              rimsAdjuncts.begin(),
+                              rimsAdjuncts.end());
     auto inventory = resource::plannerInventory(discovered);
 
     resource::ModulePolicyRequest request;

--- a/src/libs/resource/extract/installation.cpp
+++ b/src/libs/resource/extract/installation.cpp
@@ -87,6 +87,9 @@ Installation::Installation(resource::GameID game,
     _game(game),
     _root(std::move(root)),
     _odysseyRoots(std::move(odysseyRoots)) {
+    if (!_odysseyRoots.nwmFiles) {
+        _odysseyRoots.nwmFiles = resource::defaultOdysseyResourceRoots(_root).nwmFiles;
+    }
 }
 
 void Installation::clearLocationCaches() {

--- a/src/libs/resource/extractresources.cpp
+++ b/src/libs/resource/extractresources.cpp
@@ -37,7 +37,7 @@ void ExtractResources::addKEY(const std::filesystem::path &path, std::optional<R
     for (auto &res : chitin.resources()) {
         index->emplace(res.id(), res);
     }
-    addSource(ContainerKind::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(ResourceOwner::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -46,9 +46,9 @@ void ExtractResources::addKEY(const std::filesystem::path &path, std::optional<R
     });
 }
 
-void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void ExtractResources::addERF(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto capsule = std::make_shared<extract::LazyCapsule>(path);
-    addSource(kind, bucket, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(owner, bucket, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto res = capsule->find(id);
         if (!res) {
             return std::nullopt;
@@ -57,13 +57,13 @@ void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind k
     });
 }
 
-void ExtractResources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void ExtractResources::addRIM(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     // LazyCapsule picks the reader by file extension; the director only mounts
     // RIMs from *.rim paths.
-    addERF(path, kind, bucket);
+    addERF(path, owner, bucket);
 }
 
-void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket, bool rim) {
+void ExtractResources::addMemArchive(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket, bool rim) {
     auto bytes = std::make_shared<ByteBuffer>(std::move(buffer));
     auto index = std::make_shared<std::unordered_map<ResourceId, std::pair<uint32_t, uint32_t>>>();
 
@@ -84,7 +84,7 @@ void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, std:
         }
     }
 
-    addSource(kind, bucket, [bytes, index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(owner, bucket, [bytes, index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -97,15 +97,15 @@ void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, std:
     });
 }
 
-void ExtractResources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    addMemArchive(std::move(buffer), kind, bucket, false);
+void ExtractResources::addMemERF(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    addMemArchive(std::move(buffer), owner, bucket, false);
 }
 
-void ExtractResources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    addMemArchive(std::move(buffer), kind, bucket, true);
+void ExtractResources::addMemRIM(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    addMemArchive(std::move(buffer), owner, bucket, true);
 }
 
-void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void ExtractResources::addFolder(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto index = std::make_shared<std::unordered_map<ResourceId, std::filesystem::path>>();
     if (std::filesystem::exists(path)) {
         for (auto &entry : std::filesystem::recursive_directory_iterator(path)) {
@@ -118,7 +118,7 @@ void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKin
             }
         }
     }
-    addSource(kind, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(owner, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -156,7 +156,7 @@ void ExtractResources::addEXE(const std::filesystem::path &path, std::optional<R
             path);
         index->emplace(res.id(), std::move(res));
     }
-    addSource(ContainerKind::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(ResourceOwner::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;

--- a/src/libs/resource/extractresources.cpp
+++ b/src/libs/resource/extractresources.cpp
@@ -31,13 +31,13 @@ namespace reone {
 
 namespace resource {
 
-void ExtractResources::addKEY(const std::filesystem::path &path) {
+void ExtractResources::addKEY(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     auto index = std::make_shared<std::unordered_map<ResourceId, extract::FileResource>>();
     extract::Chitin chitin(path);
     for (auto &res : chitin.resources()) {
         index->emplace(res.id(), res);
     }
-    addSource(ContainerKind::Global, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(ContainerKind::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -46,9 +46,9 @@ void ExtractResources::addKEY(const std::filesystem::path &path) {
     });
 }
 
-void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind kind) {
+void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto capsule = std::make_shared<extract::LazyCapsule>(path);
-    addSource(kind, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(kind, bucket, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto res = capsule->find(id);
         if (!res) {
             return std::nullopt;
@@ -57,13 +57,13 @@ void ExtractResources::addERF(const std::filesystem::path &path, ContainerKind k
     });
 }
 
-void ExtractResources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
+void ExtractResources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     // LazyCapsule picks the reader by file extension; the director only mounts
     // RIMs from *.rim paths.
-    addERF(path, kind);
+    addERF(path, kind, bucket);
 }
 
-void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, bool rim) {
+void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket, bool rim) {
     auto bytes = std::make_shared<ByteBuffer>(std::move(buffer));
     auto index = std::make_shared<std::unordered_map<ResourceId, std::pair<uint32_t, uint32_t>>>();
 
@@ -84,7 +84,7 @@ void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, bool
         }
     }
 
-    addSource(kind, [bytes, index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(kind, bucket, [bytes, index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -97,15 +97,15 @@ void ExtractResources::addMemArchive(ByteBuffer buffer, ContainerKind kind, bool
     });
 }
 
-void ExtractResources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
-    addMemArchive(std::move(buffer), kind, false);
+void ExtractResources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    addMemArchive(std::move(buffer), kind, bucket, false);
 }
 
-void ExtractResources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
-    addMemArchive(std::move(buffer), kind, true);
+void ExtractResources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    addMemArchive(std::move(buffer), kind, bucket, true);
 }
 
-void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
+void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto index = std::make_shared<std::unordered_map<ResourceId, std::filesystem::path>>();
     if (std::filesystem::exists(path)) {
         for (auto &entry : std::filesystem::recursive_directory_iterator(path)) {
@@ -118,7 +118,7 @@ void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKin
             }
         }
     }
-    addSource(kind, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(kind, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;
@@ -133,7 +133,7 @@ void ExtractResources::addFolder(const std::filesystem::path &path, ContainerKin
     });
 }
 
-void ExtractResources::addEXE(const std::filesystem::path &path) {
+void ExtractResources::addEXE(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     static const std::unordered_map<PEResType, ResType> kPEResTypeToResType {
         {PEResType::Cursor, ResType::Cursor},
         {PEResType::CursorGroup, ResType::CursorGroup},
@@ -156,7 +156,7 @@ void ExtractResources::addEXE(const std::filesystem::path &path) {
             path);
         index->emplace(res.id(), std::move(res));
     }
-    addSource(ContainerKind::Global, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
+    addSource(ContainerKind::Global, bucket, [index](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto it = index->find(id);
         if (it == index->end()) {
             return std::nullopt;

--- a/src/libs/resource/extractresources.cpp
+++ b/src/libs/resource/extractresources.cpp
@@ -46,8 +46,24 @@ void ExtractResources::addKEY(const std::filesystem::path &path, std::optional<R
     });
 }
 
+/**
+ * Mount a container from disk.
+ *
+ * The index is read before the source is registered, so an archive that cannot
+ * be opened is rejected by the mount that took it on rather than by whichever
+ * lookup happens to reach it first. Deferring that decision would make a
+ * corrupt archive mount successfully and fail later, leaving a module that is
+ * neither loaded nor failed; it is also the point the other backend has always
+ * decided at, and one loading contract cannot be answered at two different
+ * moments depending on which backend is in use.
+ *
+ * Payloads are not read here. What is validated is the container: its signature
+ * and the table of what it holds. Resource bytes are still read one at a time,
+ * on demand, exactly as before.
+ */
 void ExtractResources::addERF(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto capsule = std::make_shared<extract::LazyCapsule>(path);
+    capsule->load();
     addSource(owner, bucket, [capsule](const ResourceId &id) -> std::optional<ByteBuffer> {
         auto res = capsule->find(id);
         if (!res) {

--- a/src/libs/resource/format/2dareader.cpp
+++ b/src/libs/resource/format/2dareader.cpp
@@ -32,7 +32,7 @@ void TwoDAReader::load() {
     _reader.skipBytes(1); // newline
     _columns = readTokens();
     _rowCount = _reader.readUint32();
-    readTokens(_rowCount);
+    _labels = readTokens(_rowCount);
 
     loadRows();
     loadTable();
@@ -56,6 +56,9 @@ void TwoDAReader::loadRows() {
 
     for (int i = 0; i < _rowCount; ++i) {
         TwoDA::Row row;
+        // A truncated label block leaves the ordinal, which is what an
+        // unlabelled table would have carried anyway.
+        row.label = i < static_cast<int>(_labels.size()) ? _labels[i] : std::to_string(i);
         for (int j = 0; j < columnCount; ++j) {
             int cellIdx = i * columnCount + j;
             size_t off = pos + offsets[cellIdx];

--- a/src/libs/resource/format/2dareader.cpp
+++ b/src/libs/resource/format/2dareader.cpp
@@ -76,14 +76,21 @@ std::vector<std::string> TwoDAReader::readTokens(int maxCount) {
     std::vector<std::string> tokens;
     StringBuilder str;
     for (auto ch = _reader.readChar();; ch = _reader.readChar()) {
-        if (ch == '\t') {
+        // Retail ships both delimiters for the same layout. The BIF copies of
+        // these tables separate labels with tabs; the copies K1 carries inside
+        // global.rim separate them with NULs and are otherwise identical, down
+        // to the row count that follows. Only a NUL with nothing accumulated
+        // ends the section, which is exactly what the tab form produces at its
+        // own terminator, so one rule reads both.
+        if (ch == '\t' || ch == '\0') {
+            if (ch == '\0' && str.string().empty()) {
+                break;
+            }
             tokens.push_back(str.string());
             if (tokens.size() == maxCount) {
                 break;
             }
             str.clear();
-        } else if (ch == '\0') {
-            break;
         } else {
             str.append(ch);
         }

--- a/src/libs/resource/format/2dawriter.cpp
+++ b/src/libs/resource/format/2dawriter.cpp
@@ -54,8 +54,11 @@ void TwoDAWriter::writeHeaders() {
 }
 
 void TwoDAWriter::writeLabels() {
-    for (int i = 0; i < _twoDa.getRowCount(); ++i) {
-        _writer->writeString(std::to_string(i));
+    // Write the label a row actually carries, so that a table keyed by label
+    // survives a read/write round trip. Synthesizing the ordinal here would
+    // silently discard that key.
+    for (auto &row : _twoDa.rows()) {
+        _writer->writeString(row.label);
         _writer->writeChar('\t');
     }
 }

--- a/src/libs/resource/format/erfreader.cpp
+++ b/src/libs/resource/format/erfreader.cpp
@@ -43,10 +43,16 @@ void ErfReader::checkSignature() {
         throw ValidationException("Invalid binary resource size");
     }
     auto signature = _erf.readString(8);
+    // One container family with three type tags. The engine's opener probes an
+    // exact basename across NWM, MOD, SAV, ERF and HAK and validates only the
+    // four-character type, because everything after it is the same layout. HAK
+    // is accepted here for that reason and no other: it carries no module
+    // metadata behaviour of its own.
     bool erf = signature == std::string("ERF V1.0", 8);
     bool mod = signature == std::string("MOD V1.0", 8);
-    if (!erf && !mod) {
-        throw ValidationException("Invalid ERF/MOD signature: " + signature);
+    bool hak = signature == std::string("HAK V1.0", 8);
+    if (!erf && !mod && !hak) {
+        throw ValidationException("Invalid ERF/MOD/HAK signature: " + signature);
     }
 }
 

--- a/src/libs/resource/modulediscovery.cpp
+++ b/src/libs/resource/modulediscovery.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/modulediscovery.h"
+
+#include <algorithm>
+#include <array>
+#include <set>
+
+#include <boost/algorithm/string.hpp>
+
+namespace reone {
+namespace resource {
+namespace {
+
+struct SuffixRule {
+    std::string_view suffix;
+    std::string_view extension;
+    ModuleArchiveFamily family;
+};
+
+/**
+ * Supported sidecar and support suffixes, longest first so that exact
+ * longest-suffix matching falls out of the search order.
+ *
+ * The table is the whole of what is recognized. A suffix outside it does not
+ * resolve to the entry it most resembles, and no catch-all entry stands in
+ * for one.
+ */
+constexpr std::array<SuffixRule, 7> kSuffixRules {{
+    {"_adx", ".rim", ModuleArchiveFamily::AdxRim},
+    {"_dlg", ".erf", ModuleArchiveFamily::Dialogue},
+    {"_dlg", ".mod", ModuleArchiveFamily::Dialogue},
+    {"_loc", ".mod", ModuleArchiveFamily::Localization},
+    {"_loc", ".erf", ModuleArchiveFamily::Localization},
+    {"_s", ".rim", ModuleArchiveFamily::StaticRim},
+    {"_a", ".rim", ModuleArchiveFamily::AreaRim},
+}};
+
+struct PrimaryRule {
+    std::string_view extension;
+    ModuleArchiveFamily family;
+};
+
+/// Families a file named exactly after its module root may belong to.
+constexpr std::array<PrimaryRule, 5> kPrimaryRules {{
+    {".mod", ModuleArchiveFamily::PrimaryMod},
+    {".rim", ModuleArchiveFamily::PrimaryRim},
+    {".nwm", ModuleArchiveFamily::Nwm},
+    {".rsv", ModuleArchiveFamily::SavedResourceImage},
+    {".sav", ModuleArchiveFamily::SavedArchive},
+}};
+
+bool endsWith(const std::string &value, std::string_view suffix) {
+    return value.size() > suffix.size() &&
+           value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+struct SplitName {
+    std::string stem;
+    std::string extension;
+};
+
+SplitName splitFilename(std::string_view filename) {
+    auto path = std::filesystem::path(filename);
+    return {boost::to_lower_copy(path.stem().string()),
+            boost::to_lower_copy(path.extension().string())};
+}
+
+/// The recognized suffix a stem ends with, longest first, or nothing.
+std::optional<std::string_view> recognizedSuffix(const std::string &stem) {
+    for (const auto &rule : kSuffixRules) {
+        if (endsWith(stem, rule.suffix)) return rule.suffix;
+    }
+    return std::nullopt;
+}
+
+/// Regular files of a location, ordered by lowercased name for reproducibility.
+std::vector<std::filesystem::path> orderedFiles(const std::filesystem::path &root) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(root, ec)) return {};
+    std::vector<std::filesystem::path> paths;
+    for (auto &entry : std::filesystem::directory_iterator(root)) {
+        if (entry.is_regular_file()) paths.push_back(entry.path());
+    }
+    std::sort(paths.begin(), paths.end(), [](const auto &a, const auto &b) {
+        return boost::to_lower_copy(a.filename().string()) <
+               boost::to_lower_copy(b.filename().string());
+    });
+    return paths;
+}
+
+} // namespace
+
+bool isPrimaryEligible(ModuleArchiveFamily family) {
+    switch (family) {
+    case ModuleArchiveFamily::PrimaryMod:
+    case ModuleArchiveFamily::PrimaryRim:
+    case ModuleArchiveFamily::Nwm:
+    case ModuleArchiveFamily::SavedResourceImage:
+    case ModuleArchiveFamily::SavedArchive:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isActiveSavedState(ModuleArchiveFamily family) {
+    return family == ModuleArchiveFamily::SavedResourceImage ||
+           family == ModuleArchiveFamily::SavedArchive;
+}
+
+ModuleArchiveClassification classifyModuleArchive(std::string_view filename) {
+    auto trimmed = boost::trim_copy(std::string(filename));
+    if (trimmed.empty()) {
+        return {std::nullopt, ModuleNameRejection::Empty};
+    }
+    auto [stem, extension] = splitFilename(trimmed);
+    if (stem.empty() || extension.empty()) {
+        return {std::nullopt, ModuleNameRejection::UnsupportedExtension};
+    }
+
+    // A recognized suffix resolves the file to the module it supports, so a
+    // sidecar never introduces a module name of its own.
+    if (auto suffix = recognizedSuffix(stem)) {
+        for (const auto &rule : kSuffixRules) {
+            if (rule.suffix != *suffix || rule.extension != extension) continue;
+            return {ClassifiedModuleArchive {stem.substr(0, stem.size() - suffix->size()),
+                                             rule.family},
+                    std::nullopt};
+        }
+        return {std::nullopt, ModuleNameRejection::SuffixExtensionMismatch};
+    }
+
+    for (const auto &rule : kPrimaryRules) {
+        if (extension == rule.extension) {
+            return {ClassifiedModuleArchive {stem, rule.family}, std::nullopt};
+        }
+    }
+    return {std::nullopt, ModuleNameRejection::UnsupportedExtension};
+}
+
+ModuleArchiveClassification classifyForModuleRoot(std::string_view filename,
+                                                  std::string_view moduleRoot) {
+    auto [stem, extension] = splitFilename(boost::trim_copy(std::string(filename)));
+    std::string root(moduleRoot);
+    // Anything outside this module's name space is another module's file:
+    // not ours, and not an error.
+    if (stem != root && !boost::starts_with(stem, root + "_")) {
+        return {std::nullopt, std::nullopt};
+    }
+    if (extension.empty()) {
+        return {std::nullopt, ModuleNameRejection::UnsupportedExtension};
+    }
+
+    if (stem == root) {
+        for (const auto &rule : kPrimaryRules) {
+            if (extension == rule.extension) {
+                return {ClassifiedModuleArchive {root, rule.family}, std::nullopt};
+            }
+        }
+        return {std::nullopt, ModuleNameRejection::UnsupportedExtension};
+    }
+
+    auto suffix = stem.substr(root.size());
+    bool suffixSupported = false;
+    for (const auto &rule : kSuffixRules) {
+        if (suffix != rule.suffix) continue;
+        if (extension == rule.extension) {
+            return {ClassifiedModuleArchive {root, rule.family}, std::nullopt};
+        }
+        suffixSupported = true;
+    }
+    return {std::nullopt,
+            suffixSupported ? ModuleNameRejection::SuffixExtensionMismatch
+                            : ModuleNameRejection::UnsupportedSuffix};
+}
+
+ModuleNameNormalization normalizeModuleName(std::string_view requested) {
+    auto trimmed = boost::trim_copy(std::string(requested));
+    if (trimmed.empty()) {
+        return {std::nullopt, ModuleNameRejection::Empty};
+    }
+    auto [stem, extension] = splitFilename(trimmed);
+    if (stem.empty()) {
+        return {std::nullopt, ModuleNameRejection::Empty};
+    }
+    if (extension.empty()) {
+        return {stem, std::nullopt};
+    }
+    // Only the extension is removed. A trailing family suffix stays part of
+    // the root: the caller has already said this is the module it wants, and
+    // reading the suffix here would discard that.
+    for (const auto &rule : kPrimaryRules) {
+        if (extension == rule.extension) {
+            return {stem, std::nullopt};
+        }
+    }
+    for (const auto &rule : kSuffixRules) {
+        if (extension == rule.extension) {
+            return {stem, std::nullopt};
+        }
+    }
+    return {std::nullopt, ModuleNameRejection::UnsupportedExtension};
+}
+
+std::vector<std::string> discoverModuleRoots(const std::vector<ModuleSearchRoot> &roots) {
+    std::set<std::string> names;
+    for (const auto &root : roots) {
+        for (const auto &path : orderedFiles(root.path)) {
+            auto classified = classifyModuleArchive(path.filename().string());
+            if (!classified.archive) continue;
+            // Only a primary-eligible archive introduces a module name.
+            if (!isPrimaryEligible(classified.archive->family)) continue;
+            names.insert(classified.archive->moduleRoot);
+        }
+    }
+    return {names.begin(), names.end()};
+}
+
+ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
+                                            const std::vector<ModuleSearchRoot> &roots) {
+    ModuleDiscoveryResult result;
+    auto normalized = normalizeModuleName(requestedModule);
+    if (!normalized.root) {
+        result.nameRejection = normalized.rejection;
+        return result;
+    }
+    result.moduleRoot = *normalized.root;
+
+    for (const auto &root : roots) {
+        for (const auto &path : orderedFiles(root.path)) {
+            auto filename = path.filename().string();
+            // The requested root is known here, so ownership is resolved
+            // against it rather than inferred from the name alone.
+            auto classified = classifyForModuleRoot(filename, result.moduleRoot);
+            if (!classified.archive) {
+                // A rejection means the file is in this module's name space
+                // but belongs to no supported family; no rejection at all
+                // means it is simply another module's file.
+                if (classified.rejection) {
+                    result.rejected.push_back(RejectedModuleFile {
+                        root.rootId, path, filename, *classified.rejection});
+                }
+                continue;
+            }
+
+            DiscoveredModuleSource source;
+            source.candidate = ModuleSourceCandidate {
+                root.rootId + ":" + boost::to_lower_copy(filename),
+                root.rootId,
+                root.origin,
+                classified.archive->family,
+                root.packageOrder,
+                root.rootOrder};
+            source.path = path;
+            source.filename = filename;
+            source.moduleRoot = result.moduleRoot;
+            result.sources.push_back(std::move(source));
+        }
+    }
+    return result;
+}
+
+std::vector<ModuleSourceCandidate> plannerInventory(const ModuleDiscoveryResult &discovered) {
+    std::vector<ModuleSourceCandidate> inventory;
+    inventory.reserve(discovered.sources.size());
+    for (const auto &source : discovered.sources) {
+        inventory.push_back(source.candidate);
+    }
+    return inventory;
+}
+
+} // namespace resource
+} // namespace reone

--- a/src/libs/resource/modulediscovery.cpp
+++ b/src/libs/resource/modulediscovery.cpp
@@ -260,6 +260,10 @@ ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
                 }
                 continue;
             }
+            if (classified.archive->family == ModuleArchiveFamily::AreaRim ||
+                classified.archive->family == ModuleArchiveFamily::AdxRim) {
+                continue;
+            }
 
             DiscoveredModuleSource source;
             source.candidate = ModuleSourceCandidate {
@@ -277,6 +281,49 @@ ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
     }
     return result;
 }
+std::vector<DiscoveredModuleSource> discoverRimsModuleAdjuncts(
+    std::string_view moduleRoot,
+    const std::filesystem::path &gamePath) {
+    std::vector<DiscoveredModuleSource> result;
+    auto normalized = normalizeModuleName(moduleRoot);
+    if (!normalized.root) {
+        return result;
+    }
+    auto rims = findFileIgnoreCase(gamePath, "rims");
+    if (!rims) {
+        return result;
+    }
+
+    struct ExactAdjunct {
+        const char *suffix;
+        ModuleArchiveFamily family;
+    };
+    static const std::array<ExactAdjunct, 2> kAdjuncts {{
+        {"_a.rim", ModuleArchiveFamily::AreaRim},
+        {"_adx.rim", ModuleArchiveFamily::AdxRim},
+    }};
+    for (const auto &adjunct : kAdjuncts) {
+        auto filename = *normalized.root + adjunct.suffix;
+        auto path = findFileIgnoreCase(*rims, filename);
+        if (!path) {
+            continue;
+        }
+        DiscoveredModuleSource source;
+        source.candidate = ModuleSourceCandidate {
+            "rims:" + filename,
+            "rims",
+            ModulePrimaryOrigin::Modules,
+            adjunct.family,
+            0,
+            0};
+        source.path = *path;
+        source.filename = path->filename().string();
+        source.moduleRoot = *normalized.root;
+        result.push_back(std::move(source));
+    }
+    return result;
+}
+
 
 const std::array<std::string_view, 5> kEncapsulatedProbeOrder {
     ".nwm", ".mod", ".sav", ".erf", ".hak"};

--- a/src/libs/resource/modulediscovery.cpp
+++ b/src/libs/resource/modulediscovery.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/resource/modulediscovery.h"
 
+#include "reone/system/fileutil.h"
+
 #include <algorithm>
 #include <array>
 #include <set>
@@ -274,6 +276,24 @@ ModuleDiscoveryResult discoverModuleSources(std::string_view requestedModule,
         }
     }
     return result;
+}
+
+const std::array<std::string_view, 5> kEncapsulatedProbeOrder {
+    ".nwm", ".mod", ".sav", ".erf", ".hak"};
+
+std::optional<std::filesystem::path> findEncapsulatedByBasename(
+    const std::filesystem::path &directory,
+    std::string_view basename) {
+    if (basename.empty()) {
+        return std::nullopt;
+    }
+    for (auto extension : kEncapsulatedProbeOrder) {
+        auto filename = std::string(basename) + std::string(extension);
+        if (auto path = findFileIgnoreCase(directory, filename)) {
+            return path;
+        }
+    }
+    return std::nullopt;
 }
 
 std::vector<ModuleSourceCandidate> plannerInventory(const ModuleDiscoveryResult &discovered) {

--- a/src/libs/resource/modulemount.cpp
+++ b/src/libs/resource/modulemount.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/modulemount.h"
+
+#include "reone/system/exception/validation.h"
+#include "reone/system/logutil.h"
+
+#include <algorithm>
+
+namespace reone {
+
+namespace resource {
+
+ContainerKind containerKindOf(ResourceOwner owner) {
+    switch (owner) {
+    case ResourceOwner::Global:
+        return ContainerKind::Global;
+    case ResourceOwner::SaveSlot:
+        return ContainerKind::Save;
+    default:
+        return ContainerKind::Local;
+    }
+}
+
+bool isResourceImageFamily(ModuleArchiveFamily family) {
+    switch (family) {
+    case ModuleArchiveFamily::PrimaryRim:
+    case ModuleArchiveFamily::StaticRim:
+    case ModuleArchiveFamily::AreaRim:
+    case ModuleArchiveFamily::AdxRim:
+    case ModuleArchiveFamily::SavedResourceImage:
+        return true;
+    default:
+        return false;
+    }
+}
+
+const RuntimeModuleSource *RuntimeModuleSourceIndex::find(const std::string &sourceId) const {
+    auto it = std::find_if(_sources.begin(), _sources.end(), [&sourceId](const auto &source) {
+        return source.candidate.sourceId == sourceId;
+    });
+    return it != _sources.end() ? &*it : nullptr;
+}
+
+std::vector<ModuleSourceCandidate> RuntimeModuleSourceIndex::inventory() const {
+    std::vector<ModuleSourceCandidate> inventory;
+    inventory.reserve(_sources.size());
+    for (const auto &source : _sources) {
+        inventory.push_back(source.candidate);
+    }
+    return inventory;
+}
+
+bool ModuleMountReport::mounted(const std::string &sourceId) const {
+    return std::any_of(outcomes.begin(), outcomes.end(), [&sourceId](const auto &outcome) {
+        return outcome.mounted && outcome.sourceId == sourceId;
+    });
+}
+
+std::size_t ModuleMountReport::mountedCount() const {
+    return static_cast<std::size_t>(std::count_if(outcomes.begin(), outcomes.end(), [](const auto &outcome) {
+        return outcome.mounted;
+    }));
+}
+
+bool ModuleMountExecutor::mount(const RuntimeModuleSource &source, const ModuleSourceMetadata &metadata) {
+    auto kind = containerKindOf(metadata.owner);
+    auto image = isResourceImageFamily(source.candidate.family);
+    try {
+        if (const auto *path = std::get_if<std::filesystem::path>(&source.locator)) {
+            if (!std::filesystem::exists(*path)) {
+                return false;
+            }
+            if (image) {
+                _resources.addRIM(*path, kind, metadata.bucket);
+            } else {
+                _resources.addERF(*path, kind, metadata.bucket);
+            }
+            return true;
+        }
+        // A module staged inside an archive already in scope. The bytes are read
+        // back through one explicit id: the container is never walked into, so
+        // nested archives do not become recursively active.
+        const auto &id = std::get<ResourceId>(source.locator);
+        auto res = _resources.find(id);
+        if (!res) {
+            return false;
+        }
+        if (image) {
+            _resources.addMemRIM(res->data, kind, metadata.bucket);
+        } else {
+            _resources.addMemERF(res->data, kind, metadata.bucket);
+        }
+        return true;
+    } catch (const ValidationException &) {
+        // Two things raise this, and neither is best effort.
+        //
+        // The source list raises it when this executor asks for something the
+        // list cannot represent, such as placing a source into a list that
+        // holds unplaced ones; that is a fault in the plan or the caller, and
+        // degrading it to a missed mount would hide it behind a best-effort
+        // result. The archive readers raise it for a malformed container, which
+        // the unactivated path does not guard against either, so swallowing it
+        // would leave an activated game quietly more tolerant of broken data.
+        //
+        // Best effort covers a source that is not there, which is answered
+        // above without opening anything.
+        throw;
+    } catch (const std::exception &e) {
+        warn("Failed mounting module source '" + source.candidate.sourceId + "': " + e.what());
+        return false;
+    }
+}
+
+bool ModuleMountExecutor::mountBySourceId(const std::string &sourceId,
+                                          ModuleArchiveFamily family,
+                                          ModuleMountPhase phase,
+                                          const ModuleSourceMetadata &metadata,
+                                          ModuleMountReport &report) {
+    const auto *source = _sources.find(sourceId);
+    bool mounted = source && mount(*source, metadata);
+    report.outcomes.push_back(ModuleMountOutcome {sourceId, family, phase, mounted});
+    return mounted;
+}
+
+void ModuleMountExecutor::runFamily(const ModuleFamilyPlan &family, ModuleMountReport &report) {
+    bool anySucceeded = false;
+    for (const auto &attempt : family.attempts) {
+        bool mounted = mountBySourceId(attempt.source.sourceId,
+                                       attempt.family,
+                                       attempt.phase,
+                                       attempt.metadata,
+                                       report);
+        anySucceeded = anySucceeded || mounted;
+        // A family limited to one source looks at one candidate and stops,
+        // whether or not that candidate mounted: the limit is on what is
+        // considered, not on what succeeds. A family that takes the first
+        // source to supply it keeps going until one does. The planner happens
+        // to give the former a single attempt, but the limit is the family's
+        // own and is enforced here rather than assumed.
+        if (family.cardinality == MountCardinality::ZeroOrOne) {
+            break;
+        }
+        if (mounted && family.cardinality == MountCardinality::FirstSuccessful) {
+            break;
+        }
+    }
+    if (anySucceeded || family.attempts.empty()) {
+        return;
+    }
+    auto effect = family.attempts.front().failureEffect;
+    if (effect != MountFailureEffect::BestEffort) {
+        report.requiredFailure = true;
+    }
+}
+
+void ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report) {
+    if (plan.primary) {
+        const auto &primary = plan.primary->candidate.source;
+        // In the MOD branch the selected archive is also a branch attempt and
+        // is already mounted. Selecting a source and mounting the module's
+        // tables are separate operations, so this is the only place the two can
+        // coincide.
+        if (!report.mounted(primary.sourceId)) {
+            auto metadata = mountMetadata(primary.family);
+            // A packaged module reaches its final form through staging, so the
+            // policy assigns it no bucket and there is nothing to mount here.
+            if (metadata) {
+                mountBySourceId(primary.sourceId,
+                                primary.family,
+                                ModuleMountPhase::ActiveCurrentGame,
+                                *metadata,
+                                report);
+            }
+        }
+    }
+    // Recovery is a consequence of the branch flow, not of the selection: a
+    // required mount can fail whether or not a primary was chosen.
+    if (!report.requiredFailure) {
+        return;
+    }
+    // Recovery route: a required branch mount failed, so the staged class-2
+    // archive stands in for it when the inventory offers one.
+    for (const auto &source : _sources.sources()) {
+        if (source.candidate.family != ModuleArchiveFamily::SavedArchive) {
+            continue;
+        }
+        if (report.mounted(source.candidate.sourceId)) {
+            break;
+        }
+        mountBySourceId(source.candidate.sourceId,
+                        ModuleArchiveFamily::SavedArchive,
+                        ModuleMountPhase::ActiveCurrentGame,
+                        plan.activeState.encapsulatedArchive,
+                        report);
+        break;
+    }
+}
+
+ModuleMountReport ModuleMountExecutor::run(const ModuleLoadPlan &plan) {
+    ModuleMountReport report;
+    for (const auto &family : plan.families) {
+        runFamily(family, report);
+    }
+    runActiveState(plan, report);
+    return report;
+}
+
+} // namespace resource
+
+} // namespace reone

--- a/src/libs/resource/modulemount.cpp
+++ b/src/libs/resource/modulemount.cpp
@@ -104,7 +104,7 @@ bool ModuleMountExecutor::mount(const RuntimeModuleSource &source, const ModuleS
         // holds unplaced ones; that is a fault in the plan or the caller, and
         // degrading it to a missed mount would hide it behind a best-effort
         // result. The archive readers raise it for a malformed container, which
-        // the unactivated path does not guard against either, so swallowing it
+        // the shared activated path does not guard against either, so swallowing it
         // would leave an activated game quietly more tolerant of broken data.
         //
         // Best effort covers a source that is not there, which is answered

--- a/src/libs/resource/modulemount.cpp
+++ b/src/libs/resource/modulemount.cpp
@@ -169,8 +169,15 @@ bool ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMount
         activeStateMounted = report.mounted(primary.sourceId);
         if (!activeStateMounted) {
             auto metadata = mountMetadata(primary.family);
-            // A packaged module reaches its final form through staging, so the
-            // policy assigns it no bucket and there is nothing to mount here.
+            // NWM has no generic mount metadata: discovery of a packaged module
+            // does not make it a permanent class-2 source. Only the selected
+            // NWM becomes the active module state, directly and without
+            // CURRENTGAME staging.
+            if (primary.family == ModuleArchiveFamily::Nwm) {
+                metadata = ModuleSourceMetadata {
+                    ResourceSourceBucket::EncapsulatedClass2,
+                    plan.activeState.owner};
+            }
             if (metadata) {
                 // What this phase mounts is the module's active state, so it
                 // takes the active-state owner whatever family supplied it. The

--- a/src/libs/resource/modulemount.cpp
+++ b/src/libs/resource/modulemount.cpp
@@ -26,17 +26,6 @@ namespace reone {
 
 namespace resource {
 
-ContainerKind containerKindOf(ResourceOwner owner) {
-    switch (owner) {
-    case ResourceOwner::Global:
-        return ContainerKind::Global;
-    case ResourceOwner::SaveSlot:
-        return ContainerKind::Save;
-    default:
-        return ContainerKind::Local;
-    }
-}
-
 bool isResourceImageFamily(ModuleArchiveFamily family) {
     switch (family) {
     case ModuleArchiveFamily::PrimaryRim:
@@ -79,7 +68,7 @@ std::size_t ModuleMountReport::mountedCount() const {
 }
 
 bool ModuleMountExecutor::mount(const RuntimeModuleSource &source, const ModuleSourceMetadata &metadata) {
-    auto kind = containerKindOf(metadata.owner);
+    auto owner = metadata.owner;
     auto image = isResourceImageFamily(source.candidate.family);
     try {
         if (const auto *path = std::get_if<std::filesystem::path>(&source.locator)) {
@@ -87,9 +76,9 @@ bool ModuleMountExecutor::mount(const RuntimeModuleSource &source, const ModuleS
                 return false;
             }
             if (image) {
-                _resources.addRIM(*path, kind, metadata.bucket);
+                _resources.addRIM(*path, owner, metadata.bucket);
             } else {
-                _resources.addERF(*path, kind, metadata.bucket);
+                _resources.addERF(*path, owner, metadata.bucket);
             }
             return true;
         }
@@ -102,9 +91,9 @@ bool ModuleMountExecutor::mount(const RuntimeModuleSource &source, const ModuleS
             return false;
         }
         if (image) {
-            _resources.addMemRIM(res->data, kind, metadata.bucket);
+            _resources.addMemRIM(res->data, owner, metadata.bucket);
         } else {
-            _resources.addMemERF(res->data, kind, metadata.bucket);
+            _resources.addMemERF(res->data, owner, metadata.bucket);
         }
         return true;
     } catch (const ValidationException &) {
@@ -181,6 +170,13 @@ void ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMount
             // A packaged module reaches its final form through staging, so the
             // policy assigns it no bucket and there is nothing to mount here.
             if (metadata) {
+                // What this phase mounts is the module's active state, so it
+                // takes the active-state owner whatever family supplied it. The
+                // bucket still comes from the family: how long a source lives
+                // and where it is searched are answered separately. Both owners
+                // are retired on a module transition today, so this separates
+                // the two lifetimes without moving either of them.
+                metadata->owner = plan.activeState.owner;
                 mountBySourceId(primary.sourceId,
                                 primary.family,
                                 ModuleMountPhase::ActiveCurrentGame,

--- a/src/libs/resource/modulemount.cpp
+++ b/src/libs/resource/modulemount.cpp
@@ -158,14 +158,16 @@ void ModuleMountExecutor::runFamily(const ModuleFamilyPlan &family, ModuleMountR
     }
 }
 
-void ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report) {
+bool ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMountReport &report) {
+    bool activeStateMounted = false;
     if (plan.primary) {
         const auto &primary = plan.primary->candidate.source;
         // In the MOD branch the selected archive is also a branch attempt and
         // is already mounted. Selecting a source and mounting the module's
         // tables are separate operations, so this is the only place the two can
         // coincide.
-        if (!report.mounted(primary.sourceId)) {
+        activeStateMounted = report.mounted(primary.sourceId);
+        if (!activeStateMounted) {
             auto metadata = mountMetadata(primary.family);
             // A packaged module reaches its final form through staging, so the
             // policy assigns it no bucket and there is nothing to mount here.
@@ -173,47 +175,59 @@ void ModuleMountExecutor::runActiveState(const ModuleLoadPlan &plan, ModuleMount
                 // What this phase mounts is the module's active state, so it
                 // takes the active-state owner whatever family supplied it. The
                 // bucket still comes from the family: how long a source lives
-                // and where it is searched are answered separately. Both owners
-                // are retired on a module transition today, so this separates
-                // the two lifetimes without moving either of them.
+                // and where it is searched are answered separately.
                 metadata->owner = plan.activeState.owner;
-                mountBySourceId(primary.sourceId,
-                                primary.family,
-                                ModuleMountPhase::ActiveCurrentGame,
-                                *metadata,
-                                report);
+                activeStateMounted = mountBySourceId(primary.sourceId,
+                                                     primary.family,
+                                                     ModuleMountPhase::ActiveCurrentGame,
+                                                     *metadata,
+                                                     report);
             }
         }
     }
-    // Recovery is a consequence of the branch flow, not of the selection: a
-    // required mount can fail whether or not a primary was chosen.
     if (!report.requiredFailure) {
-        return;
+        return false;
     }
-    // Recovery route: a required branch mount failed, so the staged class-2
-    // archive stands in for it when the inventory offers one.
+
+    // A successfully mounted saved archive is the original CURRENTGAME
+    // recovery route, including when it was already the selected primary.
+    for (const auto &outcome : report.outcomes) {
+        if (outcome.mounted &&
+            outcome.family == ModuleArchiveFamily::SavedArchive &&
+            outcome.phase == ModuleMountPhase::ActiveCurrentGame) {
+            return true;
+        }
+    }
+
+    // Otherwise try the staged class-2 archive once as recovery.
     for (const auto &source : _sources.sources()) {
         if (source.candidate.family != ModuleArchiveFamily::SavedArchive) {
             continue;
         }
-        if (report.mounted(source.candidate.sourceId)) {
-            break;
-        }
-        mountBySourceId(source.candidate.sourceId,
-                        ModuleArchiveFamily::SavedArchive,
-                        ModuleMountPhase::ActiveCurrentGame,
-                        plan.activeState.encapsulatedArchive,
-                        report);
-        break;
+        return mountBySourceId(source.candidate.sourceId,
+                               ModuleArchiveFamily::SavedArchive,
+                               ModuleMountPhase::ActiveCurrentGame,
+                               plan.activeState.encapsulatedArchive,
+                               report);
     }
+    return false;
 }
-
 ModuleMountReport ModuleMountExecutor::run(const ModuleLoadPlan &plan) {
     ModuleMountReport report;
     for (const auto &family : plan.families) {
         runFamily(family, report);
     }
-    runActiveState(plan, report);
+    bool recovered = runActiveState(plan, report);
+    if (!plan.primary) {
+        return report;
+    }
+    if (report.requiredFailure) {
+        report.outcome = recovered
+                             ? ModuleLoadOutcome::RecoveredThroughActiveState
+                             : ModuleLoadOutcome::Failed;
+    } else if (report.mounted(plan.primary->candidate.source.sourceId)) {
+        report.outcome = ModuleLoadOutcome::Succeeded;
+    }
     return report;
 }
 

--- a/src/libs/resource/odysseyroots.cpp
+++ b/src/libs/resource/odysseyroots.cpp
@@ -121,6 +121,13 @@ std::vector<ModuleSearchRoot> primaryModuleSearchRoots(
     const std::filesystem::path &gamePath,
     const OdysseyResourceRoots &roots) {
     std::vector<ModuleSearchRoot> result;
+    if (roots.nwmFiles) {
+        if (auto nwm = child(roots.nwmFiles->parent_path(),
+                             roots.nwmFiles->filename().string())) {
+            result.push_back(ModuleSearchRoot {
+                "nwm", *nwm, ModulePrimaryOrigin::NwmFiles, 0, 0});
+        }
+    }
     if (auto base = child(gamePath, "modules")) {
         result.push_back(ModuleSearchRoot {
             "modules", *base, ModulePrimaryOrigin::Modules, 0, 0});

--- a/src/libs/resource/odysseyroots.cpp
+++ b/src/libs/resource/odysseyroots.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/resource/odysseyroots.h"
+
+#include "reone/resource/strings.h"
+#include "reone/system/fileutil.h"
+
+namespace reone::resource {
+namespace {
+
+std::string pathIdentity(const std::filesystem::path &path) {
+    auto identity = path.lexically_normal().string();
+    boost::replace_all(identity, "\\", "/");
+    return identity;
+}
+
+void appendDistinct(std::vector<std::filesystem::path> &paths,
+                    const std::filesystem::path &path) {
+    auto identity = pathIdentity(path);
+    for (const auto &existing : paths) {
+        if (pathIdentity(existing) == identity) {
+            return;
+        }
+    }
+    paths.push_back(path);
+}
+
+std::optional<std::filesystem::path> child(const std::filesystem::path &root,
+                                           std::string_view name) {
+    return findFileIgnoreCase(root, name);
+}
+
+void appendConfiguredModuleRoots(std::vector<ModuleSearchRoot> &result,
+                                 const OdysseyResourceRoots &roots) {
+    for (std::size_t i = 0; i < roots.k2OverrideRoots.size(); ++i) {
+        auto modules = child(roots.k2OverrideRoots[i], "modules");
+        if (!modules) {
+            continue;
+        }
+        result.push_back(ModuleSearchRoot {
+            "configured" + std::to_string(i) + ":modules",
+            *modules,
+            ModulePrimaryOrigin::ConfiguredModuleRoot,
+            0,
+            static_cast<std::uint32_t>(i)});
+    }
+}
+
+} // namespace
+
+OdysseyResourceRoots defaultOdysseyResourceRoots(const std::filesystem::path &gamePath) {
+    OdysseyResourceRoots roots;
+    roots.nwmFiles = gamePath / "nwm";
+    return roots;
+}
+
+void loadLiveTalkTables(Strings &strings, const OdysseyResourceRoots &roots) {
+    for (std::size_t i = 0; i < roots.livePackages.size(); ++i) {
+        if (!roots.livePackages[i]) {
+            continue;
+        }
+        auto slot = i + 1;
+        auto filename = "live" + std::to_string(slot) + ".tlk";
+        strings.loadTalkTable(slot, *roots.livePackages[i] / filename);
+    }
+}
+
+std::vector<std::filesystem::path> looseOverrideRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots) {
+    std::vector<std::filesystem::path> result;
+    if (auto base = child(gamePath, "override")) {
+        appendDistinct(result, *base);
+    }
+    if (game == GameID::TSL) {
+        for (const auto &configured : roots.k2OverrideRoots) {
+            if (auto path = child(configured, "override")) {
+                appendDistinct(result, *path);
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<std::filesystem::path> lipsRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots) {
+    std::vector<std::filesystem::path> result;
+    if (auto base = child(gamePath, "lips")) {
+        appendDistinct(result, *base);
+    }
+    if (game == GameID::TSL) {
+        for (const auto &configured : roots.k2OverrideRoots) {
+            if (auto path = child(configured, "lips")) {
+                appendDistinct(result, *path);
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<ModuleSearchRoot> primaryModuleSearchRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots) {
+    std::vector<ModuleSearchRoot> result;
+    if (auto base = child(gamePath, "modules")) {
+        result.push_back(ModuleSearchRoot {
+            "modules", *base, ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    for (std::size_t i = 0; i < roots.livePackages.size(); ++i) {
+        if (!roots.livePackages[i]) {
+            continue;
+        }
+        auto modules = child(*roots.livePackages[i], "modules");
+        if (!modules) {
+            continue;
+        }
+        result.push_back(ModuleSearchRoot {
+            "live" + std::to_string(i + 1),
+            *modules,
+            ModulePrimaryOrigin::LivePackage,
+            static_cast<std::uint32_t>(i + 1),
+            0});
+    }
+    if (game == GameID::TSL) {
+        appendConfiguredModuleRoots(result, roots);
+    }
+    return result;
+}
+
+std::vector<ModuleSearchRoot> moduleSearchRoots(
+    GameID game,
+    const std::filesystem::path &gamePath,
+    const OdysseyResourceRoots &roots) {
+    auto result = primaryModuleSearchRoots(game, gamePath, roots);
+    std::vector<std::filesystem::path> added;
+    if (auto base = child(gamePath, "lips")) {
+        appendDistinct(added, *base);
+        result.push_back(ModuleSearchRoot {
+            "lips", *base, ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    if (game == GameID::TSL) {
+        for (std::size_t i = 0; i < roots.k2OverrideRoots.size(); ++i) {
+            auto configured = child(roots.k2OverrideRoots[i], "lips");
+            if (!configured) {
+                continue;
+            }
+            auto before = added.size();
+            appendDistinct(added, *configured);
+            if (added.size() == before) {
+                continue;
+            }
+            result.push_back(ModuleSearchRoot {
+                "configured" + std::to_string(i) + ":lips",
+                *configured,
+                ModulePrimaryOrigin::ConfiguredModuleRoot,
+                0,
+                static_cast<std::uint32_t>(i)});
+        }
+    }
+    return result;
+}
+
+} // namespace reone::resource

--- a/src/libs/resource/provider/audioclips.cpp
+++ b/src/libs/resource/provider/audioclips.cpp
@@ -29,9 +29,28 @@ namespace reone {
 
 namespace resource {
 
+std::optional<Resource> AudioClips::findClipData(const std::string &resRef, ResType type) {
+    auto id = ResourceId(resRef, type);
+    // The streaming directories answer for a streamed asset before the ordinary
+    // sources do. The traced engine reaches them by path rather than through
+    // raw lookup, so the streaming location is authoritative for what it holds,
+    // and retail relies on it: a K2 installation ships hundreds of voice lines
+    // in both StreamVoice and the key tables, and the streamed copy is the one
+    // that must play.
+    //
+    // This is the streaming subsystem's own rule, not a bucket. It does mean an
+    // ordinary source cannot shadow a streamed asset of the same name, which
+    // should be revisited if audio moves onto a path provider.
+    auto res = _streamResources.find(id);
+    if (res) {
+        return res;
+    }
+    return _resources.find(id);
+}
+
 std::shared_ptr<AudioClip> AudioClips::doGet(std::string resRef) {
     std::shared_ptr<AudioClip> clip;
-    auto m3pRes = _resources.find(ResourceId(resRef, ResType::Mp3));
+    auto m3pRes = findClipData(resRef, ResType::Mp3);
     if (m3pRes) {
         auto stream = MemoryInputStream(m3pRes->data);
         auto reader = Mp3Reader();
@@ -39,7 +58,7 @@ std::shared_ptr<AudioClip> AudioClips::doGet(std::string resRef) {
         clip = reader.stream();
     }
     if (!clip) {
-        auto wavRes = _resources.find(ResourceId(resRef, ResType::Wav));
+        auto wavRes = findClipData(resRef, ResType::Wav);
         if (wavRes) {
             auto stream = MemoryInputStream(wavRes->data);
             auto mp3ReaderFactory = Mp3ReaderFactory();

--- a/src/libs/resource/replacementresources.cpp
+++ b/src/libs/resource/replacementresources.cpp
@@ -27,12 +27,16 @@ void ReplacementResources::clear() {
     _backend->clear();
 }
 
-void ReplacementResources::clearLocal() {
-    _backend->clearLocal();
+void ReplacementResources::clearOwner(ResourceOwner owner) {
+    _backend->clearOwner(owner);
 }
 
-void ReplacementResources::clearSave() {
-    _backend->clearSave();
+ResourceMountToken ReplacementResources::mountToken() const {
+    return _backend->mountToken();
+}
+
+void ReplacementResources::rollbackTo(ResourceMountToken token) {
+    _backend->rollbackTo(token);
 }
 
 void ReplacementResources::addEXE(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
@@ -43,24 +47,24 @@ void ReplacementResources::addKEY(const std::filesystem::path &path, std::option
     _backend->addKEY(path, bucket);
 }
 
-void ReplacementResources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    _backend->addERF(path, kind, bucket);
+void ReplacementResources::addERF(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addERF(path, owner, bucket);
 }
 
-void ReplacementResources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    _backend->addMemERF(std::move(buffer), kind, bucket);
+void ReplacementResources::addMemERF(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addMemERF(std::move(buffer), owner, bucket);
 }
 
-void ReplacementResources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    _backend->addRIM(path, kind, bucket);
+void ReplacementResources::addRIM(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addRIM(path, owner, bucket);
 }
 
-void ReplacementResources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    _backend->addMemRIM(std::move(buffer), kind, bucket);
+void ReplacementResources::addMemRIM(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addMemRIM(std::move(buffer), owner, bucket);
 }
 
-void ReplacementResources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
-    _backend->addFolder(path, kind, bucket);
+void ReplacementResources::addFolder(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addFolder(path, owner, bucket);
 }
 
 Resource ReplacementResources::get(const ResourceId &id) {

--- a/src/libs/resource/replacementresources.cpp
+++ b/src/libs/resource/replacementresources.cpp
@@ -35,32 +35,32 @@ void ReplacementResources::clearSave() {
     _backend->clearSave();
 }
 
-void ReplacementResources::addEXE(const std::filesystem::path &path) {
-    _backend->addEXE(path);
+void ReplacementResources::addEXE(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addEXE(path, bucket);
 }
 
-void ReplacementResources::addKEY(const std::filesystem::path &path) {
-    _backend->addKEY(path);
+void ReplacementResources::addKEY(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addKEY(path, bucket);
 }
 
-void ReplacementResources::addERF(const std::filesystem::path &path, ContainerKind kind) {
-    _backend->addERF(path, kind);
+void ReplacementResources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addERF(path, kind, bucket);
 }
 
-void ReplacementResources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
-    _backend->addMemERF(std::move(buffer), kind);
+void ReplacementResources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addMemERF(std::move(buffer), kind, bucket);
 }
 
-void ReplacementResources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
-    _backend->addRIM(path, kind);
+void ReplacementResources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addRIM(path, kind, bucket);
 }
 
-void ReplacementResources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
-    _backend->addMemRIM(std::move(buffer), kind);
+void ReplacementResources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addMemRIM(std::move(buffer), kind, bucket);
 }
 
-void ReplacementResources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
-    _backend->addFolder(path, kind);
+void ReplacementResources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+    _backend->addFolder(path, kind, bucket);
 }
 
 Resource ReplacementResources::get(const ResourceId &id) {

--- a/src/libs/resource/resources.cpp
+++ b/src/libs/resource/resources.cpp
@@ -28,46 +28,46 @@ namespace reone {
 
 namespace resource {
 
-void Resources::addKEY(const std::filesystem::path &path) {
+void Resources::addKEY(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<KeyBifResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), ContainerKind::Global});
+    add(std::move(provider), ContainerKind::Global, bucket);
 }
 
-void Resources::addERF(const std::filesystem::path &path, ContainerKind kind) {
+void Resources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ErfResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+    add(std::move(provider), kind, bucket);
 }
 
-void Resources::addMemERF(ByteBuffer buffer, ContainerKind kind) {
+void Resources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ErfResourceContainer>(std::move(buffer));
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+    add(std::move(provider), kind, bucket);
 }
 
-void Resources::addRIM(const std::filesystem::path &path, ContainerKind kind) {
+void Resources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<RimResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+    add(std::move(provider), kind, bucket);
 }
 
-void Resources::addMemRIM(ByteBuffer buffer, ContainerKind kind) {
+void Resources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<RimResourceContainer>(buffer);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+    add(std::move(provider), kind, bucket);
 }
 
-void Resources::addEXE(const std::filesystem::path &path) {
+void Resources::addEXE(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ExeResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), ContainerKind::Global});
+    add(std::move(provider), ContainerKind::Global, bucket);
 }
 
-void Resources::addFolder(const std::filesystem::path &path, ContainerKind kind) {
+void Resources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<FolderResourceContainer>(path);
     provider->init();
-    _containers.push_front(ResourceContainerPair {std::move(provider), kind});
+    add(std::move(provider), kind, bucket);
 }
 
 Resource Resources::get(const ResourceId &id) {
@@ -79,8 +79,8 @@ Resource Resources::get(const ResourceId &id) {
 }
 
 std::optional<Resource> Resources::find(const ResourceId &id) {
-    for (auto &[provider, kind] : _containers) {
-        auto data = provider->findResourceData(id);
+    for (auto &container : _containers) {
+        auto data = container.provider->findResourceData(id);
         if (data) {
             return Resource {*data};
         }

--- a/src/libs/resource/resources.cpp
+++ b/src/libs/resource/resources.cpp
@@ -31,43 +31,43 @@ namespace resource {
 void Resources::addKEY(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<KeyBifResourceContainer>(path);
     provider->init();
-    add(std::move(provider), ContainerKind::Global, bucket);
+    add(std::move(provider), ResourceOwner::Global, bucket);
 }
 
-void Resources::addERF(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void Resources::addERF(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ErfResourceContainer>(path);
     provider->init();
-    add(std::move(provider), kind, bucket);
+    add(std::move(provider), owner, bucket);
 }
 
-void Resources::addMemERF(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void Resources::addMemERF(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ErfResourceContainer>(std::move(buffer));
     provider->init();
-    add(std::move(provider), kind, bucket);
+    add(std::move(provider), owner, bucket);
 }
 
-void Resources::addRIM(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void Resources::addRIM(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<RimResourceContainer>(path);
     provider->init();
-    add(std::move(provider), kind, bucket);
+    add(std::move(provider), owner, bucket);
 }
 
-void Resources::addMemRIM(ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void Resources::addMemRIM(ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<RimResourceContainer>(buffer);
     provider->init();
-    add(std::move(provider), kind, bucket);
+    add(std::move(provider), owner, bucket);
 }
 
 void Resources::addEXE(const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<ExeResourceContainer>(path);
     provider->init();
-    add(std::move(provider), ContainerKind::Global, bucket);
+    add(std::move(provider), ResourceOwner::Global, bucket);
 }
 
-void Resources::addFolder(const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket) {
+void Resources::addFolder(const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket) {
     auto provider = std::make_unique<FolderResourceContainer>(path);
     provider->init();
-    add(std::move(provider), kind, bucket);
+    add(std::move(provider), owner, bucket);
 }
 
 Resource Resources::get(const ResourceId &id) {

--- a/src/libs/resource/strings.cpp
+++ b/src/libs/resource/strings.cpp
@@ -18,6 +18,7 @@
 #include "reone/resource/strings.h"
 
 #include "reone/resource/exception/notfound.h"
+#include "reone/resource/format/tlkreader.h"
 #include "reone/resource/talktable.h"
 #include "reone/system/fileutil.h"
 #include "reone/system/stream/fileinput.h"
@@ -34,24 +35,63 @@ void Strings::init(const std::filesystem::path &gameDir) {
     auto tlk = FileInputStream(*tlkPath);
     auto tlkReader = TlkReader(tlk);
     tlkReader.load();
-    _table = tlkReader.table();
+    setTalkTable(0, tlkReader.table());
+}
+
+void Strings::setTalkTable(std::size_t slot, std::shared_ptr<TalkTable> table) {
+    if (slot >= _tables.size()) {
+        throw std::out_of_range("talk table slot is out of range");
+    }
+    _tables[slot] = std::move(table);
+}
+
+bool Strings::loadTalkTable(std::size_t slot, const std::filesystem::path &path) {
+    setTalkTable(slot, nullptr);
+    try {
+        auto tlk = FileInputStream(path);
+        auto tlkReader = TlkReader(tlk);
+        tlkReader.load();
+        setTalkTable(slot, tlkReader.table());
+        return true;
+    } catch (const std::exception &) {
+        return false;
+    }
+}
+
+const TalkTable::String *Strings::findString(int strRef) const {
+    if (strRef == -1) {
+        return nullptr;
+    }
+
+    auto row = static_cast<std::uint32_t>(strRef) & 0x00ffffff;
+    for (const auto &table : _tables) {
+        if (!table || row >= static_cast<std::uint32_t>(table->getStringCount())) {
+            continue;
+        }
+        return &table->getString(static_cast<int>(row));
+    }
+    return nullptr;
 }
 
 std::string Strings::getText(int strRef) {
-    if (!_table || strRef < 0 || strRef >= _table->getStringCount())
+    auto string = findString(strRef);
+    if (!string) {
         return "";
+    }
 
-    std::string text(_table->getString(strRef).text);
+    std::string text(string->text);
     process(text);
 
     return text;
 }
 
 std::string Strings::getSound(int strRef) {
-    if (!_table || strRef < 0 || strRef >= _table->getStringCount())
+    auto string = findString(strRef);
+    if (!string) {
         return "";
+    }
 
-    return _table->getString(strRef).soundResRef;
+    return string->soundResRef;
 }
 
 void Strings::process(std::string &str) {

--- a/src/libs/resource/typeutil.cpp
+++ b/src/libs/resource/typeutil.cpp
@@ -66,6 +66,8 @@ static std::unordered_map<ResType, std::string> g_extByType {
     {ResType::Pwk, "pwk"},
     {ResType::Jrl, "jrl"},
     {ResType::Mod, "mod"},
+    {ResType::Sav, "sav"},
+    {ResType::Rsv, "rsv"},
     {ResType::Utw, "utw"},
     {ResType::Ssf, "ssf"},
     {ResType::Ndb, "ndb"},

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/provider/scripts.cpp
     ${TESTS_SOURCE_DIR}/resource/resources.cpp
     ${TESTS_SOURCE_DIR}/resource/resref.cpp
+    ${TESTS_SOURCE_DIR}/resource/sourcebuckets.cpp
     ${TESTS_SOURCE_DIR}/resource/strings.cpp
     ${TESTS_SOURCE_DIR}/scene/model.cpp
     ${TESTS_SOURCE_DIR}/script/format/ncsreader.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
+    ${TESTS_SOURCE_DIR}/resource/archivevalidation.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
     ${TESTS_SOURCE_DIR}/resource/modulediscovery.cpp
     ${TESTS_SOURCE_DIR}/resource/moduleloading.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
+    ${TESTS_SOURCE_DIR}/resource/modulediscovery.cpp
     ${TESTS_SOURCE_DIR}/resource/modulepolicy.cpp
     ${TESTS_SOURCE_DIR}/resource/replacements.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/extract/fileresource.cpp
     ${TESTS_SOURCE_DIR}/extract/finder.cpp
     ${TESTS_SOURCE_DIR}/extract/installation.cpp
+    ${TESTS_SOURCE_DIR}/extract/modulealignment.cpp
     ${TESTS_SOURCE_DIR}/fixtures/engine.cpp
     ${TESTS_SOURCE_DIR}/game/action.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/resources.cpp
     ${TESTS_SOURCE_DIR}/resource/resref.cpp
     ${TESTS_SOURCE_DIR}/resource/sourcebuckets.cpp
+    ${TESTS_SOURCE_DIR}/resource/sourcelifetimes.cpp
     ${TESTS_SOURCE_DIR}/resource/strings.cpp
     ${TESTS_SOURCE_DIR}/scene/model.cpp
     ${TESTS_SOURCE_DIR}/script/format/ncsreader.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/format/tlkreader.cpp
     ${TESTS_SOURCE_DIR}/resource/format/tlkwriter.cpp
     ${TESTS_SOURCE_DIR}/resource/parser/jrl.cpp
+    ${TESTS_SOURCE_DIR}/resource/k1startup.cpp
     ${TESTS_SOURCE_DIR}/resource/lookup.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/2das.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/audioclips.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,8 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp
     ${TESTS_SOURCE_DIR}/resource/modulediscovery.cpp
+    ${TESTS_SOURCE_DIR}/resource/moduleloading.cpp
+    ${TESTS_SOURCE_DIR}/resource/modulemount.cpp
     ${TESTS_SOURCE_DIR}/resource/modulepolicy.cpp
     ${TESTS_SOURCE_DIR}/resource/replacements.cpp
     ${TESTS_SOURCE_DIR}/resource/format/2dareader.cpp
@@ -86,9 +88,11 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/parser/jrl.cpp
     ${TESTS_SOURCE_DIR}/resource/lookup.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/2das.cpp
+    ${TESTS_SOURCE_DIR}/resource/provider/audioclips.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/dialogs.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/gffs.cpp
     ${TESTS_SOURCE_DIR}/resource/provider/scripts.cpp
+    ${TESTS_SOURCE_DIR}/resource/2da.cpp
     ${TESTS_SOURCE_DIR}/resource/resources.cpp
     ${TESTS_SOURCE_DIR}/resource/resref.cpp
     ${TESTS_SOURCE_DIR}/resource/sourcebuckets.cpp

--- a/test/extract/installation.cpp
+++ b/test/extract/installation.cpp
@@ -139,7 +139,15 @@ TEST(InstallationModuleRoot, filters_module_capsules_by_root) {
     EXPECT_EQ("foo", str(loc->readData()));
 }
 
-TEST(InstallationModuleRoot, prioritizes_mod_then_static_rim_then_rim) {
+/**
+ * A module archive's position comes from its bucket, not from its extension.
+ *
+ * This replaces the ".mod beats _s.rim beats .rim" ladder the installation used
+ * to apply. That ladder is not an Odyssey lookup order: a resource image
+ * outranks an encapsulated class-2 archive whenever the two hold the same key,
+ * whichever of them was mounted first.
+ */
+TEST(InstallationModuleRoot, orders_module_archives_by_lookup_bucket_not_by_extension) {
     TmpDir tmp("reone_test_installation_module_archive_order");
     std::filesystem::create_directories(tmp.path / "modules");
 
@@ -153,17 +161,9 @@ TEST(InstallationModuleRoot, prioritizes_mod_then_static_rim_then_rim) {
     auto locations = installation.locations(ResourceId("probe", ResType::Txt), SearchScope {SearchLocation::Modules});
 
     ASSERT_EQ(3u, locations.size());
-    EXPECT_EQ("mod", str(locations[0].readData()));
+    EXPECT_EQ("rim", str(locations[0].readData()));
     EXPECT_EQ("static rim", str(locations[1].readData()));
-    EXPECT_EQ("rim", str(locations[2].readData()));
-}
-
-TEST(InstallationModuleRoot, getModuleRoot_strips_suffixes) {
-    EXPECT_EQ("foo", Installation::getModuleRoot("foo_s.rim"));
-    EXPECT_EQ("foo", Installation::getModuleRoot("foo_dlg.erf"));
-    EXPECT_EQ("modbar", Installation::getModuleRoot("modbar.mod"));
-    EXPECT_EQ("modbar", Installation::getModuleRoot("modbar_loc.mod"));
-    EXPECT_EQ("modbar", Installation::getModuleRoot("MODBAR.RIM"));
+    EXPECT_EQ("mod", str(locations[2].readData())) << "a class-2 archive cannot outrank a resource image";
 }
 
 TEST(InstallationModuleRoot, loads_lips_loc_capsule_for_module) {

--- a/test/extract/modulealignment.cpp
+++ b/test/extract/modulealignment.cpp
@@ -74,6 +74,9 @@ std::vector<std::pair<std::string, ModuleArchiveFamily>> sharedArchives(
     for (const auto &source : discoverModuleSources(module, roots).sources) {
         result.emplace_back(boost::to_lower_copy(source.filename), source.candidate.family);
     }
+    for (const auto &source : discoverRimsModuleAdjuncts(module, root)) {
+        result.emplace_back(boost::to_lower_copy(source.filename), source.candidate.family);
+    }
     return result;
 }
 
@@ -92,13 +95,15 @@ std::vector<std::pair<std::string, ModuleArchiveFamily>> installationArchives(
 void writeMixedInstallation(const std::filesystem::path &root) {
     auto modules = root / "modules";
     auto lips = root / "lips";
+    auto rims = root / "rims";
     std::filesystem::create_directories(modules);
     std::filesystem::create_directories(lips);
+    std::filesystem::create_directories(rims);
 
     writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "primary rim"}});
     writeRim(modules / "foo_s.rim", {{"probe", ResType::Txt, "static"}});
-    writeRim(modules / "foo_a.rim", {{"probe", ResType::Txt, "area"}});
-    writeRim(modules / "foo_adx.rim", {{"probe", ResType::Txt, "adx"}});
+    writeRim(rims / "foo_a.rim", {{"probe", ResType::Txt, "area"}});
+    writeRim(rims / "foo_adx.rim", {{"probe", ResType::Txt, "adx"}});
     writeErf(modules / "foo_dlg.erf", ErfType::ERF, {{"probe", ResType::Txt, "dialogue"}});
     writeErf(modules / "foo_loc.mod", ErfType::MOD, {{"probe", ResType::Txt, "module loc"}});
     writeErf(modules / "bar.mod", ErfType::MOD, {});
@@ -300,8 +305,9 @@ TEST(InstallationModuleArchives, k2_mod_layout_ranks_adx_above_a_above_the_modul
     std::filesystem::create_directories(tmp.path / "modules");
 
     writeErf(tmp.path / "modules" / "foo.mod", ErfType::MOD, {});
-    writeRim(tmp.path / "modules" / "foo_a.rim", {});
-    writeRim(tmp.path / "modules" / "foo_adx.rim", {});
+    std::filesystem::create_directories(tmp.path / "rims");
+    writeRim(tmp.path / "rims" / "foo_a.rim", {});
+    writeRim(tmp.path / "rims" / "foo_adx.rim", {});
 
     Installation installation(GameID::TSL, tmp.path);
     installation.setModuleRoot("foo");
@@ -351,13 +357,19 @@ TEST(InstallationModuleArchives, order_is_independent_of_directory_creation_orde
     std::filesystem::create_directories(first.path / "modules");
     std::filesystem::create_directories(second.path / "modules");
 
-    for (const auto &name : {"foo.rim", "foo_a.rim", "foo_adx.rim", "foo_s.rim"}) {
+    std::filesystem::create_directories(first.path / "rims");
+    std::filesystem::create_directories(second.path / "rims");
+    for (const auto &name : {"foo.rim", "foo_s.rim"}) {
         writeRim(first.path / "modules" / name, {});
     }
-    for (const auto &name : {"foo_s.rim", "foo_adx.rim", "foo_a.rim", "foo.rim"}) {
+    writeRim(first.path / "rims" / "foo_a.rim", {});
+    writeRim(first.path / "rims" / "foo_adx.rim", {});
+    for (const auto &name : {"foo_s.rim", "foo.rim"}) {
         writeRim(second.path / "modules" / name, {});
     }
 
+    writeRim(second.path / "rims" / "foo_adx.rim", {});
+    writeRim(second.path / "rims" / "foo_a.rim", {});
     Installation a(GameID::TSL, first.path);
     Installation b(GameID::TSL, second.path);
     a.setModuleRoot("foo");

--- a/test/extract/modulealignment.cpp
+++ b/test/extract/modulealignment.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The installation and the shared loader answer the same discovery questions.
+ *
+ * Tooling and the runtime both have to know which modules exist, which files
+ * belong to one, and what role each of those files has. These assert that the
+ * two derive those answers from the same rules rather than each carrying its
+ * own reading of a filename. Whether a running game would mount a discovered
+ * archive is a separate question and deliberately not asserted here.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/extract/installation.h"
+#include "reone/resource/modulediscovery.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::extract;
+using namespace reone::resource;
+using namespace reone::test;
+
+using ErfType = ErfWriter::FileType;
+
+namespace {
+
+std::vector<std::string> filenamesOf(const std::vector<ModuleArchive> &archives) {
+    std::vector<std::string> names;
+    names.reserve(archives.size());
+    for (const auto &archive : archives) {
+        names.push_back(boost::to_lower_copy(archive.path.filename().string()));
+    }
+    return names;
+}
+
+const ModuleArchive *archiveNamed(const std::vector<ModuleArchive> &archives,
+                                  const std::string &filename) {
+    for (const auto &archive : archives) {
+        if (boost::to_lower_copy(archive.path.filename().string()) == filename) {
+            return &archive;
+        }
+    }
+    return nullptr;
+}
+
+/// Every family and root the shared layer resolves for a module, as the
+/// installation must resolve them too.
+std::vector<std::pair<std::string, ModuleArchiveFamily>> sharedArchives(
+    const std::filesystem::path &root,
+    const std::string &module) {
+    std::vector<ModuleSearchRoot> roots {
+        ModuleSearchRoot {"modules", root / "modules", ModulePrimaryOrigin::Modules, 0, 0}};
+    if (std::filesystem::exists(root / "lips")) {
+        roots.push_back(ModuleSearchRoot {"lips", root / "lips", ModulePrimaryOrigin::Modules, 0, 0});
+    }
+    std::vector<std::pair<std::string, ModuleArchiveFamily>> result;
+    for (const auto &source : discoverModuleSources(module, roots).sources) {
+        result.emplace_back(boost::to_lower_copy(source.filename), source.candidate.family);
+    }
+    return result;
+}
+
+std::vector<std::pair<std::string, ModuleArchiveFamily>> installationArchives(
+    Installation &installation) {
+    std::vector<std::pair<std::string, ModuleArchiveFamily>> result;
+    for (const auto &archive : installation.moduleArchives()) {
+        result.emplace_back(boost::to_lower_copy(archive.path.filename().string()), archive.family);
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+/// A K2 installation holding one of every family the discovery layer knows,
+/// plus files that must not become modules of their own.
+void writeMixedInstallation(const std::filesystem::path &root) {
+    auto modules = root / "modules";
+    auto lips = root / "lips";
+    std::filesystem::create_directories(modules);
+    std::filesystem::create_directories(lips);
+
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "primary rim"}});
+    writeRim(modules / "foo_s.rim", {{"probe", ResType::Txt, "static"}});
+    writeRim(modules / "foo_a.rim", {{"probe", ResType::Txt, "area"}});
+    writeRim(modules / "foo_adx.rim", {{"probe", ResType::Txt, "adx"}});
+    writeErf(modules / "foo_dlg.erf", ErfType::ERF, {{"probe", ResType::Txt, "dialogue"}});
+    writeErf(modules / "foo_loc.mod", ErfType::MOD, {{"probe", ResType::Txt, "module loc"}});
+    writeErf(modules / "bar.mod", ErfType::MOD, {});
+    // A support archive with no primary of its own.
+    writeRim(modules / "orphan_s.rim", {});
+    // Not a family suffix. Read without a requested root it is a module.
+    writeRim(modules / "foo_adxx.rim", {});
+
+    writeErf(lips / "foo_loc.mod", ErfType::MOD, {{"probe", ResType::Txt, "lips loc"}});
+    writeErf(lips / "global.mod", ErfType::MOD, {});
+    writeErf(lips / "localization.mod", ErfType::MOD, {});
+}
+
+} // namespace
+
+// Enumeration.
+
+TEST(InstallationModuleNames, matches_shared_discovery_over_the_module_location) {
+    TmpDir tmp("reone_test_alignment_names");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+
+    auto expected = discoverModuleRoots({ModuleSearchRoot {
+        "modules", tmp.path / "modules", ModulePrimaryOrigin::Modules, 0, 0}});
+
+    EXPECT_EQ(expected, installation.moduleNames());
+    EXPECT_EQ((std::vector<std::string> {"bar", "foo", "foo_adxx"}), installation.moduleNames());
+}
+
+TEST(InstallationModuleNames, never_reports_a_support_archive_as_a_module) {
+    TmpDir tmp("reone_test_alignment_support_only");
+    writeMixedInstallation(tmp.path);
+
+    auto names = Installation(GameID::TSL, tmp.path).moduleNames();
+
+    for (const auto &sidecar : {"foo_s", "foo_a", "foo_adx", "foo_dlg", "foo_loc", "orphan"}) {
+        EXPECT_EQ(0, std::count(names.begin(), names.end(), sidecar))
+            << sidecar << " is a support archive, not a module";
+    }
+}
+
+TEST(InstallationModuleNames, never_reports_a_lips_archive_as_a_module) {
+    TmpDir tmp("reone_test_alignment_lips");
+    writeMixedInstallation(tmp.path);
+
+    auto names = Installation(GameID::TSL, tmp.path).moduleNames();
+
+    for (const auto &global : {"global", "localization"}) {
+        EXPECT_EQ(0, std::count(names.begin(), names.end(), global))
+            << global << ".mod is a support archive of the lips location";
+    }
+}
+
+TEST(InstallationModuleNames, is_empty_without_a_module_location) {
+    TmpDir tmp("reone_test_alignment_no_modules");
+
+    EXPECT_TRUE(Installation(GameID::TSL, tmp.path).moduleNames().empty());
+}
+
+// Classification.
+
+TEST(InstallationModuleArchives, resolves_the_same_families_as_shared_discovery) {
+    TmpDir tmp("reone_test_alignment_families");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo");
+
+    auto expected = sharedArchives(tmp.path, "foo");
+    std::sort(expected.begin(), expected.end());
+
+    EXPECT_EQ(expected, installationArchives(installation));
+}
+
+TEST(InstallationModuleArchives, separates_lookup_bucket_from_container_form) {
+    TmpDir tmp("reone_test_alignment_metadata");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo");
+    const auto &archives = installation.moduleArchives();
+
+    struct Expected {
+        const char *filename;
+        ModuleArchiveFamily family;
+        ResourceSourceBucket bucket;
+        bool resourceImage;
+    };
+    const std::vector<Expected> expected {
+        {"foo.rim", ModuleArchiveFamily::PrimaryRim, ResourceSourceBucket::ResourceImage, true},
+        {"foo_s.rim", ModuleArchiveFamily::StaticRim, ResourceSourceBucket::ResourceImage, true},
+        {"foo_a.rim", ModuleArchiveFamily::AreaRim, ResourceSourceBucket::ResourceImage, true},
+        {"foo_adx.rim", ModuleArchiveFamily::AdxRim, ResourceSourceBucket::ResourceImage, true},
+        // An encapsulated support archive is class 2, below every image, and
+        // its extension is what it physically is rather than where it sits.
+        {"foo_dlg.erf", ModuleArchiveFamily::Dialogue, ResourceSourceBucket::EncapsulatedClass2, false},
+        {"foo_loc.mod", ModuleArchiveFamily::Localization, ResourceSourceBucket::EncapsulatedClass2, false},
+    };
+    for (const auto &entry : expected) {
+        const auto *archive = archiveNamed(archives, entry.filename);
+        ASSERT_NE(nullptr, archive) << entry.filename;
+        EXPECT_EQ(entry.family, archive->family) << entry.filename;
+        ASSERT_TRUE(archive->bucket.has_value()) << entry.filename;
+        EXPECT_EQ(entry.bucket, *archive->bucket) << entry.filename;
+        EXPECT_EQ(entry.resourceImage, archive->resourceImage) << entry.filename;
+        EXPECT_EQ("foo", archive->moduleRoot) << entry.filename;
+    }
+}
+
+TEST(InstallationModuleArchives, keeps_a_support_archive_out_of_another_modules_scope) {
+    TmpDir tmp("reone_test_alignment_scope");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo");
+
+    auto names = filenamesOf(installation.moduleArchives());
+    EXPECT_EQ(0, std::count(names.begin(), names.end(), "bar.mod"));
+    EXPECT_EQ(0, std::count(names.begin(), names.end(), "orphan_s.rim"));
+    EXPECT_EQ(0, std::count(names.begin(), names.end(), "global.mod"));
+    EXPECT_EQ(0, std::count(names.begin(), names.end(), "localization.mod"));
+}
+
+// Context-free enumeration versus an explicitly requested root.
+
+TEST(InstallationModuleArchives, an_unrecognized_suffix_is_a_module_of_its_own) {
+    TmpDir tmp("reone_test_alignment_adxx_free");
+    writeMixedInstallation(tmp.path);
+
+    auto names = Installation(GameID::TSL, tmp.path).moduleNames();
+
+    // Read without a requested root, "_adxx" is not a family suffix and is not
+    // reduced to the one it resembles, so the file is its own primary.
+    EXPECT_EQ(1, std::count(names.begin(), names.end(), "foo_adxx"));
+}
+
+TEST(InstallationModuleArchives, an_unrecognized_suffix_belongs_to_no_other_module) {
+    TmpDir tmp("reone_test_alignment_adxx_explicit");
+    writeMixedInstallation(tmp.path);
+
+    Installation foo(GameID::TSL, tmp.path);
+    foo.setModuleRoot("foo");
+    auto fooNames = filenamesOf(foo.moduleArchives());
+    EXPECT_EQ(0, std::count(fooNames.begin(), fooNames.end(), "foo_adxx.rim"))
+        << "_adxx is unsupported for foo and must not be normalized to _adx";
+
+    Installation adxx(GameID::TSL, tmp.path);
+    adxx.setModuleRoot("foo_adxx");
+    const auto &adxxArchives = adxx.moduleArchives();
+    ASSERT_EQ(1u, adxxArchives.size());
+    EXPECT_EQ("foo_adxx.rim", boost::to_lower_copy(adxxArchives[0].path.filename().string()));
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryRim, adxxArchives[0].family)
+        << "the requested root resolves the ambiguity that inference cannot";
+    EXPECT_EQ("foo_adxx", adxxArchives[0].moduleRoot);
+}
+
+TEST(InstallationModuleArchives, a_requested_name_may_carry_a_supported_extension) {
+    TmpDir tmp("reone_test_alignment_requested_extension");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("FOO.RIM");
+
+    ASSERT_TRUE(installation.moduleRoot().has_value());
+    EXPECT_EQ("foo", *installation.moduleRoot());
+    EXPECT_FALSE(installation.moduleArchives().empty());
+}
+
+TEST(InstallationModuleArchives, an_unusable_name_leaves_the_scope_unset) {
+    TmpDir tmp("reone_test_alignment_bad_name");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo.bogus");
+
+    EXPECT_FALSE(installation.moduleRoot().has_value());
+    EXPECT_TRUE(installation.moduleArchives().empty());
+}
+
+TEST(InstallationModuleArchives, filenames_are_matched_regardless_of_case) {
+    TmpDir tmp("reone_test_alignment_case");
+    std::filesystem::create_directories(tmp.path / "Modules");
+
+    writeRim(tmp.path / "Modules" / "MODFOO.RIM", {{"probe", ResType::Txt, "rim"}});
+    writeRim(tmp.path / "Modules" / "ModFoo_S.rim", {{"probe", ResType::Txt, "static"}});
+
+    Installation installation(GameID::KotOR, tmp.path);
+    EXPECT_EQ((std::vector<std::string> {"modfoo"}), installation.moduleNames());
+
+    installation.setModuleRoot("MODFOO");
+    EXPECT_EQ(2u, installation.moduleArchives().size());
+}
+
+// Lookup order.
+
+TEST(InstallationModuleArchives, k2_mod_layout_ranks_adx_above_a_above_the_module_archive) {
+    TmpDir tmp("reone_test_alignment_k2_mod");
+    std::filesystem::create_directories(tmp.path / "modules");
+
+    writeErf(tmp.path / "modules" / "foo.mod", ErfType::MOD, {});
+    writeRim(tmp.path / "modules" / "foo_a.rim", {});
+    writeRim(tmp.path / "modules" / "foo_adx.rim", {});
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo");
+
+    EXPECT_EQ((std::vector<std::string> {"foo_adx.rim", "foo_a.rim", "foo.mod"}),
+              filenamesOf(installation.moduleArchives()));
+}
+
+TEST(InstallationModuleArchives, k2_split_layout_ranks_every_image_above_the_dialogue_archive) {
+    TmpDir tmp("reone_test_alignment_k2_split");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::TSL, tmp.path);
+    installation.setModuleRoot("foo");
+
+    EXPECT_EQ((std::vector<std::string> {"foo.rim",
+                                         "foo_s.rim",
+                                         "foo_adx.rim",
+                                         "foo_a.rim",
+                                         "foo_dlg.erf",
+                                         "foo_loc.mod",
+                                         "foo_loc.mod"}),
+              filenamesOf(installation.moduleArchives()));
+}
+
+TEST(InstallationModuleArchives, k1_lists_a_dialogue_archive_it_would_never_mount) {
+    TmpDir tmp("reone_test_alignment_k1_dlg");
+    writeMixedInstallation(tmp.path);
+
+    Installation installation(GameID::KotOR, tmp.path);
+    installation.setModuleRoot("foo");
+
+    auto names = filenamesOf(installation.moduleArchives());
+    // K1 never mounts a dialogue archive, but the file still exists and the
+    // installation still reports where the resources in it live. Being
+    // unmounted places it last within its class-2 bucket, below the
+    // localization archives K1 does mount.
+    EXPECT_EQ(1, std::count(names.begin(), names.end(), "foo_dlg.erf"));
+    EXPECT_EQ("foo_dlg.erf", names.back());
+    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_s.rim", "foo_adx.rim", "foo_a.rim"}),
+              (std::vector<std::string> {names.begin(), names.begin() + 4}));
+}
+
+TEST(InstallationModuleArchives, order_is_independent_of_directory_creation_order) {
+    TmpDir first("reone_test_alignment_order_a");
+    TmpDir second("reone_test_alignment_order_b");
+    std::filesystem::create_directories(first.path / "modules");
+    std::filesystem::create_directories(second.path / "modules");
+
+    for (const auto &name : {"foo.rim", "foo_a.rim", "foo_adx.rim", "foo_s.rim"}) {
+        writeRim(first.path / "modules" / name, {});
+    }
+    for (const auto &name : {"foo_s.rim", "foo_adx.rim", "foo_a.rim", "foo.rim"}) {
+        writeRim(second.path / "modules" / name, {});
+    }
+
+    Installation a(GameID::TSL, first.path);
+    Installation b(GameID::TSL, second.path);
+    a.setModuleRoot("foo");
+    b.setModuleRoot("foo");
+
+    EXPECT_EQ(filenamesOf(a.moduleArchives()), filenamesOf(b.moduleArchives()));
+}

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -56,15 +56,16 @@ public:
 class MockResources : public IResources, boost::noncopyable {
 public:
     MOCK_METHOD(void, clear, (), (override));
-    MOCK_METHOD(void, clearLocal, (), (override));
-    MOCK_METHOD(void, clearSave, (), (override));
+    MOCK_METHOD(void, clearOwner, (ResourceOwner owner), (override));
+    MOCK_METHOD(ResourceMountToken, mountToken, (), (const, override));
+    MOCK_METHOD(void, rollbackTo, (ResourceMountToken token), (override));
     MOCK_METHOD(void, addEXE, (const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket), (override));
     MOCK_METHOD(void, addKEY, (const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket), (override));
-    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
-    MOCK_METHOD(void, addMemERF, (ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
-    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
-    MOCK_METHOD(void, addMemRIM, (ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
-    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addMemERF, (ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addMemRIM, (ByteBuffer buffer, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ResourceOwner owner, std::optional<ResourceSourceBucket> bucket), (override));
 
     MOCK_METHOD(Resource, get, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, find, (const ResourceId &id), (override));

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -58,13 +58,13 @@ public:
     MOCK_METHOD(void, clear, (), (override));
     MOCK_METHOD(void, clearLocal, (), (override));
     MOCK_METHOD(void, clearSave, (), (override));
-    MOCK_METHOD(void, addEXE, (const std::filesystem::path &path), (override));
-    MOCK_METHOD(void, addKEY, (const std::filesystem::path &path), (override));
-    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ContainerKind kind), (override));
-    MOCK_METHOD(void, addMemERF, (ByteBuffer buffer, ContainerKind kind), (override));
-    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ContainerKind kind), (override));
-    MOCK_METHOD(void, addMemRIM, (ByteBuffer buffer, ContainerKind kind), (override));
-    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ContainerKind kind), (override));
+    MOCK_METHOD(void, addEXE, (const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addKEY, (const std::filesystem::path &path, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addERF, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addMemERF, (ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addRIM, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addMemRIM, (ByteBuffer buffer, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
+    MOCK_METHOD(void, addFolder, (const std::filesystem::path &path, ContainerKind kind, std::optional<ResourceSourceBucket> bucket), (override));
 
     MOCK_METHOD(Resource, get, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, find, (const ResourceId &id), (override));

--- a/test/game/reputes.cpp
+++ b/test/game/reputes.cpp
@@ -43,10 +43,10 @@ constexpr Faction kGamma = static_cast<Faction>(2);
 std::shared_ptr<TwoDA> makeReputeTable() {
     std::vector<std::string> columns {"label", "alpha", "beta", "gamma", "delta"};
     std::vector<TwoDA::Row> rows {
-        TwoDA::Row {{"alpha", "50", "50", "50", "50"}},
-        TwoDA::Row {{"beta", "50", "100", "0", "50"}},
-        TwoDA::Row {{"gamma", "50", "100", "100", "50"}},
-        TwoDA::Row {{"delta", "50", "50", "50", "50"}}};
+        TwoDA::newRow("0", {"alpha", "50", "50", "50", "50"}),
+        TwoDA::newRow("1", {"beta", "50", "100", "0", "50"}),
+        TwoDA::newRow("2", {"gamma", "50", "100", "100", "50"}),
+        TwoDA::newRow("3", {"delta", "50", "50", "50", "50"})};
     return std::make_shared<TwoDA>(std::move(columns), std::move(rows));
 }
 

--- a/test/resource/2da.cpp
+++ b/test/resource/2da.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Row labels.
+ *
+ * A label is a key in its own right, distinct from any column: some tables are
+ * addressed by it and its value is not always the row ordinal.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/2da.h"
+#include "reone/resource/format/2dareader.h"
+#include "reone/resource/format/2dawriter.h"
+#include "reone/system/stream/memoryinput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+namespace {
+
+std::shared_ptr<TwoDA> labelledTable() {
+    return TwoDA::Builder()
+        .columns({"modulename", "includeinsave"})
+        .row("001ebo", {"001ebo", "1"})
+        .row("007ebo", {"007ebo", "0"})
+        .row("101per", {"101per", "1"})
+        .build();
+}
+
+} // namespace
+
+TEST(TwoDARowLabel, finds_a_row_by_its_label) {
+    auto table = labelledTable();
+
+    EXPECT_EQ(0, table->indexByLabel("001ebo"));
+    EXPECT_EQ(1, table->indexByLabel("007ebo"));
+    EXPECT_EQ(2, table->indexByLabel("101per"));
+}
+
+TEST(TwoDARowLabel, reports_a_missing_label_rather_than_guessing_a_row) {
+    auto table = labelledTable();
+
+    EXPECT_EQ(-1, table->indexByLabel("235tel"));
+    EXPECT_EQ(-1, table->indexByLabel(""));
+    EXPECT_EQ(-1, table->indexByLabel("001ebo_")) << "a longer key is not a prefix match";
+    EXPECT_EQ(-1, table->indexByLabel("001eb")) << "a shorter key is not a prefix match";
+}
+
+TEST(TwoDARowLabel, folds_ascii_case_when_matching_a_label) {
+    auto table = TwoDA::Builder()
+                     .columns({"modulename", "includeinsave"})
+                     .row("003ebo", {"003ebo", "1"})
+                     .row("007ebo", {"007ebo", "0"})
+                     .build();
+
+    EXPECT_EQ(0, table->indexByLabel("003EBO"));
+    EXPECT_EQ(0, table->indexByLabel("003eBo"));
+    EXPECT_EQ(0, table->indexByLabel("003ebo"));
+    EXPECT_EQ(1, table->indexByLabel("007EBO"));
+    EXPECT_EQ(-1, table->indexByLabel("004EBO"));
+
+    // Folding is ASCII only: a byte outside A-Z is left alone, so a lookup
+    // cannot start depending on the environment's locale.
+    auto accented = TwoDA::Builder().columns({"a"}).row("\xc3\x89", {"x"}).build();
+    EXPECT_EQ(0, accented->indexByLabel("\xc3\x89"));
+    EXPECT_EQ(-1, accented->indexByLabel("\xc3\xa9"));
+}
+
+TEST(TwoDARowLabel, is_independent_of_any_column) {
+    // A table can carry a column that happens to repeat the label. The two are
+    // still separate keys, and a label lookup must not become a cell lookup.
+    auto table = TwoDA::Builder()
+                     .columns({"label"})
+                     .row("row_key", {"cell_value"})
+                     .build();
+
+    EXPECT_EQ(0, table->indexByLabel("row_key"));
+    EXPECT_EQ(-1, table->indexByLabel("cell_value"));
+    EXPECT_EQ(0, table->indexByCellValue("label", "cell_value"));
+    EXPECT_EQ(-1, table->indexByCellValue("label", "row_key"));
+}
+
+TEST(TwoDARowLabel, labels_rows_by_ordinal_when_the_builder_is_given_no_label) {
+    auto table = TwoDA::Builder()
+                     .columns({"a"})
+                     .row({"first"})
+                     .row({"second"})
+                     .build();
+
+    EXPECT_EQ(0, table->indexByLabel("0"));
+    EXPECT_EQ(1, table->indexByLabel("1"));
+}
+
+TEST(TwoDARowLabel, survives_a_write_and_read_round_trip) {
+    auto original = labelledTable();
+
+    ByteBuffer buffer;
+    {
+        MemoryOutputStream out(buffer);
+        TwoDAWriter writer(*original);
+        writer.save(out);
+    }
+
+    MemoryInputStream in(buffer);
+    TwoDAReader reader(in);
+    reader.load();
+    auto reloaded = reader.twoDA();
+    ASSERT_TRUE(reloaded);
+
+    ASSERT_EQ(3, reloaded->getRowCount());
+    EXPECT_EQ("001ebo", reloaded->rows()[0].label);
+    EXPECT_EQ("007ebo", reloaded->rows()[1].label);
+    EXPECT_EQ("101per", reloaded->rows()[2].label);
+
+    // The row a label selects must still hold that row's cells.
+    int row = reloaded->indexByLabel("007ebo");
+    ASSERT_NE(-1, row);
+    EXPECT_EQ(0, reloaded->getInt(row, "includeinsave"));
+    EXPECT_EQ(1, reloaded->getInt(reloaded->indexByLabel("001ebo"), "includeinsave"));
+}

--- a/test/resource/archivevalidation.cpp
+++ b/test/resource/archivevalidation.cpp
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * When a backend decides an archive is unusable.
+ *
+ * A source that is absent and a source that is unreadable are different
+ * answers, and the difference has to be the same on both backends: absence is
+ * best effort, and an unreadable container fails the operation that tried to
+ * mount it. A backend that accepts a corrupt archive and only fails later, at
+ * whichever lookup happens to touch it first, turns a failed load into a module
+ * that half works.
+ *
+ * What is validated is the container: its signature, and the index of what it
+ * holds. Payloads stay unread until something asks for one.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/resource/director.h"
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/resource/resources.h"
+#include "reone/system/exception/validation.h"
+#include "reone/system/stream/fileoutput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+using testing::NiceMock;
+
+namespace {
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+struct NamedRes {
+    std::string resRef;
+    ResType type;
+    std::string data;
+};
+
+void writeBuffer(const std::filesystem::path &path, const ByteBuffer &buffer) {
+    std::filesystem::create_directories(path.parent_path());
+    FileOutputStream stream(path);
+    stream.write(buffer.data(), buffer.size());
+}
+
+void writeErf(const std::filesystem::path &path,
+              ErfWriter::FileType fileType,
+              const std::vector<NamedRes> &resources) {
+    ErfWriter writer;
+    for (const auto &res : resources) {
+        writer.add(ErfWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(fileType, stream);
+    writeBuffer(path, buffer);
+}
+
+void writeRim(const std::filesystem::path &path, const std::vector<NamedRes> &resources) {
+    RimWriter writer;
+    for (const auto &res : resources) {
+        writer.add(RimWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    writeBuffer(path, buffer);
+}
+
+/// A file of the right name that is not the container its extension claims.
+void writeCorrupt(const std::filesystem::path &path) {
+    std::filesystem::create_directories(path.parent_path());
+    FileOutputStream stream(path);
+    std::string data("this is not an archive of any kind");
+    stream.write(data.data(), data.size());
+}
+
+std::string dataOf(const std::optional<Resource> &res) {
+    if (!res) {
+        return "<not found>";
+    }
+    return std::string(res->data.begin(), res->data.end());
+}
+
+struct TmpDir {
+    std::filesystem::path path;
+
+    explicit TmpDir(const std::string &name) {
+        path = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path mkdir(const std::string &name) {
+        auto dir = path / name;
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+};
+
+struct CwdGuard {
+    std::filesystem::path previous;
+
+    explicit CwdGuard(const std::filesystem::path &path) {
+        previous = std::filesystem::current_path();
+        std::filesystem::current_path(path);
+    }
+
+    ~CwdGuard() {
+        std::error_code ec;
+        std::filesystem::current_path(previous, ec);
+    }
+};
+
+enum class Backend { Legacy, Extract };
+
+std::string backendName(const testing::TestParamInfo<Backend> &info) {
+    return info.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+} // namespace
+
+/// Registration on a bare backend, with no director involved.
+class ArchiveRegistrationTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        if (GetParam() == Backend::Legacy) {
+            auto legacy = std::make_unique<Resources>();
+            _count = [raw = legacy.get()]() { return raw->containers().size(); };
+            _resources = std::move(legacy);
+        } else {
+            auto extract = std::make_unique<ExtractResources>();
+            _count = [raw = extract.get()]() { return raw->sourceCount(); };
+            _resources = std::move(extract);
+        }
+    }
+
+    std::unique_ptr<IResources> _resources;
+    std::function<std::size_t()> _count;
+};
+
+TEST_P(ArchiveRegistrationTest, rejects_a_corrupt_resource_image_as_it_is_mounted) {
+    TmpDir tmp("reone_test_validation_rim");
+    writeCorrupt(tmp.path / "broken.rim");
+
+    EXPECT_THROW(_resources->addRIM(tmp.path / "broken.rim", ResourceOwner::ActiveModule),
+                 ValidationException);
+    EXPECT_EQ(0u, _count()) << "a container that failed to open must not be left registered";
+}
+
+TEST_P(ArchiveRegistrationTest, rejects_a_corrupt_encapsulated_archive_as_it_is_mounted) {
+    TmpDir tmp("reone_test_validation_erf");
+    writeCorrupt(tmp.path / "broken.mod");
+
+    EXPECT_THROW(_resources->addERF(tmp.path / "broken.mod", ResourceOwner::ActiveModule),
+                 ValidationException);
+    EXPECT_EQ(0u, _count());
+}
+
+TEST_P(ArchiveRegistrationTest, accepts_a_valid_archive_and_reads_it_afterwards) {
+    TmpDir tmp("reone_test_validation_valid");
+    writeRim(tmp.path / "good.rim", {{"probe", ResType::Txt, "payload"}});
+    writeErf(tmp.path / "good.mod", ErfWriter::FileType::MOD, {{"other", ResType::Txt, "payload"}});
+
+    EXPECT_NO_THROW(_resources->addRIM(tmp.path / "good.rim", ResourceOwner::ActiveModule));
+    EXPECT_NO_THROW(_resources->addERF(tmp.path / "good.mod", ResourceOwner::ActiveModule));
+
+    EXPECT_EQ(2u, _count());
+    EXPECT_EQ("payload", dataOf(_resources->find(ResourceId("probe", ResType::Txt))));
+    EXPECT_EQ("payload", dataOf(_resources->find(ResourceId("other", ResType::Txt))));
+}
+
+TEST_P(ArchiveRegistrationTest, a_rejected_archive_leaves_earlier_sources_untouched) {
+    TmpDir tmp("reone_test_validation_earlier");
+    writeRim(tmp.path / "good.rim", {{"probe", ResType::Txt, "payload"}});
+    writeCorrupt(tmp.path / "broken.rim");
+
+    _resources->addRIM(tmp.path / "good.rim", ResourceOwner::ActiveModule);
+    EXPECT_THROW(_resources->addRIM(tmp.path / "broken.rim", ResourceOwner::ActiveModule),
+                 ValidationException);
+
+    EXPECT_EQ(1u, _count());
+    EXPECT_EQ("payload", dataOf(_resources->find(ResourceId("probe", ResType::Txt))));
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         ArchiveRegistrationTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+/// The same contract seen through a module load.
+class ArchiveValidationDirectorTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        _graphics.init();
+        _script.init();
+        if (GetParam() == Backend::Legacy) {
+            auto legacy = std::make_unique<Resources>();
+            _count = [raw = legacy.get()]() { return raw->containers().size(); };
+            _resources = std::move(legacy);
+        } else {
+            auto extract = std::make_unique<ExtractResources>();
+            _count = [raw = extract.get()]() { return raw->sourceCount(); };
+            _resources = std::move(extract);
+        }
+        _auxResources = std::make_unique<Resources>();
+    }
+
+    void makeInstallation(TmpDir &game, TmpDir &cwd) {
+        writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+        game.mkdir("modules");
+    }
+
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+        _gamePath = gamePath;
+        return std::make_unique<ResourceDirector>(
+            GameID::TSL, _gamePath, _graphicsOpt, _graphics.services(), _script.services(),
+            _dialogs, _gffs, _lips, _paths, *_resources, *_auxResources, _scripts, _twoDas);
+    }
+
+    std::string find(const std::string &resRef, ResType type = ResType::Txt) {
+        return dataOf(_resources->find(ResourceId(resRef, type)));
+    }
+
+    bool has(const std::string &resRef, ResType type = ResType::Txt) {
+        return static_cast<bool>(_resources->find(ResourceId(resRef, type)));
+    }
+
+    graphics::GraphicsOptions _graphicsOpt;
+    graphics::TestGraphicsModule _graphics;
+    script::TestScriptModule _script;
+
+    NiceMock<MockDialogs> _dialogs;
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockLips> _lips;
+    NiceMock<MockPaths> _paths;
+    NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
+
+    std::filesystem::path _gamePath;
+    std::unique_ptr<IResources> _resources;
+    std::unique_ptr<IResources> _auxResources;
+    std::function<std::size_t()> _count;
+};
+
+TEST_P(ArchiveValidationDirectorTest, an_absent_optional_archive_is_not_fatal) {
+    TmpDir game("reone_test_validation_absent");
+    TmpDir cwd("reone_test_validation_absent_cwd");
+    makeInstallation(game, cwd);
+
+    // Neither adjunct image, no dialogue archive and no localization exist.
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
+    writeRim(modules / "foo_s.rim", {{"from_static", ResType::Txt, "static"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ("base", find("probe"));
+    EXPECT_TRUE(has("from_static")) << "an absent optional family is not a failed load";
+}
+
+TEST_P(ArchiveValidationDirectorTest, a_corrupt_resource_image_fails_the_load_immediately) {
+    TmpDir game("reone_test_validation_module_rim");
+    TmpDir cwd("reone_test_validation_module_rim_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
+    writeCorrupt(modules / "foo_s.rim");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_THROW(director->onModuleLoad("foo"), ValidationException)
+        << "an unreadable container must fail the load, not a later lookup";
+}
+
+TEST_P(ArchiveValidationDirectorTest, a_corrupt_encapsulated_archive_fails_the_load_immediately) {
+    TmpDir game("reone_test_validation_module_mod");
+    TmpDir cwd("reone_test_validation_module_mod_cwd");
+    makeInstallation(game, cwd);
+
+    // The module archive is the required branch source for a MOD layout.
+    auto modules = game.path / "modules";
+    writeCorrupt(modules / "foo.mod");
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_THROW(director->onModuleLoad("foo"), ValidationException);
+}
+
+TEST_P(ArchiveValidationDirectorTest, rolls_back_what_the_failed_load_had_already_mounted) {
+    TmpDir game("reone_test_validation_rollback");
+    TmpDir cwd("reone_test_validation_rollback_cwd");
+    makeInstallation(game, cwd);
+
+    // The adjunct images mount before the static image is reached, so the
+    // failure genuinely happens partway through.
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
+    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(modules / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
+    writeCorrupt(modules / "foo_s.rim");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto globals = _count();
+
+    EXPECT_THROW(director->onModuleLoad("foo"), ValidationException);
+
+    EXPECT_FALSE(has("from_area")) << "sources mounted before the failure must be taken back";
+    EXPECT_FALSE(has("from_adx"));
+    EXPECT_FALSE(has("probe"));
+    EXPECT_EQ(globals, _count()) << "nothing of the failed module may remain";
+}
+
+TEST_P(ArchiveValidationDirectorTest, repeating_a_failed_load_leaves_the_same_state) {
+    TmpDir game("reone_test_validation_repeat");
+    TmpDir cwd("reone_test_validation_repeat_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
+    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeCorrupt(modules / "foo_s.rim");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto globals = _count();
+
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        EXPECT_THROW(director->onModuleLoad("foo"), ValidationException) << "attempt " << attempt;
+        EXPECT_EQ(globals, _count()) << "attempt " << attempt;
+        EXPECT_FALSE(has("from_area")) << "attempt " << attempt;
+    }
+}
+
+TEST_P(ArchiveValidationDirectorTest, a_valid_module_loads_cleanly_after_a_failure) {
+    TmpDir game("reone_test_validation_recover");
+    TmpDir cwd("reone_test_validation_recover_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "broken base"}});
+    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeCorrupt(modules / "foo_s.rim");
+
+    writeRim(modules / "bar.rim", {{"probe", ResType::Txt, "good base"}});
+    writeRim(modules / "bar_s.rim", {{"bar_static", ResType::Txt, "static"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onModuleLoad("bar");
+    auto sourcesForBar = _count();
+    EXPECT_EQ("good base", find("probe"));
+
+    EXPECT_THROW(director->onModuleLoad("foo"), ValidationException);
+    EXPECT_FALSE(has("probe")) << "the previous module was retired before the attempt";
+
+    director->onModuleLoad("bar");
+    EXPECT_EQ("good base", find("probe"));
+    EXPECT_TRUE(has("bar_static"));
+    EXPECT_FALSE(has("from_area")) << "nothing of the failed module survived into this one";
+    EXPECT_EQ(sourcesForBar, _count());
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         ArchiveValidationDirectorTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);

--- a/test/resource/archivevalidation.cpp
+++ b/test/resource/archivevalidation.cpp
@@ -340,9 +340,10 @@ TEST_P(ArchiveValidationDirectorTest, rolls_back_what_the_failed_load_had_alread
     // The adjunct images mount before the static image is reached, so the
     // failure genuinely happens partway through.
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
-    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
-    writeRim(modules / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
+    writeRim(rims / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(rims / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
     writeCorrupt(modules / "foo_s.rim");
 
     auto director = makeDirector(game.path);
@@ -366,8 +367,9 @@ TEST_P(ArchiveValidationDirectorTest, repeating_a_failed_load_leaves_the_same_st
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "base"}});
-    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(rims / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
     writeCorrupt(modules / "foo_s.rim");
 
     auto director = makeDirector(game.path);
@@ -390,8 +392,9 @@ TEST_P(ArchiveValidationDirectorTest, a_valid_module_loads_cleanly_after_a_failu
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "foo.rim", {{"probe", ResType::Txt, "broken base"}});
-    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(rims / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
     writeCorrupt(modules / "foo_s.rim");
 
     writeRim(modules / "bar.rim", {{"probe", ResType::Txt, "good base"}});

--- a/test/resource/extractresources.cpp
+++ b/test/resource/extractresources.cpp
@@ -97,10 +97,10 @@ TEST(ExtractResourcesLookup, should_prefer_last_added_source_for_colliding_id) {
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "first"},
                                   {"first_only", ResType::Txt, "from first"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "second"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
 
     EXPECT_EQ("second", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_EQ("from first", dataOf(resources.find(ResourceId("first_only", ResType::Txt))));
@@ -111,24 +111,24 @@ TEST(ExtractResourcesLookup, should_clear_sources_by_kind_only) {
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "global"},
                                   {"global_only", ResType::Txt, "global"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "save"},
                                   {"save_only", ResType::Txt, "save"}}),
-                        ContainerKind::Save);
+                        ResourceOwner::SaveSlot);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "local"},
                                   {"local_only", ResType::Txt, "local"}}),
-                        ContainerKind::Local);
+                        ResourceOwner::ActiveModule);
 
     EXPECT_EQ("local", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
 
-    resources.clearLocal();
+    resources.clearOwner(ResourceOwner::ActiveModule);
     EXPECT_EQ("save", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_FALSE(resources.find(ResourceId("local_only", ResType::Txt)));
     EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
 
-    resources.clearSave();
+    resources.clearOwner(ResourceOwner::SaveSlot);
     EXPECT_EQ("global", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_FALSE(resources.find(ResourceId("save_only", ResType::Txt)));
     EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
@@ -136,7 +136,7 @@ TEST(ExtractResourcesLookup, should_clear_sources_by_kind_only) {
 
 TEST(ExtractResourcesLookup, should_serve_memory_rim_archives) {
     ExtractResources resources;
-    resources.addMemRIM(rimBytes({{"entry", ResType::Txt, "rim payload"}}), ContainerKind::Local);
+    resources.addMemRIM(rimBytes({{"entry", ResType::Txt, "rim payload"}}), ResourceOwner::ActiveModule);
 
     EXPECT_EQ("rim payload", dataOf(resources.find(ResourceId("entry", ResType::Txt))));
     EXPECT_FALSE(resources.find(ResourceId("missing", ResType::Txt)));
@@ -324,11 +324,8 @@ TEST_F(ExtractResourcesDirectorLookup, should_mount_save_scope_and_modules_neste
 
     EXPECT_EQ("second save", find("loose")) << "the save loaded last must win";
 
-    // Same known defect the legacy characterization pins: the director mounts
-    // save sources with the default Global kind, so clearSave is a no-op and
-    // sources of previously loaded saves leak. The backend must honor caller
-    // kinds, not paper over this; the fix belongs to the director.
-    EXPECT_EQ("first save", find("first_only")) << "previous save sources currently leak";
+    EXPECT_EQ("<not found>", find("first_only"))
+        << "sources of the previous save must not survive loading another";
 }
 
 TEST_F(ExtractResourcesDirectorLookup, should_throw_when_save_slot_is_missing) {

--- a/test/resource/extractresources.cpp
+++ b/test/resource/extractresources.cpp
@@ -159,9 +159,10 @@ protected:
         _script.init();
     }
 
-    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath,
+                                                   GameID gameId = GameID::KotOR) {
         return std::make_unique<ResourceDirector>(
-            GameID::KotOR,
+            gameId,
             gamePath,
             _graphicsOpt,
             _graphics.services(),
@@ -171,7 +172,9 @@ protected:
             _lips,
             _paths,
             _resources,
-            _scripts);
+            _auxResources,
+            _scripts,
+            _twoDas);
     }
 
     std::string find(const std::string &resRef, ResType type = ResType::Txt) {
@@ -187,8 +190,10 @@ protected:
     NiceMock<MockLips> _lips;
     NiceMock<MockPaths> _paths;
     NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
 
     ExtractResources _resources;
+    ExtractResources _auxResources;
 };
 
 TEST_F(ExtractResourcesDirectorLookup, should_mount_global_locations_in_precedence_order) {
@@ -221,11 +226,16 @@ TEST_F(ExtractResourcesDirectorLookup, should_mount_global_locations_in_preceden
         director->init();
     }
 
-    EXPECT_EQ("chitin", find("a")) << "chitin must beat shaderpack";
     EXPECT_EQ("gui pack", find("b")) << "GUI texture pack must beat chitin";
     EXPECT_EQ("texture pack", find("c")) << "quality texture pack must beat GUI pack";
     EXPECT_EQ("patch", find("d")) << "patch.erf must beat texture packs";
     EXPECT_EQ("override", find("e")) << "override must beat patch.erf";
+
+    // The shader pack no longer competes with game data at all: it holds only
+    // GLSL, so it is kept out of the game's resource list entirely. This used
+    // to assert that chitin outranked it.
+    EXPECT_EQ("chitin", find("a"));
+    EXPECT_EQ("shaderpack", dataOf(_auxResources.find(ResourceId("a", ResType::Txt))));
 }
 
 TEST_F(ExtractResourcesDirectorLookup, should_mount_module_locations_over_global_and_clear_on_transition) {
@@ -289,7 +299,7 @@ TEST_F(ExtractResourcesDirectorLookup, should_mount_save_scope_and_modules_neste
     writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
              {{"loose", ResType::Txt, "save archive"},
               {"first_only", ResType::Txt, "first save"},
-              {"bar", ResType::Mod, std::string(nestedModule.begin(), nestedModule.end())}});
+              {"bar", ResType::Sav, std::string(nestedModule.begin(), nestedModule.end())}});
 
     auto secondSlot = game.path / "saves" / "000002";
     std::filesystem::create_directories(secondSlot);

--- a/test/resource/extractresources.cpp
+++ b/test/resource/extractresources.cpp
@@ -268,13 +268,18 @@ TEST_F(ExtractResourcesDirectorLookup, should_mount_module_locations_over_global
 
     director->onModuleLoad("foo");
 
-    EXPECT_EQ("mod", find("m")) << ".mod must beat _s.rim, .rim and all global locations, including override";
-    EXPECT_EQ("main rim", find("rim_only"));
-    EXPECT_EQ("data rim", find("rims_only"));
+    // K1 is activated, so buckets decide. A loose override file outranks every
+    // module archive, and the MOD branch leaves the base image unmounted and
+    // suppresses the static image.
+    EXPECT_EQ("override", find("m")) << "a loose override file outranks every module archive";
+    EXPECT_FALSE(_resources.find(ResourceId("rim_only", ResType::Txt)))
+        << "the MOD branch does not mount the base image";
+    EXPECT_FALSE(_resources.find(ResourceId("rims_only", ResType::Txt)))
+        << "the MOD branch suppresses the static image";
 
     director->onModuleLoad("bar");
 
-    EXPECT_EQ("bar rim", find("m")) << "previous module sources must be dropped on transition";
+    EXPECT_EQ("override", find("m")) << "previous module sources must be dropped on transition";
     EXPECT_FALSE(_resources.find(ResourceId("rim_only", ResType::Txt)));
 }
 
@@ -314,7 +319,10 @@ TEST_F(ExtractResourcesDirectorLookup, should_mount_save_scope_and_modules_neste
 
     director->onGameLoad("000001");
 
-    EXPECT_EQ("save archive", find("loose")) << "savegame.sav must beat loose files in the save folder";
+    // The save folder is a loose directory and the archive is class 2, so the
+    // folder wins. The old flat stack had the archive win only because it was
+    // mounted last.
+    EXPECT_EQ("save folder", find("loose")) << "a loose save file outranks the save archive";
 
     director->onModuleLoad("bar");
 

--- a/test/resource/format/2dareader.cpp
+++ b/test/resource/format/2dareader.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "reone/resource/2da.h"
 #include "reone/resource/format/2dareader.h"
 #include "reone/system/binarywriter.h"
@@ -62,4 +64,113 @@ TEST(TwoDAReader, should_read_two_da) {
     EXPECT_EQ(std::string("same"), twoDa->getString(0, "value"));
     EXPECT_EQ(std::string("same"), twoDa->getString(1, "key"));
     EXPECT_EQ(std::string("same"), twoDa->getString(1, "value"));
+}
+
+namespace {
+
+/// A V2.b table in the ordinary tab-delimited form: two columns, two rows.
+ByteBuffer tabDelimitedTwoDa() {
+    auto s = StringBuilder()
+                 .append("2DA V2.b")
+                 .append("\x0a", 1)
+                 .append("key\x09", 4)
+                 .append("value\x09", 6)
+                 .append("\x00", 1)                  // end of column labels
+                 .append("\x02\x00\x00\x00", 4)      // row count
+                 .append("\x30\x09\x31\x09", 4)      // row labels "0", "1"
+                 .append("\x00\x00", 2)              // cell offsets
+                 .append("\x03\x00", 2)
+                 .append("\x06\x00", 2)
+                 .append("\x09\x00", 2)
+                 .append("\x0c\x00", 2)              // data size
+                 .append("aa\x00", 3)
+                 .append("bb\x00", 3)
+                 .append("cc\x00", 3)
+                 .append("dd\x00", 3)
+                 .string();
+    return ByteBuffer(s.begin(), s.end());
+}
+
+/// The same table with only the label separators rewritten to NUL, which is the
+/// form K1 carries inside global.rim. Nothing else moves, so any difference in
+/// how it reads is the delimiter and nothing else.
+ByteBuffer nulDelimitedTwoDa() {
+    auto buf = tabDelimitedTwoDa();
+    // Column labels end at the first 0x00; row labels are the four bytes after
+    // the row count that follows it.
+    auto end = std::find(buf.begin(), buf.end(), '\0');
+    for (auto it = buf.begin() + 9; it != end; ++it) {
+        if (*it == '\x09') {
+            *it = '\0';
+        }
+    }
+    auto rows = end + 1 + 4;
+    for (auto it = rows; it != rows + 4; ++it) {
+        if (*it == '\x09') {
+            *it = '\0';
+        }
+    }
+    return buf;
+}
+
+std::shared_ptr<TwoDA> readTwoDa(const ByteBuffer &bytes) {
+    auto stream = MemoryInputStream(const_cast<ByteBuffer &>(bytes));
+    auto reader = TwoDAReader(stream);
+    reader.load();
+    return reader.twoDA();
+}
+
+} // namespace
+
+TEST(TwoDAReaderDelimiters, reads_the_tab_delimited_form) {
+    auto twoDa = readTwoDa(tabDelimitedTwoDa());
+
+    ASSERT_TRUE(twoDa);
+    EXPECT_EQ((std::vector<std::string> {"key", "value"}), twoDa->columns());
+    EXPECT_EQ(2, twoDa->getRowCount());
+    EXPECT_EQ("aa", twoDa->getString(0, "key"));
+    EXPECT_EQ("bb", twoDa->getString(0, "value"));
+    EXPECT_EQ("cc", twoDa->getString(1, "key"));
+    EXPECT_EQ("dd", twoDa->getString(1, "value"));
+}
+
+TEST(TwoDAReaderDelimiters, reads_the_nul_delimited_form_identically) {
+    auto tab = readTwoDa(tabDelimitedTwoDa());
+    auto nul = readTwoDa(nulDelimitedTwoDa());
+
+    ASSERT_TRUE(nul);
+    EXPECT_EQ(tab->columns(), nul->columns());
+    EXPECT_EQ(tab->getRowCount(), nul->getRowCount());
+    for (int row = 0; row < tab->getRowCount(); ++row) {
+        for (const auto &column : tab->columns()) {
+            EXPECT_EQ(tab->getString(row, column), nul->getString(row, column))
+                << "row " << row << " column " << column;
+        }
+    }
+}
+
+TEST(TwoDAReaderDelimiters, the_substitution_does_not_move_the_row_count) {
+    // The two inputs are the same length and differ only in separator bytes, so
+    // a reader that mistook a label separator for the end of the section would
+    // read the row count from the wrong place and blow up rather than differ
+    // quietly.
+    auto tab = tabDelimitedTwoDa();
+    auto nul = nulDelimitedTwoDa();
+    ASSERT_EQ(tab.size(), nul.size());
+
+    std::size_t differing = 0;
+    for (std::size_t i = 0; i < tab.size(); ++i) {
+        if (tab[i] != nul[i]) {
+            ++differing;
+        }
+    }
+    EXPECT_EQ(4u, differing) << "only the two column and two row separators change";
+    EXPECT_EQ(2, readTwoDa(nul)->getRowCount());
+}
+
+TEST(TwoDAReaderDelimiters, a_truncated_table_still_fails_rather_than_over_allocating) {
+    auto buf = nulDelimitedTwoDa();
+    buf.resize(20);
+
+    EXPECT_ANY_THROW(readTwoDa(buf));
 }

--- a/test/resource/k1startup.cpp
+++ b/test/resource/k1startup.cpp
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * K1 startup sources, and which of them wins.
+ *
+ * Several K1 startup sources share a bucket, and within a bucket the source
+ * registered later wins. The order the engine registers them in is therefore
+ * behaviour, so every collision here uses one resref and type present in more
+ * than one source: an assertion that only checked a source was reachable would
+ * pass whatever the order.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/resource/director.h"
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/format/2dareader.h"
+#include "reone/resource/modulediscovery.h"
+#include "reone/resource/resources.h"
+#include "reone/system/stream/fileoutput.h"
+#include "reone/system/stream/memoryinput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/archive.h"
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+using testing::NiceMock;
+
+namespace {
+
+ByteBuffer bytes(std::string_view v) { return ByteBuffer(v.begin(), v.end()); }
+
+struct NamedRes {
+    std::string resRef;
+    ResType type;
+    std::string data;
+};
+
+ByteBuffer erfBytes(ErfWriter::FileType t, const std::vector<NamedRes> &res) {
+    ErfWriter w;
+    for (const auto &r : res) {
+        w.add(ErfWriter::Resource {r.resRef, r.type, bytes(r.data)});
+    }
+    ByteBuffer b;
+    MemoryOutputStream s(b);
+    w.save(t, s);
+    return b;
+}
+
+void writeBuffer(const std::filesystem::path &p, const ByteBuffer &b) {
+    std::filesystem::create_directories(p.parent_path());
+    FileOutputStream s(p);
+    s.write(b.data(), b.size());
+}
+
+void writeErf(const std::filesystem::path &p, ErfWriter::FileType t, const std::vector<NamedRes> &res) {
+    writeBuffer(p, erfBytes(t, res));
+}
+
+/// A MOD-family archive whose four-character type tag is rewritten to HAK.
+/// Everything after the tag is the layout both readers already share.
+void writeHak(const std::filesystem::path &p, const std::vector<NamedRes> &res) {
+    auto b = erfBytes(ErfWriter::FileType::MOD, res);
+    const char tag[4] = {'H', 'A', 'K', ' '};
+    for (int i = 0; i < 4; ++i) {
+        b[i] = tag[i];
+    }
+    writeBuffer(p, b);
+}
+
+void writeRim(const std::filesystem::path &p, const std::vector<NamedRes> &res) {
+    RimWriter w;
+    for (const auto &r : res) {
+        w.add(RimWriter::Resource {r.resRef, r.type, bytes(r.data)});
+    }
+    ByteBuffer b;
+    MemoryOutputStream s(b);
+    w.save(s);
+    writeBuffer(p, b);
+}
+
+void writeFile(const std::filesystem::path &p, const std::string &d) {
+    std::filesystem::create_directories(p.parent_path());
+    FileOutputStream s(p);
+    s.write(d.data(), d.size());
+}
+
+std::string dataOf(const std::optional<Resource> &r) {
+    return r ? std::string(r->data.begin(), r->data.end()) : "<not found>";
+}
+
+struct TmpDir {
+    std::filesystem::path path;
+    explicit TmpDir(const std::string &n) {
+        path = std::filesystem::temp_directory_path() / n;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+    std::filesystem::path mkdir(const std::string &n) {
+        auto d = path / n;
+        std::filesystem::create_directories(d);
+        return d;
+    }
+};
+
+struct CwdGuard {
+    std::filesystem::path previous;
+    explicit CwdGuard(const std::filesystem::path &p) {
+        previous = std::filesystem::current_path();
+        std::filesystem::current_path(p);
+    }
+    ~CwdGuard() {
+        std::error_code ec;
+        std::filesystem::current_path(previous, ec);
+    }
+};
+
+enum class Backend { Legacy, Extract };
+
+std::string backendName(const testing::TestParamInfo<Backend> &i) {
+    return i.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+/// The probe resref every collision test uses.
+constexpr char kProbe[] = "probe";
+
+} // namespace
+
+class K1StartupTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        _graphics.init();
+        _script.init();
+        if (GetParam() == Backend::Legacy) {
+            auto b = std::make_unique<Resources>();
+            _count = [r = b.get()]() { return r->containers().size(); };
+            _resources = std::move(b);
+        } else {
+            auto b = std::make_unique<ExtractResources>();
+            _count = [r = b.get()]() { return r->sourceCount(); };
+            _resources = std::move(b);
+        }
+        _auxResources = std::make_unique<Resources>();
+    }
+
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &p,
+                                                   GameID game = GameID::KotOR) {
+        _gamePath = p;
+        return std::make_unique<ResourceDirector>(
+            game, _gamePath, _graphicsOpt, _graphics.services(), _script.services(),
+            _dialogs, _gffs, _lips, _paths, *_resources, *_auxResources, _scripts, _twoDas);
+    }
+
+    /// An installation with a modules directory and the shader pack the
+    /// director always mounts.
+    void makeInstallation(TmpDir &game, TmpDir &cwd) {
+        writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+        game.mkdir("modules");
+    }
+
+    std::string find(const std::string &resRef, ResType type = ResType::Txt) {
+        return dataOf(_resources->find(ResourceId(resRef, type)));
+    }
+
+    bool has(const std::string &resRef, ResType type = ResType::Txt) {
+        return static_cast<bool>(_resources->find(ResourceId(resRef, type)));
+    }
+
+    graphics::GraphicsOptions _graphicsOpt;
+    graphics::TestGraphicsModule _graphics;
+    script::TestScriptModule _script;
+    NiceMock<MockDialogs> _dialogs;
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockLips> _lips;
+    NiceMock<MockPaths> _paths;
+    NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
+    std::filesystem::path _gamePath;
+    std::unique_ptr<IResources> _resources;
+    std::unique_ptr<IResources> _auxResources;
+    std::function<std::size_t()> _count;
+};
+
+// Within the loose bucket, registration order decides.
+
+TEST_P(K1StartupTest, loose_sources_rank_by_the_order_k1_registers_them) {
+    TmpDir game("reone_test_k1_loose");
+    TmpDir cwd("reone_test_k1_loose_cwd");
+    makeInstallation(game, cwd);
+
+    // K1 registers override early and the streaming directories late, so a
+    // streamed asset outranks an override file of the same id.
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeFile(game.mkdir("rims") / "probe.txt", "rims");
+    writeFile(game.mkdir("streamwaves") / "probe.txt", "streamwaves");
+    writeFile(game.mkdir("streammusic") / "probe.txt", "streammusic");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("streammusic", find(kProbe)) << "streammusic is registered last of the loose sources";
+}
+
+TEST_P(K1StartupTest, loose_order_holds_when_the_newest_sources_are_absent) {
+    TmpDir game("reone_test_k1_loose_partial");
+    TmpDir cwd("reone_test_k1_loose_partial_cwd");
+    makeInstallation(game, cwd);
+
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeFile(game.mkdir("rims") / "probe.txt", "rims");
+    writeFile(game.mkdir("streamwaves") / "probe.txt", "streamwaves");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("streamwaves", find(kProbe)) << "streamwaves outranks rims and override";
+}
+
+TEST_P(K1StartupTest, the_rims_directory_outranks_override) {
+    TmpDir game("reone_test_k1_rims_override");
+    TmpDir cwd("reone_test_k1_rims_override_cwd");
+    makeInstallation(game, cwd);
+
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeFile(game.mkdir("rims") / "probe.txt", "rims");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("rims", find(kProbe)) << "rims is registered after override";
+}
+
+TEST_P(K1StartupTest, streamsounds_stays_out_of_raw_lookup) {
+    TmpDir game("reone_test_k1_streamsounds");
+    TmpDir cwd("reone_test_k1_streamsounds_cwd");
+    makeInstallation(game, cwd);
+
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeFile(game.mkdir("streamsounds") / "probe.txt", "streamsounds");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    // K1 has no bare STREAMSOUNDS alias and never registers the directory; it
+    // is reached by constructed path only. So it cannot answer here at all,
+    // even though it would have been the newest loose source if it did.
+    EXPECT_EQ("override", find(kProbe)) << "the sounds directory is not a raw lookup source";
+}
+
+// Class 1.
+
+TEST_P(K1StartupTest, patch_outranks_the_override_texture_archive) {
+    TmpDir game("reone_test_k1_class1");
+    TmpDir cwd("reone_test_k1_class1_cwd");
+    makeInstallation(game, cwd);
+
+    // Both are class 1; K1 registers the override archive first and patch
+    // second, so patch wins.
+    writeErf(game.mkdir("override") / "textures.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "override textures"}});
+    writeErf(game.path / "patch.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "patch"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("patch", find(kProbe)) << "patch is registered after the override texture archive";
+}
+
+TEST_P(K1StartupTest, the_override_texture_archive_is_class_one_not_class_two) {
+    TmpDir game("reone_test_k1_textures_class");
+    TmpDir cwd("reone_test_k1_textures_class_cwd");
+    makeInstallation(game, cwd);
+
+    writeErf(game.mkdir("override") / "textures.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "override textures"}});
+    // A class-2 source and a resource image, both of which class 1 outranks.
+    writeErf(game.mkdir("texturepacks") / "swpc_tex_gui.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "texture pack"}});
+    writeRim(game.mkdir("rims") / "global.rim", {{kProbe, ResType::Txt, "global rim"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("override textures", find(kProbe))
+        << "class 1 outranks both the resource image and the class-2 pack";
+}
+
+TEST_P(K1StartupTest, a_loose_file_outranks_every_encapsulated_startup_source) {
+    TmpDir game("reone_test_k1_loose_over_class1");
+    TmpDir cwd("reone_test_k1_loose_over_class1_cwd");
+    makeInstallation(game, cwd);
+
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeErf(game.path / "patch.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "patch"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("override", find(kProbe)) << "the loose bucket is searched before class 1";
+}
+
+// The global image.
+
+TEST_P(K1StartupTest, the_global_image_outranks_class_two_and_loses_to_class_one) {
+    TmpDir game("reone_test_k1_global_rim");
+    TmpDir cwd("reone_test_k1_global_rim_cwd");
+    makeInstallation(game, cwd);
+
+    writeRim(game.mkdir("rims") / "global.rim", {{kProbe, ResType::Txt, "global rim"}});
+    writeErf(game.mkdir("texturepacks") / "swpc_tex_gui.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "texture pack"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("global rim", find(kProbe)) << "the image bucket is searched before class 2";
+}
+
+TEST_P(K1StartupTest, only_the_named_global_image_is_mounted_from_the_rims_location) {
+    TmpDir game("reone_test_k1_rims_only_global");
+    TmpDir cwd("reone_test_k1_rims_only_global_cwd");
+    makeInstallation(game, cwd);
+
+    auto rims = game.mkdir("rims");
+    writeRim(rims / "global.rim", {{"from_global", ResType::Txt, "global"}});
+    writeRim(rims / "mainmenu.rim", {{"from_mainmenu", ResType::Txt, "mainmenu"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("global", find("from_global"));
+    // The directory is mounted as a loose location, so the other images are
+    // present as files but their contents are not indexed as resources.
+    EXPECT_FALSE(has("from_mainmenu")) << "startup names only the global image";
+}
+
+// Class 2, around the player archive.
+
+TEST_P(K1StartupTest, the_player_archive_outranks_the_texture_pack_and_loses_to_module_support) {
+    TmpDir game("reone_test_k1_players_order");
+    TmpDir cwd("reone_test_k1_players_order_cwd");
+    makeInstallation(game, cwd);
+
+    // Every class-2 source K1 inserts around the player archive, all colliding.
+    writeErf(game.mkdir("texturepacks") / "swpc_tex_gui.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "texture pack"}});
+    writeErf(game.path / "players.erf", ErfWriter::FileType::ERF,
+             {{kProbe, ResType::Txt, "players"}});
+    auto lips = game.mkdir("lips");
+    writeErf(lips / "foo_loc.mod", ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "module loc"}});
+    auto modules = game.path / "modules";
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "module mod"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    // Before any module: the player archive is newer than the texture pack.
+    EXPECT_EQ("players", find(kProbe)) << "the player archive is registered after the texture pack";
+
+    director->onModuleLoad("foo");
+
+    // The module's own sources are newer than both.
+    EXPECT_EQ("module mod", find(kProbe)) << "the module archive is the newest class-2 source";
+}
+
+TEST_P(K1StartupTest, the_player_archive_is_not_duplicated_or_repositioned_by_transitions) {
+    TmpDir game("reone_test_k1_players_lifetime");
+    TmpDir cwd("reone_test_k1_players_lifetime_cwd");
+    makeInstallation(game, cwd);
+
+    writeErf(game.path / "players.erf", ErfWriter::FileType::ERF,
+             {{"from_players", ResType::Txt, "players"}});
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"probe_a", ResType::Txt, "foo"}});
+    writeRim(modules / "bar.rim", {{"probe_b", ResType::Txt, "bar"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto afterInit = _count();
+    EXPECT_TRUE(has("from_players"));
+
+    director->onModuleLoad("foo");
+    auto afterFirst = _count();
+
+    director->onModuleLoad("bar");
+    director->onModuleLoad("foo");
+
+    // The engine adds this source once and never removes it; re-adding the same
+    // exact file rebuilds the existing table rather than inserting another. A
+    // transition must therefore neither drop it nor stack a second copy.
+    EXPECT_TRUE(has("from_players")) << "the player archive survives module transitions";
+    EXPECT_EQ(afterFirst, _count()) << "transitions must not accumulate sources";
+    EXPECT_LT(afterInit, afterFirst);
+}
+
+TEST_P(K1StartupTest, the_player_archive_is_found_by_basename_not_by_extension) {
+    TmpDir game("reone_test_k1_players_basename");
+    TmpDir cwd("reone_test_k1_players_basename_cwd");
+    makeInstallation(game, cwd);
+
+    // The engine mounts an exact basename, so a supported non-ERF container
+    // has to be found just the same.
+    writeErf(game.path / "players.mod", ErfWriter::FileType::MOD,
+             {{"from_players", ResType::Txt, "players mod"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("players mod", find("from_players"));
+}
+
+TEST_P(K1StartupTest, an_absent_player_archive_is_not_a_failure) {
+    TmpDir game("reone_test_k1_players_absent");
+    TmpDir cwd("reone_test_k1_players_absent_cwd");
+    makeInstallation(game, cwd);
+    writeRim(game.path / "modules" / "foo.rim", {{"probe_a", ResType::Txt, "foo"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        EXPECT_NO_THROW(director->init());
+    }
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ("foo", find("probe_a"));
+}
+
+// Game discrimination.
+
+TEST_P(K1StartupTest, k2_mounts_no_player_archive_and_no_rims_sources) {
+    TmpDir game("reone_test_k2_no_k1_sources");
+    TmpDir cwd("reone_test_k2_no_k1_sources_cwd");
+    makeInstallation(game, cwd);
+
+    writeErf(game.path / "players.erf", ErfWriter::FileType::ERF,
+             {{"from_players", ResType::Txt, "players"}});
+    writeRim(game.mkdir("rims") / "global.rim", {{"from_global", ResType::Txt, "global"}});
+    writeErf(game.mkdir("override") / "textures.erf", ErfWriter::FileType::ERF,
+             {{"from_override_textures", ResType::Txt, "textures"}});
+
+    auto director = makeDirector(game.path, GameID::TSL);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_FALSE(has("from_players")) << "the player archive is a K1 source";
+    EXPECT_FALSE(has("from_global")) << "the rims location is a K1 source";
+    EXPECT_FALSE(has("from_override_textures")) << "the override texture archive is a K1 source";
+}
+
+TEST_P(K1StartupTest, k2_keeps_its_streams_out_of_raw_lookup) {
+    TmpDir game("reone_test_k2_streams");
+    TmpDir cwd("reone_test_k2_streams_cwd");
+    makeInstallation(game, cwd);
+
+    writeFile(game.mkdir("override") / "probe.txt", "override");
+    writeFile(game.mkdir("streammusic") / "probe.txt", "streammusic");
+
+    auto director = makeDirector(game.path, GameID::TSL);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("override", find(kProbe)) << "K2 streams are not raw lookup sources";
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         K1StartupTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+// The encapsulated basename probe itself.
+
+TEST(EncapsulatedBasenameProbe, probes_the_engine_extension_order) {
+    EXPECT_EQ((std::array<std::string_view, 5> {".nwm", ".mod", ".sav", ".erf", ".hak"}),
+              kEncapsulatedProbeOrder);
+}
+
+TEST(EncapsulatedBasenameProbe, takes_the_first_extension_that_exists) {
+    TmpDir tmp("reone_test_probe_order");
+
+    // Every candidate holds the same id, so which one is returned is the only
+    // thing the assertions can be reading.
+    writeHak(tmp.path / "thing.hak", {{kProbe, ResType::Txt, "hak"}});
+    auto path = findEncapsulatedByBasename(tmp.path, "thing");
+    ASSERT_TRUE(path.has_value());
+    EXPECT_EQ("thing.hak", path->filename().string()) << "hak answers when nothing earlier exists";
+
+    writeErf(tmp.path / "thing.erf", ErfWriter::FileType::ERF, {{kProbe, ResType::Txt, "erf"}});
+    EXPECT_EQ("thing.erf", findEncapsulatedByBasename(tmp.path, "thing")->filename().string())
+        << "erf is probed before hak";
+
+    writeErf(tmp.path / "thing.sav", ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "sav"}});
+    EXPECT_EQ("thing.sav", findEncapsulatedByBasename(tmp.path, "thing")->filename().string())
+        << "sav is probed before erf";
+
+    writeErf(tmp.path / "thing.mod", ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "mod"}});
+    EXPECT_EQ("thing.mod", findEncapsulatedByBasename(tmp.path, "thing")->filename().string())
+        << "mod is probed before sav";
+
+    writeErf(tmp.path / "thing.nwm", ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "nwm"}});
+    EXPECT_EQ("thing.nwm", findEncapsulatedByBasename(tmp.path, "thing")->filename().string())
+        << "nwm is probed first";
+}
+
+TEST(EncapsulatedBasenameProbe, answers_nothing_for_an_absent_basename) {
+    TmpDir tmp("reone_test_probe_absent");
+    EXPECT_FALSE(findEncapsulatedByBasename(tmp.path, "missing").has_value());
+    EXPECT_FALSE(findEncapsulatedByBasename(tmp.path, "").has_value());
+}
+
+/// A HAK container is the ERF/MOD layout under a third type tag, which is why
+/// the opener probes it alongside the others and validates only the tag.
+class HakContainerTest : public testing::TestWithParam<Backend> {
+protected:
+    std::unique_ptr<IResources> make() {
+        if (GetParam() == Backend::Legacy) {
+            return std::make_unique<Resources>();
+        }
+        return std::make_unique<ExtractResources>();
+    }
+};
+
+TEST_P(HakContainerTest, reads_a_hak_tagged_container) {
+    TmpDir tmp("reone_test_hak");
+    writeHak(tmp.path / "thing.hak", {{kProbe, ResType::Txt, "from hak"}});
+
+    auto resources = make();
+    ASSERT_NO_THROW(resources->addERF(tmp.path / "thing.hak", ResourceOwner::Global));
+    EXPECT_EQ("from hak", dataOf(resources->find(ResourceId(kProbe, ResType::Txt))));
+}
+
+TEST_P(HakContainerTest, still_rejects_a_container_with_no_valid_tag) {
+    TmpDir tmp("reone_test_hak_invalid");
+    auto b = erfBytes(ErfWriter::FileType::MOD, {{kProbe, ResType::Txt, "x"}});
+    const char tag[4] = {'B', 'A', 'D', ' '};
+    for (int i = 0; i < 4; ++i) {
+        b[i] = tag[i];
+    }
+    writeBuffer(tmp.path / "thing.erf", b);
+
+    auto resources = make();
+    EXPECT_THROW(resources->addERF(tmp.path / "thing.erf", ResourceOwner::Global),
+                 ValidationException);
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         HakContainerTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+namespace {
+
+/**
+ * A minimal binary 2DA holding one column and one row, with a chosen label
+ * separator. Retail ships both: the BIF copies of these tables use tabs and the
+ * copies inside K1's global.rim use NULs, and are otherwise the same layout.
+ */
+std::string twoDaBytes(const std::string &value, char separator) {
+    std::string b("2DA V2.b\n");
+    b += "src";
+    b += separator;              // column label
+    b += '\0';                   // end of column labels
+    b += std::string("\x01\x00\x00\x00", 4);  // row count
+    b += "0";
+    b += separator;              // row label
+    b += std::string("\x00\x00", 2);          // one cell offset
+    auto size = static_cast<uint16_t>(value.size() + 1);
+    b += std::string(reinterpret_cast<const char *>(&size), 2);
+    b += value;
+    b += '\0';
+    return b;
+}
+
+} // namespace
+
+/**
+ * The loader, the winner and the parser, end to end.
+ *
+ * K1 registers global.rim as a resource image and chitin.key as the fixed key
+ * table, and the image bucket is searched first, so a table present in both
+ * must be served from global.rim. The copy that wins is the NUL-delimited one,
+ * so this also proves the winner is the copy that actually has to parse.
+ *
+ * It fails if global.rim is not registered, is given the wrong bucket, loses to
+ * the key table, or cannot be read once it wins.
+ */
+TEST_P(K1StartupTest, the_global_image_supplies_the_two_da_that_the_key_table_also_holds) {
+    TmpDir game("reone_test_k1_global_2da");
+    TmpDir cwd("reone_test_k1_global_2da_cwd");
+    makeInstallation(game, cwd);
+
+    // The key table carries the ordinary tab-delimited copy...
+    reone::test::writeKeyBif(game.path, "data\sample.bif",
+                             {{"probe", ResType::TwoDA, twoDaBytes("keybif", '\t')}});
+    // ...and the global image carries the NUL-delimited one, as retail does.
+    writeRim(game.mkdir("rims") / "global.rim",
+             {{"probe", ResType::TwoDA, twoDaBytes("globalrim", '\0')}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    auto res = _resources->find(ResourceId("probe", ResType::TwoDA));
+    ASSERT_TRUE(res) << "the table must resolve from one of the two sources";
+
+    auto stream = MemoryInputStream(res->data);
+    auto reader = TwoDAReader(stream);
+    ASSERT_NO_THROW(reader.load()) << "the winning copy must parse";
+    auto twoDa = reader.twoDA();
+    ASSERT_TRUE(twoDa);
+
+    EXPECT_EQ(1, twoDa->getRowCount());
+    EXPECT_EQ((std::vector<std::string> {"src"}), twoDa->columns());
+    EXPECT_EQ("globalrim", twoDa->getString(0, "src"))
+        << "the resource image outranks the key table";
+}

--- a/test/resource/k1startup.cpp
+++ b/test/resource/k1startup.cpp
@@ -492,16 +492,22 @@ TEST_P(K1StartupTest, an_absent_player_archive_is_not_a_failure) {
 
 // Game discrimination.
 
-TEST_P(K1StartupTest, k2_mounts_no_player_archive_and_no_rims_sources) {
-    TmpDir game("reone_test_k2_no_k1_sources");
-    TmpDir cwd("reone_test_k2_no_k1_sources_cwd");
+TEST_P(K1StartupTest, k2_mounts_rims_and_global_image_but_not_k1_support_archives) {
+    TmpDir game("reone_test_k2_global_images");
+    TmpDir cwd("reone_test_k2_global_images_cwd");
     makeInstallation(game, cwd);
 
     writeErf(game.path / "players.erf", ErfWriter::FileType::ERF,
              {{"from_players", ResType::Txt, "players"}});
-    writeRim(game.mkdir("rims") / "global.rim", {{"from_global", ResType::Txt, "global"}});
+    auto rims = game.mkdir("rims");
+    writeFile(rims / "loose.txt", "rims loose");
+    writeRim(rims / "global.rim",
+             {{"from_global", ResType::Txt, "global"},
+              {kProbe, ResType::Txt, "global rim"}});
     writeErf(game.mkdir("override") / "textures.erf", ErfWriter::FileType::ERF,
              {{"from_override_textures", ResType::Txt, "textures"}});
+    reone::test::writeKeyBif(game.path, "data/sample.bif",
+                             {{kProbe, ResType::Txt, "key bif"}});
 
     auto director = makeDirector(game.path, GameID::TSL);
     {
@@ -510,8 +516,14 @@ TEST_P(K1StartupTest, k2_mounts_no_player_archive_and_no_rims_sources) {
     }
 
     EXPECT_FALSE(has("from_players")) << "the player archive is a K1 source";
-    EXPECT_FALSE(has("from_global")) << "the rims location is a K1 source";
     EXPECT_FALSE(has("from_override_textures")) << "the override texture archive is a K1 source";
+    EXPECT_EQ("rims loose", find("loose")) << "RIMS is an active loose resource directory";
+    EXPECT_EQ("global", find("from_global")) << "global.rim is an active resource image";
+    EXPECT_EQ("global rim", find(kProbe)) << "the image bucket outranks KEY/BIF";
+
+    EXPECT_NO_THROW(director->onModuleLoad("missing"));
+    EXPECT_EQ("rims loose", find("loose")) << "the RIMS directory has Global lifetime";
+    EXPECT_EQ("global", find("from_global")) << "global.rim has Global lifetime";
 }
 
 TEST_P(K1StartupTest, k2_keeps_its_streams_out_of_raw_lookup) {
@@ -658,7 +670,7 @@ TEST_P(K1StartupTest, the_global_image_supplies_the_two_da_that_the_key_table_al
     makeInstallation(game, cwd);
 
     // The key table carries the ordinary tab-delimited copy...
-    reone::test::writeKeyBif(game.path, "data\sample.bif",
+    reone::test::writeKeyBif(game.path, "data/sample.bif",
                              {{"probe", ResType::TwoDA, twoDaBytes("keybif", '\t')}});
     // ...and the global image carries the NUL-delimited one, as retail does.
     writeRim(game.mkdir("rims") / "global.rim",

--- a/test/resource/k1startup.cpp
+++ b/test/resource/k1startup.cpp
@@ -172,11 +172,12 @@ protected:
     }
 
     std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &p,
-                                                   GameID game = GameID::KotOR) {
+                                                   GameID game = GameID::KotOR,
+                                                   OdysseyResourceRoots roots = {}) {
         _gamePath = p;
         return std::make_unique<ResourceDirector>(
             game, _gamePath, _graphicsOpt, _graphics.services(), _script.services(),
-            _dialogs, _gffs, _lips, _paths, *_resources, *_auxResources, _scripts, _twoDas);
+            _dialogs, _gffs, _lips, _paths, *_resources, *_auxResources, _scripts, _twoDas, std::move(roots));
     }
 
     /// An installation with a modules directory and the shader pack the
@@ -541,6 +542,63 @@ TEST_P(K1StartupTest, k2_keeps_its_streams_out_of_raw_lookup) {
     }
 
     EXPECT_EQ("override", find(kProbe)) << "K2 streams are not raw lookup sources";
+}
+
+TEST_P(K1StartupTest, k2_rims_loose_directory_outranks_base_override) {
+    TmpDir game("reone_test_k2_rims_override");
+    TmpDir cwd("reone_test_k2_rims_override_cwd");
+    makeInstallation(game, cwd);
+    writeFile(game.mkdir("override") / "probe.txt", "base override");
+    writeFile(game.mkdir("rims") / "probe.txt", "rims");
+
+    auto director = makeDirector(game.path, GameID::TSL);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    EXPECT_EQ("rims", find(kProbe));
+}
+
+TEST_P(K1StartupTest, k2_loose_startup_preserves_natural_configured_order_below_rims) {
+    TmpDir game("reone_test_k2_loose_order");
+    TmpDir cwd("reone_test_k2_loose_order_cwd");
+    TmpDir configured0("reone_test_k2_loose_order_0");
+    TmpDir configured1("reone_test_k2_loose_order_1");
+    makeInstallation(game, cwd);
+    writeFile(game.mkdir("override") / "probe.txt", "base override");
+    writeFile(configured0.mkdir("override") / "probe.txt", "configured 0");
+    writeFile(configured1.mkdir("override") / "probe.txt", "configured 1");
+    auto rims = game.mkdir("rims");
+    writeFile(rims / "probe.txt", "rims");
+
+    OdysseyResourceRoots roots;
+    roots.k2OverrideRoots = {configured0.path, configured1.path};
+    auto director = makeDirector(game.path, GameID::TSL, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    EXPECT_EQ("rims", find(kProbe));
+
+    std::filesystem::remove(rims / "probe.txt");
+    _resources->clear();
+    _auxResources->clear();
+    director = makeDirector(game.path, GameID::TSL, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    EXPECT_EQ("configured 1", find(kProbe));
+
+    std::filesystem::remove(configured1.path / "override" / "probe.txt");
+    _resources->clear();
+    _auxResources->clear();
+    director = makeDirector(game.path, GameID::TSL, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    EXPECT_EQ("configured 0", find(kProbe));
 }
 
 INSTANTIATE_TEST_SUITE_P(Backends,

--- a/test/resource/lookup.cpp
+++ b/test/resource/lookup.cpp
@@ -376,13 +376,18 @@ TEST_F(ResourceDirectorLookup, should_mount_module_locations_over_global_and_cle
 
     director->onModuleLoad("foo");
 
-    EXPECT_EQ("mod", find("m")) << ".mod must beat _s.rim, .rim and all global locations, including override";
-    EXPECT_EQ("main rim", find("rim_only"));
-    EXPECT_EQ("data rim", find("rims_only"));
+    // K1 is activated, so the buckets decide. A loose override file outranks
+    // every module source, and the MOD branch suppresses the static image and
+    // leaves the base image unmounted.
+    EXPECT_EQ("override", find("m")) << "a loose override file outranks every module archive";
+    EXPECT_FALSE(_resources.find(ResourceId("rim_only", ResType::Txt)))
+        << "the MOD branch does not mount the base image";
+    EXPECT_FALSE(_resources.find(ResourceId("rims_only", ResType::Txt)))
+        << "the MOD branch suppresses the static image";
 
     director->onModuleLoad("bar");
 
-    EXPECT_EQ("bar rim", find("m")) << "previous module containers must be dropped on transition";
+    EXPECT_EQ("override", find("m")) << "previous module containers must be dropped on transition";
     EXPECT_FALSE(_resources.find(ResourceId("rim_only", ResType::Txt)));
 }
 
@@ -419,7 +424,10 @@ TEST_F(ResourceDirectorLookup, should_mount_save_scope_and_modules_nested_in_sav
 
     director->onGameLoad("000001");
 
-    EXPECT_EQ("save archive", find("loose")) << "savegame.sav must beat loose files in the save folder";
+    // The save folder is a loose directory and the archive is class 2, so the
+    // folder wins. The old flat stack had the archive win only because it was
+    // mounted last.
+    EXPECT_EQ("save folder", find("loose")) << "a loose save file outranks the save archive";
 
     director->onModuleLoad("bar");
 

--- a/test/resource/lookup.cpp
+++ b/test/resource/lookup.cpp
@@ -214,10 +214,10 @@ TEST(ResourcesLookup, should_prefer_last_added_container_for_colliding_id) {
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "first"},
                                   {"first_only", ResType::Txt, "from first"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "second"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
 
     EXPECT_EQ("second", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_EQ("from first", dataOf(resources.find(ResourceId("first_only", ResType::Txt))));
@@ -228,24 +228,24 @@ TEST(ResourcesLookup, should_clear_containers_by_kind_only) {
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "global"},
                                   {"global_only", ResType::Txt, "global"}}),
-                        ContainerKind::Global);
+                        ResourceOwner::Global);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "save"},
                                   {"save_only", ResType::Txt, "save"}}),
-                        ContainerKind::Save);
+                        ResourceOwner::SaveSlot);
     resources.addMemERF(erfBytes(ErfWriter::FileType::ERF,
                                  {{"shared", ResType::Txt, "local"},
                                   {"local_only", ResType::Txt, "local"}}),
-                        ContainerKind::Local);
+                        ResourceOwner::ActiveModule);
 
     EXPECT_EQ("local", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
 
-    resources.clearLocal();
+    resources.clearOwner(ResourceOwner::ActiveModule);
     EXPECT_EQ("save", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_FALSE(resources.find(ResourceId("local_only", ResType::Txt)));
     EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
 
-    resources.clearSave();
+    resources.clearOwner(ResourceOwner::SaveSlot);
     EXPECT_EQ("global", dataOf(resources.find(ResourceId("shared", ResType::Txt))));
     EXPECT_FALSE(resources.find(ResourceId("save_only", ResType::Txt)));
     EXPECT_TRUE(resources.find(ResourceId("global_only", ResType::Txt)));
@@ -429,12 +429,10 @@ TEST_F(ResourceDirectorLookup, should_mount_save_scope_and_modules_nested_in_sav
 
     EXPECT_EQ("second save", find("loose")) << "the save loaded last must win";
 
-    // Known defect this test pins on purpose: loadSaveGameResources mounts
-    // save containers with the default Global kind, so clearSave is a no-op
-    // and containers of previously loaded saves leak. The newest save only
-    // wins by stacking order. A future save-scope fix should flip this
-    // expectation to "not found".
-    EXPECT_EQ("first save", find("first_only")) << "previous save containers currently leak";
+    // The newest save no longer wins merely by stacking order: the previous
+    // one is unloaded, so a resource only it held stops resolving.
+    EXPECT_EQ("<not found>", find("first_only"))
+        << "containers of the previous save must not survive loading another";
 }
 
 TEST_F(ResourceDirectorLookup, should_throw_when_save_slot_is_missing) {

--- a/test/resource/lookup.cpp
+++ b/test/resource/lookup.cpp
@@ -268,9 +268,10 @@ protected:
         _script.init();
     }
 
-    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath,
+                                                   GameID gameId = GameID::KotOR) {
         return std::make_unique<ResourceDirector>(
-            GameID::KotOR,
+            gameId,
             gamePath,
             _graphicsOpt,
             _graphics.services(),
@@ -280,7 +281,9 @@ protected:
             _lips,
             _paths,
             _resources,
-            _scripts);
+            _auxResources,
+            _scripts,
+            _twoDas);
     }
 
     std::string find(const std::string &resRef, ResType type = ResType::Txt) {
@@ -296,8 +299,10 @@ protected:
     NiceMock<MockLips> _lips;
     NiceMock<MockPaths> _paths;
     NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
 
     Resources _resources;
+    Resources _auxResources;
 };
 
 TEST_F(ResourceDirectorLookup, should_mount_global_locations_in_precedence_order) {
@@ -331,11 +336,16 @@ TEST_F(ResourceDirectorLookup, should_mount_global_locations_in_precedence_order
         director->init();
     }
 
-    EXPECT_EQ("chitin", find("a")) << "chitin must beat shaderpack";
     EXPECT_EQ("gui pack", find("b")) << "GUI texture pack must beat chitin";
     EXPECT_EQ("texture pack", find("c")) << "quality texture pack must beat GUI pack";
     EXPECT_EQ("patch", find("d")) << "patch.erf must beat texture packs";
     EXPECT_EQ("override", find("e")) << "override must beat patch.erf";
+
+    // The shader pack no longer competes with game data at all: it holds only
+    // GLSL, so it is kept out of the game's resource list entirely. This used
+    // to assert that chitin outranked it.
+    EXPECT_EQ("chitin", find("a"));
+    EXPECT_EQ("shaderpack", dataOf(_auxResources.find(ResourceId("a", ResType::Txt))));
 }
 
 TEST_F(ResourceDirectorLookup, should_mount_module_locations_over_global_and_clear_on_transition) {
@@ -395,7 +405,7 @@ TEST_F(ResourceDirectorLookup, should_mount_save_scope_and_modules_nested_in_sav
     writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
              {{"loose", ResType::Txt, "save archive"},
               {"first_only", ResType::Txt, "first save"},
-              {"bar", ResType::Mod, std::string(nestedModule.begin(), nestedModule.end())}});
+              {"bar", ResType::Sav, std::string(nestedModule.begin(), nestedModule.end())}});
 
     auto secondSlot = game.mkdir("saves/000002");
     writeErf(secondSlot / "savegame.sav", ErfWriter::FileType::ERF,

--- a/test/resource/modulediscovery.cpp
+++ b/test/resource/modulediscovery.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/modulediscovery.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::resource;
+using namespace reone::test;
+
+namespace {
+
+void touch(const std::filesystem::path &path) {
+    detail::writeFile(path, "synthetic");
+}
+
+ModuleSearchRoot root(std::string id,
+                      std::filesystem::path path,
+                      ModulePrimaryOrigin origin = ModulePrimaryOrigin::Modules,
+                      std::uint32_t packageOrder = 0,
+                      std::uint32_t rootOrder = 0) {
+    return {std::move(id), std::move(path), origin, packageOrder, rootOrder};
+}
+
+std::vector<std::string> discoveredNames(const ModuleDiscoveryResult &result) {
+    std::vector<std::string> names;
+    for (const auto &source : result.sources) names.push_back(source.filename);
+    return names;
+}
+
+std::vector<std::string> rejectedNames(const ModuleDiscoveryResult &result) {
+    std::vector<std::string> names;
+    for (const auto &file : result.rejected) names.push_back(file.filename);
+    return names;
+}
+
+std::optional<ModuleArchiveFamily> familyOf(const ModuleDiscoveryResult &result,
+                                            const std::string &filename) {
+    for (const auto &source : result.sources) {
+        if (source.filename == filename) return source.candidate.family;
+    }
+    return std::nullopt;
+}
+
+// 15.1 Root normalization
+
+TEST(ModuleDiscovery, resolves_primary_archives_to_their_own_root) {
+    for (const auto &filename : {"foo.mod", "foo.rim"}) {
+        auto classified = classifyModuleArchive(filename);
+        ASSERT_TRUE(classified.archive) << filename;
+        EXPECT_EQ("foo", classified.archive->moduleRoot) << filename;
+        EXPECT_TRUE(isPrimaryEligible(classified.archive->family)) << filename;
+    }
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryMod, classifyModuleArchive("foo.mod").archive->family);
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryRim, classifyModuleArchive("foo.rim").archive->family);
+}
+
+TEST(ModuleDiscovery, resolves_sidecars_to_the_module_they_support_and_never_to_a_primary) {
+    const std::vector<std::pair<std::string, ModuleArchiveFamily>> cases {
+        {"foo_s.rim", ModuleArchiveFamily::StaticRim},
+        {"foo_a.rim", ModuleArchiveFamily::AreaRim},
+        {"foo_adx.rim", ModuleArchiveFamily::AdxRim},
+        {"foo_dlg.erf", ModuleArchiveFamily::Dialogue},
+        {"foo_loc.mod", ModuleArchiveFamily::Localization},
+        {"foo_loc.erf", ModuleArchiveFamily::Localization},
+    };
+    for (const auto &entry : cases) {
+        auto classified = classifyModuleArchive(entry.first);
+        ASSERT_TRUE(classified.archive) << entry.first;
+        EXPECT_EQ("foo", classified.archive->moduleRoot) << entry.first;
+        EXPECT_EQ(entry.second, classified.archive->family) << entry.first;
+        EXPECT_FALSE(isPrimaryEligible(classified.archive->family)) << entry.first;
+    }
+}
+
+TEST(ModuleDiscovery, does_not_resolve_an_unrecognized_suffix_to_a_known_family) {
+    // Inference matches the recognized suffixes exactly. A name that merely
+    // resembles one is not resolved to it, so it never becomes a sidecar of
+    // the module it would then have belonged to.
+    auto isSidecarOf = [](const ModuleArchiveClassification &classified,
+                          const std::string &moduleRoot) {
+        return classified.archive && classified.archive->moduleRoot == moduleRoot &&
+               !isPrimaryEligible(classified.archive->family);
+    };
+    for (const auto &filename : {"foo_adrx.rim", "foo_ss.rim", "foo_aa.rim",
+                                 "foo_dlgx.erf", "foo_locale.erf"}) {
+        EXPECT_FALSE(isSidecarOf(classifyModuleArchive(filename), "foo")) << filename;
+    }
+}
+
+TEST(ModuleDiscovery, keeps_underscores_that_belong_to_a_module_root) {
+    auto primary = classifyModuleArchive("ebo_m12aa.rim");
+    ASSERT_TRUE(primary.archive);
+    EXPECT_EQ("ebo_m12aa", primary.archive->moduleRoot);
+
+    auto sidecar = classifyModuleArchive("ebo_m12aa_s.rim");
+    ASSERT_TRUE(sidecar.archive);
+    EXPECT_EQ("ebo_m12aa", sidecar.archive->moduleRoot);
+    EXPECT_EQ(ModuleArchiveFamily::StaticRim, sidecar.archive->family);
+}
+
+TEST(ModuleDiscovery, keeps_a_literal_requested_root_that_looks_like_a_sidecar) {
+    // Inference is only needed when no root was requested. A caller naming
+    // "foo_s" has already said which module it means.
+    for (const auto &requested : {"foo_s", "foo_a", "foo_adx", "foo_dlg", "foo_loc"}) {
+        auto normalized = normalizeModuleName(requested);
+        ASSERT_TRUE(normalized.root) << requested;
+        EXPECT_EQ(requested, *normalized.root) << requested;
+        EXPECT_FALSE(normalized.rejection) << requested;
+    }
+}
+
+TEST(ModuleDiscovery, normalizes_a_request_by_case_and_extension_only) {
+    auto bare = normalizeModuleName("  FooBar  ");
+    ASSERT_TRUE(bare.root);
+    EXPECT_EQ("foobar", *bare.root);
+
+    auto archive = normalizeModuleName("FOO_S.RIM");
+    ASSERT_TRUE(archive.root);
+    EXPECT_EQ("foo_s", *archive.root);
+}
+
+TEST(ModuleDiscovery, rejects_empty_and_unsupported_requests) {
+    EXPECT_EQ(ModuleNameRejection::Empty, normalizeModuleName("").rejection);
+    EXPECT_EQ(ModuleNameRejection::Empty, normalizeModuleName("   ").rejection);
+    EXPECT_EQ(ModuleNameRejection::UnsupportedExtension, normalizeModuleName("foo.txt").rejection);
+}
+
+TEST(ModuleDiscovery, resolves_candidates_against_a_root_that_looks_like_a_sidecar) {
+    TmpDir tmp("reone_test_discovery_suffixed_root");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo_s.rim");
+    touch(modules / "foo_s_s.rim");
+    touch(modules / "foo_s_a.rim");
+    touch(modules / "foo_s_adx.rim");
+
+    auto result = discoverModuleSources("foo_s", {root("modules", modules)});
+
+    EXPECT_EQ("foo_s", result.moduleRoot);
+    EXPECT_TRUE(result.rejected.empty());
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryRim, familyOf(result, "foo_s.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::StaticRim, familyOf(result, "foo_s_s.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::AreaRim, familyOf(result, "foo_s_a.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::AdxRim, familyOf(result, "foo_s_adx.rim"));
+}
+
+TEST(ModuleDiscovery, resolves_the_same_files_differently_with_and_without_a_root) {
+    // Without a root, ownership must be inferred and foo_s.rim belongs to foo.
+    auto inferred = classifyModuleArchive("foo_s.rim");
+    ASSERT_TRUE(inferred.archive);
+    EXPECT_EQ("foo", inferred.archive->moduleRoot);
+    EXPECT_EQ(ModuleArchiveFamily::StaticRim, inferred.archive->family);
+
+    // With the root known, the same name is that module's own primary.
+    auto resolved = classifyForModuleRoot("foo_s.rim", "foo_s");
+    ASSERT_TRUE(resolved.archive);
+    EXPECT_EQ("foo_s", resolved.archive->moduleRoot);
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryRim, resolved.archive->family);
+
+    // And relative to foo it remains the static sidecar.
+    auto sidecar = classifyForModuleRoot("foo_s.rim", "foo");
+    ASSERT_TRUE(sidecar.archive);
+    EXPECT_EQ(ModuleArchiveFamily::StaticRim, sidecar.archive->family);
+}
+
+TEST(ModuleDiscovery, reports_a_suffix_carried_by_the_wrong_extension) {
+    TmpDir tmp("reone_test_discovery_mismatch");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+    touch(modules / "foo_s.mod");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+
+    EXPECT_EQ((std::vector<std::string> {"foo.rim"}), discoveredNames(result));
+    ASSERT_EQ(1, result.rejected.size());
+    EXPECT_EQ(ModuleNameRejection::SuffixExtensionMismatch, result.rejected[0].reason);
+}
+
+// 15.2 Discovery combinations
+
+TEST(ModuleDiscovery, sidecars_alone_do_not_create_a_module) {
+    TmpDir tmp("reone_test_discovery_no_pseudo_modules");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "orphan_s.rim");
+    touch(modules / "orphan_a.rim");
+    touch(modules / "orphan_adx.rim");
+    touch(modules / "orphan_dlg.erf");
+    touch(modules / "orphan_loc.erf");
+    touch(modules / "real.rim");
+
+    EXPECT_EQ((std::vector<std::string> {"real"}),
+              discoverModuleRoots({root("modules", modules)}));
+}
+
+TEST(ModuleDiscovery, discovers_module_roots_from_every_primary_family) {
+    TmpDir tmp("reone_test_discovery_roots");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "packed.mod");
+    touch(modules / "split.rim");
+    touch(modules / "zeta.nwm");
+
+    EXPECT_EQ((std::vector<std::string> {"packed", "split", "zeta"}),
+              discoverModuleRoots({root("modules", modules)}));
+}
+
+TEST(ModuleDiscovery, discovers_a_packed_module_with_its_adjuncts) {
+    TmpDir tmp("reone_test_discovery_packed");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.mod");
+    touch(modules / "foo_a.rim");
+    touch(modules / "foo_adx.rim");
+    touch(modules / "foo_s.rim");
+    touch(modules / "foo_dlg.erf");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+
+    // Discovery reports everything present; suppressing _s and _dlg under a
+    // module archive is the policy's decision, not discovery's.
+    EXPECT_EQ(ModuleArchiveFamily::PrimaryMod, familyOf(result, "foo.mod"));
+    EXPECT_EQ(ModuleArchiveFamily::AreaRim, familyOf(result, "foo_a.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::AdxRim, familyOf(result, "foo_adx.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::StaticRim, familyOf(result, "foo_s.rim"));
+    EXPECT_EQ(ModuleArchiveFamily::Dialogue, familyOf(result, "foo_dlg.erf"));
+    EXPECT_TRUE(result.rejected.empty());
+}
+
+TEST(ModuleDiscovery, reports_an_unsupported_sidecar_rather_than_absorbing_it) {
+    TmpDir tmp("reone_test_discovery_unsupported");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+    touch(modules / "foo_adx.rim");
+    touch(modules / "foo_adrx.rim");
+    touch(modules / "foo_bar.erf");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+
+    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_adx.rim"}), discoveredNames(result));
+    EXPECT_EQ((std::vector<std::string> {"foo_adrx.rim", "foo_bar.erf"}), rejectedNames(result));
+    ASSERT_EQ(2, result.rejected.size());
+    // Relative to a known root, both carry a suffix no supported family
+    // claims, so both are reported instead of being resolved to a family
+    // they resemble.
+    EXPECT_EQ(ModuleNameRejection::UnsupportedSuffix, result.rejected[0].reason);
+    EXPECT_EQ(ModuleNameRejection::UnsupportedSuffix, result.rejected[1].reason);
+}
+
+TEST(ModuleDiscovery, ignores_files_belonging_to_other_modules) {
+    TmpDir tmp("reone_test_discovery_other_modules");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+    touch(modules / "foobar.rim");
+    touch(modules / "other.rim");
+    touch(modules / "other_s.rim");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+
+    EXPECT_EQ((std::vector<std::string> {"foo.rim"}), discoveredNames(result));
+    EXPECT_TRUE(result.rejected.empty());
+}
+
+TEST(ModuleDiscovery, preserves_configured_root_order_and_provenance) {
+    TmpDir tmp("reone_test_discovery_roots_order");
+    auto base = tmp.path / "modules";
+    auto first = tmp.path / "root0";
+    auto second = tmp.path / "root1";
+    for (const auto &dir : {base, first, second}) {
+        std::filesystem::create_directories(dir);
+        touch(dir / "foo.mod");
+    }
+
+    auto result = discoverModuleSources(
+        "foo",
+        {root("base", base, ModulePrimaryOrigin::Modules),
+         root("root0", first, ModulePrimaryOrigin::ConfiguredModuleRoot, 0, 0),
+         root("root1", second, ModulePrimaryOrigin::ConfiguredModuleRoot, 0, 1)});
+
+    ASSERT_EQ(3, result.sources.size());
+    EXPECT_EQ("base", result.sources[0].candidate.rootId);
+    EXPECT_EQ(ModulePrimaryOrigin::Modules, result.sources[0].candidate.origin);
+    EXPECT_EQ(0u, result.sources[1].candidate.rootOrder);
+    EXPECT_EQ(1u, result.sources[2].candidate.rootOrder);
+    EXPECT_EQ(ModulePrimaryOrigin::ConfiguredModuleRoot, result.sources[2].candidate.origin);
+}
+
+TEST(ModuleDiscovery, carries_numbered_package_order) {
+    TmpDir tmp("reone_test_discovery_packages");
+    auto live2 = tmp.path / "live2";
+    std::filesystem::create_directories(live2);
+    touch(live2 / "foo.mod");
+
+    auto result = discoverModuleSources(
+        "foo", {root("live2", live2, ModulePrimaryOrigin::LivePackage, 2, 0)});
+
+    ASSERT_EQ(1, result.sources.size());
+    EXPECT_EQ(ModulePrimaryOrigin::LivePackage, result.sources[0].candidate.origin);
+    EXPECT_EQ(2u, result.sources[0].candidate.packageOrder);
+}
+
+TEST(ModuleDiscovery, output_does_not_depend_on_directory_creation_order) {
+    auto build = [](const std::filesystem::path &dir, bool reverse) {
+        std::filesystem::create_directories(dir);
+        std::vector<std::string> names {"foo.rim", "foo_a.rim", "foo_adx.rim", "foo_s.rim"};
+        if (reverse) std::reverse(names.begin(), names.end());
+        for (const auto &name : names) touch(dir / name);
+    };
+    TmpDir forwardDir("reone_test_discovery_order_forward");
+    TmpDir reverseDir("reone_test_discovery_order_reverse");
+    build(forwardDir.path / "modules", false);
+    build(reverseDir.path / "modules", true);
+
+    auto forward = discoverModuleSources("foo", {root("modules", forwardDir.path / "modules")});
+    auto reverse = discoverModuleSources("foo", {root("modules", reverseDir.path / "modules")});
+
+    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_a.rim", "foo_adx.rim", "foo_s.rim"}),
+              discoveredNames(forward));
+    EXPECT_EQ(discoveredNames(forward), discoveredNames(reverse));
+}
+
+TEST(ModuleDiscovery, rejects_the_request_without_scanning_roots) {
+    TmpDir tmp("reone_test_discovery_rejected_request");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo_s.rim");
+
+    auto result = discoverModuleSources("foo.txt", {root("modules", modules)});
+
+    EXPECT_EQ(ModuleNameRejection::UnsupportedExtension, result.nameRejection);
+    EXPECT_TRUE(result.moduleRoot.empty());
+    EXPECT_TRUE(result.sources.empty());
+    EXPECT_TRUE(result.rejected.empty());
+}
+
+TEST(ModuleDiscovery, skips_locations_that_do_not_exist) {
+    TmpDir tmp("reone_test_discovery_missing_root");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+
+    auto result = discoverModuleSources(
+        "foo", {root("absent", tmp.path / "absent"), root("modules", modules)});
+
+    ASSERT_EQ(1, result.sources.size());
+    EXPECT_EQ("modules", result.sources[0].candidate.rootId);
+}
+
+// 15.3 Save and package candidates
+
+TEST(ModuleDiscovery, treats_saved_image_and_saved_archive_as_distinct_families) {
+    TmpDir tmp("reone_test_discovery_saved");
+    auto save = tmp.path / "gameinprogress";
+    std::filesystem::create_directories(save);
+    touch(save / "foo.rsv");
+    touch(save / "foo.sav");
+
+    auto result = discoverModuleSources(
+        "foo", {root("save", save, ModulePrimaryOrigin::GameInProgress)});
+
+    EXPECT_EQ(ModuleArchiveFamily::SavedResourceImage, familyOf(result, "foo.rsv"));
+    EXPECT_EQ(ModuleArchiveFamily::SavedArchive, familyOf(result, "foo.sav"));
+    for (const auto &source : result.sources) {
+        EXPECT_EQ(ModulePrimaryOrigin::GameInProgress, source.candidate.origin);
+        EXPECT_TRUE(isActiveSavedState(source.candidate.family));
+        EXPECT_TRUE(isPrimaryEligible(source.candidate.family));
+    }
+}
+
+TEST(ModuleDiscovery, treats_a_packaged_module_as_its_own_primary_family) {
+    TmpDir tmp("reone_test_discovery_nwm");
+    auto nwm = tmp.path / "nwm";
+    std::filesystem::create_directories(nwm);
+    touch(nwm / "foo.nwm");
+
+    auto result = discoverModuleSources("foo", {root("nwm", nwm, ModulePrimaryOrigin::NwmFiles)});
+
+    ASSERT_EQ(1, result.sources.size());
+    EXPECT_EQ(ModuleArchiveFamily::Nwm, result.sources[0].candidate.family);
+    EXPECT_TRUE(isPrimaryEligible(ModuleArchiveFamily::Nwm));
+    EXPECT_FALSE(isActiveSavedState(ModuleArchiveFamily::Nwm));
+}
+
+TEST(ModuleDiscovery, does_not_look_inside_archives) {
+    // A container is a source, never a directory to walk into. Discovery reads
+    // directory entries only, so a saved archive contributes exactly itself.
+    TmpDir tmp("reone_test_discovery_no_recursion");
+    auto save = tmp.path / "save";
+    std::filesystem::create_directories(save);
+    writeErf(save / "foo.sav", ErfWriter::FileType::MOD,
+             {{"inner", ResType::Mod, "nested module blob"}});
+
+    auto result = discoverModuleSources("foo", {root("save", save, ModulePrimaryOrigin::GameInProgress)});
+
+    EXPECT_EQ((std::vector<std::string> {"foo.sav"}), discoveredNames(result));
+}
+
+TEST(ModuleDiscovery, leaves_internal_module_identity_unset) {
+    TmpDir tmp("reone_test_discovery_identity");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+
+    ASSERT_EQ(1, result.sources.size());
+    EXPECT_FALSE(result.sources[0].internalModuleId);
+    EXPECT_EQ("foo", result.sources[0].moduleRoot);
+    EXPECT_EQ(modules / "foo.rim", result.sources[0].path);
+}
+
+// Hand-off to the policy
+
+TEST(ModuleDiscovery, feeds_the_policy_with_a_consumable_inventory) {
+    TmpDir tmp("reone_test_discovery_policy");
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(modules);
+    touch(modules / "foo.rim");
+    touch(modules / "foo_s.rim");
+    touch(modules / "foo_a.rim");
+    touch(modules / "foo_adx.rim");
+    touch(modules / "foo_dlg.erf");
+
+    auto result = discoverModuleSources("foo", {root("modules", modules)});
+    auto inventory = plannerInventory(result);
+    ASSERT_EQ(result.sources.size(), inventory.size());
+
+    ModulePolicyRequest request;
+    request.game = GameID::TSL;
+    request.moduleName = result.moduleRoot;
+    auto plan = planModuleLoad(request, inventory);
+
+    ASSERT_TRUE(plan.primary);
+    EXPECT_EQ("modules:foo.rim", plan.primary->candidate.source.sourceId);
+    EXPECT_EQ(ModulePrimaryKind::Rim, plan.primary->candidate.kind);
+
+    std::vector<ModuleArchiveFamily> families;
+    for (const auto &family : plan.families) families.push_back(family.family);
+    EXPECT_EQ((std::vector<ModuleArchiveFamily> {ModuleArchiveFamily::AreaRim,
+                                                 ModuleArchiveFamily::AdxRim,
+                                                 ModuleArchiveFamily::StaticRim,
+                                                 ModuleArchiveFamily::Dialogue}),
+              families);
+}
+
+TEST(ModuleDiscovery, saved_candidates_reach_the_policy_gate) {
+    TmpDir tmp("reone_test_discovery_save_gate");
+    auto save = tmp.path / "save";
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(save);
+    std::filesystem::create_directories(modules);
+    touch(save / "foo.sav");
+    touch(modules / "foo.rim");
+
+    auto result = discoverModuleSources(
+        "foo",
+        {root("save", save, ModulePrimaryOrigin::GameInProgress), root("modules", modules)});
+    auto inventory = plannerInventory(result);
+
+    ModulePolicyRequest request;
+    request.game = GameID::TSL;
+    request.moduleName = result.moduleRoot;
+
+    request.includeInSave = true;
+    auto included = selectModulePrimary(request, inventory);
+    ASSERT_TRUE(included);
+    EXPECT_EQ("save:foo.sav", included->candidate.source.sourceId);
+
+    request.includeInSave = false;
+    auto excluded = selectModulePrimary(request, inventory);
+    ASSERT_TRUE(excluded);
+    EXPECT_EQ("modules:foo.rim", excluded->candidate.source.sourceId);
+}
+
+} // namespace

--- a/test/resource/modulediscovery.cpp
+++ b/test/resource/modulediscovery.cpp
@@ -409,7 +409,7 @@ TEST(ModuleDiscovery, does_not_look_inside_archives) {
     auto save = tmp.path / "save";
     std::filesystem::create_directories(save);
     writeErf(save / "foo.sav", ErfWriter::FileType::MOD,
-             {{"inner", ResType::Mod, "nested module blob"}});
+             {{"inner", ResType::Sav, "nested module blob"}});
 
     auto result = discoverModuleSources("foo", {root("save", save, ModulePrimaryOrigin::GameInProgress)});
 

--- a/test/resource/modulediscovery.cpp
+++ b/test/resource/modulediscovery.cpp
@@ -158,8 +158,8 @@ TEST(ModuleDiscovery, resolves_candidates_against_a_root_that_looks_like_a_sidec
     EXPECT_TRUE(result.rejected.empty());
     EXPECT_EQ(ModuleArchiveFamily::PrimaryRim, familyOf(result, "foo_s.rim"));
     EXPECT_EQ(ModuleArchiveFamily::StaticRim, familyOf(result, "foo_s_s.rim"));
-    EXPECT_EQ(ModuleArchiveFamily::AreaRim, familyOf(result, "foo_s_a.rim"));
-    EXPECT_EQ(ModuleArchiveFamily::AdxRim, familyOf(result, "foo_s_adx.rim"));
+    EXPECT_FALSE(familyOf(result, "foo_s_a.rim"));
+    EXPECT_FALSE(familyOf(result, "foo_s_adx.rim"));
 }
 
 TEST(ModuleDiscovery, resolves_the_same_files_differently_with_and_without_a_root) {
@@ -239,8 +239,8 @@ TEST(ModuleDiscovery, discovers_a_packed_module_with_its_adjuncts) {
     // Discovery reports everything present; suppressing _s and _dlg under a
     // module archive is the policy's decision, not discovery's.
     EXPECT_EQ(ModuleArchiveFamily::PrimaryMod, familyOf(result, "foo.mod"));
-    EXPECT_EQ(ModuleArchiveFamily::AreaRim, familyOf(result, "foo_a.rim"));
-    EXPECT_EQ(ModuleArchiveFamily::AdxRim, familyOf(result, "foo_adx.rim"));
+    EXPECT_FALSE(familyOf(result, "foo_a.rim"));
+    EXPECT_FALSE(familyOf(result, "foo_adx.rim"));
     EXPECT_EQ(ModuleArchiveFamily::StaticRim, familyOf(result, "foo_s.rim"));
     EXPECT_EQ(ModuleArchiveFamily::Dialogue, familyOf(result, "foo_dlg.erf"));
     EXPECT_TRUE(result.rejected.empty());
@@ -257,7 +257,7 @@ TEST(ModuleDiscovery, reports_an_unsupported_sidecar_rather_than_absorbing_it) {
 
     auto result = discoverModuleSources("foo", {root("modules", modules)});
 
-    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_adx.rim"}), discoveredNames(result));
+    EXPECT_EQ((std::vector<std::string> {"foo.rim"}), discoveredNames(result));
     EXPECT_EQ((std::vector<std::string> {"foo_adrx.rim", "foo_bar.erf"}), rejectedNames(result));
     ASSERT_EQ(2, result.rejected.size());
     // Relative to a known root, both carry a suffix no supported family
@@ -335,7 +335,7 @@ TEST(ModuleDiscovery, output_does_not_depend_on_directory_creation_order) {
     auto forward = discoverModuleSources("foo", {root("modules", forwardDir.path / "modules")});
     auto reverse = discoverModuleSources("foo", {root("modules", reverseDir.path / "modules")});
 
-    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_a.rim", "foo_adx.rim", "foo_s.rim"}),
+    EXPECT_EQ((std::vector<std::string> {"foo.rim", "foo_s.rim"}),
               discoveredNames(forward));
     EXPECT_EQ(discoveredNames(forward), discoveredNames(reverse));
 }
@@ -457,16 +457,42 @@ TEST(ModuleDiscovery, feeds_the_policy_with_a_consumable_inventory) {
 
     std::vector<ModuleArchiveFamily> families;
     for (const auto &family : plan.families) families.push_back(family.family);
-    EXPECT_EQ((std::vector<ModuleArchiveFamily> {ModuleArchiveFamily::AreaRim,
-                                                 ModuleArchiveFamily::AdxRim,
-                                                 ModuleArchiveFamily::StaticRim,
+    EXPECT_EQ((std::vector<ModuleArchiveFamily> {ModuleArchiveFamily::StaticRim,
                                                  ModuleArchiveFamily::Dialogue}),
               families);
 }
 
+TEST(ModuleDiscovery, constructs_only_exact_adjunct_names_from_rims) {
+    TmpDir tmp("reone_test_discovery_exact_rims");
+    auto rims = tmp.path / "RiMs";
+    auto modules = tmp.path / "modules";
+    std::filesystem::create_directories(rims);
+    std::filesystem::create_directories(modules);
+    touch(rims / "FoO_A.RiM");
+    touch(rims / "foo_adx.rim");
+    touch(rims / "bar_a.rim");
+    touch(rims / "foo_extra.rim");
+    std::filesystem::create_directories(rims / "nested");
+    touch(rims / "nested" / "foo_a.rim");
+    touch(modules / "foo_a.rim");
+
+    auto exact = discoverRimsModuleAdjuncts("FOO.MOD", tmp.path);
+    ASSERT_EQ(2u, exact.size());
+    EXPECT_EQ(ModuleArchiveFamily::AreaRim, exact[0].candidate.family);
+    EXPECT_EQ(ModuleArchiveFamily::AdxRim, exact[1].candidate.family);
+    EXPECT_EQ("rims:foo_a.rim", exact[0].candidate.sourceId);
+    EXPECT_EQ("rims:foo_adx.rim", exact[1].candidate.sourceId);
+    EXPECT_EQ(rims / "FoO_A.RiM", exact[0].path);
+    EXPECT_EQ(rims / "foo_adx.rim", exact[1].path);
+
+    auto generic = discoverModuleSources("foo", {root("modules", modules)});
+    EXPECT_TRUE(generic.sources.empty());
+}
 TEST(ModuleDiscovery, saved_candidates_reach_the_policy_gate) {
     TmpDir tmp("reone_test_discovery_save_gate");
     auto save = tmp.path / "save";
+
+
     auto modules = tmp.path / "modules";
     std::filesystem::create_directories(save);
     std::filesystem::create_directories(modules);

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -699,9 +699,11 @@ TEST_P(K2ModuleLoadingTest, admits_a_later_loose_directory_mounted_by_another_ca
     EXPECT_EQ("late folder", find("shared")) << "the source added last wins inside its own bucket";
 }
 
-TEST(ResourceDirectorActivation, activates_only_the_game_whose_precedence_is_established) {
+TEST(ResourceDirectorActivation, places_both_games_in_the_raw_lookup_order) {
+    // Both games are activated. K1's own startup and module registration are
+    // now evidenced, so neither game keeps the insertion-ordered stack.
     EXPECT_TRUE(usesBucketedLookup(GameID::TSL));
-    EXPECT_FALSE(usesBucketedLookup(GameID::KotOR));
+    EXPECT_TRUE(usesBucketedLookup(GameID::KotOR));
 }
 
 INSTANTIATE_TEST_SUITE_P(Backends,

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -851,6 +851,66 @@ TEST_P(K2ModuleLoadingTest, preserves_the_game_specific_modules_versus_live_prim
     }
 }
 
+TEST_P(K2ModuleLoadingTest, activates_the_default_nwm_root_directly_for_both_games) {
+    for (auto gameId : {GameID::KotOR, GameID::TSL}) {
+        _resources->clear();
+        _auxResources->clear();
+        TmpDir game(gameId == GameID::KotOR ? "reone_test_k1_nwm" : "reone_test_k2_nwm");
+        TmpDir cwd(gameId == GameID::KotOR ? "reone_test_k1_nwm_cwd" : "reone_test_k2_nwm_cwd");
+        makeInstallation(game, cwd);
+        writeErf(game.mkdir("nwm") / "foo.nwm", ErfWriter::FileType::MOD,
+                 {{"nwm_only", ResType::Txt, "nwm"}});
+        auto director = makeDirector(game.path, {}, gameId);
+        { CwdGuard guard(cwd.path); director->init(); }
+        director->onModuleLoad("foo");
+        EXPECT_EQ("nwm", find("nwm_only"));
+        _resources->clearOwner(ResourceOwner::ActiveModuleState);
+        EXPECT_FALSE(has("nwm_only")) << "NWM must use the active-state owner";
+        auto runtimeNames = director->moduleNames();
+        auto toolingNames = extract::Installation(gameId, game.path).moduleNames();
+        EXPECT_THAT(toolingNames, testing::UnorderedElementsAreArray(runtimeNames));
+        EXPECT_THAT(toolingNames, testing::Contains("foo"));
+    }
+}
+
+TEST_P(K2ModuleLoadingTest, nwm_precedes_every_unsaved_disk_primary) {
+    for (auto gameId : {GameID::KotOR, GameID::TSL}) {
+        _resources->clear();
+        _auxResources->clear();
+        TmpDir game(gameId == GameID::KotOR ? "reone_test_k1_nwm_order" : "reone_test_k2_nwm_order");
+        TmpDir cwd(gameId == GameID::KotOR ? "reone_test_k1_nwm_order_cwd" : "reone_test_k2_nwm_order_cwd");
+        TmpDir live(gameId == GameID::KotOR ? "reone_test_k1_nwm_live" : "reone_test_k2_nwm_live");
+        makeInstallation(game, cwd);
+        writeErf(game.mkdir("nwm") / "foo.nwm", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "nwm"}});
+        writeErf(game.path / "modules" / "foo.mod", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "ordinary"}});
+        writeErf(live.mkdir("MODULES") / "foo.mod", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "live"}});
+        OdysseyResourceRoots roots;
+        roots.livePackages[0] = live.path;
+        auto director = makeDirector(game.path, roots, gameId);
+        { CwdGuard guard(cwd.path); director->init(); }
+        director->onModuleLoad("foo");
+        EXPECT_EQ("nwm", find("primary"));
+    }
+}
+
+TEST_P(K2ModuleLoadingTest, nwm_sidecars_without_a_nwm_primary_do_not_activate) {
+    TmpDir game("reone_test_nwm_no_primary");
+    TmpDir cwd("reone_test_nwm_no_primary_cwd");
+    makeInstallation(game, cwd);
+    auto nwm = game.mkdir("nwm");
+    writeErf(nwm / "foo_loc.mod", ErfWriter::FileType::MOD,
+             {{"sidecar", ResType::Txt, "localization"}});
+    writeRim(nwm / "foo_s.rim", {{"static_sidecar", ResType::Txt, "static"}});
+    auto director = makeDirector(game.path);
+    { CwdGuard guard(cwd.path); director->init(); }
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_FALSE(has("sidecar"));
+    EXPECT_FALSE(has("static_sidecar"));
+}
+
 TEST_P(K2ModuleLoadingTest, configured_module_families_follow_the_established_true_false_order) {
     TmpDir game("reone_test_configured_modules");
     TmpDir cwd("reone_test_configured_modules_cwd");
@@ -921,8 +981,9 @@ TEST(OdysseyResourceRoots, tooling_and_runtime_expand_the_same_bound_module_loca
     std::filesystem::create_directories(game.path / "modules");
     writeErf(live.mkdir("MODULES") / "liveonly.mod", ErfWriter::FileType::MOD, {});
     writeErf(configured.mkdir("modules") / "configuredonly.mod", ErfWriter::FileType::MOD, {});
+    writeErf(game.mkdir("nwm") / "nwmonly.nwm", ErfWriter::FileType::MOD, {});
 
-    OdysseyResourceRoots roots;
+    OdysseyResourceRoots roots = defaultOdysseyResourceRoots(game.path);
     roots.livePackages[0] = live.path;
     roots.k2OverrideRoots = {configured.path};
     auto runtimeRoots = primaryModuleSearchRoots(GameID::TSL, game.path, roots);
@@ -930,7 +991,7 @@ TEST(OdysseyResourceRoots, tooling_and_runtime_expand_the_same_bound_module_loca
     auto toolingNames = extract::Installation(GameID::TSL, game.path, roots).moduleNames();
 
     EXPECT_EQ(runtimeNames, toolingNames);
-    EXPECT_THAT(toolingNames, testing::ElementsAre("configuredonly", "liveonly"));
+    EXPECT_THAT(toolingNames, testing::ElementsAre("configuredonly", "liveonly", "nwmonly"));
 }
 
 TEST(OdysseyResourceRoots, keeps_unbound_live_slots_absent_and_deduplicates_lips_by_identity) {

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -283,10 +283,11 @@ TEST_P(K2ModuleLoadingTest, prefers_the_adx_image_then_the_area_image_over_the_m
     writeErf(modules / "foo.mod", ErfWriter::FileType::MOD,
              {{"shared", ResType::Txt, "mod"},
               {"a_vs_mod", ResType::Txt, "mod"}});
-    writeRim(modules / "foo_a.rim",
+    auto rims = game.mkdir("rims");
+    writeRim(rims / "foo_a.rim",
              {{"shared", ResType::Txt, "area image"},
               {"a_vs_mod", ResType::Txt, "area image"}});
-    writeRim(modules / "foo_adx.rim", {{"shared", ResType::Txt, "adx image"}});
+    writeRim(rims / "foo_adx.rim", {{"shared", ResType::Txt, "adx image"}});
 
     auto director = makeDirector(game.path);
     {
@@ -516,8 +517,6 @@ TEST_P(K2ModuleLoadingTest, never_reports_a_sidecar_as_a_module) {
     auto modules = game.path / "modules";
     writeRim(modules / "foo.rim", {});
     writeRim(modules / "foo_s.rim", {});
-    writeRim(modules / "foo_a.rim", {});
-    writeRim(modules / "foo_adx.rim", {});
     writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF, {});
     writeErf(modules / "bar.mod", ErfWriter::FileType::MOD, {});
 
@@ -549,8 +548,9 @@ TEST_P(K2ModuleLoadingTest, agrees_with_the_installation_indexer_on_module_archi
     auto modules = game.path / "modules";
     writeRim(modules / "foo.rim", {{"from_rim", ResType::Txt, "rim"}});
     writeRim(modules / "foo_s.rim", {{"from_static", ResType::Txt, "static"}});
-    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
-    writeRim(modules / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
+    auto rims = game.mkdir("rims");
+    writeRim(rims / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(rims / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
     writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF, {{"from_dlg", ResType::Txt, "dlg"}});
     auto lips = game.mkdir("lips");
     writeErf(lips / "foo_loc.mod", ErfWriter::FileType::MOD, {{"from_loc", ResType::Txt, "loc"}});
@@ -909,6 +909,84 @@ TEST_P(K2ModuleLoadingTest, nwm_sidecars_without_a_nwm_primary_do_not_activate) 
     EXPECT_NO_THROW(director->onModuleLoad("foo"));
     EXPECT_FALSE(has("sidecar"));
     EXPECT_FALSE(has("static_sidecar"));
+}
+
+TEST_P(K2ModuleLoadingTest, module_and_nwm_roots_cannot_supply_rims_adjuncts) {
+    {
+        TmpDir game("reone_test_adjunct_modules_negative");
+        TmpDir cwd("reone_test_adjunct_modules_negative_cwd");
+        makeInstallation(game, cwd);
+        auto modules = game.path / "modules";
+        writeErf(modules / "foo.mod", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "modules"}});
+        writeRim(modules / "foo_a.rim", {{"stray_area", ResType::Txt, "modules"}});
+        writeRim(modules / "foo_adx.rim", {{"stray_adx", ResType::Txt, "modules"}});
+        auto director = makeDirector(game.path);
+        { CwdGuard guard(cwd.path); director->init(); }
+        director->onModuleLoad("foo");
+        EXPECT_EQ("modules", find("primary"));
+        EXPECT_FALSE(has("stray_area"));
+        EXPECT_FALSE(has("stray_adx"));
+    }
+
+    _resources->clear();
+    _auxResources->clear();
+    {
+        TmpDir game("reone_test_adjunct_nwm_negative");
+        TmpDir cwd("reone_test_adjunct_nwm_negative_cwd");
+        makeInstallation(game, cwd);
+        auto nwm = game.mkdir("nwm");
+        writeErf(nwm / "foo.nwm", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "nwm"}});
+        writeRim(nwm / "foo_a.rim", {{"stray_area", ResType::Txt, "nwm"}});
+        writeRim(nwm / "foo_adx.rim", {{"stray_adx", ResType::Txt, "nwm"}});
+        auto director = makeDirector(game.path);
+        { CwdGuard guard(cwd.path); director->init(); }
+        director->onModuleLoad("foo");
+        EXPECT_EQ("nwm", find("primary"));
+        EXPECT_FALSE(has("stray_area"));
+        EXPECT_FALSE(has("stray_adx"));
+    }
+}
+
+TEST_P(K2ModuleLoadingTest, live_module_roots_cannot_supply_rims_adjuncts) {
+    TmpDir game("reone_test_adjunct_live_negative");
+    TmpDir cwd("reone_test_adjunct_live_negative_cwd");
+    TmpDir live("reone_test_adjunct_live_root");
+    makeInstallation(game, cwd);
+    auto modules = live.mkdir("MODULES");
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD,
+             {{"primary", ResType::Txt, "live"}});
+    writeRim(modules / "foo_a.rim", {{"stray_area", ResType::Txt, "live"}});
+    writeRim(modules / "foo_adx.rim", {{"stray_adx", ResType::Txt, "live"}});
+    OdysseyResourceRoots roots;
+    roots.livePackages[0] = live.path;
+    auto director = makeDirector(game.path, roots);
+    { CwdGuard guard(cwd.path); director->init(); }
+    director->onModuleLoad("foo");
+    EXPECT_EQ("live", find("primary"));
+    EXPECT_FALSE(has("stray_area"));
+    EXPECT_FALSE(has("stray_adx"));
+}
+
+TEST_P(K2ModuleLoadingTest, configured_module_roots_cannot_supply_rims_adjuncts) {
+    TmpDir game("reone_test_adjunct_configured_negative");
+    TmpDir cwd("reone_test_adjunct_configured_negative_cwd");
+    TmpDir configured("reone_test_adjunct_configured_root");
+    makeInstallation(game, cwd);
+    writeRim(game.path / "modules" / "foo.rim",
+             {{"primary", ResType::Txt, "base"}});
+    auto modules = configured.mkdir("modules");
+    writeRim(modules / "foo_a.rim", {{"stray_area", ResType::Txt, "configured"}});
+    writeRim(modules / "foo_adx.rim", {{"stray_adx", ResType::Txt, "configured"}});
+    OdysseyResourceRoots roots;
+    roots.k2OverrideRoots = {configured.path};
+    auto director = makeDirector(game.path, roots);
+    { CwdGuard guard(cwd.path); director->init(); }
+    director->onModuleLoad("foo");
+    EXPECT_EQ("base", find("primary"));
+    EXPECT_FALSE(has("stray_area"));
+    EXPECT_FALSE(has("stray_adx"));
 }
 
 TEST_P(K2ModuleLoadingTest, configured_module_families_follow_the_established_true_false_order) {

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -40,6 +40,7 @@
 #include "reone/system/stream/fileoutput.h"
 #include "reone/system/stream/memoryoutput.h"
 
+#include "../fixtures/archive.h"
 #include "../fixtures/graphics.h"
 #include "../fixtures/resource.h"
 #include "../fixtures/script.h"
@@ -194,9 +195,12 @@ protected:
         game.mkdir("modules");
     }
 
-    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+    std::unique_ptr<ResourceDirector> makeDirector(
+        const std::filesystem::path &gamePath,
+        OdysseyResourceRoots roots = {},
+        GameID game = GameID::TSL) {
         return std::make_unique<ResourceDirector>(
-            GameID::TSL,
+            game,
             gamePath,
             _graphicsOpt,
             _graphics.services(),
@@ -208,7 +212,8 @@ protected:
             *_resources,
             *_auxResources,
             _scripts,
-            _twoDas);
+            _twoDas,
+            std::move(roots));
     }
 
     std::string find(const std::string &resRef, ResType type = ResType::Txt) {
@@ -697,6 +702,261 @@ TEST_P(K2ModuleLoadingTest, admits_a_later_loose_directory_mounted_by_another_ca
     ASSERT_NO_THROW(_resources->addFolder(loose, ResourceOwner::Global, bucket));
 
     EXPECT_EQ("late folder", find("shared")) << "the source added last wins inside its own bucket";
+}
+
+TEST_P(K2ModuleLoadingTest, mounts_bound_live_packages_in_fixed_global_order) {
+    TmpDir game("reone_test_live_global");
+    TmpDir cwd("reone_test_live_global_cwd");
+    TmpDir live1("reone_test_live_global_1");
+    TmpDir live2("reone_test_live_global_2");
+    makeInstallation(game, cwd);
+
+    reone::test::writeKeyBif(live1.path, "data/live1.bif",
+                             {{"key_shared", ResType::Txt, "live1 key"}});
+    std::filesystem::rename(live1.path / "chitin.key", live1.path / "live1.key");
+    reone::test::writeKeyBif(live2.path, "data/live2.bif",
+                             {{"key_shared", ResType::Txt, "live2 key"}});
+    std::filesystem::rename(live2.path / "chitin.key", live2.path / "live2.key");
+
+    auto rims1 = live1.mkdir("RIMSXBOX");
+    auto rims2 = live2.mkdir("RIMSXBOX");
+    // A malformed member is independent: the later MOD and DX image still mount.
+    writeFile(rims1 / "live1.rim", "broken");
+    writeRim(rims1 / "live1dx.rim",
+             {{"image_shared", ResType::Txt, "live1 dx"},
+              {"after_broken", ResType::Txt, "live1 dx"}});
+    writeRim(rims2 / "live2.rim", {{"image_shared", ResType::Txt, "live2 base"}});
+    writeRim(rims2 / "live2dx.rim", {{"image_shared", ResType::Txt, "live2 dx"}});
+
+    writeErf(live1.path / "live1.mod", ErfWriter::FileType::MOD,
+             {{"class2_shared", ResType::Txt, "live1 mod"},
+              {"after_broken_mod", ResType::Txt, "live1 mod"}});
+    writeErf(live2.path / "live2.mod", ErfWriter::FileType::MOD,
+             {{"class2_shared", ResType::Txt, "live2 mod"}});
+
+    auto override1 = live1.mkdir("OVERRIDE");
+    auto override2 = live2.mkdir("OVERRIDE");
+    writeErf(override1 / "textures.erf", ErfWriter::FileType::ERF,
+             {{"class1_shared", ResType::Txt, "live1 textures"}});
+    writeErf(override2 / "textures.mod", ErfWriter::FileType::MOD,
+             {{"class1_shared", ResType::Txt, "live2 textures"}});
+    writeErf(live2.path / "unlisted.erf", ErfWriter::FileType::ERF,
+             {{"unlisted", ResType::Txt, "must stay absent"}});
+    auto implicit = game.mkdir("LIVE3");
+    writeErf(implicit / "live3.mod", ErfWriter::FileType::MOD,
+             {{"implicit_live", ResType::Txt, "must stay absent"}});
+
+    OdysseyResourceRoots roots;
+    roots.livePackages[0] = live1.path;
+    roots.livePackages[1] = live2.path;
+    auto director = makeDirector(game.path, roots);
+    {
+        CwdGuard guard(cwd.path);
+        ASSERT_NO_THROW(director->init());
+    }
+
+    EXPECT_EQ("live2 key", find("key_shared"));
+    EXPECT_EQ("live2 dx", find("image_shared"));
+    EXPECT_EQ("live2 mod", find("class2_shared"));
+    EXPECT_EQ("live2 textures", find("class1_shared"));
+    EXPECT_EQ("live1 dx", find("after_broken"));
+    EXPECT_EQ("live1 mod", find("after_broken_mod"));
+    EXPECT_FALSE(has("unlisted"));
+    EXPECT_FALSE(has("implicit_live"));
+}
+
+TEST_P(K2ModuleLoadingTest, configured_k2_override_roots_mount_in_natural_order) {
+    TmpDir game("reone_test_configured_override");
+    TmpDir cwd("reone_test_configured_override_cwd");
+    TmpDir localized("reone_test_configured_override_localized");
+    TmpDir subscribed("reone_test_configured_override_subscribed");
+    makeInstallation(game, cwd);
+
+    auto base = game.mkdir("override");
+    auto first = localized.mkdir("override");
+    auto second = subscribed.mkdir("override");
+    writeFile(base / "shared.txt", "base");
+    writeFile(first / "shared.txt", "localized");
+    writeFile(second / "shared.txt", "subscribed");
+
+    OdysseyResourceRoots roots;
+    roots.k2OverrideRoots = {localized.path, subscribed.path};
+    auto director = makeDirector(game.path, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_EQ("subscribed", find("shared"));
+
+    extract::Installation tooling(GameID::TSL, game.path, roots);
+    auto location = tooling.resource(
+        ResourceId("shared", ResType::Txt), extract::SearchScope {extract::SearchLocation::Override});
+    ASSERT_TRUE(location.has_value());
+    auto data = location->readData();
+    EXPECT_EQ("subscribed", std::string(data.begin(), data.end()));
+}
+
+TEST_P(K2ModuleLoadingTest, live_primary_selection_uses_package_order_not_global_recency) {
+    TmpDir game("reone_test_live_primary");
+    TmpDir cwd("reone_test_live_primary_cwd");
+    TmpDir live1("reone_test_live_primary_1");
+    TmpDir live2("reone_test_live_primary_2");
+    makeInstallation(game, cwd);
+
+    writeErf(live1.mkdir("MODULES") / "foo.mod", ErfWriter::FileType::MOD,
+             {{"primary", ResType::Txt, "live1"}});
+    writeErf(live2.mkdir("MODULES") / "foo.mod", ErfWriter::FileType::MOD,
+             {{"primary", ResType::Txt, "live2"}});
+
+    OdysseyResourceRoots roots;
+    roots.livePackages[0] = live1.path;
+    roots.livePackages[1] = live2.path;
+    auto director = makeDirector(game.path, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("live1", find("primary"));
+}
+
+TEST_P(K2ModuleLoadingTest, preserves_the_game_specific_modules_versus_live_primary_order) {
+    for (auto gameId : {GameID::KotOR, GameID::TSL}) {
+        _resources->clear();
+        _auxResources->clear();
+        TmpDir game(gameId == GameID::KotOR ? "reone_test_k1_live_primary"
+                                            : "reone_test_k2_live_primary");
+        TmpDir cwd(gameId == GameID::KotOR ? "reone_test_k1_live_primary_cwd"
+                                          : "reone_test_k2_live_primary_cwd");
+        TmpDir live(gameId == GameID::KotOR ? "reone_test_k1_live_root"
+                                            : "reone_test_k2_live_root");
+        makeInstallation(game, cwd);
+        writeErf(game.path / "modules" / "foo.mod", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "ordinary"}});
+        writeErf(live.mkdir("MODULES") / "foo.mod", ErfWriter::FileType::MOD,
+                 {{"primary", ResType::Txt, "live"}});
+
+        OdysseyResourceRoots roots;
+        roots.livePackages[0] = live.path;
+        auto director = makeDirector(game.path, roots, gameId);
+        {
+            CwdGuard guard(cwd.path);
+            director->init();
+        }
+        director->onModuleLoad("foo");
+
+        EXPECT_EQ(gameId == GameID::KotOR ? "ordinary" : "live", find("primary"));
+    }
+}
+
+TEST_P(K2ModuleLoadingTest, configured_module_families_follow_the_established_true_false_order) {
+    TmpDir game("reone_test_configured_modules");
+    TmpDir cwd("reone_test_configured_modules_cwd");
+    TmpDir localized("reone_test_configured_modules_localized");
+    TmpDir subscribed("reone_test_configured_modules_subscribed");
+    makeInstallation(game, cwd);
+
+    auto base = game.path / "modules";
+    auto first = localized.mkdir("modules");
+    auto second = subscribed.mkdir("modules");
+    writeRim(base / "foo.rim", {{"primary", ResType::Txt, "base rim"}});
+    writeRim(first / "foo_s.rim", {{"static", ResType::Txt, "localized static"}});
+    writeRim(second / "foo_s.rim", {{"static", ResType::Txt, "subscribed static"}});
+    writeErf(base / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"dialogue", ResType::Txt, "base dialogue"}});
+    writeErf(first / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"dialogue", ResType::Txt, "localized dialogue"}});
+    writeErf(second / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"dialogue", ResType::Txt, "subscribed dialogue"}});
+    writeErf(base / "bar.mod", ErfWriter::FileType::MOD,
+             {{"base_mod", ResType::Txt, "base"},
+              {"mod_collision", ResType::Txt, "base"}});
+    writeErf(first / "bar.mod", ErfWriter::FileType::MOD,
+             {{"localized_mod", ResType::Txt, "localized"},
+              {"mod_collision", ResType::Txt, "localized"}});
+    writeErf(second / "bar.mod", ErfWriter::FileType::MOD,
+             {{"subscribed_mod", ResType::Txt, "subscribed"},
+              {"mod_collision", ResType::Txt, "subscribed"}});
+    auto baseLips = game.mkdir("lips");
+    auto firstLips = localized.mkdir("lips");
+    auto secondLips = subscribed.mkdir("lips");
+    writeErf(baseLips / "baz_loc.mod", ErfWriter::FileType::MOD,
+             {{"base_lips", ResType::Txt, "base"}});
+    writeErf(firstLips / "baz_loc.mod", ErfWriter::FileType::MOD,
+             {{"localized_lips", ResType::Txt, "localized"}});
+    writeErf(secondLips / "baz_loc.mod", ErfWriter::FileType::MOD,
+             {{"subscribed_lips", ResType::Txt, "subscribed"}});
+    writeRim(base / "baz.rim", {{"baz_primary", ResType::Txt, "base"}});
+
+    OdysseyResourceRoots roots;
+    roots.k2OverrideRoots = {localized.path, subscribed.path};
+    auto director = makeDirector(game.path, roots);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("localized static", find("static"));
+    EXPECT_EQ("subscribed dialogue", find("dialogue"));
+
+    director->onModuleLoad("bar");
+    EXPECT_EQ("base", find("base_mod"));
+    EXPECT_EQ("localized", find("localized_mod"));
+    EXPECT_EQ("subscribed", find("subscribed_mod"));
+    EXPECT_EQ("subscribed", find("mod_collision"));
+
+    director->onModuleLoad("baz");
+    EXPECT_EQ("base", find("base_lips"));
+    EXPECT_EQ("localized", find("localized_lips"));
+    EXPECT_EQ("subscribed", find("subscribed_lips"));
+}
+
+TEST(OdysseyResourceRoots, tooling_and_runtime_expand_the_same_bound_module_locations) {
+    TmpDir game("reone_test_roots_tooling");
+    TmpDir live("reone_test_roots_tooling_live");
+    TmpDir configured("reone_test_roots_tooling_configured");
+    std::filesystem::create_directories(game.path / "modules");
+    writeErf(live.mkdir("MODULES") / "liveonly.mod", ErfWriter::FileType::MOD, {});
+    writeErf(configured.mkdir("modules") / "configuredonly.mod", ErfWriter::FileType::MOD, {});
+
+    OdysseyResourceRoots roots;
+    roots.livePackages[0] = live.path;
+    roots.k2OverrideRoots = {configured.path};
+    auto runtimeRoots = primaryModuleSearchRoots(GameID::TSL, game.path, roots);
+    auto runtimeNames = discoverModuleRoots(runtimeRoots);
+    auto toolingNames = extract::Installation(GameID::TSL, game.path, roots).moduleNames();
+
+    EXPECT_EQ(runtimeNames, toolingNames);
+    EXPECT_THAT(toolingNames, testing::ElementsAre("configuredonly", "liveonly"));
+}
+
+TEST(OdysseyResourceRoots, keeps_unbound_live_slots_absent_and_deduplicates_lips_by_identity) {
+    TmpDir game("reone_test_roots_absent");
+    TmpDir configured("reone_test_roots_dedup");
+    std::filesystem::create_directories(game.path / "modules");
+    auto lips = configured.mkdir("lips");
+
+    OdysseyResourceRoots roots;
+    roots.livePackages[1] = std::nullopt;
+    roots.k2OverrideRoots = {configured.path, configured.path};
+
+    auto primary = primaryModuleSearchRoots(GameID::TSL, game.path, roots);
+    auto support = lipsRoots(GameID::TSL, game.path, roots);
+    auto moduleRoots = moduleSearchRoots(GameID::TSL, game.path, roots);
+
+    ASSERT_EQ(1, primary.size());
+    EXPECT_EQ(ModulePrimaryOrigin::Modules, primary[0].origin);
+    ASSERT_EQ(1, support.size());
+    EXPECT_EQ(lips.lexically_normal(), support[0].lexically_normal());
+    ASSERT_EQ(2, moduleRoots.size());
+    EXPECT_EQ(ModulePrimaryOrigin::ConfiguredModuleRoot, moduleRoots[1].origin);
+    EXPECT_EQ(0, moduleRoots[1].rootOrder);
+    EXPECT_TRUE(defaultOdysseyResourceRoots(game.path).nwmFiles.has_value());
+    EXPECT_EQ((game.path / "nwm").lexically_normal(),
+              defaultOdysseyResourceRoots(game.path).nwmFiles->lexically_normal());
 }
 
 TEST(ResourceDirectorActivation, places_both_games_in_the_raw_lookup_order) {

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -29,6 +29,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "reone/extract/installation.h"
 #include "reone/graphics/options.h"
 #include "reone/resource/director.h"
 #include "reone/resource/exception/notfound.h"
@@ -525,6 +526,59 @@ TEST_P(K2ModuleLoadingTest, never_reports_a_sidecar_as_a_module) {
     auto director = makeDirector(game.path);
 
     EXPECT_EQ((std::set<std::string> {"bar", "foo"}), director->moduleNames());
+
+    // The installation indexer answers the same question over the same
+    // inventory, and must answer it identically.
+    auto tooling = extract::Installation(GameID::TSL, game.path).moduleNames();
+    EXPECT_EQ(director->moduleNames(), (std::set<std::string> {tooling.begin(), tooling.end()}));
+}
+
+/// The runtime mounts what the policy plans; the indexer reports everything
+/// that exists. Both must agree on which files belong to the module and on
+/// what each one is, which is the only part the two share.
+TEST_P(K2ModuleLoadingTest, agrees_with_the_installation_indexer_on_module_archives) {
+    TmpDir game("reone_test_k2_indexer");
+    TmpDir cwd("reone_test_k2_indexer_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"from_rim", ResType::Txt, "rim"}});
+    writeRim(modules / "foo_s.rim", {{"from_static", ResType::Txt, "static"}});
+    writeRim(modules / "foo_a.rim", {{"from_area", ResType::Txt, "area"}});
+    writeRim(modules / "foo_adx.rim", {{"from_adx", ResType::Txt, "adx"}});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF, {{"from_dlg", ResType::Txt, "dlg"}});
+    auto lips = game.mkdir("lips");
+    writeErf(lips / "foo_loc.mod", ErfWriter::FileType::MOD, {{"from_loc", ResType::Txt, "loc"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    extract::Installation installation(GameID::TSL, game.path);
+    installation.setModuleRoot("foo");
+
+    std::map<std::string, ModuleArchiveFamily> indexed;
+    for (const auto &archive : installation.moduleArchives()) {
+        indexed.emplace(boost::to_lower_copy(archive.path.filename().string()), archive.family);
+    }
+    EXPECT_EQ((std::map<std::string, ModuleArchiveFamily> {
+                  {"foo.rim", ModuleArchiveFamily::PrimaryRim},
+                  {"foo_a.rim", ModuleArchiveFamily::AreaRim},
+                  {"foo_adx.rim", ModuleArchiveFamily::AdxRim},
+                  {"foo_dlg.erf", ModuleArchiveFamily::Dialogue},
+                  {"foo_loc.mod", ModuleArchiveFamily::Localization},
+                  {"foo_s.rim", ModuleArchiveFamily::StaticRim},
+              }),
+              indexed);
+
+    // Every archive the indexer resolved really is reachable through the
+    // module the runtime just loaded.
+    for (const auto &resRef : {"from_rim", "from_static", "from_area", "from_adx", "from_dlg", "from_loc"}) {
+        EXPECT_TRUE(has(resRef)) << resRef;
+    }
 }
 
 // Transitions.

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -694,7 +694,7 @@ TEST_P(K2ModuleLoadingTest, admits_a_later_loose_directory_mounted_by_another_ca
     if (usesBucketedLookup(GameID::TSL)) {
         bucket = ResourceSourceBucket::LooseDirectory;
     }
-    ASSERT_NO_THROW(_resources->addFolder(loose, ContainerKind::Global, bucket));
+    ASSERT_NO_THROW(_resources->addFolder(loose, ResourceOwner::Global, bucket));
 
     EXPECT_EQ("late folder", find("shared")) << "the source added last wins inside its own bucket";
 }

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -23,12 +23,17 @@
  * from its bucket and not from when it was mounted. Both backends must agree.
  *
  * The K1 characterization suites in lookup.cpp and extractresources.cpp
- * continue to describe the unactivated path, which this does not change.
+ * continue to describe the shared activated path, which this does not change.
  */
 
+#include "reone/audio/di/module.h"
+#include "reone/audio/options.h"
+#include "reone/graphics/di/module.h"
+#include "reone/script/di/module.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "reone/resource/di/module.h"
 #include "reone/extract/installation.h"
 #include "reone/graphics/options.h"
 #include "reone/resource/director.h"
@@ -448,7 +453,7 @@ TEST_P(K2ModuleLoadingTest, resolves_the_save_folder_above_the_outer_save_archiv
     director->onGameLoad("000001");
 
     // The save folder is a loose directory and the outer archive is not. This
-    // reverses the unactivated order, where whichever was mounted last won.
+    // reverses the former insertion order, where whichever was mounted last won.
     EXPECT_EQ("save folder", find("loose"));
     EXPECT_EQ("save archive", find("archive_only"))
         << "the outer archive must still supply what nothing else holds";
@@ -1096,6 +1101,52 @@ TEST(OdysseyResourceRoots, keeps_unbound_live_slots_absent_and_deduplicates_lips
     EXPECT_TRUE(defaultOdysseyResourceRoots(game.path).nwmFiles.has_value());
     EXPECT_EQ((game.path / "nwm").lexically_normal(),
               defaultOdysseyResourceRoots(game.path).nwmFiles->lexically_normal());
+}
+
+TEST(OdysseyResourceRoots, resource_module_refreshes_only_a_derived_nwm_root) {
+    TmpDir newGame("reone_test_roots_set_game_path_new");
+    TmpDir custom("reone_test_roots_set_game_path_custom");
+    TmpDir cwd("reone_test_roots_set_game_path_cwd");
+    std::filesystem::create_directories(newGame.path / "nwm");
+    std::filesystem::create_directories(custom.path);
+    std::filesystem::create_directories(cwd.path / "nwm");
+    writeErf(newGame.path / "nwm" / "newonly.nwm", ErfWriter::FileType::MOD, {});
+    writeErf(custom.path / "customonly.nwm", ErfWriter::FileType::MOD, {});
+    writeErf(cwd.path / "nwm" / "cwdonly.nwm", ErfWriter::FileType::MOD, {});
+    graphics::GraphicsOptions graphicsOpt;
+    audio::AudioOptions audioOpt;
+    graphics::GraphicsModule graphics(graphicsOpt);
+    audio::AudioModule audio(audioOpt);
+    script::ScriptModule script;
+    ResourceModule derived(
+        GameID::TSL, {}, graphicsOpt, audioOpt, graphics, audio, script);
+    ASSERT_EQ(std::filesystem::path("nwm"), *derived.odysseyRoots().nwmFiles);
+    derived.setGamePath(newGame.path);
+    EXPECT_EQ((newGame.path / "nwm").lexically_normal(),
+              derived.odysseyRoots().nwmFiles->lexically_normal());
+    {
+        CwdGuard guard(cwd.path);
+        auto runtime = discoverModuleRoots(
+            primaryModuleSearchRoots(GameID::TSL, newGame.path, derived.odysseyRoots()));
+        auto tooling = extract::Installation(
+            GameID::TSL, newGame.path, derived.odysseyRoots()).moduleNames();
+        EXPECT_EQ((std::vector<std::string> {"newonly"}), runtime);
+        EXPECT_THAT(tooling, testing::ElementsAre("newonly"));
+    }
+    OdysseyResourceRoots explicitRoots;
+    explicitRoots.nwmFiles = custom.path;
+    ResourceModule explicitModule(GameID::TSL,
+                                  {},
+                                  graphicsOpt,
+                                  audioOpt,
+                                  graphics,
+                                  audio,
+                                  script,
+                                  ResourcesBackend::Legacy,
+                                  explicitRoots);
+    explicitModule.setGamePath(newGame.path);
+    EXPECT_EQ(custom.path.lexically_normal(),
+              explicitModule.odysseyRoots().nwmFiles->lexically_normal());
 }
 
 TEST(ResourceDirectorActivation, places_both_games_in_the_raw_lookup_order) {

--- a/test/resource/moduleloading.cpp
+++ b/test/resource/moduleloading.cpp
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Activated K2 module loading, against real backends.
+ *
+ * These tests observe returned bytes rather than mount calls: a mount sequence
+ * can look right and still resolve wrongly, because a source's priority comes
+ * from its bucket and not from when it was mounted. Both backends must agree.
+ *
+ * The K1 characterization suites in lookup.cpp and extractresources.cpp
+ * continue to describe the unactivated path, which this does not change.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/graphics/options.h"
+#include "reone/resource/director.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/resource/resources.h"
+#include "reone/system/stream/fileoutput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+using testing::NiceMock;
+using testing::Return;
+
+namespace {
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+struct NamedRes {
+    std::string resRef;
+    ResType type;
+    std::string data;
+};
+
+ByteBuffer erfBytes(ErfWriter::FileType fileType, const std::vector<NamedRes> &resources) {
+    ErfWriter writer;
+    for (const auto &res : resources) {
+        writer.add(ErfWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(fileType, stream);
+    return buffer;
+}
+
+ByteBuffer rimBytes(const std::vector<NamedRes> &resources) {
+    RimWriter writer;
+    for (const auto &res : resources) {
+        writer.add(RimWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    return buffer;
+}
+
+void writeBuffer(const std::filesystem::path &path, const ByteBuffer &buffer) {
+    FileOutputStream stream(path);
+    if (!buffer.empty()) {
+        stream.write(buffer.data(), buffer.size());
+    }
+}
+
+void writeErf(const std::filesystem::path &path,
+              ErfWriter::FileType fileType,
+              const std::vector<NamedRes> &resources) {
+    writeBuffer(path, erfBytes(fileType, resources));
+}
+
+void writeRim(const std::filesystem::path &path, const std::vector<NamedRes> &resources) {
+    writeBuffer(path, rimBytes(resources));
+}
+
+void writeFile(const std::filesystem::path &path, const std::string &data) {
+    FileOutputStream stream(path);
+    stream.write(data.data(), data.size());
+}
+
+/// An archive as a resource payload, for nesting one inside another.
+std::string blob(const ByteBuffer &buffer) {
+    return std::string(buffer.begin(), buffer.end());
+}
+
+/// A module-save table listing one module and whether it may be saved.
+std::shared_ptr<TwoDA> moduleSaveTable(const std::string &moduleRoot, const std::string &includeInSave) {
+    return TwoDA::Builder()
+        .columns({"modulename", "includeinsave"})
+        .row(moduleRoot, {moduleRoot, includeInSave})
+        .build();
+}
+
+std::string dataOf(const std::optional<Resource> &res) {
+    if (!res) {
+        return "<not found>";
+    }
+    return std::string(res->data.begin(), res->data.end());
+}
+
+struct TmpDir {
+    std::filesystem::path path;
+
+    explicit TmpDir(const std::string &name) {
+        path = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path mkdir(const std::string &name) {
+        auto dir = path / name;
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+};
+
+/// ResourceDirector::init loads shaderpack.erf from the working directory.
+struct CwdGuard {
+    std::filesystem::path previous;
+
+    explicit CwdGuard(const std::filesystem::path &path) {
+        previous = std::filesystem::current_path();
+        std::filesystem::current_path(path);
+    }
+
+    ~CwdGuard() {
+        std::error_code ec;
+        std::filesystem::current_path(previous, ec);
+    }
+};
+
+enum class Backend {
+    Legacy,
+    Extract,
+};
+
+std::string backendName(const testing::TestParamInfo<Backend> &info) {
+    return info.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+} // namespace
+
+class K2ModuleLoadingTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        _graphics.init();
+        _script.init();
+        if (GetParam() == Backend::Legacy) {
+            _resources = std::make_unique<Resources>();
+            _auxResources = std::make_unique<Resources>();
+        } else {
+            _resources = std::make_unique<ExtractResources>();
+            _auxResources = std::make_unique<ExtractResources>();
+        }
+    }
+
+    /// A minimal installation. Every test needs a modules directory and a
+    /// shader pack, because the director mounts both unconditionally.
+    void makeInstallation(TmpDir &game, TmpDir &cwd) {
+        writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+        game.mkdir("modules");
+    }
+
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath) {
+        return std::make_unique<ResourceDirector>(
+            GameID::TSL,
+            gamePath,
+            _graphicsOpt,
+            _graphics.services(),
+            _script.services(),
+            _dialogs,
+            _gffs,
+            _lips,
+            _paths,
+            *_resources,
+            *_auxResources,
+            _scripts,
+            _twoDas);
+    }
+
+    std::string find(const std::string &resRef, ResType type = ResType::Txt) {
+        return dataOf(_resources->find(ResourceId(resRef, type)));
+    }
+
+    bool has(const std::string &resRef, ResType type = ResType::Txt) {
+        return static_cast<bool>(_resources->find(ResourceId(resRef, type)));
+    }
+
+    graphics::GraphicsOptions _graphicsOpt;
+    graphics::TestGraphicsModule _graphics;
+    script::TestScriptModule _script;
+
+    NiceMock<MockDialogs> _dialogs;
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockLips> _lips;
+    NiceMock<MockPaths> _paths;
+    NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
+
+    std::unique_ptr<IResources> _resources;
+    std::unique_ptr<IResources> _auxResources;
+};
+
+// Buckets, not mount order, decide the winner.
+
+TEST_P(K2ModuleLoadingTest, resolves_global_and_module_sources_in_raw_lookup_order) {
+    TmpDir game("reone_test_k2_order");
+    TmpDir cwd("reone_test_k2_order_cwd");
+    makeInstallation(game, cwd);
+
+    auto override_ = game.mkdir("override");
+    writeFile(override_ / "loose.txt", "override");
+    writeErf(game.path / "patch.erf", ErfWriter::FileType::ERF,
+             {{"loose", ResType::Txt, "patch"},
+              {"class1", ResType::Txt, "patch"}});
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim",
+             {{"loose", ResType::Txt, "module image"},
+              {"class1", ResType::Txt, "module image"},
+              {"image", ResType::Txt, "module image"}});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"image", ResType::Txt, "module class 2"},
+              {"class2", ResType::Txt, "module class 2"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("override", find("loose")) << "a loose directory outranks every archive";
+    EXPECT_EQ("patch", find("class1")) << "class 1 outranks a module resource image";
+    EXPECT_EQ("module image", find("image")) << "a resource image outranks class 2";
+    EXPECT_EQ("module class 2", find("class2"));
+}
+
+TEST_P(K2ModuleLoadingTest, prefers_the_adx_image_then_the_area_image_over_the_module_archive) {
+    TmpDir game("reone_test_k2_adjunct");
+    TmpDir cwd("reone_test_k2_adjunct_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD,
+             {{"shared", ResType::Txt, "mod"},
+              {"a_vs_mod", ResType::Txt, "mod"}});
+    writeRim(modules / "foo_a.rim",
+             {{"shared", ResType::Txt, "area image"},
+              {"a_vs_mod", ResType::Txt, "area image"}});
+    writeRim(modules / "foo_adx.rim", {{"shared", ResType::Txt, "adx image"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("adx image", find("shared")) << "_adx is mounted after _a inside the image bucket";
+    EXPECT_EQ("area image", find("a_vs_mod")) << "an adjunct image outranks the class-2 module archive";
+}
+
+TEST_P(K2ModuleLoadingTest, suppresses_the_static_and_dialogue_sources_when_a_module_archive_exists) {
+    TmpDir game("reone_test_k2_mod_branch");
+    TmpDir cwd("reone_test_k2_mod_branch_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD, {{"from_mod", ResType::Txt, "mod"}});
+    writeRim(modules / "foo_s.rim", {{"from_static", ResType::Txt, "static"}});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF, {{"from_dlg", ResType::Txt, "dialogue"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("mod", find("from_mod"));
+    EXPECT_FALSE(has("from_static")) << "the MOD branch suppresses _s";
+    EXPECT_FALSE(has("from_dlg")) << "the MOD branch suppresses _dlg";
+}
+
+TEST_P(K2ModuleLoadingTest, mounts_the_static_and_dialogue_sources_in_the_split_branch) {
+    TmpDir game("reone_test_k2_split");
+    TmpDir cwd("reone_test_k2_split_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"from_rim", ResType::Txt, "rim"}});
+    writeRim(modules / "foo_s.rim",
+             {{"from_static", ResType::Txt, "static"},
+              {"shared", ResType::Txt, "static"}});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"from_dlg", ResType::Txt, "dialogue"},
+              {"shared", ResType::Txt, "dialogue"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("rim", find("from_rim"));
+    EXPECT_EQ("static", find("from_static"));
+    EXPECT_EQ("dialogue", find("from_dlg"));
+    EXPECT_EQ("static", find("shared")) << "every image source outranks the dialogue archive";
+}
+
+TEST_P(K2ModuleLoadingTest, mounts_localization_from_the_module_and_lips_locations) {
+    TmpDir game("reone_test_k2_loc");
+    TmpDir cwd("reone_test_k2_loc_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"anything", ResType::Txt, "rim"}});
+    writeErf(modules / "foo_loc.mod", ErfWriter::FileType::MOD,
+             {{"from_module_loc", ResType::Txt, "module loc"},
+              {"shared_loc", ResType::Txt, "module loc"}});
+    auto lips = game.mkdir("lips");
+    writeErf(lips / "foo_loc.mod", ErfWriter::FileType::MOD,
+             {{"from_lips_loc", ResType::Txt, "lips loc"},
+              {"shared_loc", ResType::Txt, "lips loc"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("module loc", find("from_module_loc"));
+    EXPECT_EQ("lips loc", find("from_lips_loc"));
+    EXPECT_EQ("lips loc", find("shared_loc")) << "the lips location is consulted after the module location";
+}
+
+// Saved state staged inside an archive already in scope.
+
+TEST_P(K2ModuleLoadingTest, prefers_the_staged_image_over_the_staged_archive) {
+    TmpDir game("reone_test_k2_staged");
+    TmpDir cwd("reone_test_k2_staged_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"state", ResType::Txt, "disk rim"}});
+
+    auto slot = game.mkdir("saves/000001");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"foo", ResType::Rsv, blob(rimBytes({{"state", ResType::Txt, "staged image"}}))},
+              {"foo", ResType::Sav, blob(erfBytes(ErfWriter::FileType::MOD, {{"state", ResType::Txt, "staged archive"}}))}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("000001");
+    director->onModuleLoad("foo");
+
+    // The image wins selection, so the active table takes its image form. The
+    // archive existing alongside it must not turn the active table into class 2.
+    EXPECT_EQ("staged image", find("state"));
+}
+
+TEST_P(K2ModuleLoadingTest, mounts_the_staged_archive_when_no_staged_image_exists) {
+    TmpDir game("reone_test_k2_staged_archive");
+    TmpDir cwd("reone_test_k2_staged_archive_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeErf(modules / "foo.mod", ErfWriter::FileType::MOD, {{"state", ResType::Txt, "disk mod"}});
+
+    auto nested = erfBytes(ErfWriter::FileType::MOD, {{"state", ResType::Txt, "staged archive"}});
+    auto slot = game.mkdir("saves/000001");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"foo", ResType::Sav, blob(nested)}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("000001");
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("staged archive", find("state"))
+        << "the active table is mounted last, so it wins its bucket against the disk archive";
+}
+
+TEST_P(K2ModuleLoadingTest, resolves_the_save_folder_above_the_outer_save_archive) {
+    TmpDir game("reone_test_k2_save_scope");
+    TmpDir cwd("reone_test_k2_save_scope_cwd");
+    makeInstallation(game, cwd);
+
+    auto slot = game.mkdir("saves/000001");
+    writeFile(slot / "loose.txt", "save folder");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"loose", ResType::Txt, "save archive"},
+              {"archive_only", ResType::Txt, "save archive"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("000001");
+
+    // The save folder is a loose directory and the outer archive is not. This
+    // reverses the unactivated order, where whichever was mounted last won.
+    EXPECT_EQ("save folder", find("loose"));
+    EXPECT_EQ("save archive", find("archive_only"))
+        << "the outer archive must still supply what nothing else holds";
+}
+
+// Saved-state eligibility.
+
+TEST_P(K2ModuleLoadingTest, ignores_staged_state_for_a_module_the_save_table_excludes) {
+    TmpDir game("reone_test_k2_excluded");
+    TmpDir cwd("reone_test_k2_excluded_cwd");
+    makeInstallation(game, cwd);
+
+    writeRim(game.path / "modules" / "foo.rim", {{"state", ResType::Txt, "disk rim"}});
+
+    auto nested = erfBytes(ErfWriter::FileType::MOD, {{"state", ResType::Txt, "staged archive"}});
+    auto slot = game.mkdir("saves/000001");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"foo", ResType::Sav, blob(nested)}});
+
+    EXPECT_CALL(_twoDas, get("modulesave")).WillRepeatedly(Return(moduleSaveTable("foo", "0")));
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("000001");
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("disk rim", find("state")) << "an excluded module may not be entered from saved state";
+}
+
+TEST_P(K2ModuleLoadingTest, includes_a_module_the_save_table_does_not_mention) {
+    TmpDir game("reone_test_k2_absent_row");
+    TmpDir cwd("reone_test_k2_absent_row_cwd");
+    makeInstallation(game, cwd);
+
+    writeRim(game.path / "modules" / "foo.rim", {{"state", ResType::Txt, "disk rim"}});
+
+    auto nested = erfBytes(ErfWriter::FileType::MOD, {{"state", ResType::Txt, "staged archive"}});
+    auto slot = game.mkdir("saves/000001");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"foo", ResType::Sav, blob(nested)}});
+
+    // A table that lists other modules supplies no exclusion for this one.
+    EXPECT_CALL(_twoDas, get("modulesave")).WillRepeatedly(Return(moduleSaveTable("bar", "0")));
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("000001");
+    director->onModuleLoad("foo");
+
+    EXPECT_EQ("staged archive", find("state"));
+}
+
+// Module names.
+
+TEST_P(K2ModuleLoadingTest, never_reports_a_sidecar_as_a_module) {
+    TmpDir game("reone_test_k2_names");
+    TmpDir cwd("reone_test_k2_names_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {});
+    writeRim(modules / "foo_s.rim", {});
+    writeRim(modules / "foo_a.rim", {});
+    writeRim(modules / "foo_adx.rim", {});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF, {});
+    writeErf(modules / "bar.mod", ErfWriter::FileType::MOD, {});
+
+    // The lips location holds global archives that are not modules, and is
+    // searched for a known module's support archives only.
+    auto lips = game.mkdir("lips");
+    writeErf(lips / "global.mod", ErfWriter::FileType::MOD, {});
+    writeErf(lips / "localization.mod", ErfWriter::FileType::MOD, {});
+    writeErf(lips / "foo_loc.mod", ErfWriter::FileType::MOD, {});
+
+    auto director = makeDirector(game.path);
+
+    EXPECT_EQ((std::set<std::string> {"bar", "foo"}), director->moduleNames());
+}
+
+// Transitions.
+
+TEST_P(K2ModuleLoadingTest, drops_the_previous_module_sources_on_a_transition) {
+    TmpDir game("reone_test_k2_transition");
+    TmpDir cwd("reone_test_k2_transition_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"shared", ResType::Txt, "foo"}, {"foo_only", ResType::Txt, "foo"}});
+    writeRim(modules / "bar.rim", {{"shared", ResType::Txt, "bar"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onModuleLoad("foo");
+    EXPECT_EQ("foo", find("shared"));
+
+    director->onModuleLoad("bar");
+    EXPECT_EQ("bar", find("shared"));
+    EXPECT_FALSE(has("foo_only")) << "sources of the previous module must not survive a transition";
+
+    // A module already visited must load identically the second time.
+    director->onModuleLoad("foo");
+    EXPECT_EQ("foo", find("shared"));
+    EXPECT_TRUE(has("foo_only"));
+}
+
+// Sources that are not Odyssey game data.
+
+TEST_P(K2ModuleLoadingTest, keeps_streamed_audio_out_of_the_odyssey_resource_list) {
+    TmpDir game("reone_test_k2_streams");
+    TmpDir cwd("reone_test_k2_streams_cwd");
+    makeInstallation(game, cwd);
+
+    auto music = game.mkdir("streammusic");
+    writeFile(music / "track.wav", "streamed");
+    auto override_ = game.mkdir("override");
+    writeFile(override_ / "track.wav", "override");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    // Streamed audio has no bucket, so it cannot be ranked against Odyssey
+    // sources at all and does not appear in the game's resource list. Which of
+    // the two a clip is read from is the streaming subsystem's decision, and is
+    // covered by the AudioClips tests.
+    EXPECT_EQ("override", find("track", ResType::Wav));
+    EXPECT_EQ("streamed", dataOf(_auxResources->find(ResourceId("track", ResType::Wav))));
+}
+
+TEST_P(K2ModuleLoadingTest, mounts_every_odyssey_source_into_one_placed_order) {
+    // A list is homogeneous: it rejects a mount that does not match the mode it
+    // is in. A load that completes therefore proves no Odyssey source was left
+    // unplaced, which no assertion about individual mount calls could show.
+    TmpDir game("reone_test_k2_homogeneous");
+    TmpDir cwd("reone_test_k2_homogeneous_cwd");
+    makeInstallation(game, cwd);
+
+    writeErf(game.path / "patch.erf", ErfWriter::FileType::ERF, {{"p", ResType::Txt, "patch"}});
+    game.mkdir("override");
+    game.mkdir("texturepacks");
+    game.mkdir("streammusic");
+    auto lips = game.mkdir("lips");
+    writeErf(lips / "global.mod", ErfWriter::FileType::MOD, {{"g", ResType::Txt, "global lips"}});
+    writeRim(game.path / "modules" / "foo.rim", {{"m", ResType::Txt, "module"}});
+
+    auto slot = game.mkdir("saves/000001");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF, {{"s", ResType::Txt, "save"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        EXPECT_NO_THROW(director->init());
+    }
+    EXPECT_NO_THROW(director->onGameLoad("000001"));
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+
+    EXPECT_EQ("patch", find("p"));
+    EXPECT_EQ("global lips", find("g"));
+    EXPECT_EQ("module", find("m"));
+    EXPECT_EQ("save", find("s"));
+}
+
+TEST_P(K2ModuleLoadingTest, admits_a_later_loose_directory_mounted_by_another_caller) {
+    // The toolkit mounts the resources directory itself when there is no key
+    // table. That lands in the same list the director just filled, so it has to
+    // be placed the same way; leaving it unplaced would be rejected.
+    TmpDir game("reone_test_k2_late_folder");
+    TmpDir cwd("reone_test_k2_late_folder_cwd");
+    makeInstallation(game, cwd);
+
+    auto override_ = game.mkdir("override");
+    writeFile(override_ / "shared.txt", "override");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    auto loose = game.mkdir("loose");
+    writeFile(loose / "shared.txt", "late folder");
+
+    std::optional<ResourceSourceBucket> bucket;
+    if (usesBucketedLookup(GameID::TSL)) {
+        bucket = ResourceSourceBucket::LooseDirectory;
+    }
+    ASSERT_NO_THROW(_resources->addFolder(loose, ContainerKind::Global, bucket));
+
+    EXPECT_EQ("late folder", find("shared")) << "the source added last wins inside its own bucket";
+}
+
+TEST(ResourceDirectorActivation, activates_only_the_game_whose_precedence_is_established) {
+    EXPECT_TRUE(usesBucketedLookup(GameID::TSL));
+    EXPECT_FALSE(usesBucketedLookup(GameID::KotOR));
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         K2ModuleLoadingTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);

--- a/test/resource/modulemount.cpp
+++ b/test/resource/modulemount.cpp
@@ -30,6 +30,7 @@
 #include "reone/resource/format/rimwriter.h"
 #include "reone/resource/modulemount.h"
 #include "reone/resource/resources.h"
+#include "../fixtures/resource.h"
 #include "reone/system/exception/validation.h"
 #include "reone/system/stream/fileoutput.h"
 #include "reone/system/stream/memoryoutput.h"
@@ -241,6 +242,33 @@ protected:
     Resources _resources;
     RuntimeModuleSourceIndex _index;
 };
+
+TEST(ModuleMountExecutorNwm, mounts_only_the_selected_nwm_as_class_2_active_state) {
+    testing::StrictMock<MockResources> resources;
+    RuntimeModuleSourceIndex index;
+    TmpDir tmp("reone_test_mount_nwm_metadata");
+    auto path = tmp.writeErf("foo.nwm", "nwm");
+    index.add(RuntimeModuleSource {
+        candidate("nwm:foo.nwm", ModuleArchiveFamily::Nwm), path});
+
+    ModuleLoadPlan plan;
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {
+        candidate("nwm:foo.nwm", ModuleArchiveFamily::Nwm),
+        ModulePrimaryKind::Nwm};
+    plan.primary = selection;
+    plan.activeState.owner = ResourceOwner::ActiveModuleState;
+
+    EXPECT_CALL(resources,
+                addERF(path,
+                       ResourceOwner::ActiveModuleState,
+                       std::optional<ResourceSourceBucket>(
+                           ResourceSourceBucket::EncapsulatedClass2)));
+
+    ModuleMountExecutor executor(resources, index);
+    auto report = executor.run(plan);
+    EXPECT_EQ((std::vector<std::string> {"nwm:foo.nwm"}), mountedIds(report));
+}
 
 TEST_F(ModuleMountExecutorTest, mounts_every_attempt_of_an_all_successful_family) {
     TmpDir tmp("reone_test_mount_all");

--- a/test/resource/modulemount.cpp
+++ b/test/resource/modulemount.cpp
@@ -289,7 +289,9 @@ TEST_F(ModuleMountExecutorTest, reports_a_required_family_that_mounted_nothing) 
         MountCardinality::FirstSuccessful,
         {attempt("gone", ModuleArchiveFamily::StaticRim, MountFailureEffect::FailOrCurrentGameFallback)}));
 
-    EXPECT_TRUE(run(plan).requiredFailure);
+    auto report = run(plan);
+    EXPECT_TRUE(report.requiredFailure);
+    EXPECT_EQ(ModuleLoadOutcome::Failed, report.outcome);
 }
 
 TEST_F(ModuleMountExecutorTest, keeps_a_best_effort_failure_out_of_the_required_result) {
@@ -325,6 +327,7 @@ TEST_F(ModuleMountExecutorTest, mounts_the_selected_primary_as_the_active_table)
     EXPECT_EQ((std::vector<std::string> {"modules:foo_s.rim", "modules:foo.rim"}), mountedIds(report))
         << "the active table is mounted last, so it wins its bucket";
     EXPECT_EQ("primary", shared());
+    EXPECT_EQ(ModuleLoadOutcome::Succeeded, report.outcome);
 }
 
 TEST_F(ModuleMountExecutorTest, does_not_mount_the_primary_twice_in_the_mod_branch) {
@@ -380,6 +383,11 @@ TEST_F(ModuleMountExecutorTest, recovers_through_the_staged_archive_when_a_requi
         ModuleArchiveFamily::StaticRim,
         MountCardinality::FirstSuccessful,
         {attempt("modules:foo_s.rim", ModuleArchiveFamily::StaticRim, MountFailureEffect::FailOrCurrentGameFallback)}));
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {
+        candidate("currentgame:foo.sav", ModuleArchiveFamily::SavedArchive),
+        ModulePrimaryKind::SavedArchive};
+    plan.primary = selection;
     plan.activeState.encapsulatedArchive = *mountMetadata(ModuleArchiveFamily::SavedArchive);
 
     auto report = run(plan);
@@ -387,6 +395,7 @@ TEST_F(ModuleMountExecutorTest, recovers_through_the_staged_archive_when_a_requi
     EXPECT_TRUE(report.requiredFailure);
     EXPECT_EQ((std::vector<std::string> {"currentgame:foo.sav"}), mountedIds(report));
     EXPECT_EQ("recovered", shared());
+    EXPECT_EQ(ModuleLoadOutcome::RecoveredThroughActiveState, report.outcome);
 }
 
 TEST_F(ModuleMountExecutorTest, looks_at_one_candidate_only_for_a_zero_or_one_family) {
@@ -491,4 +500,5 @@ TEST_F(ModuleMountExecutorTest, mounts_nothing_for_a_plan_without_a_primary) {
     auto report = run(plan);
     EXPECT_TRUE(report.outcomes.empty());
     EXPECT_FALSE(report.requiredFailure);
+    EXPECT_EQ(ModuleLoadOutcome::Failed, report.outcome);
 }

--- a/test/resource/modulemount.cpp
+++ b/test/resource/modulemount.cpp
@@ -142,14 +142,21 @@ std::vector<std::string> attemptedIds(const ModuleMountReport &report) {
 
 } // namespace
 
-// Ownership maps onto a lifetime scope; it never decides lookup order.
+// Ownership says when a source goes away; it never decides lookup order.
 
-TEST(ModuleMount, maps_active_module_and_its_state_onto_one_lifetime) {
-    EXPECT_EQ(ContainerKind::Global, containerKindOf(ResourceOwner::Global));
-    EXPECT_EQ(ContainerKind::Save, containerKindOf(ResourceOwner::SaveSlot));
-    // Retiring these separately needs owner handles, which do not exist yet.
-    EXPECT_EQ(ContainerKind::Local, containerKindOf(ResourceOwner::ActiveModule));
-    EXPECT_EQ(ContainerKind::Local, containerKindOf(ResourceOwner::ActiveModuleState));
+TEST(ModuleMount, gives_the_module_and_its_state_separate_owners) {
+    // The state of the module is not one of its support sources. Both are
+    // retired on a transition today, but a save can be replaced under a module
+    // that is not, so the two lifetimes stay distinct.
+    EXPECT_EQ(ResourceOwner::ActiveModule, mountMetadata(ModuleArchiveFamily::StaticRim)->owner);
+    EXPECT_EQ(ResourceOwner::ActiveModule, mountMetadata(ModuleArchiveFamily::AdxRim)->owner);
+    EXPECT_EQ(ResourceOwner::ActiveModule, mountMetadata(ModuleArchiveFamily::PrimaryMod)->owner);
+    EXPECT_EQ(ResourceOwner::ActiveModule, mountMetadata(ModuleArchiveFamily::Dialogue)->owner);
+
+    EXPECT_EQ(ResourceOwner::ActiveModuleState,
+              mountMetadata(ModuleArchiveFamily::SavedArchive)->owner);
+    EXPECT_EQ(ResourceOwner::ActiveModuleState,
+              mountMetadata(ModuleArchiveFamily::SavedResourceImage)->owner);
 }
 
 TEST(ModuleMount, derives_container_form_from_the_family_not_the_bucket) {
@@ -217,7 +224,7 @@ protected:
         MemoryOutputStream stream(buffer);
         writer.save(ErfWriter::FileType::ERF, stream);
         _resources.addMemERF(std::move(buffer),
-                             ContainerKind::Save,
+                             ResourceOwner::SaveSlot,
                              ResourceSourceBucket::EncapsulatedClass2);
     }
 
@@ -432,7 +439,7 @@ TEST_F(ModuleMountExecutorTest, lets_a_structural_rejection_escape_rather_than_r
     // the caller, not an archive that failed to open. Reporting it as a missed
     // mount would hide it behind a best-effort result.
     TmpDir tmp("reone_test_mount_structural");
-    _resources.addMemERF(erfBytes("shared", "unplaced"), ContainerKind::Global);
+    _resources.addMemERF(erfBytes("shared", "unplaced"), ResourceOwner::Global);
     addDiskSource("placed", ModuleArchiveFamily::StaticRim, tmp.writeRim("foo_s.rim", "placed"));
 
     ModuleLoadPlan plan;

--- a/test/resource/modulemount.cpp
+++ b/test/resource/modulemount.cpp
@@ -489,9 +489,9 @@ TEST_F(ModuleMountExecutorTest, lets_a_structural_rejection_escape_rather_than_r
 
 TEST_F(ModuleMountExecutorTest, treats_a_corrupt_archive_as_a_failed_load_rather_than_a_missing_source) {
     // Best effort means a source that is not there, not one that is there and
-    // unreadable. The unactivated path mounts without a guard, so a corrupt
+    // unreadable. The shared activated path mounts without a guard, so a corrupt
     // archive already aborts the module load; swallowing it here would make an
-    // activated game quietly more tolerant than an unactivated one.
+    // game quietly more tolerant than the other.
     TmpDir tmp("reone_test_mount_corrupt");
     tmp.write("foo_s.rim", ByteBuffer {'n', 'o', 't', ' ', 'a', ' ', 'r', 'i', 'm'});
     addDiskSource("corrupt", ModuleArchiveFamily::StaticRim, tmp.path / "foo_s.rim");

--- a/test/resource/modulemount.cpp
+++ b/test/resource/modulemount.cpp
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The executor that turns a mount plan into actual mounts.
+ *
+ * These tests describe what it mounts and in what order, not which source
+ * later wins a lookup: that is decided by the bucket each mount carries, and
+ * is covered against real backends elsewhere.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/resource/modulemount.h"
+#include "reone/resource/resources.h"
+#include "reone/system/exception/validation.h"
+#include "reone/system/stream/fileoutput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+namespace {
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+ByteBuffer erfBytes(const std::string &resRef, const std::string &data) {
+    ErfWriter writer;
+    writer.add(ErfWriter::Resource {resRef, ResType::Txt, bytes(data)});
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(ErfWriter::FileType::MOD, stream);
+    return buffer;
+}
+
+ByteBuffer rimBytes(const std::string &resRef, const std::string &data) {
+    RimWriter writer;
+    writer.add(RimWriter::Resource {resRef, ResType::Txt, bytes(data)});
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    return buffer;
+}
+
+/// A directory of archives written to disk, removed on destruction.
+struct TmpDir {
+    std::filesystem::path path;
+
+    explicit TmpDir(const std::string &name) {
+        path = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path writeRim(const std::string &filename, const std::string &data) {
+        return write(filename, rimBytes("shared", data));
+    }
+
+    std::filesystem::path writeErf(const std::string &filename, const std::string &data) {
+        return write(filename, erfBytes("shared", data));
+    }
+
+    std::filesystem::path write(const std::string &filename, const ByteBuffer &buffer) {
+        auto full = path / filename;
+        FileOutputStream stream(full);
+        stream.write(buffer.data(), buffer.size());
+        return full;
+    }
+};
+
+ModuleSourceCandidate candidate(std::string sourceId, ModuleArchiveFamily family) {
+    ModuleSourceCandidate result;
+    result.sourceId = std::move(sourceId);
+    result.rootId = "modules";
+    result.family = family;
+    return result;
+}
+
+ResourceMountAttempt attempt(std::string sourceId,
+                             ModuleArchiveFamily family,
+                             MountFailureEffect effect = MountFailureEffect::BestEffort) {
+    ResourceMountAttempt result;
+    result.source = candidate(sourceId, family);
+    result.family = family;
+    result.phase = ModuleMountPhase::ModuleBranch;
+    result.metadata = *mountMetadata(family);
+    result.failureEffect = effect;
+    return result;
+}
+
+ModuleFamilyPlan familyPlan(ModuleArchiveFamily family,
+                            MountCardinality cardinality,
+                            std::vector<ResourceMountAttempt> attempts) {
+    ModuleFamilyPlan plan;
+    plan.family = family;
+    plan.cardinality = cardinality;
+    plan.attempts = std::move(attempts);
+    return plan;
+}
+
+std::vector<std::string> mountedIds(const ModuleMountReport &report) {
+    std::vector<std::string> result;
+    for (const auto &outcome : report.outcomes) {
+        if (outcome.mounted) {
+            result.push_back(outcome.sourceId);
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> attemptedIds(const ModuleMountReport &report) {
+    std::vector<std::string> result;
+    for (const auto &outcome : report.outcomes) {
+        result.push_back(outcome.sourceId);
+    }
+    return result;
+}
+
+} // namespace
+
+// Ownership maps onto a lifetime scope; it never decides lookup order.
+
+TEST(ModuleMount, maps_active_module_and_its_state_onto_one_lifetime) {
+    EXPECT_EQ(ContainerKind::Global, containerKindOf(ResourceOwner::Global));
+    EXPECT_EQ(ContainerKind::Save, containerKindOf(ResourceOwner::SaveSlot));
+    // Retiring these separately needs owner handles, which do not exist yet.
+    EXPECT_EQ(ContainerKind::Local, containerKindOf(ResourceOwner::ActiveModule));
+    EXPECT_EQ(ContainerKind::Local, containerKindOf(ResourceOwner::ActiveModuleState));
+}
+
+TEST(ModuleMount, derives_container_form_from_the_family_not_the_bucket) {
+    EXPECT_TRUE(isResourceImageFamily(ModuleArchiveFamily::PrimaryRim));
+    EXPECT_TRUE(isResourceImageFamily(ModuleArchiveFamily::StaticRim));
+    EXPECT_TRUE(isResourceImageFamily(ModuleArchiveFamily::AreaRim));
+    EXPECT_TRUE(isResourceImageFamily(ModuleArchiveFamily::AdxRim));
+    EXPECT_TRUE(isResourceImageFamily(ModuleArchiveFamily::SavedResourceImage));
+
+    EXPECT_FALSE(isResourceImageFamily(ModuleArchiveFamily::PrimaryMod));
+    EXPECT_FALSE(isResourceImageFamily(ModuleArchiveFamily::SavedArchive));
+    EXPECT_FALSE(isResourceImageFamily(ModuleArchiveFamily::Dialogue));
+    EXPECT_FALSE(isResourceImageFamily(ModuleArchiveFamily::Localization));
+}
+
+// The index: two suppliers, one inventory, opaque identifiers.
+
+TEST(RuntimeModuleSourceIndex, offers_disk_and_staged_sources_as_one_inventory) {
+    RuntimeModuleSourceIndex index;
+    index.add(RuntimeModuleSource {candidate("modules:foo.rim", ModuleArchiveFamily::PrimaryRim),
+                                   std::filesystem::path("foo.rim")});
+    index.add(RuntimeModuleSource {candidate("currentgame:foo.sav", ModuleArchiveFamily::SavedArchive),
+                                   ResourceId("foo", ResType::Sav)});
+
+    auto inventory = index.inventory();
+    ASSERT_EQ(2u, inventory.size());
+    EXPECT_EQ("modules:foo.rim", inventory[0].sourceId);
+    EXPECT_EQ("currentgame:foo.sav", inventory[1].sourceId);
+
+    ASSERT_TRUE(index.find("currentgame:foo.sav"));
+    EXPECT_TRUE(std::holds_alternative<ResourceId>(index.find("currentgame:foo.sav")->locator));
+    EXPECT_TRUE(std::holds_alternative<std::filesystem::path>(index.find("modules:foo.rim")->locator));
+    EXPECT_FALSE(index.find("modules:nothing.rim"));
+}
+
+// Mounting.
+
+class ModuleMountExecutorTest : public testing::Test {
+protected:
+    void addDiskSource(const std::string &sourceId,
+                       ModuleArchiveFamily family,
+                       const std::filesystem::path &path) {
+        _index.add(RuntimeModuleSource {candidate(sourceId, family), path});
+    }
+
+    void addStagedSource(const std::string &sourceId,
+                         ModuleArchiveFamily family,
+                         const ResourceId &id) {
+        _index.add(RuntimeModuleSource {candidate(sourceId, family), id});
+    }
+
+    /// Put a save archive in scope, holding the module blobs a staged source is
+    /// read back from. The container is never walked into; only the ids the
+    /// director probes for are ever resolved out of it.
+    ///
+    /// It carries a bucket because the executor's mounts do: a list is
+    /// homogeneous, so leaving this one unplaced would have the list reject
+    /// every later mount rather than rank it.
+    void mountSaveArchive(std::vector<ErfWriter::Resource> entries) {
+        ErfWriter writer;
+        for (auto &entry : entries) {
+            writer.add(std::move(entry));
+        }
+        ByteBuffer buffer;
+        MemoryOutputStream stream(buffer);
+        writer.save(ErfWriter::FileType::ERF, stream);
+        _resources.addMemERF(std::move(buffer),
+                             ContainerKind::Save,
+                             ResourceSourceBucket::EncapsulatedClass2);
+    }
+
+    ModuleMountReport run(const ModuleLoadPlan &plan) {
+        ModuleMountExecutor executor(_resources, _index);
+        return executor.run(plan);
+    }
+
+    std::string shared() {
+        auto res = _resources.find(ResourceId("shared", ResType::Txt));
+        return res ? std::string(res->data.begin(), res->data.end()) : "<not found>";
+    }
+
+    Resources _resources;
+    RuntimeModuleSourceIndex _index;
+};
+
+TEST_F(ModuleMountExecutorTest, mounts_every_attempt_of_an_all_successful_family) {
+    TmpDir tmp("reone_test_mount_all");
+    addDiskSource("a", ModuleArchiveFamily::Dialogue, tmp.writeErf("a_dlg.erf", "a"));
+    addDiskSource("b", ModuleArchiveFamily::Dialogue, tmp.writeErf("b_dlg.erf", "b"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::Dialogue,
+                                       MountCardinality::AllSuccessful,
+                                       {attempt("a", ModuleArchiveFamily::Dialogue),
+                                        attempt("b", ModuleArchiveFamily::Dialogue)}));
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"a", "b"}), mountedIds(report));
+    EXPECT_FALSE(report.requiredFailure);
+}
+
+TEST_F(ModuleMountExecutorTest, stops_a_first_successful_family_at_its_first_success) {
+    TmpDir tmp("reone_test_mount_first");
+    addDiskSource("missing", ModuleArchiveFamily::StaticRim, tmp.path / "absent_s.rim");
+    addDiskSource("root", ModuleArchiveFamily::StaticRim, tmp.writeRim("root_s.rim", "root"));
+    addDiskSource("base", ModuleArchiveFamily::StaticRim, tmp.writeRim("base_s.rim", "base"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::StaticRim,
+                                       MountCardinality::FirstSuccessful,
+                                       {attempt("missing", ModuleArchiveFamily::StaticRim),
+                                        attempt("root", ModuleArchiveFamily::StaticRim),
+                                        attempt("base", ModuleArchiveFamily::StaticRim)}));
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"root"}), mountedIds(report));
+    EXPECT_EQ((std::vector<std::string> {"missing", "root"}), attemptedIds(report))
+        << "the fallback location must not be attempted once a location supplied the image";
+}
+
+TEST_F(ModuleMountExecutorTest, reports_a_required_family_that_mounted_nothing) {
+    TmpDir tmp("reone_test_mount_required");
+    addDiskSource("gone", ModuleArchiveFamily::StaticRim, tmp.path / "absent_s.rim");
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(
+        ModuleArchiveFamily::StaticRim,
+        MountCardinality::FirstSuccessful,
+        {attempt("gone", ModuleArchiveFamily::StaticRim, MountFailureEffect::FailOrCurrentGameFallback)}));
+
+    EXPECT_TRUE(run(plan).requiredFailure);
+}
+
+TEST_F(ModuleMountExecutorTest, keeps_a_best_effort_failure_out_of_the_required_result) {
+    TmpDir tmp("reone_test_mount_best_effort");
+    addDiskSource("gone", ModuleArchiveFamily::Dialogue, tmp.path / "absent_dlg.erf");
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::Dialogue,
+                                       MountCardinality::AllSuccessful,
+                                       {attempt("gone", ModuleArchiveFamily::Dialogue)}));
+
+    auto report = run(plan);
+    EXPECT_FALSE(report.requiredFailure);
+    EXPECT_TRUE(mountedIds(report).empty());
+}
+
+TEST_F(ModuleMountExecutorTest, mounts_the_selected_primary_as_the_active_table) {
+    TmpDir tmp("reone_test_mount_active");
+    addDiskSource("modules:foo.rim", ModuleArchiveFamily::PrimaryRim, tmp.writeRim("foo.rim", "primary"));
+    addDiskSource("modules:foo_s.rim", ModuleArchiveFamily::StaticRim, tmp.writeRim("foo_s.rim", "static"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::StaticRim,
+                                       MountCardinality::FirstSuccessful,
+                                       {attempt("modules:foo_s.rim", ModuleArchiveFamily::StaticRim)}));
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {
+        candidate("modules:foo.rim", ModuleArchiveFamily::PrimaryRim), ModulePrimaryKind::Rim};
+    plan.primary = selection;
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"modules:foo_s.rim", "modules:foo.rim"}), mountedIds(report))
+        << "the active table is mounted last, so it wins its bucket";
+    EXPECT_EQ("primary", shared());
+}
+
+TEST_F(ModuleMountExecutorTest, does_not_mount_the_primary_twice_in_the_mod_branch) {
+    TmpDir tmp("reone_test_mount_mod_branch");
+    addDiskSource("modules:foo.mod", ModuleArchiveFamily::PrimaryMod, tmp.writeErf("foo.mod", "mod"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(
+        ModuleArchiveFamily::PrimaryMod,
+        MountCardinality::AllSuccessful,
+        {attempt("modules:foo.mod", ModuleArchiveFamily::PrimaryMod, MountFailureEffect::FailOrCurrentGameFallback)}));
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {
+        candidate("modules:foo.mod", ModuleArchiveFamily::PrimaryMod), ModulePrimaryKind::Mod};
+    plan.primary = selection;
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"modules:foo.mod"}), mountedIds(report));
+    EXPECT_EQ(1u, report.mountedCount()) << "selecting a source and mounting it are separate, but not repeated";
+}
+
+TEST_F(ModuleMountExecutorTest, mounts_a_staged_image_as_an_image_and_a_staged_archive_as_an_archive) {
+    // The saved image and the saved archive are distinct sources with distinct
+    // container forms; the probe that supplied them decides which is which.
+    mountSaveArchive({{"foo", ResType::Rsv, rimBytes("shared", "staged image")},
+                      {"foo", ResType::Sav, erfBytes("shared", "staged archive")}});
+
+    addStagedSource("currentgame:foo.rsv", ModuleArchiveFamily::SavedResourceImage, ResourceId("foo", ResType::Rsv));
+
+    ModuleLoadPlan plan;
+    ModulePrimarySelection selection;
+    selection.candidate = ModulePrimaryCandidate {
+        candidate("currentgame:foo.rsv", ModuleArchiveFamily::SavedResourceImage),
+        ModulePrimaryKind::SavedResourceImage};
+    plan.primary = selection;
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"currentgame:foo.rsv"}), mountedIds(report));
+    EXPECT_EQ("staged image", shared()) << "a saved image is read back as a resource image, not as an archive";
+}
+
+TEST_F(ModuleMountExecutorTest, recovers_through_the_staged_archive_when_a_required_mount_fails) {
+    TmpDir tmp("reone_test_mount_recovery");
+    mountSaveArchive({{"foo", ResType::Sav, erfBytes("shared", "recovered")}});
+
+    addDiskSource("modules:foo_s.rim", ModuleArchiveFamily::StaticRim, tmp.path / "absent_s.rim");
+    addStagedSource("currentgame:foo.sav", ModuleArchiveFamily::SavedArchive, ResourceId("foo", ResType::Sav));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(
+        ModuleArchiveFamily::StaticRim,
+        MountCardinality::FirstSuccessful,
+        {attempt("modules:foo_s.rim", ModuleArchiveFamily::StaticRim, MountFailureEffect::FailOrCurrentGameFallback)}));
+    plan.activeState.encapsulatedArchive = *mountMetadata(ModuleArchiveFamily::SavedArchive);
+
+    auto report = run(plan);
+
+    EXPECT_TRUE(report.requiredFailure);
+    EXPECT_EQ((std::vector<std::string> {"currentgame:foo.sav"}), mountedIds(report));
+    EXPECT_EQ("recovered", shared());
+}
+
+TEST_F(ModuleMountExecutorTest, looks_at_one_candidate_only_for_a_zero_or_one_family) {
+    // The limit is on what is considered, not on what succeeds. A family
+    // allowed a single source must not fall through to a later candidate when
+    // the first one turns out not to be there, which is what distinguishes it
+    // from a family that takes the first source to supply it.
+    TmpDir tmp("reone_test_mount_zero_or_one_first_fails");
+    addDiskSource("absent", ModuleArchiveFamily::AreaRim, tmp.path / "foo_a.rim");
+    addDiskSource("usable", ModuleArchiveFamily::AreaRim, tmp.writeRim("bar_a.rim", "usable"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::AreaRim,
+                                       MountCardinality::ZeroOrOne,
+                                       {attempt("absent", ModuleArchiveFamily::AreaRim),
+                                        attempt("usable", ModuleArchiveFamily::AreaRim)}));
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"absent"}), attemptedIds(report))
+        << "the second candidate must not be considered once the one allowed candidate was";
+    EXPECT_TRUE(mountedIds(report).empty());
+    EXPECT_EQ("<not found>", shared()) << "the second candidate must not be mounted";
+}
+
+TEST_F(ModuleMountExecutorTest, stops_a_zero_or_one_family_after_its_first_success) {
+    // The planner happens to give such a family a single attempt. The limit is
+    // the family's own, so a plan built by hand with two usable attempts must
+    // still leave only one mounted.
+    TmpDir tmp("reone_test_mount_zero_or_one");
+    addDiskSource("first", ModuleArchiveFamily::AreaRim, tmp.writeRim("foo_a.rim", "first"));
+    addDiskSource("second", ModuleArchiveFamily::AreaRim, tmp.writeRim("bar_a.rim", "second"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::AreaRim,
+                                       MountCardinality::ZeroOrOne,
+                                       {attempt("first", ModuleArchiveFamily::AreaRim),
+                                        attempt("second", ModuleArchiveFamily::AreaRim)}));
+
+    auto report = run(plan);
+
+    EXPECT_EQ((std::vector<std::string> {"first"}), mountedIds(report));
+    EXPECT_EQ((std::vector<std::string> {"first"}), attemptedIds(report))
+        << "the second source must not even be attempted once one is mounted";
+    EXPECT_EQ("first", shared());
+}
+
+TEST_F(ModuleMountExecutorTest, lets_a_structural_rejection_escape_rather_than_reporting_a_failed_mount) {
+    // Mounting a placed source into a list holding unplaced ones is a fault in
+    // the caller, not an archive that failed to open. Reporting it as a missed
+    // mount would hide it behind a best-effort result.
+    TmpDir tmp("reone_test_mount_structural");
+    _resources.addMemERF(erfBytes("shared", "unplaced"), ContainerKind::Global);
+    addDiskSource("placed", ModuleArchiveFamily::StaticRim, tmp.writeRim("foo_s.rim", "placed"));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::StaticRim,
+                                       MountCardinality::FirstSuccessful,
+                                       {attempt("placed", ModuleArchiveFamily::StaticRim)}));
+
+    EXPECT_THROW(run(plan), ValidationException);
+}
+
+TEST_F(ModuleMountExecutorTest, treats_a_corrupt_archive_as_a_failed_load_rather_than_a_missing_source) {
+    // Best effort means a source that is not there, not one that is there and
+    // unreadable. The unactivated path mounts without a guard, so a corrupt
+    // archive already aborts the module load; swallowing it here would make an
+    // activated game quietly more tolerant than an unactivated one.
+    TmpDir tmp("reone_test_mount_corrupt");
+    tmp.write("foo_s.rim", ByteBuffer {'n', 'o', 't', ' ', 'a', ' ', 'r', 'i', 'm'});
+    addDiskSource("corrupt", ModuleArchiveFamily::StaticRim, tmp.path / "foo_s.rim");
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::StaticRim,
+                                       MountCardinality::FirstSuccessful,
+                                       {attempt("corrupt", ModuleArchiveFamily::StaticRim)}));
+
+    EXPECT_THROW(run(plan), ValidationException);
+}
+
+TEST_F(ModuleMountExecutorTest, still_treats_an_absent_source_as_best_effort) {
+    // The complement of the two throwing cases: absence is answered before any
+    // archive is opened, so it never reaches the exception handling at all.
+    TmpDir tmp("reone_test_mount_absent");
+    addDiskSource("gone", ModuleArchiveFamily::Dialogue, tmp.path / "absent_dlg.erf");
+    addStagedSource("unstaged", ModuleArchiveFamily::SavedArchive, ResourceId("nothing", ResType::Sav));
+
+    ModuleLoadPlan plan;
+    plan.families.push_back(familyPlan(ModuleArchiveFamily::Dialogue,
+                                       MountCardinality::AllSuccessful,
+                                       {attempt("gone", ModuleArchiveFamily::Dialogue),
+                                        attempt("unstaged", ModuleArchiveFamily::SavedArchive)}));
+
+    ModuleMountReport report;
+    ASSERT_NO_THROW(report = run(plan));
+    EXPECT_TRUE(mountedIds(report).empty());
+    EXPECT_FALSE(report.requiredFailure);
+}
+
+TEST_F(ModuleMountExecutorTest, mounts_nothing_for_a_plan_without_a_primary) {
+    ModuleLoadPlan plan;
+    auto report = run(plan);
+    EXPECT_TRUE(report.outcomes.empty());
+    EXPECT_FALSE(report.requiredFailure);
+}

--- a/test/resource/provider/audioclips.cpp
+++ b/test/resource/provider/audioclips.cpp
@@ -81,8 +81,8 @@ TEST(AudioClips, resolves_a_streamed_asset_from_the_streaming_location_first) {
     // that must play, so an ordinary source may not take its place.
     Resources ordinary;
     Resources streams;
-    ordinary.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kOrdinaryRate)), ContainerKind::Global);
-    streams.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kStreamRate)), ContainerKind::Global);
+    ordinary.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kOrdinaryRate)), ResourceOwner::Global);
+    streams.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kStreamRate)), ResourceOwner::Global);
 
     AudioClips clips(ordinary, streams);
     auto clip = clips.get("vo");
@@ -95,7 +95,7 @@ TEST(AudioClips, resolves_a_streamed_asset_from_the_streaming_location_first) {
 TEST(AudioClips, falls_back_to_ordinary_resources_for_anything_not_streamed) {
     Resources ordinary;
     Resources streams;
-    ordinary.addMemERF(erfWith("sfx", ResType::Wav, wavBytes(kOrdinaryRate)), ContainerKind::Global);
+    ordinary.addMemERF(erfWith("sfx", ResType::Wav, wavBytes(kOrdinaryRate)), ResourceOwner::Global);
 
     AudioClips clips(ordinary, streams);
     auto clip = clips.get("sfx");

--- a/test/resource/provider/audioclips.cpp
+++ b/test/resource/provider/audioclips.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Where a streamed asset is resolved from.
+ *
+ * The streaming directories are not part of the Odyssey raw lookup order, so
+ * this precedence belongs to the streaming subsystem rather than to a bucket.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/audio/clip.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/provider/audioclips.h"
+#include "reone/resource/resources.h"
+#include "reone/system/stream/memoryoutput.h"
+#include "reone/system/stringbuilder.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+namespace {
+
+/// A one-sample mono WAV whose sample rate identifies the source it came from.
+ByteBuffer wavBytes(uint32_t sampleRate) {
+    std::string rate;
+    for (int i = 0; i < 4; ++i) {
+        rate.push_back(static_cast<char>((sampleRate >> (8 * i)) & 0xff));
+    }
+    auto data = StringBuilder()
+                    .append("RIFF")
+                    .append("\x00\x00\x00\x00", 4)
+                    .append("WAVE")
+                    .append("fmt ")
+                    .append("\x10\x00\x00\x00", 4)
+                    .append("\x01\x00", 2)
+                    .append("\x01\x00", 2)
+                    .append(rate.data(), 4)
+                    .append("\x00\x00\x00\x00", 4)
+                    .append("\x00\x00", 2)
+                    .append("\x08\x00", 2)
+                    .append("data")
+                    .append("\x02\x00\x00\x00", 4)
+                    .append("\xff\x7f", 2)
+                    .string();
+    return ByteBuffer(data.begin(), data.end());
+}
+
+ByteBuffer erfWith(const std::string &resRef, ResType type, ByteBuffer data) {
+    ErfWriter writer;
+    writer.add(ErfWriter::Resource {resRef, type, std::move(data)});
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(ErfWriter::FileType::ERF, stream);
+    return buffer;
+}
+
+constexpr uint32_t kStreamRate = 22050;
+constexpr uint32_t kOrdinaryRate = 44100;
+
+} // namespace
+
+TEST(AudioClips, resolves_a_streamed_asset_from_the_streaming_location_first) {
+    // A retail K2 installation ships hundreds of voice lines in both the
+    // streaming directories and the key tables. The streamed copy is the one
+    // that must play, so an ordinary source may not take its place.
+    Resources ordinary;
+    Resources streams;
+    ordinary.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kOrdinaryRate)), ContainerKind::Global);
+    streams.addMemERF(erfWith("vo", ResType::Wav, wavBytes(kStreamRate)), ContainerKind::Global);
+
+    AudioClips clips(ordinary, streams);
+    auto clip = clips.get("vo");
+
+    ASSERT_TRUE(static_cast<bool>(clip));
+    ASSERT_EQ(1, clip->getFrameCount());
+    EXPECT_EQ(kStreamRate, clip->getFrame(0).sampleRate);
+}
+
+TEST(AudioClips, falls_back_to_ordinary_resources_for_anything_not_streamed) {
+    Resources ordinary;
+    Resources streams;
+    ordinary.addMemERF(erfWith("sfx", ResType::Wav, wavBytes(kOrdinaryRate)), ContainerKind::Global);
+
+    AudioClips clips(ordinary, streams);
+    auto clip = clips.get("sfx");
+
+    ASSERT_TRUE(static_cast<bool>(clip));
+    EXPECT_EQ(kOrdinaryRate, clip->getFrame(0).sampleRate);
+}
+
+TEST(AudioClips, reports_a_clip_that_neither_location_holds) {
+    Resources ordinary;
+    Resources streams;
+
+    AudioClips clips(ordinary, streams);
+
+    EXPECT_FALSE(static_cast<bool>(clips.get("missing")));
+}

--- a/test/resource/provider/scripts.cpp
+++ b/test/resource/provider/scripts.cpp
@@ -62,7 +62,7 @@ ByteBuffer erfBytes(std::string resRef, ByteBuffer data) {
 class ScriptsReplacementTest : public testing::Test {
 protected:
     void SetUp() override {
-        _resources.addMemERF(erfBytes("script", ncsBytes(1)), ContainerKind::Global);
+        _resources.addMemERF(erfBytes("script", ncsBytes(1)), ResourceOwner::Global);
     }
 
     ResourceId id() const {

--- a/test/resource/replacements.cpp
+++ b/test/resource/replacements.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/resource/extractresources.h"
 #include "reone/resource/format/erfwriter.h"
+#include "reone/resource/mounttransaction.h"
 #include "reone/resource/replacementresources.h"
 #include "reone/resource/replacements.h"
 #include "reone/resource/resources.h"
@@ -77,8 +78,8 @@ protected:
         return ResourceId(std::move(resRef), ResType::Txt);
     }
 
-    void addMounted(std::string resRef, std::string data, ContainerKind kind = ContainerKind::Global) {
-        _resources->addMemERF(erfBytes({ErfWriter::Resource {std::move(resRef), ResType::Txt, bytes(data)}}), kind);
+    void addMounted(std::string resRef, std::string data, ResourceOwner owner = ResourceOwner::Global) {
+        _resources->addMemERF(erfBytes({ErfWriter::Resource {std::move(resRef), ResType::Txt, bytes(data)}}), owner);
     }
 
     ResourceReplacements _replacements;
@@ -164,15 +165,33 @@ TEST_P(ReplacementResourcesTest, returned_data_remains_valid_after_replacement_c
 }
 
 TEST_P(ReplacementResourcesTest, replacements_survive_local_and_save_scope_changes) {
-    addMounted("shared", "global", ContainerKind::Global);
-    addMounted("shared", "save", ContainerKind::Save);
-    addMounted("shared", "local", ContainerKind::Local);
+    addMounted("shared", "global", ResourceOwner::Global);
+    addMounted("shared", "save", ResourceOwner::SaveSlot);
+    addMounted("shared", "local", ResourceOwner::ActiveModule);
     _replacements.replaceResource(id("shared"), bytes("replacement"));
 
-    _resources->clearLocal();
-    _resources->clearSave();
+    _resources->clearOwner(ResourceOwner::ActiveModule);
+    _resources->clearOwner(ResourceOwner::SaveSlot);
 
     EXPECT_EQ("replacement", dataOf(_resources->find(id("shared"))));
+}
+
+TEST_P(ReplacementResourcesTest, replacements_survive_an_undone_mount) {
+    addMounted("shared", "global", ResourceOwner::Global);
+    _replacements.replaceResource(id("shared"), bytes("replacement"));
+
+    {
+        ResourceMountTransaction transaction(*_resources);
+        addMounted("shared", "module", ResourceOwner::ActiveModule);
+    }
+
+    // Replacements are not mounted sources. Taking back the sources of a failed
+    // operation cannot reach them, and cannot move them either.
+    EXPECT_EQ("replacement", dataOf(_resources->find(id("shared"))));
+
+    _replacements.clearResourceReplacements();
+    EXPECT_EQ("global", dataOf(_resources->find(id("shared"))))
+        << "the undone mount really was removed underneath the replacement";
 }
 
 TEST(ResourceReplacementsRevision, advances_on_every_meaningful_state_transition) {

--- a/test/resource/sourcebuckets.cpp
+++ b/test/resource/sourcebuckets.cpp
@@ -44,8 +44,9 @@ using namespace reone::test;
 namespace {
 
 struct TestSource {
-    ContainerKind kind;
+    ResourceOwner owner;
     std::optional<ResourceSourceBucket> bucket;
+    ResourceMountToken sequence {0};
     std::string name;
 };
 
@@ -60,8 +61,8 @@ std::vector<std::string> names(const ResourceSourceList<TestSource> &list) {
 void add(ResourceSourceList<TestSource> &list,
          std::string name,
          std::optional<ResourceSourceBucket> bucket = std::nullopt,
-         ContainerKind kind = ContainerKind::Global) {
-    list.add(TestSource {kind, bucket, std::move(name)});
+         ResourceOwner owner = ResourceOwner::Global) {
+    list.add(TestSource {owner, bucket, 0, std::move(name)});
 }
 
 enum class Backend {
@@ -184,7 +185,7 @@ TEST(ResourceSourceList, should_release_its_mode_once_empty) {
     EXPECT_NO_THROW(add(list, "loose", ResourceSourceBucket::LooseDirectory));
     EXPECT_EQ(ResourceSourceOrder::Bucketed, list.order());
 
-    list.clearKind(ContainerKind::Global);
+    list.clearOwner(ResourceOwner::Global);
 
     EXPECT_EQ(ResourceSourceOrder::Empty, list.order()) << "clearing a scope empty must release the mode too";
     EXPECT_NO_THROW(add(list, "unplaced again"));
@@ -192,17 +193,17 @@ TEST(ResourceSourceList, should_release_its_mode_once_empty) {
 
 TEST(ResourceSourceList, should_clear_one_kind_across_every_bucket) {
     ResourceSourceList<TestSource> list;
-    add(list, "global_loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Global);
-    add(list, "local_loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Local);
-    add(list, "local_keybif", ResourceSourceBucket::KeyBif, ContainerKind::Local);
-    add(list, "save_image", ResourceSourceBucket::ResourceImage, ContainerKind::Save);
+    add(list, "global_loose", ResourceSourceBucket::LooseDirectory, ResourceOwner::Global);
+    add(list, "local_loose", ResourceSourceBucket::LooseDirectory, ResourceOwner::ActiveModule);
+    add(list, "local_keybif", ResourceSourceBucket::KeyBif, ResourceOwner::ActiveModule);
+    add(list, "save_image", ResourceSourceBucket::ResourceImage, ResourceOwner::SaveSlot);
 
-    list.clearKind(ContainerKind::Local);
+    list.clearOwner(ResourceOwner::ActiveModule);
 
     EXPECT_EQ((std::vector<std::string> {"global_loose", "save_image"}), names(list))
         << "scope decides when a source goes away, never where it is searched";
 
-    list.clearKind(ContainerKind::Save);
+    list.clearOwner(ResourceOwner::SaveSlot);
     EXPECT_EQ((std::vector<std::string> {"global_loose"}), names(list));
 
     list.clear();
@@ -224,8 +225,8 @@ protected:
 
     void mount(const std::string &data,
                std::optional<ResourceSourceBucket> bucket = std::nullopt,
-               ContainerKind kind = ContainerKind::Global) {
-        _resources->addMemERF(erfBytes("shared", data), kind, bucket);
+               ResourceOwner owner = ResourceOwner::Global) {
+        _resources->addMemERF(erfBytes("shared", data), owner, bucket);
     }
 
     std::string shared() {
@@ -283,26 +284,26 @@ TEST_P(ResourceSourceBucketsTest, should_place_rim_sources_in_the_requested_buck
 
     mount("loose", ResourceSourceBucket::LooseDirectory);
     _resources->addMemRIM(rimBytes("shared", "memory rim"),
-                          ContainerKind::Global,
+                          ResourceOwner::Global,
                           ResourceSourceBucket::KeyBif);
     _resources->addRIM(dir.path / "disk.rim",
-                       ContainerKind::Global,
+                       ResourceOwner::Global,
                        ResourceSourceBucket::KeyBif);
 
     EXPECT_EQ("loose", shared());
 }
 
 TEST_P(ResourceSourceBucketsTest, should_leave_bucket_order_intact_when_clearing_a_scope) {
-    mount("global keybif", ResourceSourceBucket::KeyBif, ContainerKind::Global);
-    mount("save image", ResourceSourceBucket::ResourceImage, ContainerKind::Save);
-    mount("local loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Local);
+    mount("global keybif", ResourceSourceBucket::KeyBif, ResourceOwner::Global);
+    mount("save image", ResourceSourceBucket::ResourceImage, ResourceOwner::SaveSlot);
+    mount("local loose", ResourceSourceBucket::LooseDirectory, ResourceOwner::ActiveModule);
 
     EXPECT_EQ("local loose", shared());
 
-    _resources->clearLocal();
+    _resources->clearOwner(ResourceOwner::ActiveModule);
     EXPECT_EQ("save image", shared());
 
-    _resources->clearSave();
+    _resources->clearOwner(ResourceOwner::SaveSlot);
     EXPECT_EQ("global keybif", shared());
 
     _resources->clear();
@@ -334,7 +335,7 @@ protected:
     }
 
     void mount(const std::string &data, std::optional<ResourceSourceBucket> bucket) {
-        _resources->addMemERF(erfBytes("shared", data), ContainerKind::Global, bucket);
+        _resources->addMemERF(erfBytes("shared", data), ResourceOwner::Global, bucket);
     }
 
     std::string shared() {
@@ -358,7 +359,7 @@ TEST_P(ReplacementOverlayBucketsTest, should_apply_one_store_to_every_list_that_
     ReplacementResources aux(std::move(auxBackend), _replacements);
 
     mount("bucketed", ResourceSourceBucket::LooseDirectory);
-    aux.addMemERF(erfBytes("shared", "auxiliary"), ContainerKind::Global);
+    aux.addMemERF(erfBytes("shared", "auxiliary"), ResourceOwner::Global);
 
     EXPECT_EQ("bucketed", shared());
     EXPECT_EQ("auxiliary", dataOf(aux.find(id())));

--- a/test/resource/sourcebuckets.cpp
+++ b/test/resource/sourcebuckets.cpp
@@ -345,6 +345,31 @@ protected:
     std::unique_ptr<ReplacementResources> _resources;
 };
 
+TEST_P(ReplacementOverlayBucketsTest, should_apply_one_store_to_every_list_that_shares_it) {
+    // Sources outside the Odyssey lookup order are held in a separate list, but
+    // they are read through the same replacement store. A second store would
+    // silently make those resources unreplaceable.
+    std::unique_ptr<IResources> auxBackend;
+    if (GetParam() == Backend::Legacy) {
+        auxBackend = std::make_unique<Resources>();
+    } else {
+        auxBackend = std::make_unique<ExtractResources>();
+    }
+    ReplacementResources aux(std::move(auxBackend), _replacements);
+
+    mount("bucketed", ResourceSourceBucket::LooseDirectory);
+    aux.addMemERF(erfBytes("shared", "auxiliary"), ContainerKind::Global);
+
+    EXPECT_EQ("bucketed", shared());
+    EXPECT_EQ("auxiliary", dataOf(aux.find(id())));
+
+    _replacements.replaceResource(id(), bytes("replacement"));
+
+    EXPECT_EQ("replacement", shared());
+    EXPECT_EQ("replacement", dataOf(aux.find(id())))
+        << "the same store must sit above an unplaced auxiliary source too";
+}
+
 TEST_P(ReplacementOverlayBucketsTest, should_carry_the_bucket_through_to_the_backend) {
     mount("loose", ResourceSourceBucket::LooseDirectory);
     mount("keybif", ResourceSourceBucket::KeyBif);

--- a/test/resource/sourcebuckets.cpp
+++ b/test/resource/sourcebuckets.cpp
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The shared source list, and the equivalence both IResources backends owe
+ * each other once sources carry a bucket.
+ *
+ * Placing a source in a bucket is capability only at this point: no caller
+ * does it, so the characterization suites in lookup.cpp and extractresources.cpp
+ * continue to describe what the engine actually does.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/replacementresources.h"
+#include "reone/resource/replacements.h"
+#include "reone/resource/resources.h"
+#include "reone/resource/sourcelist.h"
+#include "reone/system/exception/validation.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/archive.h"
+
+using namespace reone;
+using namespace reone::resource;
+using namespace reone::test;
+
+namespace {
+
+struct TestSource {
+    ContainerKind kind;
+    std::optional<ResourceSourceBucket> bucket;
+    std::string name;
+};
+
+std::vector<std::string> names(const ResourceSourceList<TestSource> &list) {
+    std::vector<std::string> result;
+    for (const auto &entry : list) {
+        result.push_back(entry.name);
+    }
+    return result;
+}
+
+void add(ResourceSourceList<TestSource> &list,
+         std::string name,
+         std::optional<ResourceSourceBucket> bucket = std::nullopt,
+         ContainerKind kind = ContainerKind::Global) {
+    list.add(TestSource {kind, bucket, std::move(name)});
+}
+
+enum class Backend {
+    Legacy,
+    Extract,
+};
+
+std::string backendName(const testing::TestParamInfo<Backend> &info) {
+    return info.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+ByteBuffer erfBytes(const std::string &resRef, const std::string &data) {
+    ErfWriter writer;
+    writer.add(ErfWriter::Resource {resRef, ResType::Txt, bytes(data)});
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(ErfWriter::FileType::ERF, stream);
+    return buffer;
+}
+
+ByteBuffer rimBytes(const std::string &resRef, const std::string &data) {
+    RimWriter writer;
+    writer.add(RimWriter::Resource {resRef, ResType::Txt, bytes(data)});
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    return buffer;
+}
+
+std::string dataOf(const std::optional<Resource> &resource) {
+    if (!resource) {
+        return "<not found>";
+    }
+    return std::string(resource->data.begin(), resource->data.end());
+}
+
+} // namespace
+
+// The list itself: which source wins, and when a source goes away.
+
+TEST(ResourceSourceRank, should_rank_buckets_in_raw_lookup_order) {
+    std::optional<std::size_t> previous;
+    for (auto bucket : kRawResourceLookupOrder) {
+        if (previous) {
+            EXPECT_LT(*previous, bucketRank(bucket)) << "buckets must rank in kRawResourceLookupOrder";
+        }
+        previous = bucketRank(bucket);
+    }
+
+    EXPECT_EQ(0u, bucketRank(kRawResourceLookupOrder.front()));
+    EXPECT_EQ(kRawResourceLookupOrder.size() - 1, bucketRank(kRawResourceLookupOrder.back()));
+}
+
+TEST(ResourceSourceList, should_search_unbucketed_sources_newest_first) {
+    ResourceSourceList<TestSource> list;
+    add(list, "first");
+    add(list, "second");
+    add(list, "third");
+
+    EXPECT_EQ((std::vector<std::string> {"third", "second", "first"}), names(list));
+}
+
+TEST(ResourceSourceList, should_order_bucketed_sources_by_bucket_not_by_add_order) {
+    ResourceSourceList<TestSource> list;
+    add(list, "keybif", ResourceSourceBucket::KeyBif);
+    add(list, "loose", ResourceSourceBucket::LooseDirectory);
+    add(list, "class2", ResourceSourceBucket::EncapsulatedClass2);
+    add(list, "image", ResourceSourceBucket::ResourceImage);
+    add(list, "class1", ResourceSourceBucket::EncapsulatedClass1);
+
+    EXPECT_EQ((std::vector<std::string> {"loose", "class1", "image", "class2", "keybif"}), names(list));
+}
+
+TEST(ResourceSourceList, should_search_one_bucket_newest_first) {
+    ResourceSourceList<TestSource> list;
+    add(list, "older", ResourceSourceBucket::EncapsulatedClass2);
+    add(list, "newer", ResourceSourceBucket::EncapsulatedClass2);
+    add(list, "loose", ResourceSourceBucket::LooseDirectory);
+
+    EXPECT_EQ((std::vector<std::string> {"loose", "newer", "older"}), names(list));
+}
+
+TEST(ResourceSourceList, should_take_its_mode_from_the_first_source) {
+    ResourceSourceList<TestSource> unbucketed;
+    EXPECT_EQ(ResourceSourceOrder::Empty, unbucketed.order());
+    add(unbucketed, "unplaced");
+    EXPECT_EQ(ResourceSourceOrder::Insertion, unbucketed.order());
+
+    ResourceSourceList<TestSource> bucketed;
+    add(bucketed, "loose", ResourceSourceBucket::LooseDirectory);
+    EXPECT_EQ(ResourceSourceOrder::Bucketed, bucketed.order());
+}
+
+TEST(ResourceSourceList, should_reject_a_bucketed_source_in_an_insertion_ordered_list) {
+    ResourceSourceList<TestSource> list;
+    add(list, "unplaced");
+
+    EXPECT_THROW(add(list, "loose", ResourceSourceBucket::LooseDirectory), ValidationException);
+    EXPECT_EQ((std::vector<std::string> {"unplaced"}), names(list)) << "a rejected mount must not be held";
+}
+
+TEST(ResourceSourceList, should_reject_an_unbucketed_source_in_a_bucketed_list) {
+    ResourceSourceList<TestSource> list;
+    add(list, "loose", ResourceSourceBucket::LooseDirectory);
+
+    EXPECT_THROW(add(list, "unplaced"), ValidationException);
+    EXPECT_EQ((std::vector<std::string> {"loose"}), names(list)) << "a rejected mount must not be held";
+}
+
+TEST(ResourceSourceList, should_release_its_mode_once_empty) {
+    ResourceSourceList<TestSource> list;
+    add(list, "unplaced");
+    list.clear();
+
+    EXPECT_EQ(ResourceSourceOrder::Empty, list.order());
+    EXPECT_NO_THROW(add(list, "loose", ResourceSourceBucket::LooseDirectory));
+    EXPECT_EQ(ResourceSourceOrder::Bucketed, list.order());
+
+    list.clearKind(ContainerKind::Global);
+
+    EXPECT_EQ(ResourceSourceOrder::Empty, list.order()) << "clearing a scope empty must release the mode too";
+    EXPECT_NO_THROW(add(list, "unplaced again"));
+}
+
+TEST(ResourceSourceList, should_clear_one_kind_across_every_bucket) {
+    ResourceSourceList<TestSource> list;
+    add(list, "global_loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Global);
+    add(list, "local_loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Local);
+    add(list, "local_keybif", ResourceSourceBucket::KeyBif, ContainerKind::Local);
+    add(list, "save_image", ResourceSourceBucket::ResourceImage, ContainerKind::Save);
+
+    list.clearKind(ContainerKind::Local);
+
+    EXPECT_EQ((std::vector<std::string> {"global_loose", "save_image"}), names(list))
+        << "scope decides when a source goes away, never where it is searched";
+
+    list.clearKind(ContainerKind::Save);
+    EXPECT_EQ((std::vector<std::string> {"global_loose"}), names(list));
+
+    list.clear();
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(0u, list.size());
+}
+
+// Both backends must resolve an identical mount sequence identically.
+
+class ResourceSourceBucketsTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        if (GetParam() == Backend::Legacy) {
+            _resources = std::make_unique<Resources>();
+        } else {
+            _resources = std::make_unique<ExtractResources>();
+        }
+    }
+
+    void mount(const std::string &data,
+               std::optional<ResourceSourceBucket> bucket = std::nullopt,
+               ContainerKind kind = ContainerKind::Global) {
+        _resources->addMemERF(erfBytes("shared", data), kind, bucket);
+    }
+
+    std::string shared() {
+        return dataOf(_resources->find(ResourceId("shared", ResType::Txt)));
+    }
+
+    std::unique_ptr<IResources> _resources;
+};
+
+TEST_P(ResourceSourceBucketsTest, should_resolve_by_insertion_order_when_no_source_is_bucketed) {
+    mount("first");
+    mount("second");
+
+    EXPECT_EQ("second", shared()) << "an unbucketed list must behave exactly as it always has";
+}
+
+TEST_P(ResourceSourceBucketsTest, should_resolve_bucketed_sources_in_raw_lookup_order) {
+    mount("loose", ResourceSourceBucket::LooseDirectory);
+    mount("class2", ResourceSourceBucket::EncapsulatedClass2);
+    mount("keybif", ResourceSourceBucket::KeyBif);
+
+    EXPECT_EQ("loose", shared()) << "bucket order must beat add order";
+}
+
+TEST_P(ResourceSourceBucketsTest, should_prefer_the_last_added_source_within_one_bucket) {
+    mount("older", ResourceSourceBucket::ResourceImage);
+    mount("newer", ResourceSourceBucket::ResourceImage);
+
+    EXPECT_EQ("newer", shared());
+}
+
+TEST_P(ResourceSourceBucketsTest, should_reject_mounting_across_the_mode_it_is_already_in) {
+    mount("loose", ResourceSourceBucket::LooseDirectory);
+
+    EXPECT_THROW(mount("unplaced"), ValidationException)
+        << "an unbucketed source has no rank in the raw lookup order to be placed at";
+    EXPECT_EQ("loose", shared()) << "a rejected mount must leave the backend as it was";
+}
+
+TEST_P(ResourceSourceBucketsTest, should_reject_a_bucketed_mount_once_ordering_by_insertion) {
+    mount("unplaced");
+
+    EXPECT_THROW(mount("loose", ResourceSourceBucket::LooseDirectory), ValidationException);
+    EXPECT_EQ("unplaced", shared());
+}
+
+TEST_P(ResourceSourceBucketsTest, should_place_rim_sources_in_the_requested_bucket) {
+    // RIM mounts take routes of their own on the way to the source list: the
+    // extract backend resolves a RIM path through its ERF mount, and both
+    // backends build a memory RIM through a shared archive helper. A bucket
+    // dropped on either route would leave the source unplaced, and unplaced
+    // beats every bucket, so the last one added would win instead.
+    TmpDir dir("reone_test_source_buckets_rim");
+    writeRim(dir.path / "disk.rim", {{"shared", ResType::Txt, "disk rim"}});
+
+    mount("loose", ResourceSourceBucket::LooseDirectory);
+    _resources->addMemRIM(rimBytes("shared", "memory rim"),
+                          ContainerKind::Global,
+                          ResourceSourceBucket::KeyBif);
+    _resources->addRIM(dir.path / "disk.rim",
+                       ContainerKind::Global,
+                       ResourceSourceBucket::KeyBif);
+
+    EXPECT_EQ("loose", shared());
+}
+
+TEST_P(ResourceSourceBucketsTest, should_leave_bucket_order_intact_when_clearing_a_scope) {
+    mount("global keybif", ResourceSourceBucket::KeyBif, ContainerKind::Global);
+    mount("save image", ResourceSourceBucket::ResourceImage, ContainerKind::Save);
+    mount("local loose", ResourceSourceBucket::LooseDirectory, ContainerKind::Local);
+
+    EXPECT_EQ("local loose", shared());
+
+    _resources->clearLocal();
+    EXPECT_EQ("save image", shared());
+
+    _resources->clearSave();
+    EXPECT_EQ("global keybif", shared());
+
+    _resources->clear();
+    EXPECT_EQ("<not found>", shared());
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         ResourceSourceBucketsTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+// The replacement overlay wraps whichever backend is in use. It has to carry a
+// bucket through to that backend, and it is not itself a bucket.
+
+class ReplacementOverlayBucketsTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        std::unique_ptr<IResources> backend;
+        if (GetParam() == Backend::Legacy) {
+            backend = std::make_unique<Resources>();
+        } else {
+            backend = std::make_unique<ExtractResources>();
+        }
+        _resources = std::make_unique<ReplacementResources>(std::move(backend), _replacements);
+    }
+
+    ResourceId id() const {
+        return ResourceId("shared", ResType::Txt);
+    }
+
+    void mount(const std::string &data, std::optional<ResourceSourceBucket> bucket) {
+        _resources->addMemERF(erfBytes("shared", data), ContainerKind::Global, bucket);
+    }
+
+    std::string shared() {
+        return dataOf(_resources->find(id()));
+    }
+
+    ResourceReplacements _replacements;
+    std::unique_ptr<ReplacementResources> _resources;
+};
+
+TEST_P(ReplacementOverlayBucketsTest, should_carry_the_bucket_through_to_the_backend) {
+    mount("loose", ResourceSourceBucket::LooseDirectory);
+    mount("keybif", ResourceSourceBucket::KeyBif);
+
+    EXPECT_EQ("loose", shared())
+        << "a bucket dropped on the way to the backend would leave both sources unplaced, "
+           "and the one added last would win instead";
+}
+
+TEST_P(ReplacementOverlayBucketsTest, should_keep_the_overlay_above_every_bucket) {
+    mount("loose", ResourceSourceBucket::LooseDirectory);
+    _replacements.replaceResource(id(), bytes("replacement"));
+
+    EXPECT_EQ("replacement", shared())
+        << "the overlay is not a bucket of its own: it outranks even the first one";
+
+    _replacements.removeResourceReplacement(id());
+
+    EXPECT_EQ("loose", shared()) << "dropping the replacement must expose the bucketed source again";
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         ReplacementOverlayBucketsTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -372,6 +372,73 @@ INSTANTIATE_TEST_SUITE_P(Backends,
                          testing::Values(Backend::Legacy, Backend::Extract),
                          backendName);
 
+/**
+ * Test-only backend decorator that turns one otherwise valid disk mount into a
+ * non-validation failure. ModuleMountExecutor catches std::exception from a
+ * backend and reports a missed mount, which is the production path that must
+ * now produce Failed rather than committing a partial module.
+ */
+class RejectingResources : public IResources {
+public:
+    RejectingResources(std::unique_ptr<IResources> backend, std::string rejectedName) :
+        _backend(std::move(backend)),
+        _rejectedName(std::move(rejectedName)) {
+    }
+
+    void clear() override { _backend->clear(); }
+    void clearOwner(ResourceOwner owner) override { _backend->clearOwner(owner); }
+    ResourceMountToken mountToken() const override { return _backend->mountToken(); }
+    void rollbackTo(ResourceMountToken token) override { _backend->rollbackTo(token); }
+
+    void addEXE(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket) override {
+        _backend->addEXE(path, bucket);
+    }
+    void addKEY(const std::filesystem::path &path,
+                std::optional<ResourceSourceBucket> bucket) override {
+        _backend->addKEY(path, bucket);
+    }
+    void addERF(const std::filesystem::path &path,
+                ResourceOwner owner,
+                std::optional<ResourceSourceBucket> bucket) override {
+        reject(path);
+        _backend->addERF(path, owner, bucket);
+    }
+    void addMemERF(ByteBuffer buffer,
+                   ResourceOwner owner,
+                   std::optional<ResourceSourceBucket> bucket) override {
+        _backend->addMemERF(std::move(buffer), owner, bucket);
+    }
+    void addRIM(const std::filesystem::path &path,
+                ResourceOwner owner,
+                std::optional<ResourceSourceBucket> bucket) override {
+        reject(path);
+        _backend->addRIM(path, owner, bucket);
+    }
+    void addMemRIM(ByteBuffer buffer,
+                   ResourceOwner owner,
+                   std::optional<ResourceSourceBucket> bucket) override {
+        _backend->addMemRIM(std::move(buffer), owner, bucket);
+    }
+    void addFolder(const std::filesystem::path &path,
+                   ResourceOwner owner,
+                   std::optional<ResourceSourceBucket> bucket) override {
+        _backend->addFolder(path, owner, bucket);
+    }
+
+    Resource get(const ResourceId &id) override { return _backend->get(id); }
+    std::optional<Resource> find(const ResourceId &id) override { return _backend->find(id); }
+
+private:
+    void reject(const std::filesystem::path &path) const {
+        if (path.filename().string() == _rejectedName) {
+            throw std::runtime_error("injected non-validation mount failure");
+        }
+    }
+
+    std::unique_ptr<IResources> _backend;
+    std::string _rejectedName;
+};
 /// Save and module lifetimes as the director drives them.
 class SourceLifetimeFixture {
 protected:
@@ -390,6 +457,9 @@ protected:
         _auxResources = std::make_unique<Resources>();
     }
 
+    void rejectDiskMount(const std::string &filename) {
+        _resources = std::make_unique<RejectingResources>(std::move(_resources), filename);
+    }
     void makeInstallation(TmpDir &game, TmpDir &cwd) {
         writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
         game.mkdir("modules");
@@ -857,6 +927,104 @@ TEST_P(SourceLifetimeDirectorTest, a_module_that_fails_partway_leaves_none_of_it
     EXPECT_EQ(beforeAttempt, _count());
 }
 
+TEST_P(SourceLifetimeDirectorTest, a_non_exception_required_failure_rolls_back_the_new_module) {
+    TmpDir game("reone_test_lifetime_required_result_failure");
+    TmpDir cwd("reone_test_lifetime_required_result_failure_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"foo_base", ResType::Txt, "base"}});
+    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
+    rejectDiskMount("foo_s.rim");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto globalCount = _count();
+
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ(globalCount, _count());
+    EXPECT_FALSE(has("foo_area")) << "an adjunct mounted before the required failure is rolled back";
+    EXPECT_FALSE(has("foo_base")) << "an ordinary active image is not the CURRENTGAME recovery route";
+    EXPECT_FALSE(has("foo_static"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, a_required_failure_can_recover_through_active_saved_state) {
+    TmpDir game("reone_test_lifetime_required_recovery");
+    TmpDir cwd("reone_test_lifetime_required_recovery_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"disk_base", ResType::Txt, "disk"}});
+    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
+
+    auto staged = erfBytes(ErfWriter::FileType::MOD,
+                           {{"recovered", ResType::Txt, "saved state"}});
+    auto slot = game.mkdir("saves/slot_a");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"foo", ResType::Sav, blob(staged)}});
+    rejectDiskMount("foo_s.rim");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("slot_a");
+
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ("saved state", find("recovered"));
+    EXPECT_TRUE(has("foo_area")) << "the recovered module transaction is committed";
+    EXPECT_FALSE(has("foo_static"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, no_primary_with_discoverable_sidecars_rolls_back_everything) {
+    TmpDir game("reone_test_lifetime_no_primary_sidecars");
+    TmpDir cwd("reone_test_lifetime_no_primary_sidecars_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto globalCount = _count();
+
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ(globalCount, _count());
+    EXPECT_FALSE(has("foo_area"));
+    EXPECT_FALSE(has("foo_static"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, a_best_effort_failure_does_not_fail_the_module) {
+    TmpDir game("reone_test_lifetime_best_effort_result");
+    TmpDir cwd("reone_test_lifetime_best_effort_result_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "foo.rim", {{"foo_base", ResType::Txt, "base"}});
+    writeErf(modules / "foo_dlg.erf", ErfWriter::FileType::ERF,
+             {{"foo_dialogue", ResType::Txt, "dialogue"}});
+    rejectDiskMount("foo_dlg.erf");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_NO_THROW(director->onModuleLoad("foo"));
+    EXPECT_EQ("base", find("foo_base"));
+    EXPECT_FALSE(has("foo_dialogue"));
+}
 /// The same rollback for an unreadable archive on disk. Both backends decide an
 /// archive is unusable as they mount it, so both fail here; archivevalidation
 /// covers that contract itself.

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -1,0 +1,987 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * When a mounted source goes away, and what happens when putting one in place
+ * fails partway through.
+ *
+ * These observe lookups rather than list positions: a source that has been
+ * retired must stop answering, and one that has not must keep answering
+ * exactly as before. Ownership and lookup order are separate throughout, so
+ * clearing an owner is never allowed to change which of the survivors wins.
+ *
+ * Both backends run everything, because a lifetime rule that holds for only
+ * one of them is not a rule.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "reone/resource/director.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/extractresources.h"
+#include "reone/resource/format/erfwriter.h"
+#include "reone/resource/format/rimwriter.h"
+#include "reone/resource/mounttransaction.h"
+#include "reone/resource/provider/gffs.h"
+#include "reone/resource/resources.h"
+#include "reone/system/exception/validation.h"
+#include "reone/system/stream/fileoutput.h"
+#include "reone/system/stream/memoryoutput.h"
+
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/script.h"
+
+using namespace reone;
+using namespace reone::resource;
+
+using testing::NiceMock;
+
+namespace {
+
+ByteBuffer bytes(std::string_view value) {
+    return ByteBuffer(value.begin(), value.end());
+}
+
+struct NamedRes {
+    std::string resRef;
+    ResType type;
+    std::string data;
+};
+
+ByteBuffer erfBytes(ErfWriter::FileType fileType, const std::vector<NamedRes> &resources) {
+    ErfWriter writer;
+    for (const auto &res : resources) {
+        writer.add(ErfWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(fileType, stream);
+    return buffer;
+}
+
+ByteBuffer rimBytes(const std::vector<NamedRes> &resources) {
+    RimWriter writer;
+    for (const auto &res : resources) {
+        writer.add(RimWriter::Resource {res.resRef, res.type, bytes(res.data)});
+    }
+    ByteBuffer buffer;
+    MemoryOutputStream stream(buffer);
+    writer.save(stream);
+    return buffer;
+}
+
+void writeBuffer(const std::filesystem::path &path, const ByteBuffer &buffer) {
+    std::filesystem::create_directories(path.parent_path());
+    FileOutputStream stream(path);
+    stream.write(buffer.data(), buffer.size());
+}
+
+void writeErf(const std::filesystem::path &path,
+              ErfWriter::FileType fileType,
+              const std::vector<NamedRes> &resources) {
+    writeBuffer(path, erfBytes(fileType, resources));
+}
+
+void writeRim(const std::filesystem::path &path, const std::vector<NamedRes> &resources) {
+    writeBuffer(path, rimBytes(resources));
+}
+
+void writeFile(const std::filesystem::path &path, const std::string &data) {
+    std::filesystem::create_directories(path.parent_path());
+    FileOutputStream stream(path);
+    stream.write(data.data(), data.size());
+}
+
+std::string blob(const ByteBuffer &buffer) {
+    return std::string(buffer.begin(), buffer.end());
+}
+
+/// A GFF with no fields. Enough to parse, which is all a cache-identity check
+/// needs: what is compared is whether the record was parsed again, not what it
+/// says.
+std::string emptyGff() {
+    std::string data("GFF V3.2");
+    data.append(48, '\0');
+    return data;
+}
+
+std::string dataOf(const std::optional<Resource> &res) {
+    if (!res) {
+        return "<not found>";
+    }
+    return std::string(res->data.begin(), res->data.end());
+}
+
+struct TmpDir {
+    std::filesystem::path path;
+
+    explicit TmpDir(const std::string &name) {
+        path = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path mkdir(const std::string &name) {
+        auto dir = path / name;
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+};
+
+struct CwdGuard {
+    std::filesystem::path previous;
+
+    explicit CwdGuard(const std::filesystem::path &path) {
+        previous = std::filesystem::current_path();
+        std::filesystem::current_path(path);
+    }
+
+    ~CwdGuard() {
+        std::error_code ec;
+        std::filesystem::current_path(previous, ec);
+    }
+};
+
+enum class Backend { Legacy, Extract };
+
+std::string backendName(const testing::TestParamInfo<Backend> &info) {
+    return info.param == Backend::Legacy ? "Legacy" : "Extract";
+}
+
+} // namespace
+
+/// Owner semantics on a bare backend, with no director deciding anything.
+class SourceOwnerTest : public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override {
+        if (GetParam() == Backend::Legacy) {
+            auto backend = std::make_unique<Resources>();
+            _count = [raw = backend.get()]() { return raw->containers().size(); };
+            _resources = std::move(backend);
+        } else {
+            auto backend = std::make_unique<ExtractResources>();
+            _count = [raw = backend.get()]() { return raw->sourceCount(); };
+            _resources = std::move(backend);
+        }
+    }
+
+    /// One source holding a resource of its own plus the shared probe, so both
+    /// "did it go away" and "who wins now" are observable.
+    void mount(const std::string &label, ResourceOwner owner) {
+        _resources->addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                       {{"shared", ResType::Txt, label},
+                                        {label + "_only", ResType::Txt, label}}),
+                              owner);
+    }
+
+    std::string find(const std::string &resRef) {
+        return dataOf(_resources->find(ResourceId(resRef, ResType::Txt)));
+    }
+
+    bool has(const std::string &resRef) {
+        return static_cast<bool>(_resources->find(ResourceId(resRef, ResType::Txt)));
+    }
+
+    std::unique_ptr<IResources> _resources;
+    std::function<std::size_t()> _count;
+};
+
+TEST_P(SourceOwnerTest, retires_only_the_owner_asked_for) {
+    mount("global", ResourceOwner::Global);
+    mount("save", ResourceOwner::SaveSlot);
+    mount("module", ResourceOwner::ActiveModule);
+    mount("state", ResourceOwner::ActiveModuleState);
+    mount("temp", ResourceOwner::TemporaryDiscovery);
+
+    EXPECT_TRUE(has("global_only"));
+    EXPECT_TRUE(has("save_only"));
+    EXPECT_TRUE(has("module_only"));
+    EXPECT_TRUE(has("state_only"));
+    EXPECT_TRUE(has("temp_only"));
+
+    _resources->clearOwner(ResourceOwner::TemporaryDiscovery);
+    EXPECT_FALSE(has("temp_only"));
+    EXPECT_TRUE(has("global_only"));
+    EXPECT_TRUE(has("save_only"));
+    EXPECT_TRUE(has("module_only"));
+    EXPECT_TRUE(has("state_only"));
+
+    _resources->clearOwner(ResourceOwner::ActiveModuleState);
+    EXPECT_FALSE(has("state_only"));
+    EXPECT_TRUE(has("module_only")) << "the module's state is not one of its support sources";
+    EXPECT_TRUE(has("save_only"));
+    EXPECT_TRUE(has("global_only"));
+
+    _resources->clearOwner(ResourceOwner::ActiveModule);
+    EXPECT_FALSE(has("module_only"));
+    EXPECT_TRUE(has("save_only")) << "a module transition does not unload the save";
+    EXPECT_TRUE(has("global_only"));
+
+    _resources->clearOwner(ResourceOwner::SaveSlot);
+    EXPECT_FALSE(has("save_only"));
+    EXPECT_TRUE(has("global_only")) << "unloading a save does not rebuild the installation";
+
+    _resources->clearOwner(ResourceOwner::Global);
+    EXPECT_FALSE(has("global_only"));
+    EXPECT_EQ(0u, _count());
+}
+
+TEST_P(SourceOwnerTest, retiring_an_owner_does_not_reorder_the_survivors) {
+    mount("global", ResourceOwner::Global);
+    mount("module", ResourceOwner::ActiveModule);
+    mount("save", ResourceOwner::SaveSlot);
+
+    // The save was mounted last, so it wins. Ownership had no part in that and
+    // must have no part in what wins after the module is retired either.
+    EXPECT_EQ("save", find("shared"));
+
+    _resources->clearOwner(ResourceOwner::ActiveModule);
+    EXPECT_EQ("save", find("shared"));
+
+    _resources->clearOwner(ResourceOwner::SaveSlot);
+    EXPECT_EQ("global", find("shared"));
+}
+
+TEST_P(SourceOwnerTest, retiring_an_owner_with_no_members_changes_nothing) {
+    mount("global", ResourceOwner::Global);
+
+    _resources->clearOwner(ResourceOwner::SaveSlot);
+    _resources->clearOwner(ResourceOwner::ActiveModuleState);
+    _resources->clearOwner(ResourceOwner::TemporaryDiscovery);
+
+    EXPECT_EQ("global", find("shared"));
+    EXPECT_EQ(1u, _count());
+}
+
+// Undoing an operation.
+
+TEST_P(SourceOwnerTest, rolls_back_exactly_what_was_mounted_after_the_token) {
+    mount("global", ResourceOwner::Global);
+    auto token = _resources->mountToken();
+    mount("module", ResourceOwner::ActiveModule);
+    mount("state", ResourceOwner::ActiveModuleState);
+
+    _resources->rollbackTo(token);
+
+    EXPECT_FALSE(has("module_only"));
+    EXPECT_FALSE(has("state_only")) << "rollback spans every owner the operation touched";
+    EXPECT_EQ("global", find("shared"));
+    EXPECT_EQ(1u, _count());
+}
+
+TEST_P(SourceOwnerTest, a_scope_that_is_not_committed_undoes_itself) {
+    mount("global", ResourceOwner::Global);
+    {
+        ResourceMountTransaction transaction(*_resources);
+        mount("module", ResourceOwner::ActiveModule);
+        EXPECT_TRUE(has("module_only"));
+    }
+
+    EXPECT_FALSE(has("module_only"));
+    EXPECT_EQ("global", find("shared"));
+}
+
+TEST_P(SourceOwnerTest, a_committed_scope_keeps_what_it_mounted) {
+    mount("global", ResourceOwner::Global);
+    {
+        ResourceMountTransaction transaction(*_resources);
+        mount("module", ResourceOwner::ActiveModule);
+        transaction.commit();
+    }
+
+    EXPECT_TRUE(has("module_only"));
+    EXPECT_EQ("module", find("shared"));
+}
+
+TEST_P(SourceOwnerTest, a_scope_left_by_an_exception_undoes_itself) {
+    mount("global", ResourceOwner::Global);
+    try {
+        ResourceMountTransaction transaction(*_resources);
+        mount("module", ResourceOwner::ActiveModule);
+        throw ValidationException("mount failed");
+    } catch (const ValidationException &) {
+    }
+
+    EXPECT_FALSE(has("module_only"));
+    EXPECT_EQ("global", find("shared"));
+    EXPECT_EQ(1u, _count());
+}
+
+TEST_P(SourceOwnerTest, a_rejected_mount_leaves_the_list_and_the_token_alone) {
+    _resources->addMemERF(erfBytes(ErfWriter::FileType::ERF, {{"shared", ResType::Txt, "unplaced"}}),
+                          ResourceOwner::Global);
+    auto token = _resources->mountToken();
+
+    // A list holding unplaced sources cannot take a placed one. Nothing is
+    // mounted, so nothing may be spent either: a token read afterwards has to
+    // still name the same point.
+    EXPECT_THROW(_resources->addMemERF(erfBytes(ErfWriter::FileType::ERF,
+                                                {{"shared", ResType::Txt, "placed"}}),
+                                       ResourceOwner::Global,
+                                       ResourceSourceBucket::EncapsulatedClass2),
+                 ValidationException);
+
+    EXPECT_EQ(token, _resources->mountToken());
+    EXPECT_EQ("unplaced", find("shared"));
+    EXPECT_EQ(1u, _count());
+}
+
+TEST_P(SourceOwnerTest, the_mount_sequence_never_rewinds) {
+    mount("first", ResourceOwner::Global);
+    auto afterFirst = _resources->mountToken();
+
+    _resources->clear();
+    EXPECT_EQ(afterFirst, _resources->mountToken())
+        << "emptying the list must not hand out a spent number again";
+
+    mount("rebuilt", ResourceOwner::Global);
+    EXPECT_GT(_resources->mountToken(), afterFirst);
+
+    // A scope opened after the clear still covers exactly its own mounts, which
+    // is what reusing numbers would break.
+    auto token = _resources->mountToken();
+    mount("scoped", ResourceOwner::ActiveModule);
+    _resources->rollbackTo(token);
+    EXPECT_EQ("rebuilt", find("shared"));
+    EXPECT_EQ(1u, _count());
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         SourceOwnerTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+/// Save and module lifetimes as the director drives them.
+class SourceLifetimeFixture {
+protected:
+    void initBackend(Backend backend) {
+        _graphics.init();
+        _script.init();
+        if (backend == Backend::Legacy) {
+            auto legacy = std::make_unique<Resources>();
+            _count = [raw = legacy.get()]() { return raw->containers().size(); };
+            _resources = std::move(legacy);
+        } else {
+            auto extract = std::make_unique<ExtractResources>();
+            _count = [raw = extract.get()]() { return raw->sourceCount(); };
+            _resources = std::move(extract);
+        }
+        _auxResources = std::make_unique<Resources>();
+    }
+
+    void makeInstallation(TmpDir &game, TmpDir &cwd) {
+        writeErf(cwd.path / "shaderpack.erf", ErfWriter::FileType::ERF, {});
+        game.mkdir("modules");
+    }
+
+    std::unique_ptr<ResourceDirector> makeDirector(const std::filesystem::path &gamePath,
+                                                   GameID game = GameID::TSL,
+                                                   IGffs *gffs = nullptr) {
+        _gamePath = gamePath;
+        return std::make_unique<ResourceDirector>(
+            game, _gamePath, _graphicsOpt, _graphics.services(), _script.services(),
+            _dialogs, gffs ? *gffs : static_cast<IGffs &>(_gffs), _lips, _paths,
+            *_resources, *_auxResources, _scripts, _twoDas);
+    }
+
+    std::string find(const std::string &resRef, ResType type = ResType::Txt) {
+        return dataOf(_resources->find(ResourceId(resRef, type)));
+    }
+
+    bool has(const std::string &resRef, ResType type = ResType::Txt) {
+        return static_cast<bool>(_resources->find(ResourceId(resRef, type)));
+    }
+
+    graphics::GraphicsOptions _graphicsOpt;
+    graphics::TestGraphicsModule _graphics;
+    script::TestScriptModule _script;
+
+    NiceMock<MockDialogs> _dialogs;
+    NiceMock<MockGffs> _gffs;
+    NiceMock<MockLips> _lips;
+    NiceMock<MockPaths> _paths;
+    NiceMock<MockScripts> _scripts;
+    NiceMock<MockTwoDAs> _twoDas;
+
+    std::filesystem::path _gamePath;
+    std::unique_ptr<IResources> _resources;
+    std::unique_ptr<IResources> _auxResources;
+    std::function<std::size_t()> _count;
+};
+
+/// Everything a lifetime rule says must hold on both backends.
+class SourceLifetimeDirectorTest : public SourceLifetimeFixture,
+                                   public testing::TestWithParam<Backend> {
+protected:
+    void SetUp() override { initBackend(GetParam()); }
+};
+
+/// The few things only the eagerly validating backend can observe.
+class LegacySourceLifetimeTest : public SourceLifetimeFixture, public testing::Test {
+protected:
+    void SetUp() override { initBackend(Backend::Legacy); }
+};
+
+// Save slots.
+
+namespace {
+
+/// Two slots holding a resource under the same id and one of their own.
+void writeSaveSlots(TmpDir &game) {
+    auto a = game.mkdir("saves/slot_a");
+    writeFile(a / "loose_a.txt", "loose from a");
+    writeErf(a / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"common", ResType::Txt, "from a"},
+              {"a_only", ResType::Txt, "from a"}});
+
+    auto b = game.mkdir("saves/slot_b");
+    writeFile(b / "loose_b.txt", "loose from b");
+    writeErf(b / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"common", ResType::Txt, "from b"},
+              {"b_only", ResType::Txt, "from b"}});
+}
+
+} // namespace
+
+TEST_P(SourceLifetimeDirectorTest, a_save_is_unloaded_when_another_is_loaded) {
+    TmpDir game("reone_test_lifetime_saves");
+    TmpDir cwd("reone_test_lifetime_saves_cwd");
+    makeInstallation(game, cwd);
+    writeSaveSlots(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    EXPECT_EQ("from a", find("common"));
+    EXPECT_TRUE(has("a_only"));
+    EXPECT_TRUE(has("loose_a"));
+
+    director->onGameLoad("slot_b");
+    EXPECT_EQ("from b", find("common"));
+    EXPECT_TRUE(has("b_only"));
+    EXPECT_FALSE(has("a_only")) << "a resource only the previous save held must stop resolving";
+    EXPECT_FALSE(has("loose_a")) << "the previous save's loose directory goes with it";
+
+    director->onGameLoad("slot_a");
+    EXPECT_EQ("from a", find("common"));
+    EXPECT_TRUE(has("a_only"));
+    EXPECT_FALSE(has("b_only"));
+    EXPECT_FALSE(has("loose_b"));
+}
+
+/**
+ * Retiring a source does not reach a record already parsed out of it.
+ *
+ * The save's own records are read between loading a save and loading its
+ * module, so the module load's cache clear comes too late for them. They are
+ * keyed by resref and type alone, which is the same in every slot, so without
+ * clearing here the previous save's parsed copy answers for the new one however
+ * the sources are mounted. This is the one cache the save path clears, and this
+ * is why.
+ */
+TEST_P(SourceLifetimeDirectorTest, a_parsed_record_of_the_previous_save_is_not_served_for_the_next) {
+    TmpDir game("reone_test_lifetime_save_cache");
+    TmpDir cwd("reone_test_lifetime_save_cache_cwd");
+    makeInstallation(game, cwd);
+
+    auto a = game.mkdir("saves/slot_a");
+    writeErf(a / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"savenfo", ResType::Res, emptyGff()}});
+    auto b = game.mkdir("saves/slot_b");
+    writeErf(b / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"savenfo", ResType::Res, emptyGff()}});
+
+    Gffs gffs(*_resources);
+    auto director = makeDirector(game.path, GameID::TSL, &gffs);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    auto first = gffs.get("savenfo", ResType::Res);
+    ASSERT_TRUE(first);
+    EXPECT_EQ(first, gffs.get("savenfo", ResType::Res)) << "the provider really does cache";
+
+    director->onGameLoad("slot_b");
+    auto afterSwitch = gffs.get("savenfo", ResType::Res);
+    ASSERT_TRUE(afterSwitch);
+    EXPECT_NE(first, afterSwitch)
+        << "the record must be read again from the save that is now loaded";
+}
+
+TEST_P(SourceLifetimeDirectorTest, loading_the_same_save_twice_accumulates_nothing) {
+    TmpDir game("reone_test_lifetime_same_save");
+    TmpDir cwd("reone_test_lifetime_same_save_cwd");
+    makeInstallation(game, cwd);
+    writeSaveSlots(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    auto after = _count();
+    auto common = find("common");
+
+    director->onGameLoad("slot_a");
+    EXPECT_EQ(after, _count());
+    EXPECT_EQ(common, find("common"));
+
+    director->onGameLoad("slot_a");
+    EXPECT_EQ(after, _count());
+    EXPECT_EQ(common, find("common"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, a_save_that_cannot_be_loaded_leaves_none_of_itself_behind) {
+    TmpDir game("reone_test_lifetime_save_failure");
+    TmpDir cwd("reone_test_lifetime_save_failure_cwd");
+    makeInstallation(game, cwd);
+    writeSaveSlots(game);
+
+    // A slot with its loose directory but no archive. The directory is mounted
+    // before the archive is looked for, so this is the partial case.
+    auto broken = game.mkdir("saves/slot_broken");
+    writeFile(broken / "loose_broken.txt", "loose from broken");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("slot_a");
+    auto globals = _count();
+
+    EXPECT_THROW(director->onGameLoad("slot_broken"), ResourceNotFoundException);
+    EXPECT_FALSE(has("loose_broken")) << "the half-loaded save must leave nothing mounted";
+    EXPECT_FALSE(has("a_only")) << "the previous save was already unloaded before the attempt";
+
+    // Repeating the failed load starts from the same state and ends in it.
+    auto afterFailure = _count();
+    EXPECT_THROW(director->onGameLoad("slot_broken"), ResourceNotFoundException);
+    EXPECT_EQ(afterFailure, _count());
+    EXPECT_FALSE(has("loose_broken"));
+
+    // And a good slot still loads afterwards.
+    director->onGameLoad("slot_b");
+    EXPECT_EQ("from b", find("common"));
+    EXPECT_LT(globals - globals, _count());
+}
+
+// Module transitions.
+
+namespace {
+
+/// Two split modules and one MOD-layout module, each with its own support
+/// families, all serving the same probe id.
+void writeTransitionModules(TmpDir &game) {
+    auto modules = game.path / "modules";
+    auto lips = game.mkdir("lips");
+
+    writeRim(modules / "a.rim", {{"probe", ResType::Txt, "a base"}, {"a_base", ResType::Txt, "x"}});
+    writeRim(modules / "a_s.rim", {{"a_static", ResType::Txt, "x"}});
+    writeRim(modules / "a_a.rim", {{"a_area", ResType::Txt, "x"}});
+    writeRim(modules / "a_adx.rim", {{"a_adx", ResType::Txt, "x"}});
+    writeErf(modules / "a_dlg.erf", ErfWriter::FileType::ERF, {{"a_dlg", ResType::Txt, "x"}});
+    writeErf(lips / "a_loc.mod", ErfWriter::FileType::MOD, {{"a_loc", ResType::Txt, "x"}});
+
+    writeRim(modules / "b.rim", {{"probe", ResType::Txt, "b base"}, {"b_base", ResType::Txt, "x"}});
+    writeRim(modules / "b_s.rim", {{"b_static", ResType::Txt, "x"}});
+    writeErf(modules / "b_dlg.erf", ErfWriter::FileType::ERF, {{"b_dlg", ResType::Txt, "x"}});
+
+    // MOD layout. The static image and dialogue archive exist but the branch
+    // suppresses them, so they must not become reachable through a transition
+    // out of a module that did mount its own.
+    writeErf(modules / "c.mod", ErfWriter::FileType::MOD,
+             {{"probe", ResType::Txt, "c mod"}, {"c_mod", ResType::Txt, "x"}});
+    writeRim(modules / "c_s.rim", {{"c_static", ResType::Txt, "x"}});
+    writeErf(modules / "c_dlg.erf", ErfWriter::FileType::ERF, {{"c_dlg", ResType::Txt, "x"}});
+    writeRim(modules / "c_a.rim", {{"c_area", ResType::Txt, "x"}});
+}
+
+} // namespace
+
+TEST_P(SourceLifetimeDirectorTest, a_transition_leaves_nothing_of_the_previous_module) {
+    TmpDir game("reone_test_lifetime_transition");
+    TmpDir cwd("reone_test_lifetime_transition_cwd");
+    makeInstallation(game, cwd);
+    writeTransitionModules(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    auto expectOnlyA = [&]() {
+        EXPECT_EQ("a base", find("probe"));
+        for (const auto *id : {"a_base", "a_static", "a_area", "a_adx", "a_dlg", "a_loc"}) {
+            EXPECT_TRUE(has(id)) << id;
+        }
+        for (const auto *id : {"b_base", "b_static", "b_dlg", "c_mod", "c_area", "c_static", "c_dlg"}) {
+            EXPECT_FALSE(has(id)) << id;
+        }
+    };
+    auto expectOnlyB = [&]() {
+        EXPECT_EQ("b base", find("probe"));
+        for (const auto *id : {"b_base", "b_static", "b_dlg"}) {
+            EXPECT_TRUE(has(id)) << id;
+        }
+        for (const auto *id : {"a_base", "a_static", "a_area", "a_adx", "a_dlg", "a_loc", "c_mod"}) {
+            EXPECT_FALSE(has(id)) << id;
+        }
+    };
+    auto expectOnlyC = [&]() {
+        EXPECT_EQ("c mod", find("probe"));
+        EXPECT_TRUE(has("c_mod"));
+        EXPECT_TRUE(has("c_area")) << "adjunct images coexist with the module archive";
+        EXPECT_FALSE(has("c_static")) << "the MOD branch suppresses the static image";
+        EXPECT_FALSE(has("c_dlg")) << "the MOD branch suppresses dialogue";
+        for (const auto *id : {"a_base", "a_static", "a_dlg", "b_base", "b_static", "b_dlg"}) {
+            EXPECT_FALSE(has(id)) << id;
+        }
+    };
+
+    director->onModuleLoad("a");
+    expectOnlyA();
+    auto sourcesForA = _count();
+
+    director->onModuleLoad("b");
+    expectOnlyB();
+
+    director->onModuleLoad("a");
+    expectOnlyA();
+    EXPECT_EQ(sourcesForA, _count()) << "re-entering a module must not accumulate sources";
+
+    // split -> MOD -> split.
+    director->onModuleLoad("c");
+    expectOnlyC();
+
+    director->onModuleLoad("a");
+    expectOnlyA();
+    EXPECT_EQ(sourcesForA, _count());
+
+    // MOD -> split -> MOD.
+    director->onModuleLoad("c");
+    auto sourcesForC = _count();
+    director->onModuleLoad("b");
+    expectOnlyB();
+    director->onModuleLoad("c");
+    expectOnlyC();
+    EXPECT_EQ(sourcesForC, _count());
+}
+
+TEST_P(SourceLifetimeDirectorTest, loading_the_same_module_twice_accumulates_nothing) {
+    TmpDir game("reone_test_lifetime_same_module");
+    TmpDir cwd("reone_test_lifetime_same_module_cwd");
+    makeInstallation(game, cwd);
+    writeTransitionModules(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onModuleLoad("a");
+    auto after = _count();
+
+    director->onModuleLoad("a");
+    EXPECT_EQ(after, _count());
+    EXPECT_EQ("a base", find("probe"));
+
+    director->onModuleLoad("a");
+    EXPECT_EQ(after, _count());
+    EXPECT_EQ("a base", find("probe"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, a_module_transition_does_not_unload_the_save) {
+    TmpDir game("reone_test_lifetime_save_survives");
+    TmpDir cwd("reone_test_lifetime_save_survives_cwd");
+    makeInstallation(game, cwd);
+    writeTransitionModules(game);
+    writeSaveSlots(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    director->onModuleLoad("a");
+    EXPECT_TRUE(has("a_only")) << "the save is still loaded";
+
+    director->onModuleLoad("b");
+    EXPECT_TRUE(has("a_only")) << "walking to another module does not leave the save";
+    EXPECT_EQ("from a", find("common"));
+}
+
+TEST_P(SourceLifetimeDirectorTest, replacing_the_save_does_not_disturb_the_active_module) {
+    TmpDir game("reone_test_lifetime_module_survives");
+    TmpDir cwd("reone_test_lifetime_module_survives_cwd");
+    makeInstallation(game, cwd);
+    writeTransitionModules(game);
+    writeSaveSlots(game);
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    director->onModuleLoad("a");
+
+    director->onGameLoad("slot_b");
+    EXPECT_TRUE(has("a_static")) << "the module's sources are not the save's to retire";
+    EXPECT_TRUE(has("a_area"));
+    EXPECT_EQ("a base", find("probe"));
+    EXPECT_FALSE(has("a_only"));
+}
+
+// The module's own state, separately from its support sources.
+
+TEST_P(SourceLifetimeDirectorTest, the_staged_module_state_goes_with_the_module) {
+    TmpDir game("reone_test_lifetime_staged_state");
+    TmpDir cwd("reone_test_lifetime_staged_state_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "a.rim", {{"probe", ResType::Txt, "disk a"}});
+    writeRim(modules / "b.rim", {{"probe", ResType::Txt, "disk b"}});
+
+    // The save holds state for module a only.
+    auto staged = erfBytes(ErfWriter::FileType::MOD,
+                           {{"probe", ResType::Txt, "staged a"},
+                            {"staged_only", ResType::Txt, "staged a"}});
+    auto slot = game.mkdir("saves/slot_a");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"a", ResType::Sav, blob(staged)}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    director->onModuleLoad("a");
+    EXPECT_EQ("staged a", find("probe"));
+    EXPECT_TRUE(has("staged_only"));
+
+    director->onModuleLoad("b");
+    EXPECT_EQ("disk b", find("probe"));
+    EXPECT_FALSE(has("staged_only")) << "the previous module's state is not the new module's";
+
+    // The outer save is still loaded, so returning restores the same state.
+    director->onModuleLoad("a");
+    EXPECT_EQ("staged a", find("probe"));
+    EXPECT_TRUE(has("staged_only"));
+}
+
+// Failure.
+
+/**
+ * A module load that throws partway through leaves none of itself mounted.
+ *
+ * The staged archive is the failure point because both backends read a staged
+ * blob eagerly, so this pins the rollback identically on each. It is also the
+ * latest phase there is: the adjunct images are already mounted when it runs.
+ */
+TEST_P(SourceLifetimeDirectorTest, a_module_that_fails_partway_leaves_none_of_itself_behind) {
+    TmpDir game("reone_test_lifetime_module_failure");
+    TmpDir cwd("reone_test_lifetime_module_failure_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "good.rim", {{"probe", ResType::Txt, "good"}});
+
+    writeRim(modules / "broken.rim", {{"probe", ResType::Txt, "broken base"}});
+    writeRim(modules / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
+    writeRim(modules / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
+
+    // Saved state for the module that is not a readable archive. It wins
+    // primary selection, so the active-state phase tries to read it.
+    auto slot = game.mkdir("saves/slot_a");
+    writeErf(slot / "savegame.sav", ErfWriter::FileType::ERF,
+             {{"broken", ResType::Sav, "not an archive at all"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    director->onGameLoad("slot_a");
+    director->onModuleLoad("good");
+    auto beforeAttempt = _count();
+    EXPECT_TRUE(has("probe"));
+
+    EXPECT_THROW(director->onModuleLoad("broken"), ValidationException);
+
+    EXPECT_FALSE(has("broken_area")) << "sources mounted before the failure must be taken back";
+    EXPECT_FALSE(has("broken_adx"));
+    EXPECT_FALSE(has("probe")) << "the previous module was retired before the attempt began";
+
+    // Failing again starts from, and ends in, the same state.
+    auto afterFailure = _count();
+    EXPECT_THROW(director->onModuleLoad("broken"), ValidationException);
+    EXPECT_EQ(afterFailure, _count());
+    EXPECT_FALSE(has("broken_area"));
+
+    // A good module still loads afterwards, with nothing of the failed one.
+    director->onModuleLoad("good");
+    EXPECT_EQ("good", find("probe"));
+    EXPECT_FALSE(has("broken_area"));
+    EXPECT_EQ(beforeAttempt, _count());
+}
+
+/**
+ * The same rollback for an unreadable archive on disk, which only the legacy
+ * backend notices at mount time.
+ *
+ * Resources opens and validates a container as it is mounted; ExtractResources
+ * mounts a lazy handle and does not touch the file until something is read out
+ * of it. So a corrupt file on disk fails the module load on one backend and
+ * not on the other. That divergence predates this suite and is about when an
+ * archive is validated rather than about who owns it, so it is pinned here
+ * rather than changed.
+ */
+TEST_F(LegacySourceLifetimeTest, a_corrupt_archive_on_disk_rolls_back_the_module) {
+    TmpDir game("reone_test_lifetime_corrupt_disk");
+    TmpDir cwd("reone_test_lifetime_corrupt_disk_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "broken.rim", {{"probe", ResType::Txt, "broken base"}});
+    writeRim(modules / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
+    writeRim(modules / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
+    writeFile(modules / "broken_s.rim", "not a rim at all");
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+    auto globals = _count();
+
+    EXPECT_THROW(director->onModuleLoad("broken"), ValidationException);
+
+    EXPECT_FALSE(has("broken_area"));
+    EXPECT_FALSE(has("broken_adx"));
+    EXPECT_EQ(globals, _count()) << "nothing of the failed module may remain";
+}
+
+TEST_P(SourceLifetimeDirectorTest, an_absent_optional_source_is_not_a_failure) {
+    TmpDir game("reone_test_lifetime_optional_absent");
+    TmpDir cwd("reone_test_lifetime_optional_absent_cwd");
+    makeInstallation(game, cwd);
+
+    // No adjunct images, no dialogue archive, no localization: every optional
+    // family of this module is missing.
+    auto modules = game.path / "modules";
+    writeRim(modules / "lonely.rim", {{"probe", ResType::Txt, "base"}});
+    writeRim(modules / "lonely_s.rim", {{"static_only", ResType::Txt, "static"}});
+
+    auto director = makeDirector(game.path);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    EXPECT_NO_THROW(director->onModuleLoad("lonely"));
+    EXPECT_EQ("base", find("probe"));
+    EXPECT_TRUE(has("static_only")) << "a missing optional family does not roll back a good one";
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         SourceLifetimeDirectorTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);
+
+/// K1 is not activated, so its sources are unplaced. Ownership is generic and
+/// applies to it all the same.
+class K1SourceLifetimeTest : public SourceLifetimeDirectorTest {};
+
+TEST_P(K1SourceLifetimeTest, retires_module_sources_on_the_unactivated_path) {
+    TmpDir game("reone_test_lifetime_k1");
+    TmpDir cwd("reone_test_lifetime_k1_cwd");
+    makeInstallation(game, cwd);
+
+    auto modules = game.path / "modules";
+    writeRim(modules / "a.rim", {{"probe", ResType::Txt, "a base"}, {"a_base", ResType::Txt, "x"}});
+    writeRim(modules / "a_s.rim", {{"a_static", ResType::Txt, "x"}});
+    writeRim(modules / "b.rim", {{"probe", ResType::Txt, "b base"}, {"b_base", ResType::Txt, "x"}});
+
+    auto director = makeDirector(game.path, GameID::KotOR);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onModuleLoad("a");
+    EXPECT_EQ("a base", find("probe"));
+    EXPECT_TRUE(has("a_static"));
+    auto sourcesForA = _count();
+
+    director->onModuleLoad("b");
+    EXPECT_EQ("b base", find("probe"));
+    EXPECT_FALSE(has("a_base"));
+    EXPECT_FALSE(has("a_static")) << "the unactivated stack is retired by owner too";
+
+    director->onModuleLoad("a");
+    EXPECT_EQ("a base", find("probe"));
+    EXPECT_EQ(sourcesForA, _count());
+}
+
+TEST_P(K1SourceLifetimeTest, unloads_a_save_on_the_unactivated_path) {
+    TmpDir game("reone_test_lifetime_k1_saves");
+    TmpDir cwd("reone_test_lifetime_k1_saves_cwd");
+    makeInstallation(game, cwd);
+    writeSaveSlots(game);
+
+    auto director = makeDirector(game.path, GameID::KotOR);
+    {
+        CwdGuard guard(cwd.path);
+        director->init();
+    }
+
+    director->onGameLoad("slot_a");
+    EXPECT_TRUE(has("a_only"));
+
+    director->onGameLoad("slot_b");
+    EXPECT_EQ("from b", find("common"));
+    EXPECT_FALSE(has("a_only"));
+}
+
+INSTANTIATE_TEST_SUITE_P(Backends,
+                         K1SourceLifetimeTest,
+                         testing::Values(Backend::Legacy, Backend::Extract),
+                         backendName);

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -1075,6 +1075,62 @@ TEST_P(SourceLifetimeDirectorTest, an_absent_optional_source_is_not_a_failure) {
     EXPECT_TRUE(has("static_only")) << "a missing optional family does not roll back a good one";
 }
 
+TEST_P(SourceLifetimeDirectorTest, nwm_state_is_replaced_across_nwm_and_ordinary_transitions) {
+    TmpDir game("reone_test_lifetime_nwm_transitions");
+    TmpDir cwd("reone_test_lifetime_nwm_transitions_cwd");
+    makeInstallation(game, cwd);
+    auto nwm = game.mkdir("nwm");
+    auto modules = game.path / "modules";
+    writeErf(nwm / "a.nwm", ErfWriter::FileType::MOD,
+             {{"probe", ResType::Txt, "nwm a"}, {"a_only", ResType::Txt, "a"}});
+    writeErf(nwm / "b.nwm", ErfWriter::FileType::MOD,
+             {{"probe", ResType::Txt, "nwm b"}, {"b_only", ResType::Txt, "b"}});
+    writeErf(modules / "ordinary.mod", ErfWriter::FileType::MOD,
+             {{"probe", ResType::Txt, "ordinary"}, {"ordinary_only", ResType::Txt, "m"}});
+
+    auto director = makeDirector(game.path);
+    { CwdGuard guard(cwd.path); director->init(); }
+    auto globals = _count();
+
+    director->onModuleLoad("a");
+    EXPECT_EQ("nwm a", find("probe"));
+    EXPECT_EQ(globals + 1, _count());
+    director->onModuleLoad("b");
+    EXPECT_EQ("nwm b", find("probe"));
+    EXPECT_FALSE(has("a_only"));
+    EXPECT_EQ(globals + 1, _count());
+    director->onModuleLoad("a");
+    EXPECT_EQ("nwm a", find("probe"));
+    EXPECT_FALSE(has("b_only"));
+    EXPECT_EQ(globals + 1, _count());
+    director->onModuleLoad("ordinary");
+    EXPECT_EQ("ordinary", find("probe"));
+    EXPECT_FALSE(has("a_only"));
+    EXPECT_EQ(globals + 1, _count());
+    director->onModuleLoad("a");
+    EXPECT_EQ("nwm a", find("probe"));
+    EXPECT_FALSE(has("ordinary_only"));
+    EXPECT_EQ(globals + 1, _count());
+}
+
+TEST_P(SourceLifetimeDirectorTest, a_corrupt_selected_nwm_rolls_back_without_restoring_old_state) {
+    TmpDir game("reone_test_lifetime_nwm_corrupt");
+    TmpDir cwd("reone_test_lifetime_nwm_corrupt_cwd");
+    makeInstallation(game, cwd);
+    auto nwm = game.mkdir("nwm");
+    writeErf(nwm / "good.nwm", ErfWriter::FileType::MOD,
+             {{"good_only", ResType::Txt, "good"}});
+    writeFile(nwm / "broken.nwm", "not an erf");
+    auto director = makeDirector(game.path);
+    { CwdGuard guard(cwd.path); director->init(); }
+    auto globals = _count();
+    director->onModuleLoad("good");
+    ASSERT_TRUE(has("good_only"));
+    EXPECT_THROW(director->onModuleLoad("broken"), ValidationException);
+    EXPECT_FALSE(has("good_only"));
+    EXPECT_EQ(globals, _count());
+}
+
 INSTANTIATE_TEST_SUITE_P(Backends,
                          SourceLifetimeDirectorTest,
                          testing::Values(Backend::Legacy, Backend::Extract),

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -668,11 +668,12 @@ namespace {
 void writeTransitionModules(TmpDir &game) {
     auto modules = game.path / "modules";
     auto lips = game.mkdir("lips");
+    auto rims = game.mkdir("rims");
 
     writeRim(modules / "a.rim", {{"probe", ResType::Txt, "a base"}, {"a_base", ResType::Txt, "x"}});
     writeRim(modules / "a_s.rim", {{"a_static", ResType::Txt, "x"}});
-    writeRim(modules / "a_a.rim", {{"a_area", ResType::Txt, "x"}});
-    writeRim(modules / "a_adx.rim", {{"a_adx", ResType::Txt, "x"}});
+    writeRim(rims / "a_a.rim", {{"a_area", ResType::Txt, "x"}});
+    writeRim(rims / "a_adx.rim", {{"a_adx", ResType::Txt, "x"}});
     writeErf(modules / "a_dlg.erf", ErfWriter::FileType::ERF, {{"a_dlg", ResType::Txt, "x"}});
     writeErf(lips / "a_loc.mod", ErfWriter::FileType::MOD, {{"a_loc", ResType::Txt, "x"}});
 
@@ -687,7 +688,7 @@ void writeTransitionModules(TmpDir &game) {
              {{"probe", ResType::Txt, "c mod"}, {"c_mod", ResType::Txt, "x"}});
     writeRim(modules / "c_s.rim", {{"c_static", ResType::Txt, "x"}});
     writeErf(modules / "c_dlg.erf", ErfWriter::FileType::ERF, {{"c_dlg", ResType::Txt, "x"}});
-    writeRim(modules / "c_a.rim", {{"c_area", ResType::Txt, "x"}});
+    writeRim(rims / "c_a.rim", {{"c_area", ResType::Txt, "x"}});
 }
 
 } // namespace
@@ -886,11 +887,12 @@ TEST_P(SourceLifetimeDirectorTest, a_module_that_fails_partway_leaves_none_of_it
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "good.rim", {{"probe", ResType::Txt, "good"}});
 
     writeRim(modules / "broken.rim", {{"probe", ResType::Txt, "broken base"}});
-    writeRim(modules / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
-    writeRim(modules / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
+    writeRim(rims / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
+    writeRim(rims / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
 
     // Saved state for the module that is not a readable archive. It wins
     // primary selection, so the active-state phase tries to read it.
@@ -933,8 +935,9 @@ TEST_P(SourceLifetimeDirectorTest, a_non_exception_required_failure_rolls_back_t
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "foo.rim", {{"foo_base", ResType::Txt, "base"}});
-    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    writeRim(rims / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
     writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
     rejectDiskMount("foo_s.rim");
 
@@ -959,7 +962,8 @@ TEST_P(SourceLifetimeDirectorTest, a_required_failure_can_recover_through_active
 
     auto modules = game.path / "modules";
     writeRim(modules / "foo.rim", {{"disk_base", ResType::Txt, "disk"}});
-    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    auto rims = game.mkdir("rims");
+    writeRim(rims / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
     writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
 
     auto staged = erfBytes(ErfWriter::FileType::MOD,
@@ -988,7 +992,8 @@ TEST_P(SourceLifetimeDirectorTest, no_primary_with_discoverable_sidecars_rolls_b
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
-    writeRim(modules / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
+    auto rims = game.mkdir("rims");
+    writeRim(rims / "foo_a.rim", {{"foo_area", ResType::Txt, "area"}});
     writeRim(modules / "foo_s.rim", {{"foo_static", ResType::Txt, "static"}});
 
     auto director = makeDirector(game.path);
@@ -1034,9 +1039,10 @@ TEST_P(SourceLifetimeDirectorTest, a_corrupt_archive_on_disk_rolls_back_the_modu
     makeInstallation(game, cwd);
 
     auto modules = game.path / "modules";
+    auto rims = game.mkdir("rims");
     writeRim(modules / "broken.rim", {{"probe", ResType::Txt, "broken base"}});
-    writeRim(modules / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
-    writeRim(modules / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
+    writeRim(rims / "broken_a.rim", {{"broken_area", ResType::Txt, "x"}});
+    writeRim(rims / "broken_adx.rim", {{"broken_adx", ResType::Txt, "x"}});
     writeFile(modules / "broken_s.rim", "not a rim at all");
 
     auto director = makeDirector(game.path);

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -1146,7 +1146,7 @@ INSTANTIATE_TEST_SUITE_P(Backends,
 /// applies to it all the same.
 class K1SourceLifetimeTest : public SourceLifetimeDirectorTest {};
 
-TEST_P(K1SourceLifetimeTest, retires_module_sources_on_the_unactivated_path) {
+TEST_P(K1SourceLifetimeTest, retires_module_sources_on_the_activated_path) {
     TmpDir game("reone_test_lifetime_k1");
     TmpDir cwd("reone_test_lifetime_k1_cwd");
     makeInstallation(game, cwd);
@@ -1170,14 +1170,14 @@ TEST_P(K1SourceLifetimeTest, retires_module_sources_on_the_unactivated_path) {
     director->onModuleLoad("b");
     EXPECT_EQ("b base", find("probe"));
     EXPECT_FALSE(has("a_base"));
-    EXPECT_FALSE(has("a_static")) << "the unactivated stack is retired by owner too";
+    EXPECT_FALSE(has("a_static")) << "the activated stack is retired by owner too";
 
     director->onModuleLoad("a");
     EXPECT_EQ("a base", find("probe"));
     EXPECT_EQ(sourcesForA, _count());
 }
 
-TEST_P(K1SourceLifetimeTest, unloads_a_save_on_the_unactivated_path) {
+TEST_P(K1SourceLifetimeTest, unloads_a_save_on_the_activated_path) {
     TmpDir game("reone_test_lifetime_k1_saves");
     TmpDir cwd("reone_test_lifetime_k1_saves_cwd");
     makeInstallation(game, cwd);

--- a/test/resource/sourcelifetimes.cpp
+++ b/test/resource/sourcelifetimes.cpp
@@ -437,12 +437,6 @@ protected:
     void SetUp() override { initBackend(GetParam()); }
 };
 
-/// The few things only the eagerly validating backend can observe.
-class LegacySourceLifetimeTest : public SourceLifetimeFixture, public testing::Test {
-protected:
-    void SetUp() override { initBackend(Backend::Legacy); }
-};
-
 // Save slots.
 
 namespace {
@@ -863,18 +857,10 @@ TEST_P(SourceLifetimeDirectorTest, a_module_that_fails_partway_leaves_none_of_it
     EXPECT_EQ(beforeAttempt, _count());
 }
 
-/**
- * The same rollback for an unreadable archive on disk, which only the legacy
- * backend notices at mount time.
- *
- * Resources opens and validates a container as it is mounted; ExtractResources
- * mounts a lazy handle and does not touch the file until something is read out
- * of it. So a corrupt file on disk fails the module load on one backend and
- * not on the other. That divergence predates this suite and is about when an
- * archive is validated rather than about who owns it, so it is pinned here
- * rather than changed.
- */
-TEST_F(LegacySourceLifetimeTest, a_corrupt_archive_on_disk_rolls_back_the_module) {
+/// The same rollback for an unreadable archive on disk. Both backends decide an
+/// archive is unusable as they mount it, so both fail here; archivevalidation
+/// covers that contract itself.
+TEST_P(SourceLifetimeDirectorTest, a_corrupt_archive_on_disk_rolls_back_the_module) {
     TmpDir game("reone_test_lifetime_corrupt_disk");
     TmpDir cwd("reone_test_lifetime_corrupt_disk_cwd");
     makeInstallation(game, cwd);

--- a/test/resource/strings.cpp
+++ b/test/resource/strings.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include "reone/resource/format/tlkwriter.h"
+#include "reone/resource/odysseyroots.h"
 #include "reone/resource/strings.h"
 #include "reone/system/binarywriter.h"
 #include "reone/system/logutil.h"
@@ -201,4 +203,46 @@ TEST(Strings, a_slot_beyond_the_observable_seven_is_rejected) {
                  std::out_of_range);
     EXPECT_THROW(strings.loadTalkTable(Strings::kTalkTableSlotCount, "unused.tlk"),
                  std::out_of_range);
+}
+
+TEST(Strings, shared_roots_populate_bound_live_slots_without_disturbing_dialog) {
+    auto dir = std::filesystem::temp_directory_path() / "reone_test_live_tlk_composition";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir / "game");
+    std::filesystem::create_directories(dir / "live1");
+    std::filesystem::create_directories(dir / "live2");
+    std::filesystem::create_directories(dir / "live3");
+    std::filesystem::create_directories(dir / "live4");
+
+    TalkTable dialog(std::vector<TalkTable::String> {{"dialog", ""}});
+    TlkWriter(dialog).save(dir / "game" / "dialog.tlk");
+    TalkTable live1(std::vector<TalkTable::String> {
+        {"live1 collision", ""}, {"live1 fallback", ""}});
+    TlkWriter(live1).save(dir / "live1" / "live1.tlk");
+    TalkTable live2(std::vector<TalkTable::String> {
+        {"", ""}, {"live2 collision", ""}, {"live2 fallback", ""}});
+    TlkWriter(live2).save(dir / "live2" / "live2.tlk");
+    FileOutputStream malformed(dir / "live3" / "live3.tlk");
+    malformed.write("broken", 6);
+    malformed.close();
+    TalkTable live4(std::vector<TalkTable::String> {
+        {"", ""}, {"", ""}, {"", ""}, {"live4 after malformed", ""}});
+    TlkWriter(live4).save(dir / "live4" / "live4.tlk");
+
+    OdysseyResourceRoots roots;
+    roots.livePackages[0] = dir / "live1";
+    roots.livePackages[1] = dir / "live2";
+    roots.livePackages[2] = dir / "live3";
+    roots.livePackages[3] = dir / "live4";
+
+    Strings strings;
+    strings.init(dir / "game");
+    ASSERT_NO_THROW(loadLiveTalkTables(strings, roots));
+
+    EXPECT_EQ("dialog", strings.getText(0));
+    EXPECT_EQ("live1 fallback", strings.getText(1));
+    EXPECT_EQ("live2 fallback", strings.getText(2));
+    EXPECT_EQ("live4 after malformed", strings.getText(3));
+
+    std::filesystem::remove_all(dir);
 }

--- a/test/resource/strings.cpp
+++ b/test/resource/strings.cpp
@@ -25,6 +25,20 @@
 using namespace reone;
 using namespace reone::resource;
 
+namespace {
+
+std::shared_ptr<TalkTable> table(std::initializer_list<TalkTable::String> strings) {
+    return std::make_shared<TalkTable>(std::vector<TalkTable::String>(strings));
+}
+
+std::shared_ptr<TalkTable> tableWithWinningRow(std::size_t row, std::string text) {
+    std::vector<TalkTable::String> strings(row + 1);
+    strings[row].text = std::move(text);
+    return std::make_shared<TalkTable>(std::move(strings));
+}
+
+} // namespace
+
 TEST(Strings, should_init_talktable_and_get_string_and_sound) {
     // given
 
@@ -71,4 +85,120 @@ TEST(Strings, should_init_talktable_and_get_string_and_sound) {
     // cleanup
 
     std::filesystem::remove_all(tmpDirPath);
+}
+
+TEST(Strings, searches_loaded_slots_in_observable_order) {
+    Strings strings;
+    strings.setTalkTable(0, table({{"base zero", "base zero sound"}}));
+    strings.setTalkTable(1, table({{"live1 zero", "live1 zero sound"},
+                                   {"live1 one", "live1 one sound"}}));
+    strings.setTalkTable(2, table({{"live2 zero", "live2 zero sound"},
+                                   {"live2 one", "live2 one sound"},
+                                   {"live2 two", "live2 two sound"}}));
+
+    EXPECT_EQ("base zero", strings.getText(0));
+    EXPECT_EQ("live1 one", strings.getText(1));
+    EXPECT_EQ("live2 two", strings.getText(2));
+    EXPECT_EQ("live1 one sound", strings.getSound(1));
+}
+
+TEST(Strings, skips_missing_intermediate_slots) {
+    Strings strings;
+    strings.setTalkTable(0, table({{"base", ""}}));
+    strings.setTalkTable(2, table({{"live2 zero", ""}, {"live2 one", ""}}));
+
+    EXPECT_EQ("live2 one", strings.getText(1));
+}
+
+TEST(Strings, the_first_table_containing_the_row_wins_even_when_fields_are_empty) {
+    Strings strings;
+    strings.setTalkTable(0, table({{"", ""}}));
+    strings.setTalkTable(1, table({{"later text", "later sound"}}));
+
+    EXPECT_EQ("", strings.getText(0));
+    EXPECT_EQ("", strings.getSound(0));
+}
+
+TEST(Strings, live1_wins_a_collision_when_dialog_lacks_the_row) {
+    Strings strings;
+    strings.setTalkTable(0, table({}));
+    strings.setTalkTable(1, table({{"live1", "live1 sound"}}));
+    strings.setTalkTable(2, table({{"live2", "live2 sound"}}));
+
+    EXPECT_EQ("live1", strings.getText(0));
+    EXPECT_EQ("live1 sound", strings.getSound(0));
+}
+
+TEST(Strings, unresolved_rows_and_minus_one_are_empty) {
+    Strings strings;
+    strings.setTalkTable(0, table({{"base", "base sound"}}));
+
+    EXPECT_EQ("", strings.getText(42));
+    EXPECT_EQ("", strings.getSound(42));
+    EXPECT_EQ("", strings.getText(-1));
+    EXPECT_EQ("", strings.getSound(-1));
+}
+
+TEST(Strings, negative_values_other_than_minus_one_are_masked) {
+    Strings strings;
+    strings.setTalkTable(0, table({{"zero", ""}, {"one", "one sound"}}));
+    auto strRefWithNegativeSignAndRowOne = static_cast<int>(0xff000001u);
+
+    EXPECT_LT(strRefWithNegativeSignAndRowOne, 0);
+    EXPECT_EQ("one", strings.getText(strRefWithNegativeSignAndRowOne));
+    EXPECT_EQ("one sound", strings.getSound(strRefWithNegativeSignAndRowOne));
+}
+
+TEST(Strings, replacing_a_slot_changes_only_that_slot_and_never_reorders_it) {
+    Strings strings;
+    strings.setTalkTable(1, table({{"live1 old", ""}}));
+    strings.setTalkTable(2, table({{"live2", ""}, {"live2 one", ""}}));
+
+    EXPECT_EQ("live1 old", strings.getText(0));
+    EXPECT_EQ("live2 one", strings.getText(1));
+
+    strings.setTalkTable(1, table({{"live1 new", ""}}));
+
+    EXPECT_EQ("live1 new", strings.getText(0));
+    EXPECT_EQ("live2 one", strings.getText(1));
+}
+
+TEST(Strings, a_failed_file_replacement_leaves_only_that_slot_empty) {
+    auto dir = std::filesystem::temp_directory_path() / "reone_test_strings_replace";
+    std::filesystem::create_directories(dir);
+
+    Strings strings;
+    strings.setTalkTable(1, table({{"live1", ""}}));
+    strings.setTalkTable(2, table({{"live2", ""}}));
+
+    EXPECT_FALSE(strings.loadTalkTable(1, dir / "missing.tlk"));
+    EXPECT_EQ("live2", strings.getText(0));
+
+    auto malformedPath = dir / "malformed.tlk";
+    FileOutputStream malformed(malformedPath);
+    malformed.write("not a tlk", 9);
+    malformed.close();
+    strings.setTalkTable(1, table({{"live1 again", ""}}));
+    EXPECT_FALSE(strings.loadTalkTable(1, malformedPath));
+    EXPECT_EQ("live2", strings.getText(0));
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(Strings, every_observable_slot_is_searchable) {
+    for (std::size_t target = 0; target < Strings::kTalkTableSlotCount; ++target) {
+        Strings strings;
+        strings.setTalkTable(target, tableWithWinningRow(target, "slot " + std::to_string(target)));
+
+        EXPECT_EQ("slot " + std::to_string(target), strings.getText(static_cast<int>(target)));
+    }
+}
+
+TEST(Strings, a_slot_beyond_the_observable_seven_is_rejected) {
+    Strings strings;
+
+    EXPECT_THROW(strings.setTalkTable(Strings::kTalkTableSlotCount, table({{"eighth", ""}})),
+                 std::out_of_range);
+    EXPECT_THROW(strings.loadTalkTable(Strings::kTalkTableSlotCount, "unused.tlk"),
+                 std::out_of_range);
 }


### PR DESCRIPTION
## Summary

Completes the resource-loader work built on L0 (#262 ) and the earlier A/B/C/D preparatory series.

This PR brings together the remaining loader roadmap:

- **L1 — Module discovery:** canonical module/archive classification and enumeration.
- **L2 — Resource lookup:** Odyssey-style bucketed source ordering shared by both resource backends.
- **L3 — K2 runtime activation:** policy-driven K2 module loading, including split/MOD layouts and saved module state.
- **L4 — Extract alignment:** aligns `extract::Installation` with the shared discovery and lookup model.
- **L5 — Source lifetime:** owner-scoped cleanup, transition isolation, idempotence and failed-load rollback.
- **L6 — K1 runtime activation:** moves K1 onto the shared loader while preserving K1-specific module families and lookup behaviour.

## Scope

The result is a single shared resource-loading model used by runtime and tooling, with resource priority kept separate from source ownership/lifetime.

Save/load persistence and structured restoration remain separate work in the following E series and are not implemented here.