### PR TITLE
[for reference only] K2 Xbox UI updates

### DIFF
--- a/include/reone/game/gui.h
+++ b/include/reone/game/gui.h
@@ -61,6 +61,7 @@ protected:
 
     void loadBackground(BackgroundType type);
     void tintK2InGameFooter();
+    void tintK2InGameHeader();
     void updateK2FilterButton(const std::shared_ptr<gui::Control> &button, bool selected);
 
     virtual void configureControls() {}

--- a/include/reone/game/gui.h
+++ b/include/reone/game/gui.h
@@ -61,6 +61,7 @@ protected:
 
     void loadBackground(BackgroundType type);
     void tintK2InGameFooter();
+    void updateK2FilterButton(const std::shared_ptr<gui::Control> &button, bool selected);
 
     virtual void configureControls() {}
     void onClick(const std::string &control) override;

--- a/include/reone/game/gui.h
+++ b/include/reone/game/gui.h
@@ -60,6 +60,7 @@ protected:
     virtual void onGUILoaded() {}
 
     void loadBackground(BackgroundType type);
+    void tintK2InGameFooter();
 
     virtual void configureControls() {}
     void onClick(const std::string &control) override;

--- a/include/reone/game/gui.h
+++ b/include/reone/game/gui.h
@@ -26,6 +26,12 @@
 
 namespace reone {
 
+namespace gui {
+
+class Control;
+
+} // namespace gui
+
 namespace game {
 
 class Game;
@@ -42,6 +48,8 @@ public:
         _gui->clearSelection();
     }
 
+    std::shared_ptr<gui::Control> k2InGameTitleControl() const { return _k2InGameTitleControl; }
+
 protected:
     Game &_game;
     ServicesView &_services;
@@ -49,6 +57,7 @@ protected:
 
     std::shared_ptr<gui::IGUI> _gui;
     std::shared_ptr<audio::AudioSource> _audioSource;
+    std::shared_ptr<gui::Control> _k2InGameTitleControl;
 
     glm::vec3 _baseColor {0.0f};
     glm::vec3 _disabledColor {0.0f};
@@ -62,6 +71,10 @@ protected:
     void loadBackground(BackgroundType type);
     void tintK2InGameFooter();
     void tintK2InGameHeader();
+    void enableK2ButtonBodyFill(gui::Control &control);
+    void enableK2ButtonBodyFill(const std::shared_ptr<gui::Control> &control);
+    void fillK2SectionStrip(const std::shared_ptr<gui::Control> &topBar, const std::shared_ptr<gui::Control> &bottomBar);
+    void useK2ShellTitle(const std::shared_ptr<gui::Control> &control);
     void updateK2FilterButton(const std::shared_ptr<gui::Control> &button, bool selected);
 
     virtual void configureControls() {}

--- a/include/reone/game/gui/ingame.h
+++ b/include/reone/game/gui/ingame.h
@@ -186,6 +186,7 @@ private:
 
     void updateTabButtons();
     void changeTab(InGameMenuTab tab);
+    void updateK2SectionTitle();
     void refreshK2Footer();
 
     void loadCharacter();

--- a/include/reone/game/gui/ingame/journal.h
+++ b/include/reone/game/gui/ingame/journal.h
@@ -41,6 +41,13 @@ public:
     }
 
 private:
+    enum class Filter {
+        Priority,
+        Planet,
+        Name,
+        Time,
+    };
+
     struct Controls {
         std::shared_ptr<gui::Button> BTN_EXIT;
         std::shared_ptr<gui::Button> BTN_FILTER_NAME;
@@ -62,8 +69,11 @@ private:
     };
 
     Controls _controls;
+    Filter _filter {Filter::Priority};
 
     void onGUILoaded() override;
+    void setFilter(Filter filter);
+    void updateFilterControls();
 
     void bindControls() {
         _controls.BTN_EXIT = findControl<gui::Button>("BTN_EXIT");

--- a/include/reone/game/gui/ingame/messages.h
+++ b/include/reone/game/gui/ingame/messages.h
@@ -41,8 +41,16 @@ public:
     }
 
     void onGUILoaded() override;
+    void resetFilter();
 
 private:
+    enum class Filter {
+        Dialog,
+        Feedback,
+        Combat,
+        Effects,
+    };
+
     struct Controls {
         std::shared_ptr<gui::Button> BTN_COMBAT;
         std::shared_ptr<gui::Button> BTN_DIALOG;
@@ -68,6 +76,10 @@ private:
     };
 
     Controls _controls;
+    Filter _filter {Filter::Dialog};
+
+    void refreshFilterVisibility();
+    void setFilter(Filter filter);
 
     void bindControls() {
         _controls.BTN_COMBAT = findControl<gui::Button>("BTN_COMBAT");

--- a/src/libs/game/gui.cpp
+++ b/src/libs/game/gui.cpp
@@ -153,6 +153,28 @@ void GameGUI::tintK2InGameFooter() {
     }
 }
 
+void GameGUI::tintK2InGameHeader() {
+    if (!_game.isTSL()) {
+        return;
+    }
+
+    for (auto &tag : {"LBL_BAR1", "LBL_BAR2", "LBL_BAR6"}) {
+        auto control = _gui->findControl(tag);
+        if (control) {
+            control->setTintBorderFill(true);
+        }
+    }
+}
+
+void GameGUI::updateK2FilterButton(const std::shared_ptr<Control> &button, bool selected) {
+    if (!button) {
+        return;
+    }
+
+    button->setSelected(selected);
+    button->setTextColor(selected ? glm::vec3 {1.0f} : _baseColor);
+}
+
 std::string GameGUI::guiResRef(const std::string &base) const {
     return _game.isTSL() ? base + "_p" : base;
 }

