### PR TITLE
[game] Check for equipped items in GetItemPossessedBy

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -374,18 +374,27 @@ static Variable GetItemPossessor(const std::vector<Variable> &args, const Routin
 
 static Variable GetItemPossessedBy(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Load
-    auto oCreature = getObject(args, 0, ctx);
+    auto oObject = getObject(args, 0, ctx);
     auto sItemTag = getString(args, 1);
 
     // Transform
-    auto creature = checkCreature(oCreature);
     auto itemTag = boost::to_lower_copy(sItemTag);
 
     // Execute
     if (itemTag.empty()) {
         return Variable::ofObject(kObjectInvalid);
     }
-    auto item = creature->getItemByTag(itemTag);
+    auto item = oObject->getItemByTag(itemTag);
+    if (!item) {
+        if (auto creature = dyn_cast<Creature>(oObject)) {
+            for (auto &[slot, equippedItem] : creature->equipment()) {
+                if (equippedItem->tag() == itemTag) {
+                    item = equippedItem;
+                }
+            }
+        }
+    }
+
     return Variable::ofObject(getObjectIdOrInvalid(item));
 }
 


### PR DESCRIPTION
`GetItemPossessedBy` is used on `korr_m38aa` to check if any of the
party members wears a sound dampening belt. Before the patch,
`GetItemPossessedBy` used to only check inventory.

Also, `GetItemPossessedBy` is used on  `tar_m05ab` to check if an item
is placed  in a  pile of  corpses to feed  the Rancor.  The pile  is a
Placeable, so the patch removes the requirement for the target to be a
Creature.