### PR TITLE
[engine] Rebase frame timing after synchronous module loads

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -137,6 +137,17 @@ public:
     void update(float frameTime);
     void render();
 
+    /**
+     * Report, and clear, whether a break in gameplay time has occurred since
+     * the last call.
+     *
+     * Loading a module blocks for as long as reading it takes, and that wall
+     * time is not time the game world experienced. The caller owns the frame
+     * clock, so it is the caller that has to open a new epoch; this only says
+     * that one is due.
+     */
+    bool consumeTimingDiscontinuity();
+
     void playVideo(const std::string &name);
 
     bool isPaused() const { return _paused; }
@@ -491,6 +502,7 @@ private:
     CameraType _cameraType {CameraType::ThirdPerson};
     CameraType _savedCameraType {CameraType::ThirdPerson};
     bool _paused {false};
+    bool _timingDiscontinuity {false};
     std::set<std::string> _moduleNames;
     std::set<std::string> _saveNames;
     bool _quitRequested {false};

--- a/src/apps/engine/engine.cpp
+++ b/src/apps/engine/engine.cpp
@@ -244,6 +244,12 @@ int Engine::run() {
             continue;
         }
         uint64_t ticks = clock.micros();
+        if (_game->consumeTimingDiscontinuity()) {
+            // A synchronous load blocked somewhere in the last frame. Rebase
+            // onto now so that interval is not charged to the world as elapsed
+            // gameplay time: this frame opens a new epoch and starts at zero.
+            _ticks = ticks;
+        }
         auto frameTime = (ticks - _ticks) / 10e5f;
         _ticks = ticks;
         _profiler->measure(kMainThreadName, kProfilerInputTimeIndex, [this, &quit]() {

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -563,6 +563,12 @@ bool Game::handle(const input::Event &event) {
     return false;
 }
 
+bool Game::consumeTimingDiscontinuity() {
+    bool discontinuity = _timingDiscontinuity;
+    _timingDiscontinuity = false;
+    return discontinuity;
+}
+
 void Game::update(float frameTime) {
     float dt = frameTime * _gameSpeed;
     if (_movie) {
@@ -877,12 +883,17 @@ void Game::loadModule(const std::string &name, std::string entry, bool fromSave)
             std::string musicName(_module->area()->music());
             playMusic(musicName);
 
-            //_ticks = _services.system.clock.ticks();
             openInGame();
         } catch (const std::exception &e) {
             error("Failed loading module '" + name + "': " + std::string(e.what()));
         }
     });
+
+    // However long that took, none of it was time the game world lived
+    // through. Whoever drives the frame clock has to start a new epoch before
+    // the next update, or the whole load lands on the world as one enormous
+    // step.
+    _timingDiscontinuity = true;
 }
 
 void Game::resetGame() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/reputes.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
+    ${TESTS_SOURCE_DIR}/game/timingepoch.cpp
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp
     ${TESTS_SOURCE_DIR}/game/turret.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -160,6 +160,7 @@ public:
         PazaakSession::MainDeckFactory mainDeckFactory,
         std::function<void(const std::string &, uint32_t)> continuation);
     static void setCurrentScreen(Game &game, int screen);
+    static void raiseTimingDiscontinuity(Game &game);
     static void initConsole(Game &game);
     static void setActiveModule(Game &game, bool active);
     static void setPazaakDevelopmentSelectedObject(

--- a/test/game/timingepoch.cpp
+++ b/test/game/timingepoch.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "reone/game/game.h"
+#include "reone/resource/types.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace testing;
+
+void reone::game::TestGameModule::raiseTimingDiscontinuity(Game &game) {
+    game._timingDiscontinuity = true;
+}
+
+TEST(TimingEpoch, should_report_no_discontinuity_on_a_game_that_has_not_loaded) {
+    // given
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    // when / then
+    // Ordinary frames must measure the whole interval between them, so nothing
+    // may claim a discontinuity that did not happen.
+    EXPECT_FALSE(game.consumeTimingDiscontinuity());
+    EXPECT_FALSE(game.consumeTimingDiscontinuity());
+}
+
+TEST(TimingEpoch, should_report_a_raised_discontinuity_exactly_once) {
+    // given
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+    TestGameModule::raiseTimingDiscontinuity(game);
+
+    // when
+    bool first = game.consumeTimingDiscontinuity();
+    bool second = game.consumeTimingDiscontinuity();
+
+    // then
+    // One load rebases one frame. If the report stuck, every later frame would
+    // also start from zero and the world would stop advancing altogether.
+    EXPECT_TRUE(first);
+    EXPECT_FALSE(second);
+}
+
+TEST(TimingEpoch, should_report_the_latest_discontinuity_after_an_earlier_one_was_consumed) {
+    // given
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    // when / then
+    // Loads recur - warping, transitions, loading a save - and each one owes
+    // the next frame an epoch of its own.
+    TestGameModule::raiseTimingDiscontinuity(game);
+    EXPECT_TRUE(game.consumeTimingDiscontinuity());
+    EXPECT_FALSE(game.consumeTimingDiscontinuity());
+
+    TestGameModule::raiseTimingDiscontinuity(game);
+    EXPECT_TRUE(game.consumeTimingDiscontinuity());
+    EXPECT_FALSE(game.consumeTimingDiscontinuity());
+}


### PR DESCRIPTION
## Summary

Prevents synchronous module-loading time from being counted as elapsed gameplay time.

Module loads block the main loop. Previously that wall-clock interval was included in the following frame's `dt`, allowing several seconds of loading to advance gameplay timers in a single update.

A completed synchronous module load now reports a timing discontinuity. `Engine`, which owns the frame clock, consumes that signal and begins a new timing epoch for the following frame.

This uses no delta clamp or content-specific timing threshold.

## Vanilla case

K2 `103PER` exposes the issue.

Loading the module took roughly 7.7 seconds, and Reone passed that interval to the first gameplay update after the transition. The opening dialogue entry has an authored 3-second timer, so it expired within the same update in which the entry was started, before its queued pause action could execute.

This skipped the opening door camera entirely and advanced directly to the later corpse shot.

Excluding synchronous load time restores the authored sequence.

## Testing

- Focused timing-epoch tests covering that a discontinuity is raised, consumed exactly once, and that ordinary updates report none.
- Discrimination of the post-load frame delta with this change applied in isolation: roughly 8.2 seconds before, roughly 0.000 seconds after.
- Full Release suite.
- Manual validation through both a console warp to `103PER` and the genuine 102PER to 103PER turbolift transition
