### PR TITLE
[game] Update area visibility on JumpToLocation and JumpToObject

### DIFF
--- a/src/libs/game/action/commonactions.cpp
+++ b/src/libs/game/action/commonactions.cpp
@@ -18,6 +18,7 @@
 #include "commonactions.h"
 
 #include "reone/game/action.h"
+#include "reone/game/game.h"
 #include "reone/game/object.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/door.h"
@@ -96,6 +97,32 @@ bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float 
     placeable.setLocked(false);
 
     return true;
+}
+
+void jumpToPositionFacing(Object &actor, const glm::vec3 &position,
+                          float facing, Game &game) {
+    actor.setPosition(position);
+    actor.setFacing(facing);
+
+    auto module = game.module();
+    if (!module) {
+        return;
+    }
+
+    auto area = game.module()->area();
+    if (!area) {
+        return;
+    }
+
+    Room *roomBefore = actor.room();
+    area->determineObjectRoom(actor);
+    Room *roomAfter = actor.room();
+
+    if (auto leader = game.party().getLeader()) {
+        if (leader->id() == actor.id()) {
+            area->onPartyLeaderMoved(roomBefore != roomAfter);
+        }
+    }
 }
 
 } // namespace game

--- a/src/libs/game/action/commonactions.h
+++ b/src/libs/game/action/commonactions.h
@@ -22,6 +22,7 @@ namespace reone {
 namespace game {
 
 class Door;
+class Game;
 class Object;
 class Party;
 class Placeable;
@@ -38,6 +39,10 @@ bool unlockDoor(Door &door, Object &actor, float distance, float dt);
 // Move an actor to a placeable and unlock it. Returns true when this action is
 // complete.
 bool unlockPlaceable(Placeable &placeable, Object &actor, float distance, float dt);
+
+// Set position and facing of an actor, and update area visibility.
+void jumpToPositionFacing(Object &actor, const glm::vec3 &position,
+                          float facing, Game &game);
 
 } // namespace game
 

--- a/src/libs/game/action/jumptolocation.cpp
+++ b/src/libs/game/action/jumptolocation.cpp
@@ -17,6 +17,7 @@
 
 #include "reone/game/action/jumptolocation.h"
 
+#include "commonactions.h"
 #include "reone/game/object.h"
 
 namespace reone {
@@ -24,9 +25,7 @@ namespace reone {
 namespace game {
 
 void JumpToLocationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    actor.setPosition(_location->position());
-    actor.setFacing(_location->facing());
-
+    jumpToPositionFacing(actor, _location->position(), _location->facing(), _game);
     complete();
 }
 

--- a/src/libs/game/action/jumptoobject.cpp
+++ b/src/libs/game/action/jumptoobject.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/action/jumptoobject.h"
 
+#include "commonactions.h"
+#include "reone/game/game.h"
 #include "reone/game/object.h"
 
 namespace reone {
@@ -24,9 +26,7 @@ namespace reone {
 namespace game {
 
 void JumpToObjectAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
-    actor.setPosition(_toJumpTo->position());
-    actor.setFacing(_toJumpTo->getFacing());
-
+    jumpToPositionFacing(actor, _toJumpTo->position(), _toJumpTo->getFacing(), _game);
     complete();
 }
 


### PR DESCRIPTION
JumpToLocation and JumpToObject actions should run perform the same
updates as a player manually running between rooms:

1. Objects are tied to rooms they're in for visibility, so we need to
determine the room first.

2. Party leader moves are special, because we need to update the 3rd
person camera.