### PR TITLE
[game] Implement K2 overlay animations

### DIFF
--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -173,6 +173,15 @@ public:
     bool playExternalAnimation(const std::shared_ptr<graphics::Animation> &anim, scene::AnimationProperties properties = scene::AnimationProperties());
     void resumeStateDrivenAnimation();
 
+    /**
+     * Play an animation as a layer over whatever the creature is already doing,
+     * including while it is walking or running. Unlike the other playAnimation
+     * overloads this neither waits for the creature to stand still nor takes
+     * over its state-driven animation, so locomotion carries on underneath and
+     * the layer disappears on its own once it has run.
+     */
+    void playOverlayAnimation(AnimationType type);
+
     void updateModelAnimation();
 
     // END Animation

--- a/include/reone/scene/types.h
+++ b/include/reone/scene/types.h
@@ -56,6 +56,13 @@ struct AnimationFlags {
 
     static constexpr int propagate = 0x10; /**< propagate animation to attached models */
 
+    /**
+     * With overlay, layer on top of whatever is already playing instead of
+     * replacing it, so the animations underneath keep running and keep
+     * supplying the nodes this one does not animate.
+     */
+    static constexpr int layer = 0x20;
+
     static constexpr int loopOverlay = loop | overlay;
     static constexpr int loopBlend = loop | blend;
 };

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -850,6 +850,30 @@ bool Creature::playExternalAnimation(const std::shared_ptr<Animation> &anim, Ani
     });
 }
 