--- a/src/libs/game/gui.cpp
+++ b/src/libs/game/gui.cpp
@@ -140,6 +140,19 @@ void GameGUI::loadBackground(BackgroundType type) {
     }
 }
 
+void GameGUI::tintK2InGameFooter() {
+    if (!_game.isTSL()) {
+        return;
+    }
+
+    for (auto &tag : {"LBL_BAR3", "LBL_BAR4", "LBL_BAR5"}) {
+        auto control = _gui->findControl(tag);
+        if (control) {
+            control->setTintBorderFill(true);
+        }
+    }
+}
+
 std::string GameGUI::guiResRef(const std::string &base) const {
     return _game.isTSL() ? base + "_p" : base;
 }

--- a/src/libs/game/gui.cpp
+++ b/src/libs/game/gui.cpp
@@ -23,6 +23,7 @@
 #include "reone/game/game.h"
 #include "reone/game/gui/sounds.h"
 #include "reone/graphics/di/services.h"
+#include "reone/gui/control.h"
 #include "reone/gui/guis.h"
 #include "reone/resource/di/services.h"
 #include "reone/resource/exception/notfound.h"
@@ -164,6 +165,75 @@ void GameGUI::tintK2InGameHeader() {
             control->setTintBorderFill(true);
         }
     }
