### PR TITLE
[game] Let NPCs handle doors blocking their path

### DIFF
--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -205,6 +205,33 @@ public:
 
     // END Pathfinding
 
+    // Blocking doors
+
+    /**
+     * Remember the door that obstructed the last attempted step. Written by the
+     * collision layer for every mover, including the directly controlled player.
+     *
+     * This lives only to carry the obstruction from the collision test to the
+     * blocked event raised after the step. It is not what scripts read:
+     * GetBlockingDoor answers from the argument captured when the event was
+     * raised, so it stays fixed for that run while this keeps changing.
+     */
+    void setBlockingDoor(uint32_t doorId) { _blockingDoorId = doorId; }
+
+    void clearBlockingDoor() { _blockingDoorId = script::kObjectInvalid; }
+
+    uint32_t blockingDoorId() const { return _blockingDoorId; }
+
+    /**
+     * Edge-trigger ScriptOnBlocked for the door currently obstructing this
+     * creature. Called by navigation after each attempted step, so it only
+     * applies to AI, script and action driven movement. A continuous
+     * obstruction by the same door reports once; an unobstructed step re-arms.
+     */
+    void dispatchBlockedEvent();
+
+    // END Blocking doors
+
     // Perception
 
     void onObjectSeen(const std::shared_ptr<Object> &object);
@@ -289,6 +316,7 @@ public:
     // Scripts
 
     void runSpawnScript();
+    void runBlockedScript(uint32_t blockingDoorId);
     void runEndRoundScript();
     void runDialogueScript(uint32_t speakerId, int32_t listenNumber);
     void runAttackedScript(uint32_t attackerId);
@@ -363,6 +391,12 @@ private:
     std::string _onSpawn;
     std::string _onDeath;
     std::string _onBlocked;
+
+    // Door currently obstructing this creature, and the door the blocked event
+    // was last reported for. Object ids rather than pointers, so a door that is
+    // destroyed while remembered simply resolves to no object.
+    uint32_t _blockingDoorId {script::kObjectInvalid};
+    uint32_t _blockedEventDoorId {script::kObjectInvalid};
 
     resource::LocString _firstName;
     resource::LocString _lastName;

