### PR TITLE
[game] Fix SwitchPlayerCharacter and AddPartyMember routines

### DIFF
--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1023,6 +1023,7 @@ void Game::deserializeParty(resource::Gff &ifoGff) {
     player->deserialize(*players.front());
     player->setTag(kObjectTagPlayer);
     _party.addMember(kNpcPlayer, player);
+    _party.addAvailableMember(kNpcPlayer, player);
     _party.setPlayer(player);
 
     std::shared_ptr<Gff> ptGff(_services.resource.gffs.get("partytable", ResType::Res));

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -227,12 +227,7 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
         return Variable::ofInt(1);
     }
 
-    std::shared_ptr<Creature> creature;
-    if (nNPC == kNpcPlayer) {
-        creature = party.player();
-    } else {
-        creature = party.getAvailableMember(nNPC);
-    }
+    std::shared_ptr<Creature> creature = party.getAvailableMember(nNPC);
     if (!creature) {
         warn("Party: NPC not found: " + std::to_string(nNPC));
         return Variable::ofInt(0);
@@ -250,6 +245,7 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
 
     party.clear();
     party.addMember(nNPC, creature);
+    party.setPlayer(creature);
 
     if (area) {
         area->loadParty(position, facing);
@@ -5288,7 +5284,7 @@ static Variable AddPartyMember(const std::vector<Variable> &args, const RoutineC
     auto creature = checkCreature(oCreature);
 
     // Execute
-    bool added = ctx.game.party().addAvailableMember(nNPC, creature->blueprintResRef());
+    bool added = ctx.game.party().addMember(nNPC, creature);
     return Variable::ofInt(static_cast<int>(added));
 }
 


### PR DESCRIPTION
`SwitchPlayerCharacter` now sets the requested party member as the
player, and then restores the original player character when called
with `nNPC == -1`.

This fixes a transition between the player character and the jail
breaker on the Leviathan.

The patch also fixes `AddPartyMember` to actually add a creature to the
party, instead of adding them as an available NPC for party selection
screen. This makes C3FD join the party on K2 Ebon Hawk prologue
section.