+}
+
+void GameGUI::enableK2ButtonBodyFill(Control &control) {
+    if (!_game.isTSL()) {
+        return;
+    }
+
+    auto edge = _services.resource.textures.get("uibit_brdr_16wet", TextureUsage::GUI);
+    auto corner = _services.resource.textures.get("uibit_brdr_16wct", TextureUsage::GUI);
+
+    auto border = control.border();
+    border.edge = edge;
+    border.corner = corner;
+    control.setBorder(std::move(border));
+
+    auto hilight = control.hilight();
+    hilight.edge = std::move(edge);
+    hilight.corner = std::move(corner);
+    control.setHilight(std::move(hilight));
+}
+
+void GameGUI::enableK2ButtonBodyFill(const std::shared_ptr<Control> &control) {
+    if (!control) {
+        return;
+    }
+
+    enableK2ButtonBodyFill(*control);
+}
+
+void GameGUI::fillK2SectionStrip(const std::shared_ptr<Control> &topBar, const std::shared_ptr<Control> &bottomBar) {
+    static constexpr int kLineThickness = 2;
+
+    if (!_game.isTSL() || !topBar || !bottomBar) {
+        return;
+    }
+
+    topBar->setBorderFill("uibit_brdr_16we");
+    topBar->setTintBorderFill(true);
+
+    bottomBar->setBorderFill("uibit_brdr_16we");
+    bottomBar->setBorderFillTransform(Control::Border::FillTransform::Rotate180);
+    bottomBar->setTintBorderFill(true);
+
+    auto &upper = topBar->extent();
+    auto &lower = bottomBar->extent();
+    int lowerLineTop = lower.top + kLineThickness;
+    bottomBar->setExtentTop(lowerLineTop - lower.height);
+
+    int top = upper.top;
+    int height = lowerLineTop - top;
+    if (height <= 0) {
+        return;
+    }
+
+    auto fill = std::shared_ptr<Control>(_gui->newControl(ControlType::Label, topBar->tag() + "_SECTION_FILL"));
+    fill->setExtent({upper.left, top, upper.width, height});
+    fill->setBorderFill("uibit_fill_2wt");
+    fill->setBorderColor(topBar->border().color);
+    fill->setTintBorderFill(true);
+    _gui->addControlToFront(std::move(fill));
+}
+
+void GameGUI::useK2ShellTitle(const std::shared_ptr<Control> &control) {
+    if (!_game.isTSL() || !control) {
+        return;
+    }
+
+    _k2InGameTitleControl = control;
+    control->setVisible(false);
 }
 
 void GameGUI::updateK2FilterButton(const std::shared_ptr<Control> &button, bool selected) {

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -62,6 +62,10 @@ void CharacterGeneration::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
 
+    if (_game.isTSL()) {
+        _controls.LBL_STATSBACK->setTintBorderFill(true);
+    }
+
     _controls.LBL_LEVEL_VAL->setVisible(false);
     _controls.LBL_NAME->setTextMessage("");
 

--- a/src/libs/game/gui/chargen/abilities.cpp
+++ b/src/libs/game/gui/chargen/abilities.cpp
@@ -61,6 +61,9 @@ void CharGenAbilities::onGUILoaded() {
     bindControls();
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    if (_game.isTSL()) {
+        _controls.LB_DESC->setTintBorderFill(true);
+    }
 
     std::vector<Label *> labels {
         _controls.STR_LBL.get(),

--- a/src/libs/game/gui/chargen/feats.cpp
+++ b/src/libs/game/gui/chargen/feats.cpp
@@ -200,6 +200,10 @@ void CharGenFeats::onGUILoaded() {
     _gui->addControlToBack(_controls.ICONCHAIN_FEATS);
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    if (_game.isTSL()) {
+        _controls.LB_DESC->setTintBorderFill(true);
+        _controls.LB_FEATS->setTintBorderFill(true);
+    }
     _controls.LB_FEATS->setSelectionMode(ListBox::SelectionMode::OnClick);
     _controls.LB_FEATS->setRenderItemIconsForButtonProto(true);
     _controls.LB_FEATS->setOnItemClick([this](const std::string &item) {

--- a/src/libs/game/gui/chargen/levelup.cpp
+++ b/src/libs/game/gui/chargen/levelup.cpp
@@ -38,6 +38,12 @@ namespace game {
 void LevelUpMenu::onGUILoaded() {
     bindControls();
 
+    if (_game.isTSL()) {
+        for (auto &control : {_controls.LBL_1, _controls.LBL_2, _controls.LBL_3, _controls.LBL_4, _controls.LBL_5}) {
+            control->setTintBorderFill(true);
+        }
+    }
+
     doSetStep(0);
 
     _controls.BTN_BACK->setOnClick([this]() {

--- a/src/libs/game/gui/chargen/levelup.cpp
+++ b/src/libs/game/gui/chargen/levelup.cpp
@@ -42,6 +42,15 @@ void LevelUpMenu::onGUILoaded() {
         for (auto &control : {_controls.LBL_1, _controls.LBL_2, _controls.LBL_3, _controls.LBL_4, _controls.LBL_5}) {
             control->setTintBorderFill(true);
         }
+        for (auto &button : {
+                 _controls.BTN_BACK,
+                 _controls.BTN_STEPNAME1,
+                 _controls.BTN_STEPNAME2,
+                 _controls.BTN_STEPNAME3,
+                 _controls.BTN_STEPNAME4,
+                 _controls.BTN_STEPNAME5}) {
+            enableK2ButtonBodyFill(button);
+        }
     }
 
     doSetStep(0);

--- a/src/libs/game/gui/chargen/powers.cpp
+++ b/src/libs/game/gui/chargen/powers.cpp
@@ -201,6 +201,9 @@ void CharGenPowers::onGUILoaded() {
     _gui->addControlToBack(_controls.ICONCHAIN_POWERS);
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    if (_game.isTSL()) {
+        _controls.LB_DESC->setTintBorderFill(true);
+    }
     _controls.LB_POWERS->setVisible(false);
     _controls.SELECT_BTN->setOnClick([this]() {
         activateFocusedPower();

--- a/src/libs/game/gui/chargen/skills.cpp
+++ b/src/libs/game/gui/chargen/skills.cpp
@@ -64,6 +64,9 @@ void CharGenSkills::onGUILoaded() {
     }
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    if (_game.isTSL()) {
+        _controls.LB_DESC->setTintBorderFill(true);
+    }
 
     _controls.COMPUTER_USE_POINTS_BTN->setDisabled(true);
     _controls.DEMOLITIONS_POINTS_BTN->setDisabled(true);

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -79,6 +79,7 @@ void InGameMenu::onGUILoaded() {
         tintK2TopNavigationIcon(_controls.LBLH_JOU, _baseColor);
         tintK2TopNavigationIcon(_controls.LBLH_MAP, _baseColor);
         tintK2TopNavigationIcon(_controls.LBLH_OPT, _baseColor);
+        _controls.LBL_BACK1->setTintBorderFill(true);
         refreshK2Footer();
     }
 

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -379,6 +379,7 @@ void InGameMenu::openPartySelection() {
 }
 
 void InGameMenu::openMessages() {
+    _messages->resetFilter();
     changeTab(InGameMenuTab::Messages);
 }
 

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -25,6 +25,7 @@
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/party.h"
+#include "reone/resource/provider/textures.h"
 #include "reone/game/types.h"
 
 using namespace reone::audio;
@@ -80,6 +81,7 @@ void InGameMenu::onGUILoaded() {
         tintK2TopNavigationIcon(_controls.LBLH_MAP, _baseColor);
         tintK2TopNavigationIcon(_controls.LBLH_OPT, _baseColor);
         _controls.LBL_SECTITLE->setBorderFill(std::string());
+        updateK2SectionTitle();
         _controls.LBL_BACK1->setTintBorderFill(true);
         refreshK2Footer();
     }
@@ -247,8 +249,29 @@ void InGameMenu::changeTab(InGameMenuTab tab) {
         gui->clearSelection();
     }
     _tab = tab;
+    updateK2SectionTitle();
     updateTabButtons();
     refreshK2Footer();
+}
+
+void InGameMenu::updateK2SectionTitle() {
+    if (!_game.isTSL() || !_controls.LBL_SECTITLE) {
+        return;
+    }
+
+    auto border = _controls.LBL_SECTITLE->border();
+    border.edge = _services.resource.textures.get("uibit_brdr_16bet", TextureUsage::GUI);
+    border.corner = _services.resource.textures.get("uibit_brdr_16bct", TextureUsage::GUI);
+    border.fill.reset();
+    _controls.LBL_SECTITLE->setBorder(std::move(border));
+
+    auto activeTab = getActiveTabGUI();
+    auto titleControl = activeTab ? activeTab->k2InGameTitleControl() : nullptr;
+    if (titleControl) {
+        _controls.LBL_SECTITLE->setText(titleControl->text());
+    } else {
+        _controls.LBL_SECTITLE->setTextMessage(std::string());
+    }
 }
 
 void InGameMenu::refreshK2Footer() {

--- a/src/libs/game/gui/ingame.cpp
+++ b/src/libs/game/gui/ingame.cpp
@@ -79,6 +79,7 @@ void InGameMenu::onGUILoaded() {
         tintK2TopNavigationIcon(_controls.LBLH_JOU, _baseColor);
         tintK2TopNavigationIcon(_controls.LBLH_MAP, _baseColor);
         tintK2TopNavigationIcon(_controls.LBLH_OPT, _baseColor);
+        _controls.LBL_SECTITLE->setBorderFill(std::string());
         _controls.LBL_BACK1->setTintBorderFill(true);
         refreshK2Footer();
     }

--- a/src/libs/game/gui/ingame/abilities.cpp
+++ b/src/libs/game/gui/ingame/abilities.cpp
@@ -47,6 +47,7 @@ static constexpr int kStrRefTotalRank = 41904;
 void AbilitiesMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     _controls.BTN_SKILLS->setDisabled(true);
     _controls.BTN_POWERS->setDisabled(true);
@@ -61,6 +62,11 @@ void AbilitiesMenu::onGUILoaded() {
     _controls.LBL_NAME->setTextMessage("");
 
     _controls.LB_DESC->setProtoMatchContent(true);
+    if (_game.isTSL()) {
+        _controls.LB_ABILITY->setTintBorderFill(true);
+        _controls.LB_DESC->setTintBorderFill(true);
+        _controls.LB_DESC_FEATS->setTintBorderFill(true);
+    }
     _controls.LB_ABILITY->setOnItemClick([this](const std::string &item) {
         auto skill = static_cast<SkillType>(stoi(item));
         auto maybeSkillInfo = _skills.find(skill);

--- a/src/libs/game/gui/ingame/abilities.cpp
+++ b/src/libs/game/gui/ingame/abilities.cpp
@@ -64,6 +64,7 @@ void AbilitiesMenu::onGUILoaded() {
 
     _controls.LB_DESC->setProtoMatchContent(true);
     if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
         _controls.BTN_SKILLS->setDisabled(false);
         updateK2FilterButton(_controls.BTN_SKILLS, true);
         updateK2FilterButton(_controls.BTN_POWERS, false);
@@ -72,6 +73,15 @@ void AbilitiesMenu::onGUILoaded() {
         _controls.LB_DESC->setTintBorderFill(true);
         _controls.LB_DESC_FEATS->setTintBorderFill(true);
         _controls.LBL_INFOBG->setTintBorderFill(true);
+        _controls.LBL_NAME->setTintBorderFill(true);
+        useK2ShellTitle(_controls.LBL_ABILITIES);
+        enableK2ButtonBodyFill(_controls.BTN_EXIT);
+        if (auto protoItem = _controls.LB_ABILITY->protoItemOrNull()) {
+            enableK2ButtonBodyFill(*protoItem);
+            protoItem->setBorderFill("uibit_fill_2wt");
+            protoItem->setHilightFill("uibit_fill_2wt");
+            protoItem->setTintBorderFill(true);
+        }
     }
     _controls.LB_ABILITY->setOnItemClick([this](const std::string &item) {
         auto skill = static_cast<SkillType>(stoi(item));

--- a/src/libs/game/gui/ingame/abilities.cpp
+++ b/src/libs/game/gui/ingame/abilities.cpp
@@ -48,6 +48,7 @@ void AbilitiesMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     _controls.BTN_SKILLS->setDisabled(true);
     _controls.BTN_POWERS->setDisabled(true);
@@ -63,6 +64,10 @@ void AbilitiesMenu::onGUILoaded() {
 
     _controls.LB_DESC->setProtoMatchContent(true);
     if (_game.isTSL()) {
+        _controls.BTN_SKILLS->setDisabled(false);
+        updateK2FilterButton(_controls.BTN_SKILLS, true);
+        updateK2FilterButton(_controls.BTN_POWERS, false);
+        updateK2FilterButton(_controls.BTN_FEATS, false);
         _controls.LB_ABILITY->setTintBorderFill(true);
         _controls.LB_DESC->setTintBorderFill(true);
         _controls.LB_DESC_FEATS->setTintBorderFill(true);

--- a/src/libs/game/gui/ingame/abilities.cpp
+++ b/src/libs/game/gui/ingame/abilities.cpp
@@ -71,6 +71,7 @@ void AbilitiesMenu::onGUILoaded() {
         _controls.LB_ABILITY->setTintBorderFill(true);
         _controls.LB_DESC->setTintBorderFill(true);
         _controls.LB_DESC_FEATS->setTintBorderFill(true);
+        _controls.LBL_INFOBG->setTintBorderFill(true);
     }
     _controls.LB_ABILITY->setOnItemClick([this](const std::string &item) {
         auto skill = static_cast<SkillType>(stoi(item));

--- a/src/libs/game/gui/ingame/character.cpp
+++ b/src/libs/game/gui/ingame/character.cpp
@@ -44,6 +44,7 @@ void CharacterMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     if (_controls.LBL_GOOD1)
         _lblGood.push_back(_controls.LBL_GOOD1);
@@ -80,6 +81,7 @@ void CharacterMenu::onGUILoaded() {
         _lblBar.push_back(_controls.LBL_BAR6);
 
     if (_game.isTSL()) {
+        _controls.LBL_STATSBORDER->setTintBorderFill(true);
         _controls.BTN_CHANGE1 = _inGameMenu.getBtnChange2();
         _controls.BTN_CHANGE2 = _inGameMenu.getBtnChange3();
     }

--- a/src/libs/game/gui/ingame/character.cpp
+++ b/src/libs/game/gui/ingame/character.cpp
@@ -82,6 +82,9 @@ void CharacterMenu::onGUILoaded() {
 
     if (_game.isTSL()) {
         _controls.LBL_STATSBORDER->setTintBorderFill(true);
+        _controls.LBL_XP_BACK->setTintBorderFill(true);
+        useK2ShellTitle(_controls.LBL_TITLE);
+        enableK2ButtonBodyFill(_controls.BTN_EXIT);
         _controls.BTN_CHANGE1 = _inGameMenu.getBtnChange2();
         _controls.BTN_CHANGE2 = _inGameMenu.getBtnChange3();
     }

--- a/src/libs/game/gui/ingame/character.cpp
+++ b/src/libs/game/gui/ingame/character.cpp
@@ -43,6 +43,7 @@ namespace game {
 void CharacterMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     if (_controls.LBL_GOOD1)
         _lblGood.push_back(_controls.LBL_GOOD1);

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -79,17 +79,17 @@ static void enableBorderFillTint(const std::shared_ptr<Control> &control) {
     control->setTintBorderFill(true);
 }
 
-static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
+static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox) {
     if (!listBox) {
         return;
     }
-    listBox->setBorderColor(baseColor);
     listBox->setTintBorderFill(true);
 }
 
 void Equipment::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     if (_controls.LBL_BAR1)
         _lblBar.push_back(_controls.LBL_BAR1);
@@ -188,8 +188,8 @@ void Equipment::configureItemsListBox() {
     protoItem.setHilightColor(_hilightColor);
 
     if (_game.isTSL()) {
-        tintK2PanelFill(_controls.LB_ITEMS, _baseColor);
-        tintK2PanelFill(_controls.LB_DESC, _baseColor);
+        tintK2PanelFill(_controls.LB_ITEMS);
+        tintK2PanelFill(_controls.LB_DESC);
     }
 }
 
@@ -412,9 +412,6 @@ void Equipment::tintK2LoadoutOverlay() {
     enableBorderFillTint(_controls.LBL_DEF_BACK);
     enableBorderFillTint(_controls.LBL_BAR1);
     enableBorderFillTint(_controls.LBL_BAR2);
-    enableBorderFillTint(_controls.LBL_BAR3);
-    enableBorderFillTint(_controls.LBL_BAR4);
-    enableBorderFillTint(_controls.LBL_BAR5);
 }
 
 void Equipment::updateK2LoadoutOverlayVisibility(bool visible) {

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -115,6 +115,13 @@ void Equipment::onGUILoaded() {
     if (_controls.BTN_CHANGE2) {
         _controls.BTN_CHANGE2->setSelectable(false);
     }
+    if (_game.isTSL()) {
+        useK2ShellTitle(_controls.LBL_TITLE);
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
+        for (auto &button : {_controls.BTN_BACK, _controls.BTN_EQUIP, _controls.BTN_SWAPWEAPONS}) {
+            enableK2ButtonBodyFill(button);
+        }
+    }
     // _controls.btnCharLeft->setVisible(false);
     // _controls.btnCharRight->setVisible(false);
     _controls.LB_DESC->setVisible(false);
@@ -184,12 +191,17 @@ void Equipment::configureItemsListBox() {
     });
 
     auto &protoItem = _controls.LB_ITEMS->protoItem();
-    protoItem.setBorderColor(_baseColor);
-    protoItem.setHilightColor(_hilightColor);
 
     if (_game.isTSL()) {
+        enableK2ButtonBodyFill(protoItem);
+        protoItem.setBorderFill("uibit_fill_2wt");
+        protoItem.setHilightFill("uibit_fill_2wt");
+        protoItem.setTintBorderFill(true);
         tintK2PanelFill(_controls.LB_ITEMS);
         tintK2PanelFill(_controls.LB_DESC);
+    } else {
+        protoItem.setBorderColor(_baseColor);
+        protoItem.setHilightColor(_hilightColor);
     }
 }
 
@@ -410,8 +422,6 @@ void Equipment::tintK2LoadoutOverlay() {
     // Preserve the muted K2 panel colours authored in equip_p.gui.
     enableBorderFillTint(_controls.LBL_BACK1);
     enableBorderFillTint(_controls.LBL_DEF_BACK);
-    enableBorderFillTint(_controls.LBL_BAR1);
-    enableBorderFillTint(_controls.LBL_BAR2);
 }
 
 void Equipment::updateK2LoadoutOverlayVisibility(bool visible) {

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -64,11 +64,10 @@ static bool isInventoryListedEquipmentSlot(int slot) {
     }
 }
 
-static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox, const glm::vec3 &baseColor) {
+static void tintK2PanelFill(const std::shared_ptr<ListBox> &listBox) {
     if (!listBox) {
         return;
     }
-    listBox->setBorderColor(baseColor);
     listBox->setTintBorderFill(true);
 }
 
@@ -263,6 +262,7 @@ static void updateK2FilterButton(const std::shared_ptr<Button> &button, bool sel
 void InventoryMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     if (_controls.LBL_CREDITS_VALUE) {
         _controls.LBL_CREDITS_VALUE->setVisible(false);
@@ -306,8 +306,8 @@ void InventoryMenu::configureItemsListBox() {
     }
 
     if (_game.isTSL()) {
-        tintK2PanelFill(_controls.LB_ITEMS, _baseColor);
-        tintK2PanelFill(_controls.LB_DESCRIPTION, _baseColor);
+        tintK2PanelFill(_controls.LB_ITEMS);
+        tintK2PanelFill(_controls.LB_DESCRIPTION);
     }
 
     _controls.LB_ITEMS->setSelectionMode(ListBox::SelectionMode::OnClick);

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -272,9 +272,13 @@ void InventoryMenu::onGUILoaded() {
     configureItemsListBox();
     configureFilterControls();
     if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
         enableBorderFillTint(_controls.LBL_BAR1);
         enableBorderFillTint(_controls.LBL_BAR2);
         enableBorderFillTint(_controls.LBL_BAR6);
+        useK2ShellTitle(_controls.LBL_INV);
+        enableK2ButtonBodyFill(_controls.BTN_USEITEM);
+        enableK2ButtonBodyFill(_controls.BTN_EXIT);
     }
     if (_controls.LB_DESCRIPTION) {
         _controls.LB_DESCRIPTION->setProtoMatchContent(true);
@@ -308,8 +312,15 @@ void InventoryMenu::configureItemsListBox() {
     });
 
     if (auto protoItem = _controls.LB_ITEMS->protoItemOrNull()) {
-        protoItem->setBorderColor(_baseColor);
-        protoItem->setHilightColor(_hilightColor);
+        if (_game.isTSL()) {
+            enableK2ButtonBodyFill(*protoItem);
+            protoItem->setBorderFill("uibit_fill_2wt");
+            protoItem->setHilightFill("uibit_fill_2wt");
+            protoItem->setTintBorderFill(true);
+        } else {
+            protoItem->setBorderColor(_baseColor);
+            protoItem->setHilightColor(_hilightColor);
+        }
     }
 }
 

--- a/src/libs/game/gui/ingame/inventory.cpp
+++ b/src/libs/game/gui/ingame/inventory.cpp
@@ -45,7 +45,6 @@ namespace game {
 
 static constexpr char kEquippedItemSuffix[] = " (equipped)";
 static constexpr char kK1InventoryTitlePrefix[] = "Party Inventory - ";
-static constexpr glm::vec3 kK2InventoryFilterSelectedColor {1.0f, 1.0f, 1.0f};
 
 static bool isInventoryListedEquipmentSlot(int slot) {
     switch (slot) {
@@ -250,15 +249,6 @@ static std::string k1NextFilterAction(InventoryFilter filter) {
     }
 }
 
-static void updateK2FilterButton(const std::shared_ptr<Button> &button, bool selected, const glm::vec3 &baseColor) {
-    if (!button) {
-        return;
-    }
-
-    button->setSelected(selected);
-    button->setTextColor(selected ? kK2InventoryFilterSelectedColor : baseColor);
-}
-
 void InventoryMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
@@ -442,13 +432,13 @@ void InventoryMenu::setFilter(InventoryFilter filter) {
 
 void InventoryMenu::updateFilterControls() {
     if (_game.isTSL()) {
-        updateK2FilterButton(_controls.BTN_ALL, _filter == InventoryFilter::All, _baseColor);
-        updateK2FilterButton(_controls.BTN_DATAPADS, _filter == InventoryFilter::Datapad, _baseColor);
-        updateK2FilterButton(_controls.BTN_WEAPONS, _filter == InventoryFilter::Weapon, _baseColor);
-        updateK2FilterButton(_controls.BTN_ARMOR, _filter == InventoryFilter::Armor, _baseColor);
-        updateK2FilterButton(_controls.BTN_USEABLE, _filter == InventoryFilter::Useable, _baseColor);
-        updateK2FilterButton(_controls.BTN_QUESTS, _filter == InventoryFilter::Quest, _baseColor);
-        updateK2FilterButton(_controls.BTN_MISC, _filter == InventoryFilter::Misc, _baseColor);
+        updateK2FilterButton(_controls.BTN_ALL, _filter == InventoryFilter::All);
+        updateK2FilterButton(_controls.BTN_DATAPADS, _filter == InventoryFilter::Datapad);
+        updateK2FilterButton(_controls.BTN_WEAPONS, _filter == InventoryFilter::Weapon);
+        updateK2FilterButton(_controls.BTN_ARMOR, _filter == InventoryFilter::Armor);
+        updateK2FilterButton(_controls.BTN_USEABLE, _filter == InventoryFilter::Useable);
+        updateK2FilterButton(_controls.BTN_QUESTS, _filter == InventoryFilter::Quest);
+        updateK2FilterButton(_controls.BTN_MISC, _filter == InventoryFilter::Misc);
         return;
     }
 

--- a/src/libs/game/gui/ingame/journal.cpp
+++ b/src/libs/game/gui/ingame/journal.cpp
@@ -36,8 +36,12 @@ void JournalMenu::onGUILoaded() {
     tintK2InGameHeader();
 
     if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
         _controls.LB_ITEMS->setTintBorderFill(true);
         _controls.LBL_ITEM_DESCRIPTION->setTintBorderFill(true);
+        useK2ShellTitle(_controls.LBL_TITLE);
+        enableK2ButtonBodyFill(_controls.BTN_EXIT);
+        enableK2ButtonBodyFill(_controls.BTN_MESSAGES);
         _controls.BTN_MESSAGES->setOnClick([this]() {
             _game.openInGameMenu(InGameMenuTab::Messages);
         });

--- a/src/libs/game/gui/ingame/journal.cpp
+++ b/src/libs/game/gui/ingame/journal.cpp
@@ -32,6 +32,8 @@ namespace game {
 void JournalMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
+    tintK2InGameHeader();
 
     if (_game.isTSL()) {
         _controls.LB_ITEMS->setTintBorderFill(true);
@@ -39,6 +41,19 @@ void JournalMenu::onGUILoaded() {
         _controls.BTN_MESSAGES->setOnClick([this]() {
             _game.openInGameMenu(InGameMenuTab::Messages);
         });
+        _controls.BTN_FILTER_PRIORITY->setOnClick([this]() {
+            setFilter(Filter::Priority);
+        });
+        _controls.BTN_FILTER_PLANET->setOnClick([this]() {
+            setFilter(Filter::Planet);
+        });
+        _controls.BTN_FILTER_NAME->setOnClick([this]() {
+            setFilter(Filter::Name);
+        });
+        _controls.BTN_FILTER_TIME->setOnClick([this]() {
+            setFilter(Filter::Time);
+        });
+        updateFilterControls();
     }
     _controls.BTN_EXIT->setOnClick([this]() {
         _game.openInGame();
@@ -49,6 +64,18 @@ void JournalMenu::onGUILoaded() {
         _controls.BTN_QUESTITEMS->setDisabled(true);
         _controls.BTN_SORT->setDisabled(true);
     }
+}
+
+void JournalMenu::setFilter(Filter filter) {
+    _filter = filter;
+    updateFilterControls();
+}
+
+void JournalMenu::updateFilterControls() {
+    updateK2FilterButton(_controls.BTN_FILTER_PRIORITY, _filter == Filter::Priority);
+    updateK2FilterButton(_controls.BTN_FILTER_PLANET, _filter == Filter::Planet);
+    updateK2FilterButton(_controls.BTN_FILTER_NAME, _filter == Filter::Name);
+    updateK2FilterButton(_controls.BTN_FILTER_TIME, _filter == Filter::Time);
 }
 
 } // namespace game

--- a/src/libs/game/gui/ingame/map.cpp
+++ b/src/libs/game/gui/ingame/map.cpp
@@ -38,6 +38,7 @@ static constexpr int kStrRefMapNote = 349;
 void MapMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     _controls.BTN_RETURN->setDisabled(true);
     _controls.BTN_EXIT->setOnClick([this]() {

--- a/src/libs/game/gui/ingame/map.cpp
+++ b/src/libs/game/gui/ingame/map.cpp
@@ -58,6 +58,13 @@ void MapMenu::onGUILoaded() {
         refreshSelectedNote();
     });
 
+    if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
+        useK2ShellTitle(_controls.LBL_TITLE);
+        enableK2ButtonBodyFill(_controls.BTN_RETURN);
+        enableK2ButtonBodyFill(_controls.BTN_EXIT);
+    }
+
     if (!_game.isTSL()) {
         _controls.BTN_PRTYSLCT->setOnClick([this]() {
             _game.openPartySelection(PartySelectionContext());

--- a/src/libs/game/gui/ingame/map.cpp
+++ b/src/libs/game/gui/ingame/map.cpp
@@ -39,6 +39,7 @@ void MapMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     _controls.BTN_RETURN->setDisabled(true);
     _controls.BTN_EXIT->setOnClick([this]() {

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -44,7 +44,56 @@ void MessagesMenu::onGUILoaded() {
 
     if (!_game.isTSL()) {
         _controls.BTN_SHOW->setDisabled(true);
+        return;
     }
+
+    _controls.BTN_DIALOG->setOnClick([this]() {
+        setFilter(Filter::Dialog);
+    });
+    _controls.BTN_FEEDBACK->setOnClick([this]() {
+        setFilter(Filter::Feedback);
+    });
+    _controls.BTN_COMBAT->setOnClick([this]() {
+        setFilter(Filter::Combat);
+    });
+    _controls.BTN_EFFECTS->setOnClick([this]() {
+        setFilter(Filter::Effects);
+    });
+
+    resetFilter();
+}
+
+void MessagesMenu::resetFilter() {
+    if (!_game.isTSL()) {
+        return;
+    }
+
+    setFilter(Filter::Dialog);
+}
+
+void MessagesMenu::setFilter(Filter filter) {
+    _filter = filter;
+    refreshFilterVisibility();
+}
+
+void MessagesMenu::refreshFilterVisibility() {
+    bool dialog = _filter == Filter::Dialog;
+    bool feedback = _filter == Filter::Feedback;
+    bool combat = _filter == Filter::Combat;
+    bool effects = _filter == Filter::Effects;
+
+    _controls.BTN_DIALOG->setSelected(dialog);
+    _controls.BTN_FEEDBACK->setSelected(feedback);
+    _controls.BTN_COMBAT->setSelected(combat);
+    _controls.BTN_EFFECTS->setSelected(effects);
+
+    _controls.LB_DIALOG->setVisible(dialog);
+    _controls.LB_MESSAGES->setVisible(feedback);
+    _controls.LB_COMBAT->setVisible(combat);
+    _controls.LBL_EFFECTS_GOOD->setVisible(effects);
+    _controls.LBL_EFFECTS_BAD->setVisible(effects);
+    _controls.LB_EFFECTS_GOOD->setVisible(effects);
+    _controls.LB_EFFECTS_BAD->setVisible(effects);
 }
 
 } // namespace game

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -34,6 +34,7 @@ void MessagesMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     _controls.BTN_EXIT->setOnClick([this]() {
         if (_game.isTSL()) {
@@ -91,10 +92,10 @@ void MessagesMenu::refreshFilterVisibility() {
     bool combat = _filter == Filter::Combat;
     bool effects = _filter == Filter::Effects;
 
-    _controls.BTN_DIALOG->setSelected(dialog);
-    _controls.BTN_FEEDBACK->setSelected(feedback);
-    _controls.BTN_COMBAT->setSelected(combat);
-    _controls.BTN_EFFECTS->setSelected(effects);
+    updateK2FilterButton(_controls.BTN_DIALOG, dialog);
+    updateK2FilterButton(_controls.BTN_FEEDBACK, feedback);
+    updateK2FilterButton(_controls.BTN_COMBAT, combat);
+    updateK2FilterButton(_controls.BTN_EFFECTS, effects);
 
     _controls.LB_DIALOG->setVisible(dialog);
     _controls.LB_MESSAGES->setVisible(feedback);

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -33,6 +33,7 @@ namespace game {
 void MessagesMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
     _controls.BTN_EXIT->setOnClick([this]() {
         if (_game.isTSL()) {
@@ -46,6 +47,14 @@ void MessagesMenu::onGUILoaded() {
         _controls.BTN_SHOW->setDisabled(true);
         return;
     }
+
+    _controls.LB_DIALOG->setTintBorderFill(true);
+    _controls.LB_MESSAGES->setTintBorderFill(true);
+    _controls.LB_COMBAT->setTintBorderFill(true);
+    _controls.LB_EFFECTS_GOOD->setTintBorderFill(true);
+    _controls.LB_EFFECTS_BAD->setTintBorderFill(true);
+    _controls.LBL_EFFECTS_GOOD->setTintBorderFill(true);
+    _controls.LBL_EFFECTS_BAD->setTintBorderFill(true);
 
     _controls.BTN_DIALOG->setOnClick([this]() {
         setFilter(Filter::Dialog);

--- a/src/libs/game/gui/ingame/messages.cpp
+++ b/src/libs/game/gui/ingame/messages.cpp
@@ -49,6 +49,8 @@ void MessagesMenu::onGUILoaded() {
         return;
     }
 
+    useK2ShellTitle(_controls.LBL_MESSAGES);
+    enableK2ButtonBodyFill(_controls.BTN_EXIT);
     _controls.LB_DIALOG->setTintBorderFill(true);
     _controls.LB_MESSAGES->setTintBorderFill(true);
     _controls.LB_COMBAT->setTintBorderFill(true);

--- a/src/libs/game/gui/ingame/options.cpp
+++ b/src/libs/game/gui/ingame/options.cpp
@@ -34,6 +34,7 @@ void OptionsMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     if (_game.isTSL()) {
         _controls.LB_DESC->setTintBorderFill(true);

--- a/src/libs/game/gui/ingame/options.cpp
+++ b/src/libs/game/gui/ingame/options.cpp
@@ -37,7 +37,21 @@ void OptionsMenu::onGUILoaded() {
     tintK2InGameHeader();
 
     if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
         _controls.LB_DESC->setTintBorderFill(true);
+        useK2ShellTitle(_controls.LBL_TITLE);
+        for (auto &button : {
+                 _controls.BTN_SAVEGAME,
+                 _controls.BTN_LOADGAME,
+                 _controls.BTN_GAMEPLAY,
+                 _controls.BTN_FEEDBACK,
+                 _controls.BTN_AUTOPAUSE,
+                 _controls.BTN_GRAPHICS,
+                 _controls.BTN_SOUND,
+                 _controls.BTN_QUIT,
+                 _controls.BTN_EXIT}) {
+            enableK2ButtonBodyFill(button);
+        }
     }
     _controls.BTN_LOADGAME->setOnClick([this]() {
         _game.openSaveLoad(SaveLoadMode::LoadFromInGame);

--- a/src/libs/game/gui/ingame/options.cpp
+++ b/src/libs/game/gui/ingame/options.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/game/game.h"
 #include "reone/gui/control/button.h"
+#include "reone/gui/control/listbox.h"
 
 using namespace reone::audio;
 using namespace reone::graphics;
@@ -32,7 +33,11 @@ namespace game {
 void OptionsMenu::onGUILoaded() {
     loadBackground(BackgroundType::Menu);
     bindControls();
+    tintK2InGameFooter();
 
+    if (_game.isTSL()) {
+        _controls.LB_DESC->setTintBorderFill(true);
+    }
     _controls.BTN_LOADGAME->setOnClick([this]() {
         _game.openSaveLoad(SaveLoadMode::LoadFromInGame);
     });

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -70,11 +70,16 @@ void PartySelection::onGUILoaded() {
     tintK2InGameHeader();
 
     if (_game.isTSL()) {
+        fillK2SectionStrip(_controls.LBL_BAR1, _controls.LBL_BAR2);
         for (auto &control : {
                  _controls.LBL_NA0, _controls.LBL_NA1, _controls.LBL_NA2, _controls.LBL_NA3,
                  _controls.LBL_NA4, _controls.LBL_NA5, _controls.LBL_NA6, _controls.LBL_NA7,
                  _controls.LBL_NA8, _controls.LBL_NA9, _controls.LBL_NA10, _controls.LBL_NA11}) {
             control->setTintBorderFill(true);
+        }
+        useK2ShellTitle(_controls.LBL_TITLE);
+        for (auto &button : {_controls.BTN_ACCEPT, _controls.BTN_DONE, _controls.BTN_BACK}) {
+            enableK2ButtonBodyFill(button);
         }
     }
 

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -67,6 +67,7 @@ void PartySelection::onGUILoaded() {
 
     bindControls();
     tintK2InGameFooter();
+    tintK2InGameHeader();
 
     for (int i = 0; i < kNpcCount; ++i) {
         ToggleButton &button = getNpcButton(i);

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -66,6 +66,7 @@ void PartySelection::onGUILoaded() {
     }
 
     bindControls();
+    tintK2InGameFooter();
 
     for (int i = 0; i < kNpcCount; ++i) {
         ToggleButton &button = getNpcButton(i);

--- a/src/libs/game/gui/partyselect.cpp
+++ b/src/libs/game/gui/partyselect.cpp
@@ -69,6 +69,15 @@ void PartySelection::onGUILoaded() {
     tintK2InGameFooter();
     tintK2InGameHeader();
 
+    if (_game.isTSL()) {
+        for (auto &control : {
+                 _controls.LBL_NA0, _controls.LBL_NA1, _controls.LBL_NA2, _controls.LBL_NA3,
+                 _controls.LBL_NA4, _controls.LBL_NA5, _controls.LBL_NA6, _controls.LBL_NA7,
+                 _controls.LBL_NA8, _controls.LBL_NA9, _controls.LBL_NA10, _controls.LBL_NA11}) {
+            control->setTintBorderFill(true);
+        }
+    }
+
     for (int i = 0; i < kNpcCount; ++i) {
         ToggleButton &button = getNpcButton(i);
         button.setOnColor(g_kotorColorOn);


### PR DESCRIPTION
This is unfinished UI parity work targeting a restoration of the XBOX color scheme from June, opened as a draft primarily so @MichaelMoroz can inspect it alongside #285.

It includes:

K2 Messages Dialog / Feedback / Combat / Effects pane routing
content-panel and menu-chrome tinting
K2 menu/filter visual state
party/footer/header treatment
level-up and party-selection visual fixes
further in-game menu chrome polish

The branch predates a substantial amount of current master and is not intended to be merged as-is. In particular, #285 appears to provide a cleaner GUI-wide solution for much of the TSL border-fill tinting, so several visual changes here may now be obsolete.

The main purpose of this draft is to make the older work easy to compare and identify anything that should complement #285 — especially behavior such as the K2 Messages pane implementation.