--- a/include/reone/game/object/door.h
+++ b/include/reone/game/object/door.h
@@ -26,6 +26,9 @@ namespace reone {
 
 namespace game {
 
+class Creature;
+class IReputes;
+
 class Door : public Object {
 public:
     Door(
@@ -201,6 +204,13 @@ private:
     void loadLinkedTransitionGeometry(const graphics::Walkmesh &walkmesh);
     void updateTransform() override;
 };
+
+/**
+ * Whether actor is allowed to bash door open. This is the single definition of
+ * door bash eligibility, shared by the player context action and by the
+ * DOOR_ACTION_BASH script routines.
+ */
+bool canBashDoor(const Door &door, const Creature &actor, const IReputes &reputes);
 
 } // namespace game
 

--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -91,6 +91,8 @@ public:
     Player &player() { return *_player; }
 
 private:
+    friend class TestGameModule;
+
     std::string _name;
     ModuleInfo _info;
     std::shared_ptr<Area> _area;

--- a/include/reone/script/variable.h
+++ b/include/reone/script/variable.h
@@ -91,6 +91,7 @@ enum class ArgKind {
     ClickingObject,
     EnteringObject,
     ExitingObject,
+    BlockingDoor,
     LastClosedBy,
     LastOpenedBy,
     LastPerceived,

--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -26,6 +26,7 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/location.h"
+#include "reone/game/object/door.h"
 #include "reone/game/party.h"
 #include "reone/game/reputes.h"
 #include "reone/game/room.h"
@@ -900,7 +901,21 @@ bool Area::moveCreature(const std::shared_ptr<Creature> &creature, const glm::ve
     dest.x += dir.x * speedDt;
     dest.y += dir.y * speedDt;
 
-    if (sceneGraph.testWalk(origin, dest, creature.get(), collision)) {
+    bool obstructed = sceneGraph.testWalk(origin, dest, creature.get(), collision);
+
+    // Remember a door that obstructs the intended direction of travel, so that
+    // navigation can raise the blocked event and GetBlockingDoor can report it.
+    // This is taken from the test against the intended direction: the slide
+    // below may still salvage some sideways motion, but the door did block
+    // where the creature wanted to go.
+    auto *blockingDoor = obstructed ? dynamic_cast<Door *>(collision.user) : nullptr;
+    if (blockingDoor) {
+        creature->setBlockingDoor(blockingDoor->id());
+    } else {
+        creature->clearBlockingDoor();
+    }
+
+    if (obstructed) {
         // Try moving along the surface
         glm::vec2 right(glm::normalize(glm::vec2(glm::cross(up, collision.normal))));
         glm::vec2 newDir(glm::normalize(right * glm::dot(dir, right)));

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -1050,6 +1050,19 @@ void Creature::runSpawnScript() {
     }
 }
 
+void Creature::runBlockedScript(uint32_t blockingDoorId) {
+    if (_onBlocked.empty()) {
+        return;
+    }
+    // The obstructing door travels with the run as an argument, so every
+    // continuation and delayed action started from it goes on seeing the door
+    // this event was raised for, whatever the creature has run into since.
+    _game.scriptRunner().run(
+        _onBlocked,
+        {{script::ArgKind::Caller, Variable::ofObject(_id)},
+         {script::ArgKind::BlockingDoor, Variable::ofObject(blockingDoorId)}});
+}
+
 void Creature::runEndRoundScript() {
     if (!_onEndRound.empty()) {
         _game.scriptRunner().run(_onEndRound, _id);
@@ -2277,7 +2290,27 @@ void Creature::advanceOnPath(bool run, float dt) {
         } else {
             setMovementType(Creature::MovementType::None);
         }
+        // Report a door that obstructed this step. A door can stop the creature
+        // from making progress while the slide in moveCreature still produces
+        // some sideways motion, so this is keyed on the recorded obstruction
+        // rather than on whether the step moved the creature at all.
+        dispatchBlockedEvent();
     }
+}
+
+void Creature::dispatchBlockedEvent() {
+    if (_blockingDoorId == script::kObjectInvalid) {
+        // Nothing obstructed this step. Re-arm, so meeting the same door again
+        // later reports again.
+        _blockedEventDoorId = script::kObjectInvalid;
+        return;
+    }
+    if (_blockedEventDoorId == _blockingDoorId) {
+        // Still the same obstruction that was already reported.
+        return;
+    }
+    _blockedEventDoorId = _blockingDoorId;
+    runBlockedScript(_blockingDoorId);
 }
 
 void Creature::updatePath(const glm::vec3 &dest) {

--- a/src/libs/game/object/door.cpp
+++ b/src/libs/game/object/door.cpp
@@ -37,6 +37,8 @@
 
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/reputes.h"
 
 using namespace reone::graphics;
 using namespace reone::resource;
@@ -434,6 +436,16 @@ void Door::runDeathScript(uint32_t damagerId) {
 
 void Door::setLocked(bool locked) {
     _locked = locked;
+}
+
+bool canBashDoor(const Door &door, const Creature &actor, const IReputes &reputes) {
+    return door.isLocked() &&
+           door.isSelectable() &&
+           !door.isDead() &&
+           !door.plotFlag() &&
+           !door.isNotBlastable() &&
+           reputes.getIsEnemy(actor.faction(), door.faction()) &&
+           (door.hitPoints() > 0 || door.currentHitPoints() > 0);
 }
 
 void Door::updateTransform() {

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -45,16 +45,6 @@ namespace reone {
 
 namespace game {
 
-static bool canBashDoor(const Door &door, const Creature &actor, const IReputes &reputes) {
-    return door.isLocked() &&
-           door.isSelectable() &&
-           !door.isDead() &&
-           !door.plotFlag() &&
-           !door.isNotBlastable() &&
-           reputes.getIsEnemy(actor.faction(), door.faction()) &&
-           (door.hitPoints() > 0 || door.currentHitPoints() > 0);
-}
-
 static bool canUseSecurityOnPlaceable(const Placeable &placeable, const Creature &actor) {
     return placeable.hasInventory() &&
            placeable.isLocked() &&

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3286,7 +3286,14 @@ static Variable GetDistanceToObject2D(const std::vector<Variable> &args, const R
 
 static Variable GetBlockingDoor(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetBlockingDoor");
+    // Captured when the blocked event was raised, so a continuation of that run
+    // reports the door the event was about rather than whatever obstructs the
+    // creature by the time the continuation asks. Validity is left to
+    // GetIsObjectValid, as for any other object a script holds on to.
+    if (const Variable *blockingDoor = ctx.execution.findArg(ArgKind::BlockingDoor)) {
+        return *blockingDoor;
+    }
+    return Variable::ofObject(kObjectInvalid);
 }
 
 static Variable GetIsDoorActionPossible(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -3295,9 +3302,29 @@ static Variable GetIsDoorActionPossible(const std::vector<Variable> &args, const
     auto nDoorAction = getInt(args, 1);
 
     // Transform
+    auto targetDoor = checkDoor(oTargetDoor);
+    auto doorAction = static_cast<DoorAction>(nDoorAction);
 
     // Execute
-    throw RoutineNotImplementedException("GetIsDoorActionPossible");
+    bool possible = false;
+    switch (doorAction) {
+    case DoorAction::Open:
+        possible = !targetDoor->isLocked();
+        break;
+    case DoorAction::Bash: {
+        auto caller = std::dynamic_pointer_cast<Creature>(getCaller(ctx));
+        possible = caller && canBashDoor(*targetDoor, *caller, ctx.services.game.reputes);
+        break;
+    }
+    default:
+        // No shipped K1 or K2 content performs UNLOCK, IGNORE or KNOCK, so
+        // there is no behaviour to reproduce. Report them as impossible rather
+        // than guessing at semantics.
+        debug(str(boost::format("Unsupported door action: %d") % nDoorAction), LogChannel::Script);
+        break;
+    }
+
+    return Variable::ofInt(static_cast<int>(possible));
 }
 
 static Variable DoDoorAction(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -3306,9 +3333,39 @@ static Variable DoDoorAction(const std::vector<Variable> &args, const RoutineCon
     auto nDoorAction = getInt(args, 1);
 
     // Transform
+    auto targetDoor = checkDoor(oTargetDoor);
+    auto doorAction = static_cast<DoorAction>(nDoorAction);
+    auto caller = getCaller(ctx);
 
     // Execute
-    throw RoutineNotImplementedException("DoDoorAction");
+    switch (doorAction) {
+    case DoorAction::Open:
+        // Opening is immediate: the routine returns void and the door state,
+        // animation, walkmesh swap and OnOpen event are the same ones a door
+        // opened through OpenDoorAction goes through. Nothing is queued, so a
+        // movement action that was blocked by this door stays in place and
+        // resumes once the door stops obstructing.
+        if (!targetDoor->isLocked()) {
+            targetDoor->open();
+            targetDoor->onOpen(caller->id());
+        }
+        break;
+    case DoorAction::Bash: {
+        // Bashing is a sustained attack rather than an immediate state change,
+        // so it goes on top of the queue: whatever the creature was doing stays
+        // behind it instead of being discarded.
+        auto creature = std::dynamic_pointer_cast<Creature>(caller);
+        if (creature && canBashDoor(*targetDoor, *creature, ctx.services.game.reputes)) {
+            creature->addActionOnTop(ctx.game.newAction<AttackObjectAction>(targetDoor));
+        }
+        break;
+    }
+    default:
+        debug(str(boost::format("Unsupported door action: %d") % nDoorAction), LogChannel::Script);
+        break;
+    }
+
+    return Variable::ofNull();
 }
 
 static Variable GetFirstItemInInventory(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/script/variable.cpp
+++ b/src/libs/script/variable.cpp
@@ -163,6 +163,8 @@ const char *argKindToString(ArgKind kind) {
         return "EnteringObject";
     case ArgKind::ExitingObject:
         return "ExitingObject";
+    case ArgKind::BlockingDoor:
+        return "BlockingDoor";
     case ArgKind::LastClosedBy:
         return "LastClosedBy";
     case ArgKind::LastOpenedBy:
@@ -244,6 +246,9 @@ Argument Argument::fromString(std::string str) {
     }
     if (kind == "ExitingObject") {
         return {ArgKind::ExitingObject, Variable::ofObject(std::stoul(value))};
+    }
+    if (kind == "BlockingDoor") {
+        return {ArgKind::BlockingDoor, Variable::ofObject(std::stoul(value))};
     }
     if (kind == "LastClosedBy") {
         return {ArgKind::LastClosedBy, Variable::ofObject(std::stoul(value))};
@@ -327,6 +332,7 @@ void Argument::verify() {
     case ArgKind::ClickingObject:
     case ArgKind::EnteringObject:
     case ArgKind::ExitingObject:
+    case ArgKind::BlockingDoor:
     case ArgKind::LastClosedBy:
     case ArgKind::LastOpenedBy:
     case ArgKind::LastPerceived:

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -51,6 +51,7 @@ class Gff;
 
 namespace game {
 
+class Area;
 class Game;
 class Module;
 class Object;
@@ -162,6 +163,7 @@ public:
     static void setCurrentScreen(Game &game, int screen);
     static void initConsole(Game &game);
     static void setActiveModule(Game &game, bool active);
+    static void setActiveModuleArea(Game &game, std::shared_ptr<Area> area);
     static void setPazaakDevelopmentSelectedObject(
         Game &game,
         std::shared_ptr<Object> object);

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -23,6 +23,8 @@
 #include "../fixtures/engine.h"
 
 #include "reone/game/action/closedoor.h"
+#include "reone/game/action/movetopoint.h"
+#include "reone/game/action/opendoor.h"
 #include "reone/game/action/unlockobject.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/areatransition.h"
@@ -34,9 +36,11 @@
 #include "reone/game/object/creature.h"
 #include "reone/game/object/door.h"
 #include "reone/game/object/item.h"
+#include "reone/game/object/module.h"
 #include "reone/game/object/placeable.h"
 #include "reone/game/object/trigger.h"
 #include "reone/game/reputes.h"
+#include "reone/game/room.h"
 #include "reone/game/script/routines.h"
 #include "reone/graphics/animation.h"
 #include "reone/graphics/model.h"
@@ -146,6 +150,11 @@ public:
 
 std::pair<std::string, std::string> reone::game::TestGameModule::scheduledTransition(const Game &game) {
     return {game._nextModule, game._nextEntry};
+}
+
+void reone::game::TestGameModule::setActiveModuleArea(Game &game, std::shared_ptr<Area> area) {
+    game._module = game.newModule();
+    game._module->_area = std::move(area);
 }
 
 namespace {
@@ -264,6 +273,24 @@ std::shared_ptr<Gff> makeJournalWithPlotXP() {
             Gff::Field::newList("Categories", {category})});
 }
 
+// Obstruction reported by the shared testWalk stub. Null by default, so walking
+// is unobstructed unless a test opts in through ScopedWalkObstruction.
+scene::IUser *&walkObstruction() {
+    static scene::IUser *obstruction = nullptr;
+    return obstruction;
+}
+
+class ScopedWalkObstruction {
+public:
+    explicit ScopedWalkObstruction(scene::IUser &obstruction) {
+        walkObstruction() = &obstruction;
+    }
+
+    ~ScopedWalkObstruction() {
+        walkObstruction() = nullptr;
+    }
+};
+
 scene::MockSceneGraph &testSceneGraph(TestEngine &engine) {
     static NiceMock<scene::MockSceneGraph> graph;
     // A real SceneGraph keeps every node it hands out alive in its own set, and
@@ -324,7 +351,20 @@ scene::MockSceneGraph &testSceneGraph(TestEngine &engine) {
                 return node;
             }));
         ON_CALL(graph, testWalk(_, _, _, _))
-            .WillByDefault(Return(false));
+            .WillByDefault(Invoke([](const glm::vec3 &origin,
+                                     const glm::vec3 &dest,
+                                     const scene::IUser *excludeUser,
+                                     scene::Collision &collision) {
+                auto *obstruction = walkObstruction();
+                if (!obstruction || obstruction == excludeUser) {
+                    return false;
+                }
+                collision.user = obstruction;
+                collision.intersection = dest;
+                collision.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+                collision.material = 0;
+                return true;
+            }));
         ON_CALL(graph, testElevation(_, _))
             .WillByDefault(Invoke([](const glm::vec3 &position, scene::Collision &collision) {
                 collision.intersection = position;
@@ -387,7 +427,49 @@ std::shared_ptr<Door> makeTransitionDoor(
     return door;
 }
 
-std::shared_ptr<Creature> makeMovingCreature(Game &game, TestEngine &engine) {
+// Door without linked-module metadata, so it blocks and opens without also
+// generating a transition trigger.
+std::shared_ptr<Door> makePlainDoor(
+    Game &game,
+    TestEngine &engine,
+    bool locked = false,
+    std::string onOpen = "",
+    glm::vec3 position = glm::vec3(0.0f)) {
+
+    testSceneGraph(engine);
+    auto walkmesh = makeDoorWalkmesh();
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("genericdoors"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeGenericDoorsTable()));
+    EXPECT_CALL(engine.resourceModule().models(), get(_))
+        .Times(AnyNumber());
+    EXPECT_CALL(engine.resourceModule().walkmeshes(), get("testdoor0", ResType::Dwk))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(walkmesh));
+    EXPECT_CALL(engine.resourceModule().walkmeshes(), get("testdoor1", ResType::Dwk))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeDoorWalkmesh()));
+
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newByte("GenericType", 1))
+                   .field(Gff::Field::newByte("Static", 0))
+                   .field(Gff::Field::newByte("Locked", locked ? 1 : 0))
+                   .field(Gff::Field::newShort("HP", 20))
+                   .field(Gff::Field::newResRef("OnOpen", std::move(onOpen)))
+                   .field(Gff::Field::newFloat("X", position.x))
+                   .field(Gff::Field::newFloat("Y", position.y))
+                   .field(Gff::Field::newFloat("Z", position.z))
+                   .build();
+    auto door = game.newDoor();
+    door->deserialize(*gff);
+    return door;
+}
+
+std::shared_ptr<Creature> makeMovingCreature(
+    Game &game,
+    TestEngine &engine,
+    std::string onBlocked = "") {
+
     EXPECT_CALL(engine.resourceModule().twoDas(), get("appearance"))
         .Times(AnyNumber())
         .WillRepeatedly(Return(makeAppearanceTable()));
@@ -401,10 +483,19 @@ std::shared_ptr<Creature> makeMovingCreature(Game &game, TestEngine &engine) {
                    .field(Gff::Field::newWord("SoundSetFile", 0xffff))
                    .field(Gff::Field::newByte("BodyBag", 0xff))
                    .field(Gff::Field::newByte("PerceptionRange", 0xff))
+                   .field(Gff::Field::newResRef("ScriptOnBlocked", std::move(onBlocked)))
                    .build();
     auto creature = game.newCreature();
     creature->deserialize(*gff);
     return creature;
+}
+
+// Navigation-driven step towards dest. Goes through Creature::advanceOnPath, so
+// it exercises the same path AI, scripts and actions take, unlike direct player
+// locomotion which calls Area::moveCreature.
+void navigationStep(Creature &creature, const glm::vec3 &dest, float dt = 1.0f) {
+    creature.setPath(dest, std::vector<glm::vec3> {dest}, 0);
+    creature.advanceOnPath(false, dt);
 }
 
 std::shared_ptr<Gff> makeTransitionTriggerGff(
@@ -2940,4 +3031,581 @@ TEST(AreaReputationSearch, treats_the_creature_being_searched_around_as_the_sour
         {CreatureType::Reputation, static_cast<int>(ReputationType::Enemy)}};
 
     EXPECT_EQ(candidate, area->getNearestCreature(searching, criterias));
+}
+
+namespace {
+
+// Script execution counts, keyed by resref. Static so the stub registered on the
+// shared scripts mock stays valid past the test that installed it.
+std::map<std::string, int> &scriptRunCounts() {
+    static std::map<std::string, int> counts;
+    return counts;
+}
+
+struct BlockedDoorFixtureBase {
+    TestEngine &engine;
+    StubConsole console;
+    Game game;
+    std::shared_ptr<Area> area;
+
+    BlockedDoorFixtureBase() :
+        engine(testEngine()),
+        game(GameID::KotOR, "", engine.options(), engine.services(), console) {
+
+        game.initLocalServices();
+        area = game.newArea();
+        TestGameModule::setActiveModuleArea(game, area);
+    }
+
+    std::shared_ptr<Creature> addCreature(std::string onBlocked) {
+        auto creature = makeMovingCreature(game, engine, std::move(onBlocked));
+        creature->setPosition(glm::vec3(0.0f));
+        area->add(creature);
+        return creature;
+    }
+
+    // Start counting executions of a script. The script itself resolves to
+    // nothing, which is enough to observe dispatch.
+    void countScriptRuns(const std::string &resRef) {
+        scriptRunCounts()[resRef] = 0;
+        EXPECT_CALL(engine.resourceModule().scripts(), get(resRef))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke([](const std::string &key) {
+                ++scriptRunCounts()[key];
+                return std::shared_ptr<script::ScriptProgram>();
+            }));
+    }
+
+    int scriptRuns(const std::string &resRef) const {
+        return scriptRunCounts()[resRef];
+    }
+};
+
+// A door that swaps its collision the instant it is told to open: makePlainDoor
+// gives it no model, so there is no opening animation to wait on.
+struct BlockedDoorFixture : BlockedDoorFixtureBase {
+    std::shared_ptr<Door> door;
+
+    explicit BlockedDoorFixture(bool locked = false, std::string onOpen = "") {
+        door = makePlainDoor(game, engine, locked, std::move(onOpen));
+        area->add(door);
+    }
+};
+
+// A door that actually swings. makeLifecycleDoor gives it a real opening1
+// animation, so it spends several frames in the doorway on its way open, which
+// is the case the blocked event has to sit through without repeating.
+struct SwingingDoorFixture : BlockedDoorFixtureBase {
+    std::shared_ptr<Door> door;
+
+    SwingingDoorFixture() {
+        door = makeLifecycleDoor(game, engine, /*openState=*/0);
+        area->add(door);
+    }
+
+    // Keep the walk obstruction in step with what the door's own collision is
+    // doing, so navigation meets exactly the doorway the door presents.
+    void syncObstruction() {
+        if (doorwayBlocks(*door)) {
+            if (!_obstruction) {
+                _obstruction.emplace(*door);
+            }
+        } else {
+            _obstruction.reset();
+        }
+    }
+
+private:
+    std::optional<ScopedWalkObstruction> _obstruction;
+};
+
+const glm::vec3 kFarDestination {0.0f, 10.0f, 0.0f};
+
+} // namespace
+
+TEST(CreatureBlockedByDoor, should_record_the_door_that_obstructs_navigation) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+
+    EXPECT_EQ(script::kObjectInvalid, npc->blockingDoorId());
+
+    ScopedWalkObstruction obstruction(*fixture.door);
+    navigationStep(*npc, kFarDestination);
+
+    EXPECT_EQ(fixture.door->id(), npc->blockingDoorId());
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+}
+
+TEST(CreatureBlockedByDoor, should_dispatch_authored_blocked_script_once_per_continuous_obstruction) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+
+    fixture.countScriptRuns("k_def_blocked01");
+
+    ScopedWalkObstruction obstruction(*fixture.door);
+    for (int i = 0; i < 10; ++i) {
+        navigationStep(*npc, kFarDestination);
+    }
+
+    // Ten obstructed steps against the same door, one dispatch.
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+}
+
+TEST(CreatureBlockedByDoor, should_rearm_blocked_script_after_unobstructed_movement) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+
+    {
+        ScopedWalkObstruction obstruction(*fixture.door);
+        navigationStep(*npc, kFarDestination);
+        navigationStep(*npc, kFarDestination);
+    }
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+
+    // An unobstructed step re-arms.
+    navigationStep(*npc, kFarDestination);
+    EXPECT_EQ(script::kObjectInvalid, npc->blockingDoorId());
+
+    ScopedWalkObstruction obstruction(*fixture.door);
+    navigationStep(*npc, kFarDestination);
+    EXPECT_EQ(fixture.door->id(), npc->blockingDoorId());
+    EXPECT_EQ(2, fixture.scriptRuns("k_def_blocked01"));
+}
+
+// A door keeps filling the doorway for the whole of its opening animation, so a
+// creature walking into one it has already reported keeps meeting the same
+// blocker for several frames. That is one obstruction, not one per frame.
+TEST(CreatureBlockedByDoor, should_not_repeat_while_the_door_it_reported_is_opening) {
+    SwingingDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+
+    fixture.syncObstruction();
+    ASSERT_TRUE(doorwayBlocks(*fixture.door));
+
+    navigationStep(*npc, kFarDestination);
+    EXPECT_EQ(fixture.door->id(), npc->blockingDoorId());
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+
+    // What the authored AI does in response to that one report.
+    fixture.door->open();
+    ASSERT_TRUE(fixture.door->isOpening());
+    ASSERT_TRUE(doorwayBlocks(*fixture.door));
+
+    // Frames inside the one-second opening animation. The door is on its way
+    // but has not arrived, so it is still standing in the doorway.
+    for (int frame = 0; frame < 3; ++frame) {
+        stepDoor(*fixture.door, 0.4f);
+        fixture.syncObstruction();
+        ASSERT_TRUE(doorwayBlocks(*fixture.door)) << "frame " << frame;
+        navigationStep(*npc, kFarDestination);
+        EXPECT_TRUE(fixture.door->isOpening()) << "frame " << frame;
+        EXPECT_EQ(fixture.door->id(), npc->blockingDoorId()) << "frame " << frame;
+    }
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+
+    // The transition arrives and the doorway opens up.
+    stepDoor(*fixture.door, 0.4f);
+    fixture.syncObstruction();
+    ASSERT_FALSE(fixture.door->isOpening());
+    ASSERT_FALSE(doorwayBlocks(*fixture.door));
+    ASSERT_TRUE(fixture.door->isOpen());
+
+    // The movement that was blocked all along now makes progress, and the
+    // blocked state clears so this door can report again another time.
+    float before = npc->position().y;
+    navigationStep(*npc, kFarDestination);
+    EXPECT_GT(npc->position().y, before);
+    EXPECT_EQ(script::kObjectInvalid, npc->blockingDoorId());
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+}
+
+// A different door taking over the doorway is a new obstruction, and reports in
+// its own right even though the creature never got an unobstructed step.
+TEST(CreatureBlockedByDoor, should_report_another_door_that_takes_over_the_obstruction) {
+    BlockedDoorFixture fixture;
+    auto other = makePlainDoor(fixture.game, fixture.engine, false, "", glm::vec3(0.0f, 2.0f, 0.0f));
+    fixture.area->add(other);
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+
+    {
+        ScopedWalkObstruction obstruction(*fixture.door);
+        navigationStep(*npc, kFarDestination);
+    }
+    EXPECT_EQ(fixture.door->id(), npc->blockingDoorId());
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+
+    {
+        ScopedWalkObstruction obstruction(*other);
+        navigationStep(*npc, kFarDestination);
+    }
+    EXPECT_EQ(other->id(), npc->blockingDoorId());
+    EXPECT_EQ(2, fixture.scriptRuns("k_def_blocked01"));
+}
+
+TEST(CreatureBlockedByDoor, should_run_the_script_authored_on_each_creature) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    auto companion = fixture.addCreature("k_hen_blocked01");
+    fixture.game.party().addMember(0, companion);
+
+    // Each creature runs what its own template names. The engine picks neither
+    // the script nor the 1009/2009 event number those scripts pass on.
+    fixture.countScriptRuns("k_def_blocked01");
+    fixture.countScriptRuns("k_hen_blocked01");
+
+    ScopedWalkObstruction obstruction(*fixture.door);
+    navigationStep(*npc, kFarDestination);
+    navigationStep(*companion, kFarDestination);
+
+    EXPECT_EQ(1, fixture.scriptRuns("k_def_blocked01"));
+    EXPECT_EQ(1, fixture.scriptRuns("k_hen_blocked01"));
+}
+
+TEST(CreatureBlockedByDoor, should_not_dispatch_for_directly_controlled_player_locomotion) {
+    BlockedDoorFixture fixture;
+    auto leader = fixture.addCreature("k_hen_blocked01");
+    fixture.game.party().addMember(kNpcPlayer, leader);
+    fixture.game.party().setPlayer(leader);
+
+    // Player::update drives the leader through Area::moveCreature directly and
+    // never through navigation, so no blocked event is raised.
+    fixture.countScriptRuns("k_hen_blocked01");
+
+    ScopedWalkObstruction obstruction(*fixture.door);
+    EXPECT_FALSE(fixture.area->moveCreature(leader, glm::vec2(0.0f, 1.0f), false, 1.0f));
+
+    EXPECT_EQ(0, fixture.scriptRuns("k_hen_blocked01"));
+
+    // The collision layer still records what obstructed the leader.
+    EXPECT_EQ(fixture.door->id(), leader->blockingDoorId());
+}
+
+TEST(CreatureBlockedByDoor, should_ignore_obstructions_that_are_not_doors) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+
+    Room room("testroom", glm::vec3(0.0f), nullptr, nullptr, nullptr);
+    ScopedWalkObstruction obstruction(room);
+    navigationStep(*npc, kFarDestination);
+
+    EXPECT_EQ(script::kObjectInvalid, npc->blockingDoorId());
+    EXPECT_EQ(0, fixture.scriptRuns("k_def_blocked01"));
+}
+
+// Invoke GetBlockingDoor with the arguments a blocked-event run would carry.
+uint32_t callGetBlockingDoor(Routines &routines, const script::ExecutionContext &execution) {
+    script::ExecutionContext copy(execution);
+    return routines.get(336).invoke({}, copy).objectId;
+}
+
+script::ExecutionContext blockedEventContext(uint32_t callerId, uint32_t blockingDoorId) {
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(callerId));
+    execution.args.emplace_back(script::ArgKind::BlockingDoor, script::Variable::ofObject(blockingDoorId));
+    return execution;
+}
+
+TEST(BlockingDoorRoutines, get_blocking_door_reports_the_door_captured_by_the_event) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+
+    auto execution = blockedEventContext(npc->id(), fixture.door->id());
+
+    EXPECT_EQ(fixture.door->id(), callGetBlockingDoor(routines, execution));
+}
+
+TEST(BlockingDoorRoutines, get_blocking_door_reports_invalid_without_a_captured_door) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+
+    // A run that is not a blocked event carries no such argument, whoever the
+    // caller is.
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(npc->id()));
+
+    EXPECT_EQ(script::kObjectInvalid, callGetBlockingDoor(routines, execution));
+}
+
+TEST(BlockingDoorRoutines, get_blocking_door_keeps_the_captured_door_when_the_obstruction_moves_on) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("k_def_blocked01");
+    auto other = makePlainDoor(fixture.game, fixture.engine);
+    fixture.area->add(other);
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+
+    // Blocked by the first door, and a continuation of that run holds it.
+    {
+        ScopedWalkObstruction obstruction(*fixture.door);
+        navigationStep(*npc, kFarDestination);
+    }
+    ASSERT_EQ(fixture.door->id(), npc->blockingDoorId());
+    auto execution = blockedEventContext(npc->id(), fixture.door->id());
+
+    // The creature then runs into a different door entirely.
+    {
+        ScopedWalkObstruction obstruction(*other);
+        navigationStep(*npc, kFarDestination);
+    }
+    ASSERT_EQ(other->id(), npc->blockingDoorId());
+
+    // The continuation still speaks for the event it came from.
+    EXPECT_EQ(fixture.door->id(), callGetBlockingDoor(routines, execution));
+}
+
+TEST(BlockingDoorRoutines, a_captured_door_that_is_destroyed_is_reported_but_not_valid) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+
+    auto execution = blockedEventContext(npc->id(), fixture.door->id());
+    TestGameModule::removeObject(fixture.game, fixture.door->id());
+
+    // GetBlockingDoor keeps no validity policy of its own: the captured id comes
+    // back, and it is GetIsObjectValid that reports the object has gone.
+    EXPECT_EQ(fixture.door->id(), callGetBlockingDoor(routines, execution));
+
+    script::ExecutionContext validityCtx(execution);
+    std::vector<script::Variable> validityArgs {script::Variable::ofObject(fixture.door->id())};
+    EXPECT_EQ(0, routines.get(42).invoke(validityArgs, validityCtx).intValue);
+}
+
+TEST(BlockingDoorRoutines, the_authored_blocked_script_can_act_on_the_door_that_blocked_it) {
+    BlockedDoorFixture fixture;
+    auto npc = fixture.addCreature("k_def_blocked01");
+    ASSERT_FALSE(fixture.door->isLocked());
+
+    // An OnBlocked script that locks whatever door GetBlockingDoor hands it.
+    // SetLocked takes the object on top of the flag, matching how the shipped
+    // scripts push it.
+    auto program = std::make_shared<script::ScriptProgram>("k_def_blocked01");
+    program->add(script::Instruction::newCONSTI(1));
+    program->add(script::Instruction::newACTION(336, 0));
+    program->add(script::Instruction::newACTION(324, 2));
+    program->add(script::Instruction(script::InstructionType::RETN));
+    EXPECT_CALL(fixture.engine.resourceModule().scripts(), get("k_def_blocked01"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(program));
+
+    {
+        ScopedWalkObstruction obstruction(*fixture.door);
+        navigationStep(*npc, kFarDestination);
+    }
+
+    // The door reached the script, so the argument survived dispatch.
+    EXPECT_TRUE(fixture.door->isLocked());
+}
+
+TEST(BlockingDoorRoutines, unlocked_door_is_openable_and_door_action_open_opens_it) {
+    BlockedDoorFixture fixture(false, "door_on_open");
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("door_on_open");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(npc->id()));
+
+    auto possible = routines.get(337).invoke(
+        {script::Variable::ofObject(fixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Open))},
+        execution);
+    EXPECT_EQ(1, possible.intValue);
+
+    ASSERT_FALSE(fixture.door->isOpen());
+
+    routines.get(338).invoke(
+        {script::Variable::ofObject(fixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Open))},
+        execution);
+
+    // Opened, and the OnOpen event fired, exactly as for any other open.
+    EXPECT_TRUE(fixture.door->isOpen());
+    EXPECT_EQ(1, fixture.scriptRuns("door_on_open"));
+}
+
+TEST(BlockingDoorRoutines, door_action_open_leaves_the_same_state_as_open_door_action) {
+    BlockedDoorFixture routineFixture;
+    auto routineNpc = routineFixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &routineFixture.game, &routineFixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(routineNpc->id()));
+
+    routines.get(338).invoke(
+        {script::Variable::ofObject(routineFixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Open))},
+        execution);
+
+    BlockedDoorFixture actionFixture;
+    auto actionNpc = actionFixture.addCreature("k_def_blocked01");
+    actionNpc->setPosition(actionFixture.door->position());
+    auto action = actionFixture.game.newAction<OpenDoorAction>(actionFixture.door);
+    action->execute(action, *actionNpc, 0.0f);
+
+    // The routine and the action leave a door in the same state, because both
+    // go through Door::open.
+    EXPECT_EQ(actionFixture.door->isOpen(), routineFixture.door->isOpen());
+    EXPECT_EQ(actionFixture.door->isLocked(), routineFixture.door->isLocked());
+    EXPECT_EQ(actionFixture.door->isSelectable(), routineFixture.door->isSelectable());
+    EXPECT_TRUE(routineFixture.door->isOpen());
+}
+
+TEST(BlockingDoorRoutines, locked_door_is_not_openable_and_door_action_open_leaves_it_shut) {
+    BlockedDoorFixture fixture(true);
+    auto npc = fixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(npc->id()));
+
+    auto possible = routines.get(337).invoke(
+        {script::Variable::ofObject(fixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Open))},
+        execution);
+    EXPECT_EQ(0, possible.intValue);
+
+    routines.get(338).invoke(
+        {script::Variable::ofObject(fixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Open))},
+        execution);
+
+    EXPECT_FALSE(fixture.door->isOpen());
+    EXPECT_TRUE(fixture.door->isLocked());
+}
+
+TEST(BlockingDoorRoutines, bash_follows_shared_eligibility_and_keeps_the_blocked_action) {
+    BlockedDoorFixture fixture(true);
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.door->setCurrentHitPoints(20);
+    auto &reputes = static_cast<MockReputes &>(fixture.engine.services().game.reputes);
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(npc->id()));
+
+    auto bashPossible = [&]() {
+        return routines.get(337)
+            .invoke(
+                {script::Variable::ofObject(fixture.door->id()),
+                 script::Variable::ofInt(static_cast<int>(DoorAction::Bash))},
+                execution)
+            .intValue;
+    };
+
+    // Not an enemy of the door: the same answer the player context action gives.
+    EXPECT_CALL(reputes, getIsEnemy(A<Faction>(), A<Faction>()))
+        .WillRepeatedly(Return(false));
+    EXPECT_EQ(0, bashPossible());
+
+    Mock::VerifyAndClearExpectations(&reputes);
+    EXPECT_CALL(reputes, getIsEnemy(A<Faction>(), A<Faction>()))
+        .WillRepeatedly(Return(true));
+    EXPECT_EQ(1, bashPossible());
+
+    // A plot door is never bashable, so the AI cannot get through it at all.
+    fixture.door->setPlotFlag(true);
+    EXPECT_EQ(0, bashPossible());
+    fixture.door->setPlotFlag(false);
+
+    // The movement the creature was blocked on stays queued behind the bash.
+    auto movement = fixture.game.newAction<MoveToPointAction>(kFarDestination);
+    npc->addAction(movement);
+
+    routines.get(338).invoke(
+        {script::Variable::ofObject(fixture.door->id()),
+         script::Variable::ofInt(static_cast<int>(DoorAction::Bash))},
+        execution);
+
+    ASSERT_EQ(2, npc->actions().size());
+    EXPECT_EQ(ActionType::AttackObject, npc->actions().front()->type());
+    EXPECT_EQ(movement, npc->actions().back());
+}
+
+TEST(BlockingDoorRoutines, unsupported_door_actions_are_impossible_and_do_nothing) {
+    BlockedDoorFixture fixture(true);
+    auto npc = fixture.addCreature("k_def_blocked01");
+    Routines routines(GameID::KotOR, &fixture.game, &fixture.engine.services());
+    routines.init();
+    script::ExecutionContext execution;
+    execution.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(npc->id()));
+
+    for (auto action : {DoorAction::Unlock, DoorAction::Ignore, DoorAction::Knock}) {
+        auto possible = routines.get(337).invoke(
+            {script::Variable::ofObject(fixture.door->id()),
+             script::Variable::ofInt(static_cast<int>(action))},
+            execution);
+        EXPECT_EQ(0, possible.intValue);
+
+        routines.get(338).invoke(
+            {script::Variable::ofObject(fixture.door->id()),
+             script::Variable::ofInt(static_cast<int>(action))},
+            execution);
+    }
+
+    EXPECT_FALSE(fixture.door->isOpen());
+    EXPECT_TRUE(fixture.door->isLocked());
+    EXPECT_TRUE(npc->actions().empty());
+}
+
+TEST(BlockingDoorRoutines, are_registered_for_both_kotor_and_tsl) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    Routines k1Routines(GameID::KotOR, &game, &engine.services());
+    Routines k2Routines(GameID::TSL, &game, &engine.services());
+    k1Routines.init();
+    k2Routines.init();
+
+    for (auto *routines : {&k1Routines, &k2Routines}) {
+        EXPECT_EQ("GetBlockingDoor", routines->get(336).name());
+        EXPECT_EQ("GetIsDoorActionPossible", routines->get(337).name());
+        EXPECT_EQ("DoDoorAction", routines->get(338).name());
+        EXPECT_EQ(336, routines->getIndexByName("GetBlockingDoor"));
+        EXPECT_EQ(337, routines->getIndexByName("GetIsDoorActionPossible"));
+        EXPECT_EQ(338, routines->getIndexByName("DoDoorAction"));
+    }
+}
+
+TEST(OpenDoorAction, still_opens_an_unlocked_door_and_fires_on_open) {
+    BlockedDoorFixture fixture(false, "door_on_open");
+    auto npc = fixture.addCreature("k_def_blocked01");
+    fixture.countScriptRuns("door_on_open");
+    npc->setPosition(fixture.door->position());
+
+    auto action = fixture.game.newAction<OpenDoorAction>(fixture.door);
+    action->execute(action, *npc, 0.0f);
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_TRUE(fixture.door->isOpen());
+    EXPECT_EQ(1, fixture.scriptRuns("door_on_open"));
+}
+
+TEST(OpenDoorAction, still_refuses_a_locked_door_and_fires_on_fail_to_open) {
+    BlockedDoorFixture fixture(true);
+    auto npc = fixture.addCreature("k_def_blocked01");
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newResRef("OnFailToOpen", "door_on_fail"))
+                   .build();
+    fixture.door->deserialize(*gff);
+    fixture.countScriptRuns("door_on_fail");
+    npc->setPosition(fixture.door->position());
+
+    auto action = fixture.game.newAction<OpenDoorAction>(fixture.door);
+    action->execute(action, *npc, 0.0f);
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_FALSE(fixture.door->isOpen());
+    EXPECT_TRUE(fixture.door->isLocked());
+    EXPECT_EQ(1, fixture.scriptRuns("door_on_fail"));
 }


### PR DESCRIPTION
## Summary

Restores NPC handling of doors that block pathfinding.

When an NPC path is obstructed by a door, Reone now records that door and
raises the creature's authored `OnBlocked` event once for that continuous
obstruction.

Implements the corresponding script routines:

- `GetBlockingDoor`
- `GetIsDoorActionPossible`
- `DoDoorAction`

The engine does not automatically open doors. Existing K1/K2 AI scripts,
including `k_ai_master`, decide whether to open, bash or otherwise handle the
door.

Repeated collision with the same door does not repeatedly fire `OnBlocked`
while the door is opening. Once the obstruction clears, the latch resets so
the same door can trigger it again on a later encounter.

## Validation
-  K1:  'danm16' demonstrates NPC opening a blocking door at the end of dialogue
-  K2:  droids in 103per open doors in the upper levels of the module
