### PR TITLE
[engine] Seed the frame clock in microseconds

### DIFF
--- a/src/apps/engine/engine.cpp
+++ b/src/apps/engine/engine.cpp
@@ -230,7 +230,11 @@ void Engine::deinit() {
 
 int Engine::run() {
     auto &clock = _services->system.clock;
-    _ticks = clock.millis();
+    // Sampled in microseconds every frame below, so the baseline has to be
+    // microseconds too. Seeding it from millis() made the first frame time
+    // come out as very nearly the whole clock epoch - the counter runs from
+    // system boot, so it was routinely days.
+    _ticks = clock.micros();
 
     bool quit = false;
     while (!quit) {


### PR DESCRIPTION
## Summary

Seeds the engine frame clock in the same unit used for subsequent frame samples.

`Engine::run()` initialized `_ticks` with `Clock::millis()` but sampled later frames with `Clock::micros()`. Since both values share the same underlying counter epoch, the first frame could be interpreted as an extremely large elapsed interval.

The frame clock is now initialized with `Clock::micros()` as well.

## Validation

During investigation, the first-frame delta changed from approximately 267,000 seconds to approximately 0.001 seconds when this correction was applied in isolation.
