### PR TITLE
[game] Apply authored dialogue cut animations

### DIFF
--- a/include/reone/game/gui/dialog.h
+++ b/include/reone/game/gui/dialog.h
@@ -50,6 +50,15 @@ private:
         bool restoreCulling {true};
     };
 
+    /**
+     * A cutscene clip named directly by a DLG animation ordinal, together with
+     * whether the clip loops rather than playing once.
+     */
+    struct CutAnimation {
+        std::string name;
+        bool looping {false};
+    };
+
     struct Controls {
         std::shared_ptr<gui::Label> LBL_MESSAGE;
         std::shared_ptr<gui::ListBox> LB_REPLIES;
@@ -59,6 +68,12 @@ private:
 
     std::shared_ptr<Object> _currentSpeaker;
     std::map<std::string, Participant> _participantByTag;
+
+    /**
+     * Ordinary creatures currently holding an authored cutscene pose. They keep
+     * it until another authored animation replaces it or the dialogue ends.
+     */
+    std::vector<std::shared_ptr<Creature>> _heldCutParticipants;
 
     void preload(gui::IGUI &gui) override;
     void onGUILoaded() override;
@@ -75,14 +90,17 @@ private:
 
     void updateCamera();
     void updateParticipantAnimations();
+    void applyCutAnimation(const std::string &participant, const CutAnimation &cut);
+    void applyDialogAnimation(const std::string &participant, int ordinal);
     void restoreInactiveStuntParticipants();
-    bool enterMixedStunt(Participant &participant, const std::shared_ptr<graphics::Animation> &animation);
+    bool enterMixedStunt(Participant &participant, const std::shared_ptr<graphics::Animation> &animation, bool looping);
     void leaveMixedStunt(Participant &participant);
 
     glm::vec3 getTalkPosition(const Object &object) const;
     DialogCamera::Variant getRandomCameraVariant() const;
-    std::string getStuntAnimationName(int ordinal) const;
-    AnimationType getStuntAnimationType(int ordinal) const;
+    static std::optional<CutAnimation> decodeCutAnimation(int ordinal);
+    AnimationType getDialogAnimationType(int ordinal) const;
+    std::shared_ptr<Creature> resolveParticipantCreature(const std::string &participant) const;
     bool hasStuntPresentation() const;
     std::shared_ptr<graphics::Animation> getStuntParticipantAnimation(
         const std::string &participant,
@@ -107,6 +125,8 @@ private:
 
     void loadStuntParticipants();
     void releaseStuntParticipants();
+    void holdCutParticipant(const std::shared_ptr<Creature> &creature);
+    void releaseHeldCutParticipants();
 
     // END Participants
 };

--- a/src/libs/game/gui/dialog.cpp
+++ b/src/libs/game/gui/dialog.cpp
@@ -51,6 +51,27 @@ static const char kControlTagTopFrame[] = "TOP";
 static const char kControlTagBottomFrame[] = "BOTTOM";
 static const char kObjectTagOwner[] = "owner";
 
+// Odyssey DLG participant animation ordinals occupy two namespaces.
+//
+// Ordinals at or above kDialogAnimationBase index dialoganimations.2da and name
+// a semantic dialogue animation. Lower ordinals name a cutscene clip on the
+// target model directly, and are split into fixed-width bands: the band selects
+// the clip name suffix and whether the clip is held, while the offset within the
+// band selects the clip number. Both namespaces are independent of AnimatedCut
+// and of whether the participant is driven by a stunt model.
+static constexpr int kDialogAnimationBase = 10000;
+static constexpr int kCutAnimationBandSize = 200;
+
+static const struct CutAnimationBand {
+    int base;
+    const char *suffix;
+    bool looping;
+} g_cutAnimationBands[] {
+    {1000, "", false},
+    {1200, "w", false},
+    {1400, "l", true},
+    {1600, "wl", true}};
+
 static const std::unordered_map<std::string, AnimationType> g_animTypeByName {
     {"dead", AnimationType::LoopingDead},
     {"taunt", AnimationType::FireForgetTaunt},
@@ -136,6 +157,7 @@ void DialogGUI::configureReplies() {
 
 void DialogGUI::onStart() {
     _currentSpeaker = _owner;
+    _heldCutParticipants.clear();
     loadStuntParticipants();
 
     auto camera = _game.module()->area()->getCamera<AnimatedCamera>(CameraType::Animated);
@@ -150,14 +172,7 @@ void DialogGUI::loadStuntParticipants() {
     _participantByTag.clear();
 
     for (auto &stunt : _dialog->stunts) {
-        std::shared_ptr<Creature> creature;
-        if (stunt.participant == kObjectTagOwner) {
-            creature = std::dynamic_pointer_cast<Creature>(_owner);
-        } else if (boost::iequals(stunt.participant, kObjectTagPlayer)) {
-            creature = _game.party().player();
-        } else {
-            creature = std::dynamic_pointer_cast<Creature>(_game.module()->area()->getObjectByTag(stunt.participant));
-        }
+        std::shared_ptr<Creature> creature(resolveParticipantCreature(stunt.participant));
         if (!creature) {
             warn("Dialog: participant creature not found by tag: " + stunt.participant);
             continue;
@@ -185,12 +200,26 @@ bool DialogGUI::hasStuntPresentation() const {
     return _dialog->isAnimatedCutscene() || !_dialog->stunts.empty();
 }
 
+std::shared_ptr<Creature> DialogGUI::resolveParticipantCreature(const std::string &participant) const {
+    if (participant == kObjectTagOwner) {
+        return std::dynamic_pointer_cast<Creature>(_owner);
+    }
+    if (boost::iequals(participant, kObjectTagPlayer)) {
+        return _game.party().player();
+    }
+    return std::dynamic_pointer_cast<Creature>(_game.module()->area()->getObjectByTag(participant));
+}
+
 std::shared_ptr<Animation> DialogGUI::getStuntParticipantAnimation(
     const std::string &participant,
     int ordinal) const {
+    auto cut = decodeCutAnimation(ordinal);
+    if (!cut) {
+        return nullptr;
+    }
     auto maybeParticipant = _participantByTag.find(participant);
     return maybeParticipant != _participantByTag.end()
-               ? maybeParticipant->second.model->getAnimation(getStuntAnimationName(ordinal))
+               ? maybeParticipant->second.model->getAnimation(cut->name)
                : nullptr;
 }
 
@@ -225,14 +254,14 @@ void DialogGUI::restoreInactiveStuntParticipants() {
     }
 }
 
-bool DialogGUI::enterMixedStunt(Participant &participant, const std::shared_ptr<Animation> &animation) {
+bool DialogGUI::enterMixedStunt(Participant &participant, const std::shared_ptr<Animation> &animation, bool looping) {
     if (!participant.mixedStuntActive && participant.creature->isStuntMode()) {
         warn("Dialog: participant is already in stunt mode: " + participant.creature->tag());
         return false;
     }
 
     AnimationProperties properties;
-    properties.flags = AnimationFlags::propagate;
+    properties.flags = AnimationFlags::propagate | (looping ? AnimationFlags::loop : 0);
     properties.scale = 1.0f;
     if (!participant.creature->playExternalAnimation(animation, std::move(properties))) {
         return false;
@@ -342,53 +371,107 @@ DialogCamera::Variant DialogGUI::getRandomCameraVariant() const {
 }
 
 void DialogGUI::updateParticipantAnimations() {
+    // Each authored animation is resolved on its own. The ordinal decides which
+    // animation is meant, the participant decides which model plays it, and a
+    // single entry may drive stunt-bound participants and ordinary area
+    // creatures side by side.
     for (auto &anim : _currentEntry->animations) {
-        if (_dialog->isAnimatedCutscene()) {
-            auto maybeParticipant = _participantByTag.find(anim.participant);
-            if (maybeParticipant == _participantByTag.end()) {
-                warn("Dialog: participant not found by tag: " + anim.participant);
-                continue;
-            }
-            const Participant &participant = maybeParticipant->second;
-            std::string animName(getStuntAnimationName(anim.animation));
-            std::shared_ptr<Animation> animation(participant.model->getAnimation(animName));
-            if (animation) {
-                AnimationProperties properties;
-                properties.flags = AnimationFlags::propagate;
-                properties.scale = 1.0f;
-                participant.creature->playExternalAnimation(animation, std::move(properties));
-            }
-        } else if (auto animation = getStuntParticipantAnimation(anim.participant, anim.animation)) {
-            Participant &participant = _participantByTag.at(anim.participant);
-            enterMixedStunt(participant, animation);
+        if (auto cut = decodeCutAnimation(anim.animation)) {
+            applyCutAnimation(anim.participant, *cut);
         } else {
-            std::shared_ptr<Creature> participant;
-            if (anim.participant == "owner") {
-                participant = std::dynamic_pointer_cast<Creature>(_owner);
-            } else {
-                participant = std::dynamic_pointer_cast<Creature>(_game.module()->area()->getObjectByTag(anim.participant));
-            }
-            if (!participant) {
-                warn("Dialog: participant creature not found by tag: " + anim.participant);
-                continue;
-            }
-            AnimationType animType = getStuntAnimationType(anim.animation);
-            if (animType != AnimationType::Invalid) {
-                participant->playAnimation(animType);
-            }
+            applyDialogAnimation(anim.participant, anim.animation);
         }
     }
 }
 
-std::string DialogGUI::getStuntAnimationName(int ordinal) const {
-    return str(boost::format("cut%03dw") % (ordinal - 1200 + 1));
+void DialogGUI::applyCutAnimation(const std::string &participant, const CutAnimation &cut) {
+    auto maybeParticipant = _participantByTag.find(participant);
+    if (maybeParticipant != _participantByTag.end()) {
+        Participant &stunt = maybeParticipant->second;
+        if (auto animation = stunt.model->getAnimation(cut.name)) {
+            if (_dialog->isAnimatedCutscene()) {
+                AnimationProperties properties;
+                properties.flags = AnimationFlags::propagate | (cut.looping ? AnimationFlags::loop : 0);
+                properties.scale = 1.0f;
+                stunt.creature->playExternalAnimation(animation, std::move(properties));
+            } else {
+                enterMixedStunt(stunt, animation, cut.looping);
+            }
+            return;
+        }
+        // The stunt model is the authored source for this participant, so a
+        // missing clip is a data problem rather than a reason to silently
+        // animate from somewhere else. Staged participants also sit at the
+        // stunt origin, where an in-place clip would play in the wrong place.
+        warn("Dialog: stunt model has no animation: " + cut.name);
+        return;
+    }
+
+    auto creature = resolveParticipantCreature(participant);
+    if (!creature) {
+        warn("Dialog: participant creature not found by tag: " + participant);
+        return;
+    }
+    auto node = creature->sceneNode();
+    if (!node || node->type() != SceneNodeType::Model) {
+        return;
+    }
+    // Cut clips authored without the world-space suffix live on the creature's
+    // own model, so they play in place rather than through stunt staging.
+    auto animation = std::static_pointer_cast<ModelSceneNode>(node)->model().getAnimation(cut.name);
+    if (!animation) {
+        return;
+    }
+    AnimationProperties properties;
+    if (cut.looping) {
+        properties.flags |= AnimationFlags::loop;
+    }
+    // Authored cutscene clips stay under dialogue ownership: a one-shot clip
+    // holds its final frame instead of falling back to the state-driven idle,
+    // because the authored sequence may leave entries without an AnimList
+    // before the next clip takes over.
+    if (creature->playExternalAnimation(animation, std::move(properties))) {
+        holdCutParticipant(creature);
+    }
 }
 
-AnimationType DialogGUI::getStuntAnimationType(int ordinal) const {
-    std::shared_ptr<TwoDA> animations(_services.resource.twoDas.get("dialoganimations"));
-    int index = ordinal - 10000;
+void DialogGUI::applyDialogAnimation(const std::string &participant, int ordinal) {
+    auto creature = resolveParticipantCreature(participant);
+    if (!creature) {
+        warn("Dialog: participant creature not found by tag: " + participant);
+        return;
+    }
+    AnimationType animType = getDialogAnimationType(ordinal);
+    if (animType != AnimationType::Invalid) {
+        creature->playAnimation(animType);
+    }
+}
 
-    if (index < 0 || index >= animations->getRowCount()) {
+std::optional<DialogGUI::CutAnimation> DialogGUI::decodeCutAnimation(int ordinal) {
+    for (auto &band : g_cutAnimationBands) {
+        int offset = ordinal - band.base;
+        if (offset < 0 || offset >= kCutAnimationBandSize) {
+            continue;
+        }
+        CutAnimation cut;
+        cut.name = str(boost::format("cut%03d%s") % (offset + 1) % band.suffix);
+        cut.looping = band.looping;
+        return cut;
+    }
+    return std::nullopt;
+}
+
+AnimationType DialogGUI::getDialogAnimationType(int ordinal) const {
+    if (ordinal < kDialogAnimationBase) {
+        // Cut-band ordinals never reach here. Anything else below the 2DA base
+        // belongs to no namespace reone recognises, so it is left unplayed.
+        warn("Dialog: unsupported animation ordinal: " + std::to_string(ordinal));
+        return AnimationType::Invalid;
+    }
+    std::shared_ptr<TwoDA> animations(_services.resource.twoDas.get("dialoganimations"));
+    int index = ordinal - kDialogAnimationBase;
+
+    if (index >= animations->getRowCount()) {
         warn("Dialog: animation index out of bounds: " + std::to_string(index));
         return AnimationType::Invalid;
     }
@@ -419,12 +502,27 @@ void DialogGUI::onFinish() {
     if (hasStuntPresentation()) {
         releaseStuntParticipants();
     }
+    releaseHeldCutParticipants();
 
     // Make current speaker stop talking, if any
     auto speakerCreature = std::dynamic_pointer_cast<Creature>(_currentSpeaker);
     if (speakerCreature) {
         speakerCreature->stopTalking();
     }
+}
+
+void DialogGUI::holdCutParticipant(const std::shared_ptr<Creature> &creature) {
+    auto maybeHeld = std::find(_heldCutParticipants.begin(), _heldCutParticipants.end(), creature);
+    if (maybeHeld == _heldCutParticipants.end()) {
+        _heldCutParticipants.push_back(creature);
+    }
+}
+
+void DialogGUI::releaseHeldCutParticipants() {
+    for (auto &creature : _heldCutParticipants) {
+        creature->resumeStateDrivenAnimation();
+    }
+    _heldCutParticipants.clear();
 }
 
 void DialogGUI::releaseStuntParticipants() {

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -106,7 +106,24 @@ public:
 
     static bool applyAnimation(DialogGUI &gui, const std::string &tag, int ordinal) {
         auto animation = gui.getStuntParticipantAnimation(tag, ordinal);
-        return animation && gui.enterMixedStunt(gui._participantByTag.at(tag), animation);
+        if (!animation) {
+            return false;
+        }
+        auto cut = DialogGUI::decodeCutAnimation(ordinal);
+        return gui.enterMixedStunt(gui._participantByTag.at(tag), animation, cut && cut->looping);
+    }
+
+    static std::optional<DialogGUI::CutAnimation> decodeCut(int ordinal) {
+        return DialogGUI::decodeCutAnimation(ordinal);
+    }
+
+    static void setOwner(DialogGUI &gui, std::shared_ptr<Object> owner) {
+        gui._owner = std::move(owner);
+    }
+
+    static void updateAnimationsForEntry(DialogGUI &gui, const resource::Dialog::EntryReply &entry) {
+        gui._currentEntry = &entry;
+        gui.updateParticipantAnimations();
     }
 
     static bool isActive(DialogGUI &gui, const std::string &tag) {
@@ -888,6 +905,388 @@ TEST(DialogGUI, should_leave_no_partial_mixed_stunt_state_when_inputs_are_missin
     EXPECT_FALSE(MixedStuntTestAccess::applyAnimation(gui, "PLAYER", 1200));
     EXPECT_FALSE(MixedStuntTestAccess::isActive(gui, "PLAYER"));
     EXPECT_FALSE(player->isStuntMode());
+}
+
+// Owns the graphics options the scene graph keeps a reference to.
+struct DialogAnimScene {
+    graphics::GraphicsOptions graphicsOptions;
+    scene::SceneGraph graph;
+
+    explicit DialogAnimScene(TestEngine &engine) :
+        graph(
+            "test",
+            engine.sceneModule().renderPipelineFactory(),
+            graphicsOptions,
+            engine.services().graphics,
+            engine.services().audio,
+            engine.services().resource) {
+    }
+
+    std::shared_ptr<TestCreature> newCreature(
+        Game &game,
+        TestEngine &engine,
+        uint32_t id,
+        std::string tag,
+        const std::shared_ptr<graphics::Model> &model) {
+        auto creature = std::make_shared<TestCreature>(id, std::move(tag), game, engine.services());
+        creature->setSceneNode(graph.newModel(*model, scene::ModelUsage::Creature));
+        return creature;
+    }
+};
+
+std::shared_ptr<scene::ModelSceneNode> modelNodeOf(const std::shared_ptr<Creature> &creature) {
+    return std::static_pointer_cast<scene::ModelSceneNode>(creature->sceneNode());
+}
+
+std::shared_ptr<TwoDA> makeDialogAnimationsTable() {
+    TwoDA::Builder builder;
+    builder.columns({"name"});
+    for (int i = 0; i < 30; ++i) {
+        builder.row({""});
+    }
+    builder.row({"Talk_Normal"});
+    return builder.build();
+}
+
+TEST(DialogGUI, should_decode_participant_animation_ordinals_by_cut_band) {
+    struct Expectation {
+        int ordinal;
+        const char *name;
+        bool looping;
+    };
+    const Expectation expectations[] {
+        {1000, "cut001", false},
+        {1011, "cut012", false},
+        {1013, "cut014", false},
+        {1199, "cut200", false},
+        {1200, "cut001w", false},
+        {1201, "cut002w", false},
+        {1399, "cut200w", false},
+        {1400, "cut001l", true},
+        {1409, "cut010l", true},
+        {1412, "cut013l", true},
+        {1599, "cut200l", true},
+        {1600, "cut001wl", true},
+        {1601, "cut002wl", true},
+        {1799, "cut200wl", true}};
+
+    for (auto &expected : expectations) {
+        auto cut = MixedStuntTestAccess::decodeCut(expected.ordinal);
+        ASSERT_TRUE(cut.has_value()) << "ordinal " << expected.ordinal;
+        EXPECT_EQ(cut->name, expected.name) << "ordinal " << expected.ordinal;
+        EXPECT_EQ(cut->looping, expected.looping) << "ordinal " << expected.ordinal;
+    }
+
+    // Ordinals outside the known cut bands keep their own meaning and must not
+    // be reinterpreted as clip names.
+    for (int ordinal : {0, 35, 40, 70, 999, 1800, 2000, 9999, 10000, 10038, 10511}) {
+        EXPECT_FALSE(MixedStuntTestAccess::decodeCut(ordinal).has_value()) << "ordinal " << ordinal;
+    }
+}
+
+TEST(DialogGUI, should_animate_the_real_player_when_an_animated_cut_authors_no_stunt_participants) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    auto held = makeAnimation("cut010l");
+    auto oneShot = makeAnimation("cut012");
+    auto superModel = makeModel("supermodel", {held, oneShot});
+    auto bodyModel = makeModel("player_body", {makeAnimation("cpause1")});
+    bodyModel->setSuperModel(superModel);
+    auto player = scene.newCreature(game, engine, 1, "player", bodyModel);
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    auto node = modelNodeOf(player);
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = true;
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 0);
+
+    // A held clip resolves through the supermodel and stays on the creature.
+    Dialog::EntryReply inTank;
+    inTank.animations.push_back({"player", 1409});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, inTank);
+
+    ASSERT_EQ(node->animationChannels().size(), 1);
+    EXPECT_EQ(node->activeAnimationName(), "cut010l");
+    EXPECT_EQ(node->animationChannels().front().anim, held.get());
+    EXPECT_TRUE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+    node->update(0.6f);
+    node->update(0.6f);
+    EXPECT_FALSE(node->isAnimationFinished());
+
+    // A one-shot clip from the same band group plays once.
+    Dialog::EntryReply draining;
+    draining.animations.push_back({"player", 1011});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, draining);
+
+    EXPECT_EQ(node->activeAnimationName(), "cut012");
+    EXPECT_EQ(node->animationChannels().front().anim, oneShot.get());
+    EXPECT_FALSE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+    node->update(0.6f);
+    node->update(0.6f);
+    EXPECT_TRUE(node->isAnimationFinished());
+}
+
+TEST(DialogGUI, should_animate_an_ordinary_participant_from_a_cut_band_ordinal) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    auto prone = makeAnimation("cut013l");
+    auto rise = makeAnimation("cut014");
+    auto ownerModel = makeModel("owner_body", {prone, rise});
+    auto owner = scene.newCreature(game, engine, 2, "owner", ownerModel);
+    auto node = modelNodeOf(owner);
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = false;
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    MixedStuntTestAccess::setOwner(gui, owner);
+
+    Dialog::EntryReply lying;
+    lying.animations.push_back({"owner", 1412});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, lying);
+    EXPECT_EQ(node->activeAnimationName(), "cut013l");
+    EXPECT_EQ(node->animationChannels().front().anim, prone.get());
+    EXPECT_TRUE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+
+    Dialog::EntryReply standing;
+    standing.animations.push_back({"owner", 1013});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, standing);
+    EXPECT_EQ(node->activeAnimationName(), "cut014");
+    EXPECT_EQ(node->animationChannels().front().anim, rise.get());
+    EXPECT_FALSE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+}
+
+TEST(DialogGUI, should_hold_an_authored_cut_pose_until_the_dialogue_releases_the_participant) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    auto idle = makeAnimation("cpause1");
+    auto drain = makeAnimation("cut012");
+    auto prone = makeAnimation("cut013l");
+    auto ownerModel = makeModel("owner_body", {idle, drain, prone}, graphics::MdlClassification::character);
+    auto owner = scene.newCreature(game, engine, 7, "owner", ownerModel);
+    owner->resumeStateDrivenAnimation();
+    auto node = modelNodeOf(owner);
+    ASSERT_EQ(node->activeAnimationName(), "cpause1");
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = true;
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    MixedStuntTestAccess::setOwner(gui, owner);
+
+    // A one-shot cut clip runs to its end.
+    Dialog::EntryReply draining;
+    draining.animations.push_back({"owner", 1011});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, draining);
+    EXPECT_EQ(node->activeAnimationName(), "cut012");
+
+    node->update(0.6f);
+    owner->update(0.0f);
+    node->update(0.6f);
+    owner->update(0.0f);
+
+    // Having finished, it holds its final frame rather than falling back to the
+    // state-driven idle.
+    ASSERT_EQ(node->animationChannels().size(), 1);
+    EXPECT_TRUE(node->isAnimationFinished());
+    EXPECT_EQ(node->activeAnimationName(), "cut012");
+    EXPECT_EQ(node->animationChannels().front().anim, drain.get());
+
+    // The authored sequence puts a script-only entry between the two clips. It
+    // must not release the held pose.
+    Dialog::EntryReply scriptOnly;
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, scriptOnly);
+    owner->update(0.0f);
+    EXPECT_EQ(node->activeAnimationName(), "cut012");
+    EXPECT_EQ(node->animationChannels().front().anim, drain.get());
+
+    // The next authored animation replaces it.
+    Dialog::EntryReply lying;
+    lying.animations.push_back({"owner", 1412});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, lying);
+    owner->update(0.0f);
+    EXPECT_EQ(node->activeAnimationName(), "cut013l");
+    EXPECT_TRUE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+
+    // A looping clip is not dropped when it passes its end either.
+    node->update(0.6f);
+    owner->update(0.0f);
+    node->update(0.6f);
+    owner->update(0.0f);
+    EXPECT_FALSE(node->isAnimationFinished());
+    EXPECT_EQ(node->activeAnimationName(), "cut013l");
+
+    // Finishing the dialogue hands the creature back to state-driven animation.
+    MixedStuntTestAccess::finish(gui);
+    EXPECT_EQ(node->activeAnimationName(), "cpause1");
+}
+
+TEST(DialogGUI, should_drive_stunt_and_ordinary_participants_from_one_animated_cut_entry) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    // Both models carry a clip of the same name, so the assertions below
+    // distinguish the model each participant was driven from.
+    auto stuntClip = makeAnimation("cut001w");
+    auto stuntModel = makeModel("principal_stunt", {stuntClip});
+    auto principalModel = makeModel("principal_body", {makeAnimation("cut001w")});
+    auto principal = scene.newCreature(game, engine, 3, "owner", principalModel);
+    auto extraClip = makeAnimation("cut001w");
+    auto extraModel = makeModel("extra_body", {extraClip});
+    auto extra = scene.newCreature(game, engine, 4, "player", extraModel);
+    game.party().addMember(kNpcPlayer, extra);
+    game.party().setPlayer(extra);
+
+    EXPECT_CALL(engine.resourceModule().models(), get("principal_stunt"))
+        .WillOnce(Return(stuntModel));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = true;
+    dialog->stunts.push_back({"owner", "principal_stunt"});
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::setOwner(gui, principal);
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+
+    Dialog::EntryReply entry;
+    entry.animations.push_back({"owner", 1200});
+    entry.animations.push_back({"player", 1200});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, entry);
+
+    // The stunt-bound principal is driven from the stunt model.
+    auto principalNode = modelNodeOf(principal);
+    ASSERT_EQ(principalNode->animationChannels().size(), 1);
+    EXPECT_EQ(principalNode->animationChannels().front().anim, stuntClip.get());
+
+    // The ordinary extra is driven from its own model in the same entry.
+    auto extraNode = modelNodeOf(extra);
+    ASSERT_EQ(extraNode->animationChannels().size(), 1);
+    EXPECT_EQ(extraNode->animationChannels().front().anim, extraClip.get());
+}
+
+TEST(DialogGUI, should_keep_driving_fully_stunted_animated_cuts_from_the_stunt_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    auto first = makeAnimation("cut001w");
+    auto second = makeAnimation("cut002w");
+    auto stuntModel = makeModel("player_stunt", {first, second});
+    auto bodyModel = makeModel("player_body", {makeAnimation("cut001w"), makeAnimation("cpause1")});
+    auto player = scene.newCreature(game, engine, 5, "player", bodyModel);
+    game.party().addMember(kNpcPlayer, player);
+    game.party().setPlayer(player);
+    auto node = modelNodeOf(player);
+
+    EXPECT_CALL(engine.resourceModule().models(), get("player_stunt"))
+        .WillOnce(Return(stuntModel));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = true;
+    dialog->stunts.push_back({"player", "player_stunt"});
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+
+    Dialog::EntryReply entry;
+    entry.animations.push_back({"player", 1201});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, entry);
+
+    ASSERT_EQ(node->animationChannels().size(), 1);
+    EXPECT_EQ(node->activeAnimationName(), "cut002w");
+    EXPECT_EQ(node->animationChannels().front().anim, second.get());
+    EXPECT_FALSE(node->animationChannels().front().properties.flags & scene::AnimationFlags::loop);
+    EXPECT_TRUE(node->animationChannels().front().properties.flags & scene::AnimationFlags::propagate);
+}
+
+TEST(DialogGUI, should_not_animate_a_stunt_participant_from_its_own_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    // The stunt model is the authored source, and it lacks the requested clip.
+    // The creature's own model carries a clip of that name, which must not be
+    // substituted for it.
+    auto stuntModel = makeModel("owner_stunt", {makeAnimation("cut001w")});
+    auto ownModel = makeModel("owner_body", {makeAnimation("cpause1"), makeAnimation("cut002w")},
+                              graphics::MdlClassification::character);
+    auto owner = scene.newCreature(game, engine, 8, "owner", ownModel);
+    owner->resumeStateDrivenAnimation();
+    auto node = modelNodeOf(owner);
+    ASSERT_EQ(node->activeAnimationName(), "cpause1");
+
+    EXPECT_CALL(engine.resourceModule().models(), get("owner_stunt"))
+        .WillOnce(Return(stuntModel));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = true;
+    dialog->stunts.push_back({"owner", "owner_stunt"});
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::setOwner(gui, owner);
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+
+    Dialog::EntryReply entry;
+    entry.animations.push_back({"owner", 1201});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, entry);
+
+    EXPECT_EQ(node->activeAnimationName(), "cpause1");
+}
+
+TEST(DialogGUI, should_not_resolve_dialoganimations_ordinals_against_a_stunt_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    DialogAnimScene scene(engine);
+
+    // Shape of 650DAN/650kreia: a stunt-bound participant that also receives a
+    // dialoganimations ordinal.
+    auto stuntClip = makeAnimation("cut001w");
+    auto stuntModel = makeModel("owner_stunt", {stuntClip});
+    auto talk = makeAnimation("tlknorm");
+    auto ownerModel = makeModel("owner_body", {talk, makeAnimation("cpause1")});
+    auto owner = scene.newCreature(game, engine, 6, "owner", ownerModel);
+    auto node = modelNodeOf(owner);
+
+    EXPECT_CALL(engine.resourceModule().models(), get("owner_stunt"))
+        .WillOnce(Return(stuntModel));
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("dialoganimations"))
+        .WillOnce(Return(makeDialogAnimationsTable()));
+
+    auto dialog = std::make_shared<Dialog>();
+    dialog->animatedCutscene = false;
+    dialog->stunts.push_back({"owner", "owner_stunt"});
+    DialogGUI gui(game, engine.services());
+    MixedStuntTestAccess::setOwner(gui, owner);
+    MixedStuntTestAccess::loadParticipants(gui, dialog);
+    ASSERT_EQ(MixedStuntTestAccess::participantCount(gui), 1);
+
+    Dialog::EntryReply entry;
+    entry.animations.push_back({"owner", 10030});
+    MixedStuntTestAccess::updateAnimationsForEntry(gui, entry);
+
+    // Resolved through dialoganimations.2da on the creature's own model, and
+    // the stunt model was never asked for a semantic animation name.
+    ASSERT_EQ(node->animationChannels().size(), 1);
+    EXPECT_EQ(node->animationChannels().front().anim, talk.get());
+    EXPECT_NE(node->animationChannels().front().anim, stuntClip.get());
+    EXPECT_FALSE(MixedStuntTestAccess::isActive(gui, "owner"));
 }
 
 TEST(Object, should_convert_credits_to_party_gold_when_looted_by_party_member) {


### PR DESCRIPTION
## Summary

Fixes dialogue cut animations for both K1 and K2.  Partially addresses #250.

Reone was treating `AnimatedCut` as meaning every animated participant had to use a stunt model. That is not true of the game data — animated cutscenes can drive ordinary creatures as well, and K2 also uses additional cut-animation ordinal bands.

This change:

* routes cut animations per participant;
* supports the `1000`, `1200`, `1400` and `1600` animation bands;
* plays ordinary-creature cut animations through their normal model/supermodel chain;
* preserves stunt-model animations where authored;
* handles looping cut animations and holds authored poses until the dialogue releases them.

K2 `101awake` is the main visible case: the player now performs the authored kolto tank, prone and stand-up animations rather than returning to the default standing pose.

This also fixes equivalent mixed stunt/ordinary animation cases in K1.

## Known issues

Does not include the separate Kreia corpse `AnimationState`, dialogue fade (which appears to hide the kneeling to prone transition after the kolto tank), or remaining K2 `10000+` animation work.