+void Creature::playOverlayAnimation(AnimationType type) {
+    std::string animName(getAnimationName(type));
+    if (animName.empty()) {
+        return;
+    }
+    auto model = std::static_pointer_cast<ModelSceneNode>(_sceneNode);
+    if (!model) {
+        return;
+    }
+    // Deliberately not routed through doPlayAnimation: that refuses to play
+    // anything while the creature is moving, which is the one case an overlay
+    // exists to cover. _animFireForget is left alone too, so
+    // updateModelAnimation goes on driving locomotion underneath the layer,
+    // and the layer erases itself once it has finished.
+    model->playAnimation(
+        animName,
+        nullptr,
+        AnimationProperties::fromFlags(
+            AnimationFlags::overlay |
+            AnimationFlags::layer |
+            AnimationFlags::fireForget |
+            AnimationFlags::propagate));
+}
+
 void Creature::resumeStateDrivenAnimation() {
     _animFireForget = false;
     _animDirty = true;
@@ -2390,6 +2414,11 @@ std::string Creature::getAnimationName(AnimationType anim) const {
         return "greeting";
     case AnimationType::FireForgetTaunt:
         return getFirstIfCreatureModel("ctaunt", "taunt");
+    case AnimationType::FireForgetDiveRoll:
+        // Row 567 of K2 animations.2da, the one animation the shipped scripts
+        // ever ask PlayOverlayAnimation for. K1 has neither the clip nor the
+        // constant.
+        return getFirstIfCreatureModel("cdiveroll", "diveroll");
     case AnimationType::FireForgetVictory1:
         return getFirstIfCreatureModel("cvictory", "victory");
     case AnimationType::FireForgetInject:
@@ -2434,7 +2463,6 @@ std::string Creature::getAnimationName(AnimationType anim) const {
     case AnimationType::FireForgetThrowLow:
     case AnimationType::FireForgetCustom01:
     case AnimationType::FireForgetForceCast:
-    case AnimationType::FireForgetDiveRoll:
     case AnimationType::FireForgetScream:
     default:
         debug("CreatureAnimationResolver: unsupported animation type: " + std::to_string(static_cast<int>(anim)));

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -6934,9 +6934,14 @@ static Variable PlayOverlayAnimation(const std::vector<Variable> &args, const Ro
     auto nAnimation = getInt(args, 1);
 
     // Transform
+    auto target = checkCreature(oTarget);
+    auto animation = static_cast<AnimationType>(nAnimation);
 
     // Execute
-    throw RoutineNotImplementedException("PlayOverlayAnimation");
+    // As nwscript describes it: plays on the creature even while it is moving,
+    // and places no action on the queue.
+    target->playOverlayAnimation(animation);
+    return Variable::ofNull();
 }
 
 static Variable UnlockAllSongs(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -241,8 +241,12 @@ void ModelSceneNode::playAnimation(Animation &anim, std::shared_ptr<LipAnimation
 
     case AnimationBlendMode::Overlay:
         // In Overlay mode, clear channels only if previous mode is not
-        // Overlay and add animation on top
-        if (_animBlendMode != AnimationBlendMode::Overlay) {
+        // Overlay and add animation on top. A layered animation keeps them
+        // instead: it plays over whatever the model is already doing, so the
+        // channels underneath go on running and go on supplying every node the
+        // layered animation leaves alone.
+        if (_animBlendMode != AnimationBlendMode::Overlay &&
+            !(properties.flags & AnimationFlags::layer)) {
             _animChannels.clear();
         }
         _animChannels.push_front(AnimationChannel(anim, lipAnim, properties));

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -223,6 +223,9 @@ std::shared_ptr<TwoDA> makeAppearanceTable() {
     builder.row({"S", "1", "1", "-1", "", "", ""});
     builder.row({"S", "1", "1", "-1", "", "", ""});
     builder.row({"S", "1", "1", "-1", "", "", ""});
+    // Row 3 is a body model rather than a creature model, so tests can cover
+    // the humanoid side of the animation naming split.
+    builder.row({"B", "1", "1", "-1", "", "", ""});
     return std::shared_ptr<TwoDA>(builder.build());
 }
 
@@ -3608,4 +3611,260 @@ TEST(OpenDoorAction, still_refuses_a_locked_door_and_fires_on_fail_to_open) {
     EXPECT_FALSE(fixture.door->isOpen());
     EXPECT_TRUE(fixture.door->isLocked());
     EXPECT_EQ(1, fixture.scriptRuns("door_on_fail"));
+}
+
+namespace {
+
+// Locomotion is what an overlay has to survive, and Creature drives it with
+// loopBlend, so the base channel below the overlay is a blended looping one.
+constexpr int kLocomotionFlags = scene::AnimationFlags::loopBlend | scene::AnimationFlags::propagate;
+
+struct OverlayFixture {
+    graphics::GraphicsOptions graphicsOptions;
+    std::shared_ptr<graphics::Model> model;
+    std::unique_ptr<scene::SceneGraph> graph;
+    std::shared_ptr<scene::ModelSceneNode> node;
+
+    std::vector<std::string> channelNames() const {
+        std::vector<std::string> names;
+        for (auto &channel : node->animationChannels()) {
+            names.push_back(channel.anim->name());
+        }
+        return names;
+    }
+};
+
+// A creature with a live model carrying both spellings of the dive roll plus a
+// run clip to act as locomotion underneath it.
+void setUpOverlay(OverlayFixture &fixture, TestEngine &engine) {
+    fixture.model = makeModel(
+        "body",
+        {makeAnimation("run"),
+         makeAnimation("pause1"),
+         makeAnimation("diveroll"),
+         makeAnimation("cdiveroll")});
+    fixture.graph = std::make_unique<scene::SceneGraph>(
+        "test",
+        engine.sceneModule().renderPipelineFactory(),
+        fixture.graphicsOptions,
+        engine.services().graphics,
+        engine.services().audio,
+        engine.services().resource);
+    fixture.node = fixture.graph->newModel(*fixture.model, scene::ModelUsage::Creature);
+}
+
+// A creature whose appearance row makes it a body model, i.e. the humanoid
+// naming branch the player character takes.
+void makeHumanoid(TestCreature &creature, TestEngine &engine) {
+    EXPECT_CALL(engine.resourceModule().twoDas(), get("appearance"))
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(makeAppearanceTable()));
+    EXPECT_CALL(engine.resourceModule().models(), get(_)).Times(AnyNumber());
+    EXPECT_CALL(static_cast<MockPortraits &>(engine.services().game.portraits), getTextureByAppearance(_))
+        .Times(AnyNumber());
+
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newDword("Appearance_Type", 3))
+                   .field(Gff::Field::newWord("SoundSetFile", 0xffff))
+                   .field(Gff::Field::newByte("BodyBag", 0xff))
+                   .field(Gff::Field::newByte("PerceptionRange", 0xff))
+                   .build();
+    creature.deserialize(*gff);
+    ASSERT_EQ(Creature::ModelType::Character, creature.modelType());
+}
+
+} // namespace
+
+// A. The dive roll resolves through the ordinary animation naming path, on both
+// sides of the creature/body model split.
+TEST(OverlayAnimation, should_resolve_the_dive_roll_for_a_body_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    makeHumanoid(creature, engine);
+    creature.setSceneNode(fixture.node);
+
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+
+    EXPECT_EQ("diveroll", fixture.node->activeAnimationName());
+}
+
+TEST(OverlayAnimation, should_resolve_the_dive_roll_for_a_creature_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    ASSERT_EQ(Creature::ModelType::Creature, creature.modelType());
+    creature.setSceneNode(fixture.node);
+
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+
+    EXPECT_EQ("cdiveroll", fixture.node->activeAnimationName());
+}
+
+// C and D. The overlay plays while the creature is running, and the locomotion
+// channel underneath survives it. The other playAnimation overloads refuse
+// outright while a creature is moving, which is exactly what an overlay must
+// not do.
+TEST(OverlayAnimation, should_layer_over_locomotion_without_displacing_it) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(fixture.node);
+    creature.setMovementType(Creature::MovementType::Run);
+    fixture.node->playAnimation(
+        "run", nullptr, scene::AnimationProperties::fromFlags(kLocomotionFlags));
+    ASSERT_EQ("run", fixture.node->activeAnimationName());
+
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+
+    // The overlay is on top, and the run it was layered over is still there.
+    EXPECT_EQ("cdiveroll", fixture.node->activeAnimationName());
+    EXPECT_THAT(fixture.channelNames(), ElementsAre("cdiveroll", "run"));
+}
+
+// A normal animation request is still refused while moving, so the overlay path
+// is doing something the ordinary one cannot.
+TEST(OverlayAnimation, should_still_refuse_a_plain_animation_while_moving) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(fixture.node);
+    creature.setMovementType(Creature::MovementType::Run);
+    fixture.node->playAnimation(
+        "run", nullptr, scene::AnimationProperties::fromFlags(kLocomotionFlags));
+
+    creature.playAnimation("cdiveroll");
+
+    EXPECT_EQ("run", fixture.node->activeAnimationName());
+}
+
+// C. Queued actions are untouched: the routine places nothing on the queue and
+// completes nothing already on it.
+TEST(OverlayAnimation, should_leave_the_action_queue_alone) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(fixture.node);
+    creature.setMovementType(Creature::MovementType::Run);
+    auto pending = game.newAction<PlayAnimationAction>(AnimationType::LoopingPause, 1.0f, 0.0f);
+    creature.addAction(pending);
+    ASSERT_EQ(1u, creature.actions().size());
+
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+
+    EXPECT_EQ(1u, creature.actions().size());
+    EXPECT_EQ(pending, creature.getCurrentAction());
+    EXPECT_FALSE(pending->isCompleted());
+}
+
+// F. Fire and forget: the layer expires on its own and the locomotion beneath
+// it becomes current again.
+TEST(OverlayAnimation, should_expire_and_hand_back_to_locomotion) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(fixture.node);
+    creature.setMovementType(Creature::MovementType::Run);
+    fixture.node->playAnimation(
+        "run", nullptr, scene::AnimationProperties::fromFlags(kLocomotionFlags));
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+    ASSERT_EQ("cdiveroll", fixture.node->activeAnimationName());
+
+    // Part way through, the layer is still on top.
+    fixture.node->update(0.5f);
+    EXPECT_EQ("cdiveroll", fixture.node->activeAnimationName());
+
+    // The clip is one second long; once past it the layer is dropped.
+    fixture.node->update(0.6f);
+    fixture.node->update(0.1f);
+
+    EXPECT_EQ("run", fixture.node->activeAnimationName());
+    EXPECT_THAT(fixture.channelNames(), ElementsAre("run"));
+}
+
+// E. An animation with no mapping is a no-op rather than a corruption.
+TEST(OverlayAnimation, should_ignore_an_animation_it_cannot_name) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    TestCreature creature(1, "test", game, engine.services());
+    creature.setSceneNode(fixture.node);
+    fixture.node->playAnimation(
+        "run", nullptr, scene::AnimationProperties::fromFlags(kLocomotionFlags));
+
+    creature.playOverlayAnimation(AnimationType::FireForgetScream);
+
+    EXPECT_EQ("run", fixture.node->activeAnimationName());
+    EXPECT_THAT(fixture.channelNames(), ElementsAre("run"));
+}
+
+TEST(OverlayAnimation, should_ignore_an_overlay_on_a_creature_with_no_model) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    TestCreature creature(1, "test", game, engine.services());
+    ASSERT_FALSE(creature.sceneNode());
+
+    // Nothing to animate, so this must simply do nothing.
+    creature.playOverlayAnimation(AnimationType::FireForgetDiveRoll);
+
+    EXPECT_FALSE(creature.sceneNode());
+}
+
+// B and E. Routine 854 resolves its target and drives the overlay, and a
+// non-creature target is reported rather than crashing.
+TEST(OverlayAnimation, routine_854_plays_the_overlay_on_its_target) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::TSL, "", engine.options(), engine.services(), console);
+    Routines routines(GameID::TSL, &game, &engine.services());
+    routines.init();
+    auto &routine = routines.get(854);
+    ASSERT_EQ("PlayOverlayAnimation", routine.name());
+
+    // Registered with the game so the routine can resolve it by id, and given a
+    // model so the overlay it plays is observable.
+    OverlayFixture fixture;
+    setUpOverlay(fixture, engine);
+    auto creature = game.newObject<TestCreature>("test", game, engine.services());
+    creature->setSceneNode(fixture.node);
+    fixture.node->playAnimation(
+        "run", nullptr, scene::AnimationProperties::fromFlags(kLocomotionFlags));
+    auto placeable = game.newPlaceable();
+    script::ExecutionContext ctx;
+
+    routine.invoke(
+        {script::Variable::ofObject(creature->id()), script::Variable::ofInt(123)}, ctx);
+
+    // The requested animation reached the creature and was layered on.
+    EXPECT_EQ("cdiveroll", fixture.node->activeAnimationName());
+    EXPECT_THAT(fixture.channelNames(), ElementsAre("cdiveroll", "run"));
+
+    // A non-creature target is rejected by argument checking, which the routine
+    // framework turns into a logged failure and a default return value, leaving
+    // the animation state alone.
+    auto result = routine.invoke(
+        {script::Variable::ofObject(placeable->id()), script::Variable::ofInt(123)}, ctx);
+    EXPECT_EQ(script::VariableType::Void, result.type);
+    EXPECT_EQ("cdiveroll", fixture.node->activeAnimationName());
 }


### PR DESCRIPTION
## Summary

Implements K2 `PlayOverlayAnimation`.

Overlay animations are played independently of the creature's ordinary animation channel, allowing authored animations such as the dive roll to play while the creature continues moving.

This includes:

- overlay animation-layer handling;
- K2 `PlayOverlayAnimation` script routine;
- `FireForgetDiveRoll` mapping used by shipped K2 content.

## Vanilla cases

K2 uses `PlayOverlayAnimation` with animation type 123 for the authored dive roll in several scenes. Type 123 resolves to `diveroll`, which `animations.2da` marks `overlay=1` and `fireforget=1`, and nwscript documents the routine as playing even while the creature is moving and as placing no action on the action queue.

In `306NAR`, the Twin Suns now perform the dive roll while moving.

The same routine is also used in the `103PER` intro sequence. In the complete integration, it produces the authored moving dive roll once the separate `AssignCommand` and module-transition issues are corrected.

## Scope

This PR implements overlay animation playback only.

`AssignCommand` semantics, module-load timing and door behaviour are separate fixes.