### PR TITLE
[game] Discard StartConversation while a conversation is active

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -224,6 +224,11 @@ public:
         return _screen;
     }
 
+    /** True while a conversation owns the screen, i.e. a dialogue is running. */
+    bool isConversationActive() const {
+        return _screen == Screen::Conversation;
+    }
+
     std::shared_ptr<movie::IMovie> movie() const {
         return _movie;
     }

--- a/src/libs/game/action/startconversation.cpp
+++ b/src/libs/game/action/startconversation.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/action/startconversation.h"
 
+#include "reone/system/logutil.h"
+
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/party.h"
@@ -28,6 +30,28 @@ namespace game {
 static constexpr float kMaxConversationDistance = 4.0f;
 
 void StartConversationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
+    // A queued ActionStartConversation that comes up while a dialogue is
+    // already running is discarded, not honored and not deferred.
+    //
+    // Scripts queue a conversation on a creature as a recovery measure, to be
+    // taken only once whatever is on screen has finished - K2 103PER reply
+    // scripts do this, and reaching one mid-scene must not restart the scene.
+    // Honoring the action would replace the running conversation, which also
+    // robs it of its EndConversation script and of the globals that script
+    // latches, so the replacement can pick the same opening entry and loop
+    // forever. Deferring it until the conversation ends is equally wrong: the
+    // recovery call would then fire the moment the dialogue it was guarding
+    // against completed, and the speaker would immediately re-greet the player.
+    //
+    // Dropping it matches retail, where the action fails outright while the
+    // engine is in dialogue mode.
+    if (_game.isConversationActive()) {
+        debug("Discarding StartConversation, a conversation is already active",
+              LogChannel::Conversation);
+        complete();
+        return;
+    }
+
     auto actorPtr = _game.getObjectById(actor.id());
 
     // A creature walks up to its conversation partner before talking. If the

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -5599,7 +5599,7 @@ static Variable IsNPCPartyMember(const std::vector<Variable> &args, const Routin
 
 static Variable GetIsConversationActive(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    bool active = ctx.game.currentScreen() == game::Game::Screen::Conversation;
+    bool active = ctx.game.isConversationActive();
     return Variable::ofInt(active);
 }
 

--- a/test/game/action.cpp
+++ b/test/game/action.cpp
@@ -19,9 +19,12 @@
 #include <gtest/gtest.h>
 
 #include "../fixtures/engine.h"
+#include "reone/game/action/startconversation.h"
 #include "reone/game/action/usetalentonobject.h"
 #include "reone/game/game.h"
+#include "reone/game/script/routines.h"
 #include "reone/resource/types.h"
+#include "reone/script/executioncontext.h"
 
 using namespace reone;
 using namespace reone::game;
@@ -84,4 +87,141 @@ TEST(Action, use_talent_dispatch_to_cast_spell) {
 
     EXPECT_TRUE(action->isCompleted());
     EXPECT_TRUE(subAction->isCompleted());
+}
+
+namespace {
+
+constexpr char kScriptedDialog[] = "hk50";
+
+// A conversation-start action queued on a speaker and aimed at a listener, in
+// the shape scripts use: a named dialogue, as K2 103PER k_102exit and
+// a_hk50forcedlg both do.
+//
+// The speaker is left with an approach still to make, which is what makes the
+// action's fate observable either way: discarded actions complete, whereas an
+// honored one stays in progress while its speaker walks over. The guard runs
+// before the approach, so it behaves the same whichever start range a script
+// asks for.
+std::shared_ptr<StartConversationAction> makeScriptedStartConversation(
+    Game &game,
+    const std::shared_ptr<Object> &listener) {
+
+    return game.newAction<StartConversationAction>(
+        listener,
+        kScriptedDialog,
+        /*privateConversation=*/false,
+        resource::ConversationType::Cinematic,
+        /*ignoreStartRange=*/false);
+}
+
+// Restricted movement keeps that approach unfinished for a whole test, so
+// assertions stay on the action rather than on pathfinding.
+std::shared_ptr<Creature> makeApproachingSpeaker(Game &game) {
+    auto speaker = game.newCreature();
+    speaker->setMovementRestricted(true);
+    return speaker;
+}
+
+void setScreen(Game &game, Game::Screen screen) {
+    TestGameModule::setCurrentScreen(game, static_cast<int>(screen));
+}
+
+} // namespace
+
+// A. An already-running conversation rejects a newly executed
+// ActionStartConversation. The action is dropped outright rather than beginning
+// the approach it would otherwise begin, no dialogue is resolved or loaded, and
+// the running conversation keeps the screen.
+TEST(Action, start_conversation_is_discarded_while_a_conversation_is_active) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::TSL, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().gffs(), get(_, resource::ResType::Dlg)).Times(0);
+
+    auto speaker = makeApproachingSpeaker(game);
+    auto listener = game.newCreature();
+    setScreen(game, Game::Screen::Conversation);
+    ASSERT_TRUE(game.isConversationActive());
+
+    auto action = makeScriptedStartConversation(game, listener);
+    action->execute(action, *speaker, 1.0f);
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_EQ(Game::Screen::Conversation, game.currentScreen());
+    EXPECT_TRUE(game.isConversationActive());
+}
+
+// B. The rejected action is dropped, not deferred. Once the running
+// conversation ends, the action must not come back to life - if it did, K2
+// 103PER would answer its own recovery call the instant a_tlkhk50 finished and
+// HK-50 would immediately re-greet the player.
+TEST(Action, discarded_start_conversation_does_not_run_after_the_conversation_ends) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::TSL, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().gffs(), get(_, resource::ResType::Dlg)).Times(0);
+
+    auto speaker = makeApproachingSpeaker(game);
+    auto listener = game.newCreature();
+    setScreen(game, Game::Screen::Conversation);
+
+    auto action = makeScriptedStartConversation(game, listener);
+    speaker->addAction(action);
+
+    // Executed while the conversation owns the screen: rejected on the spot.
+    speaker->update(1.0f);
+    EXPECT_TRUE(action->isCompleted());
+
+    // A completed action is reaped on the following update, leaving the queue
+    // empty rather than holding the conversation call open.
+    speaker->update(1.0f);
+    EXPECT_TRUE(speaker->actions().empty());
+
+    // The conversation ends and the queue is pumped again.
+    setScreen(game, Game::Screen::InGame);
+    ASSERT_FALSE(game.isConversationActive());
+    speaker->update(1.0f);
+    speaker->update(1.0f);
+
+    EXPECT_TRUE(speaker->actions().empty());
+    EXPECT_EQ(Game::Screen::InGame, game.currentScreen());
+}
+
+// C. The complement of A, and the check that the guard rejects nothing it
+// should not: with no conversation running, the very same action survives and
+// its speaker sets about approaching the listener instead of being discarded.
+TEST(Action, start_conversation_survives_when_no_conversation_is_active) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::TSL, "", engine.options(), engine.services(), console);
+    EXPECT_CALL(engine.resourceModule().gffs(), get(_, resource::ResType::Dlg)).Times(0);
+
+    auto speaker = makeApproachingSpeaker(game);
+    auto listener = game.newCreature();
+    setScreen(game, Game::Screen::InGame);
+    ASSERT_FALSE(game.isConversationActive());
+
+    auto action = makeScriptedStartConversation(game, listener);
+    action->execute(action, *speaker, 1.0f);
+
+    EXPECT_FALSE(action->isCompleted());
+}
+
+// D. Routine 701 reports the same conversation-active state the guard uses.
+TEST(Action, get_is_conversation_active_reports_the_shared_predicate) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::TSL, "", engine.options(), engine.services(), console);
+    Routines routines(resource::GameID::TSL, &game, &engine.services());
+    routines.init();
+    script::Routine &routine = routines.get(701);
+    ASSERT_EQ("GetIsConversationActive", routine.name());
+
+    script::ExecutionContext ctx;
+
+    setScreen(game, Game::Screen::InGame);
+    EXPECT_EQ(0, routine.invoke({}, ctx).intValue);
+
+    setScreen(game, Game::Screen::Conversation);
+    EXPECT_EQ(1, routine.invoke({}, ctx).intValue);
 }


