### PR TITLE
[game] Search only the current area for SelectObjectByTag console command

### DIFF
--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -3657,9 +3657,10 @@ void Game::consoleSelectObjectByTag(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 1, "tag");
     std::string_view tag = args[1].value();
 
-    for (auto [id, object] : _objectById) {
+    auto area = getConsoleArea();
+    for (auto &object : area->objects()) {
         if (object->tag() == tag) {
-            getConsoleArea()->selectObject(object, /*force=*/true);
+            area->selectObject(object, /*force=*/true);
             return;
         }
     }


### PR DESCRIPTION
There can be multiple objects with the same tag across different
modules. Some companions are also NPCs in other modules (Mission and
Canderous, for example).

Scope selectobjectbytag only to the current area to avoid selecting
NPCs instead of companions.