### PR TITLE
[scene] Cull particles using rendered billboard bounds

### DIFF
--- a/include/reone/scene/node/emitter.h
+++ b/include/reone/scene/node/emitter.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "reone/graphics/aabb.h"
 #include "reone/system/timer.h"
 
 #include "modelnode.h"
@@ -30,6 +31,11 @@ class ParticleSceneNode;
 
 class EmitterSceneNode : public ModelNodeSceneNode {
 public:
+    struct ParticleBasis {
+        glm::vec3 right {0.0f};
+        glm::vec3 up {0.0f};
+    };
+
     EmitterSceneNode(
         graphics::ModelNode &modelNode,
         ISceneGraph &sceneGraph,
@@ -53,6 +59,13 @@ public:
 
     void detonate();
     void rearmSingle();
+
+    static ParticleBasis localZParticleBasis(const glm::mat4 &emitterTransform);
+    static graphics::AABB particleBounds(
+        const glm::vec3 &origin,
+        const glm::vec2 &size,
+        const ParticleBasis &basis);
+    graphics::AABB particleBounds(const ParticleSceneNode &particle) const;
 
     float getParticleSize(float time) const { return _particleSize.get(time); };
     glm::vec3 getColor(float time) const { return _color.get(time); };

--- a/include/reone/scene/node/model.h
+++ b/include/reone/scene/node/model.h
@@ -110,6 +110,7 @@ public:
     void signalEvent(const std::string &name);
 
     bool isPickable() const { return _pickable; }
+    bool hasActiveRenderableEmitters() const;
 
     ModelNodeSceneNode *getNodeByNumber(uint16_t number);
     ModelNodeSceneNode *getNodeByName(const std::string &name);

--- a/src/libs/scene/graph.cpp
+++ b/src/libs/scene/graph.cpp
@@ -184,6 +184,11 @@ void SceneGraph::cullRoots() {
             continue; // disable distance and frustum culling
         }
 
+        if (root->isPoint() && root->hasActiveRenderableEmitters()) {
+            root->setCulled(false);
+            continue; // emitter-only models are culled per live particle
+        }
+
         float distanceToCamera = root->getSquareDistanceTo(*_activeCamera);
         float drawDistance = root->drawDistance() * root->drawDistance();
 
@@ -418,7 +423,7 @@ void SceneGraph::prepareTransparentLeafs() {
                 continue;
             }
             auto particle = static_cast<ParticleSceneNode *>(child);
-            if (!camera->isInFrustum(particle->origin())) {
+            if (!camera->isInFrustum(emitter->particleBounds(*particle))) {
                 continue;
             }
             leafs.push_back(particle);

--- a/src/libs/scene/node/emitter.cpp
+++ b/src/libs/scene/node/emitter.cpp
@@ -257,6 +257,67 @@ void EmitterSceneNode::rearmSingle() {
     }
 }
 
+EmitterSceneNode::ParticleBasis EmitterSceneNode::localZParticleBasis(const glm::mat4 &emitterTransform) {
+    return {
+        glm::vec3(emitterTransform[0]),
+        glm::vec3(emitterTransform[1]),
+    };
+}
+
+graphics::AABB EmitterSceneNode::particleBounds(
+    const glm::vec3 &origin,
+    const glm::vec2 &size,
+    const ParticleBasis &basis) {
+    auto halfExtent = 0.5f * (
+        glm::abs(size.x) * glm::abs(basis.right) +
+        glm::abs(size.y) * glm::abs(basis.up));
+    return graphics::AABB(origin - halfExtent, origin + halfExtent);
+}
+
+graphics::AABB EmitterSceneNode::particleBounds(const ParticleSceneNode &particle) const {
+    auto emitter = _modelNode.emitter();
+    auto size = particle.size();
+    ParticleBasis basis;
+
+    auto emitterRight = glm::vec3(_absTransform[0]);
+    auto emitterUp = glm::vec3(_absTransform[1]);
+    auto emitterForward = glm::vec3(_absTransform[2]);
+
+    auto view = _sceneGraph.camera()->get().camera()->view();
+    auto cameraRight = glm::vec3(view[0][0], view[1][0], view[2][0]);
+    auto cameraUp = glm::vec3(view[0][1], view[1][1], view[2][1]);
+
+    switch (emitter->renderMode) {
+    case ModelNode::Emitter::RenderMode::BillboardToLocalZ:
+        basis = localZParticleBasis(_absTransform);
+        break;
+    case ModelNode::Emitter::RenderMode::MotionBlur:
+        size.y *= 1.0f + kMotionBlurStrength * kProjectileSpeed;
+        basis = {emitterUp, emitterRight};
+        break;
+    case ModelNode::Emitter::RenderMode::BillboardToWorldZ:
+        basis = {
+            glm::vec3(0.0f, 1.0f, 0.0f),
+            glm::vec3(1.0f, 0.0f, 0.0f),
+        };
+        break;
+    case ModelNode::Emitter::RenderMode::AlignedToParticleDir:
+        basis = {emitterRight, emitterForward};
+        break;
+    case ModelNode::Emitter::RenderMode::Linked: {
+        auto particleUp = particle.dir();
+        auto particleForward = glm::cross(particleUp, cameraRight);
+        auto particleRight = glm::cross(particleForward, particleUp);
+        basis = {particleRight, particleUp};
+        break;
+    }
+    case ModelNode::Emitter::RenderMode::Normal:
+    default:
+        basis = {cameraRight, cameraUp};
+        break;
+    }
+    return particleBounds(particle.origin(), size, basis);
+}
 void EmitterSceneNode::renderLeafs(IRenderPass &pass, const std::vector<SceneNode *> &leafs) {
     if (leafs.empty()) {
         return;
@@ -283,7 +344,12 @@ void EmitterSceneNode::renderLeafs(IRenderPass &pass, const std::vector<SceneNod
         particles[i].size = glm::vec2(particle->size());
         particles[i].color = glm::vec4(particle->color(), particle->alpha());
         switch (emitter->renderMode) {
-        case ModelNode::Emitter::RenderMode::BillboardToLocalZ:
+        case ModelNode::Emitter::RenderMode::BillboardToLocalZ: {
+            auto basis = localZParticleBasis(_absTransform);
+            particles[i].right = glm::vec4(basis.right, 0.0f);
+            particles[i].up = glm::vec4(basis.up, 0.0f);
+            break;
+        }
         case ModelNode::Emitter::RenderMode::MotionBlur:
             if (emitter->renderMode == ModelNode::Emitter::RenderMode::MotionBlur) {
                 particles[i].size = glm::vec2(particle->size().x, (1.0f + kMotionBlurStrength * kProjectileSpeed) * particle->size().y);

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -144,6 +144,24 @@ void ModelSceneNode::signalEvent(const std::string &name) {
     }
 }
 
+bool ModelSceneNode::hasActiveRenderableEmitters() const {
+    std::function<bool(const SceneNode &)> visit = [&](const SceneNode &node) {
+        if (!node.isEnabled()) {
+            return false;
+        }
+        if (node.type() == SceneNodeType::Emitter) {
+            auto &emitterNode = static_cast<const EmitterSceneNode &>(node);
+            auto emitter = emitterNode.modelNode().emitter();
+            return emitter &&
+                   emitter->updateMode != ModelNode::Emitter::UpdateMode::Invalid &&
+                   emitter->renderMode != ModelNode::Emitter::RenderMode::Invalid;
+        }
+        return std::any_of(node.children().begin(), node.children().end(), [&](const auto &child) {
+            return visit(*child);
+        });
+    };
+    return visit(*this);
+}
 void ModelSceneNode::attach(const std::string &parentName, SceneNode &node) {
     auto maybeParent = _nodeByName.find(parentName);
     if (maybeParent == _nodeByName.end()) {

--- a/test/scene/emitter.cpp
+++ b/test/scene/emitter.cpp
@@ -6,6 +6,7 @@
 #include "reone/scene/graph.h"
 #include "reone/scene/node/emitter.h"
 #include "reone/scene/node/model.h"
+#include "reone/scene/node/particle.h"
 #include "../fixtures/audio.h"
 #include "../fixtures/graphics.h"
 #include "../fixtures/resource.h"
@@ -17,6 +18,107 @@ using namespace reone::audio;
 using namespace reone::scene;
 using namespace reone::resource;
 
+TEST(EmitterSceneNode, local_z_particle_basis_preserves_authored_winding) {
+    auto orientation = glm::angleAxis(glm::half_pi<float>(), glm::normalize(glm::vec3(1.0f, 2.0f, 3.0f)));
+    auto transform = glm::mat4_cast(orientation);
+
+    auto basis = EmitterSceneNode::localZParticleBasis(transform);
+    auto authoredRight = glm::vec3(transform[0]);
+    auto authoredUp = glm::vec3(transform[1]);
+    auto authoredForward = glm::normalize(glm::vec3(transform[2]));
+
+    EXPECT_LT(glm::length(basis.right - authoredRight), 0.0001f);
+    EXPECT_LT(glm::length(basis.up - authoredUp), 0.0001f);
+    EXPECT_GT(glm::dot(glm::normalize(glm::cross(basis.right, basis.up)), authoredForward), 0.9999f);
+}
+
+TEST(EmitterSceneNode, particle_bounds_include_rendered_billboard_extent) {
+    EmitterSceneNode::ParticleBasis basis {
+        glm::vec3(2.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, 0.5f, 0.0f),
+    };
+
+    auto bounds = EmitterSceneNode::particleBounds(
+        glm::vec3(10.0f, 20.0f, 30.0f),
+        glm::vec2(8.0f, 4.0f),
+        basis);
+
+    EXPECT_FLOAT_EQ(2.0f, bounds.min().x);
+    EXPECT_FLOAT_EQ(19.0f, bounds.min().y);
+    EXPECT_FLOAT_EQ(30.0f, bounds.min().z);
+    EXPECT_FLOAT_EQ(18.0f, bounds.max().x);
+    EXPECT_FLOAT_EQ(21.0f, bounds.max().y);
+    EXPECT_FLOAT_EQ(30.0f, bounds.max().z);
+}
+
+TEST(EmitterSceneNode, billboard_intersecting_frustum_is_retained_when_center_is_outside) {
+    auto graphicsOpt = GraphicsOptions();
+    auto pipelineFactory = MockRenderPipelineFactory();
+    auto graphicsModule = TestGraphicsModule();
+    graphicsModule.init();
+    auto audioModule = TestAudioModule();
+    audioModule.init();
+    auto resourceModule = TestResourceModule();
+    resourceModule.init();
+
+    auto scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt, graphicsModule.services(), audioModule.services(), resourceModule.services());
+    auto cameraNode = scene->newCamera();
+    cameraNode->setPerspectiveProjection(glm::half_pi<float>(), 1.0f, 0.25f, 10.0f);
+    scene->setActiveCamera(cameraNode.get());
+
+    auto emitterData = std::make_shared<ModelNode::Emitter>();
+    emitterData->updateMode = ModelNode::Emitter::UpdateMode::Fountain;
+    emitterData->renderMode = ModelNode::Emitter::RenderMode::Normal;
+    auto modelNode = ModelNode(0, "emitter", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+    modelNode.setEmitter(emitterData);
+    auto emitter = scene->newEmitter(modelNode);
+    emitter->init();
+
+    auto particle = scene->newParticle(*emitter);
+    particle->setLocalTransform(glm::translate(glm::mat4(1.0f), glm::vec3(5.5f, 0.0f, -5.0f)));
+    particle->setSize(glm::vec2(2.0f));
+
+    auto camera = cameraNode->camera();
+    ASSERT_FALSE(camera->isInFrustum(particle->origin()));
+    EXPECT_TRUE(camera->isInFrustum(emitter->particleBounds(*particle)));
+}
+
+TEST(ModelSceneNode, emitter_only_model_is_not_rejected_by_degenerate_root_bounds) {
+    auto graphicsOpt = GraphicsOptions();
+    auto pipelineFactory = MockRenderPipelineFactory();
+    auto graphicsModule = TestGraphicsModule();
+    graphicsModule.init();
+    auto audioModule = TestAudioModule();
+    audioModule.init();
+    auto resourceModule = TestResourceModule();
+    resourceModule.init();
+
+    auto scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt, graphicsModule.services(), audioModule.services(), resourceModule.services());
+    auto rootNode = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+    auto emitterData = std::make_shared<ModelNode::Emitter>();
+    emitterData->updateMode = ModelNode::Emitter::UpdateMode::Fountain;
+    emitterData->renderMode = ModelNode::Emitter::RenderMode::Normal;
+    auto emitterNode = std::make_shared<ModelNode>(1, "emitter_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
+    emitterNode->setEmitter(emitterData);
+    rootNode->addChild(emitterNode);
+
+    auto model = Model("emitter_only", 0, rootNode, std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+    model.init();
+    auto modelNode = scene->newModel(model, ModelUsage::GUI);
+    modelNode->setLocalTransform(glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -100.0f)));
+    scene->addRoot(modelNode);
+
+    auto cameraNode = scene->newCamera();
+    cameraNode->setPerspectiveProjection(glm::radians(55.0f), 1.0f, 0.25f, 10.0f);
+    scene->setActiveCamera(cameraNode.get());
+
+    ASSERT_TRUE(modelNode->isPoint());
+    ASSERT_TRUE(modelNode->hasActiveRenderableEmitters());
+
+    scene->update(0.0f);
+
+    EXPECT_FALSE(modelNode->isCulled());
+}
 TEST(EmitterSceneNode, looping_model_animation_rearms_single_emitter_after_particle_expires) {
     auto graphicsOpt = GraphicsOptions();
     auto pipelineFactory = MockRenderPipelineFactory();


### PR DESCRIPTION
### Summary

Corrects particle and emitter-model frustum culling to use the geometry that is actually rendered.

* Keeps emitter-only models traversable when their mesh-derived root bounds are degenerate.
* Culls live particles using their complete rendered billboard bounds rather than only their centre point.
* Accounts for billboard orientation, dimensions and motion-blur stretching.
* Preserves the authored Local-Z right/up basis consistently between rendering and bounds.