### PR DESCRIPTION
## Summary

Discards `ActionStartConversation` when a conversation is already active.

K1/K2 content can queue a conversation-start action while another conversation is still running. Odyssey drops that action rather than allowing it to replace the active conversation.

Reone currently starts the new conversation, which can interrupt the existing dialogue and prevent its normal completion.

## Behaviour

When `StartConversationAction::execute` runs during an active conversation:

* the action completes immediately;
* the active conversation is left unchanged;
* no replacement conversation is started;
* the discarded action is not deferred and cannot run after the current conversation ends.

Normal `ActionStartConversation` behaviour is unchanged when no conversation is active.

`GetIsConversationActive` now uses the same shared game-state predicate.

## Vanilla case

K2 `103PER` exposes the missing behaviour.

During the HK-50 introduction, `a_hk50forcedlg` queues an `ActionStartConversation` while `hk50.dlg` is still active.

Previously Reone honoured that action, restarted `hk50.dlg`, and repeatedly replayed the corridor explosion and corpse shots. Because the original conversation never completed, its `EndConversation` script never ran and the scene could not progress.

With this change the queued restart is discarded and the authored sequence proceeds normally through the HK-50 introduction and conversation exit.

Manual verification confirmed:

* the intro conversation starts once;
* the explosion sequence occurs once;
* entries 5, 6 and 7 are reached;
* `a_tlkhk50` runs on conversation completion;
* the progression global is set;
* `HK50Door2` is unlocked and opened;
* subsequent dialogue selects the post-introduction entry rather than restarting the intro.