### PR TITLE
[game] Implement GiveItem routine

### DIFF
--- a/include/reone/game/object.h
+++ b/include/reone/game/object.h
@@ -123,6 +123,7 @@ public:
     std::shared_ptr<Item> addItem(const std::string &resRef, int stackSize = 1, bool dropable = true);
     void addItem(const std::shared_ptr<Item> &item);
     bool removeItem(const std::shared_ptr<Item> &item, bool &last);
+    bool removeItemStack(const std::shared_ptr<Item> &item);
     void moveDropableItemsTo(Object &other);
 
     std::shared_ptr<Item> getFirstItem();

--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -136,6 +136,9 @@ public:
     void setIdentified(bool value);
     void setEquipped(bool equipped);
 
+    uint32_t owner() const { return _ownerId; }
+    void setOwner(uint32_t id) { _ownerId = id; }
+
 private:
     // Serializable
     int32_t _baseItem {0};
@@ -153,6 +156,8 @@ private:
     uint8_t _textureVariation {0};
     bool _dropable {false};
     // END Serializable
+
+    uint32_t _ownerId {0};
 
     std::string _baseBodyVariation;
     std::string _itemClass;

--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -237,6 +237,7 @@ std::shared_ptr<Item> Object::addItem(const std::string &resRef, int stackSize, 
         result->loadFromBlueprint(resRef);
         result->setStackSize(stackSize);
         result->setDropable(dropable);
+        result->setOwner(_id);
 
         _items.push_back(result);
 
@@ -256,6 +257,7 @@ void Object::addItem(const std::shared_ptr<Item> &item) {
         (*maybeItem)->setStackSize((*maybeItem)->stackSize() + stackSize);
     } else {
         _items.push_back(item);
+        item->setOwner(_id);
         if (Creature *creature = dyn_cast<Creature>(this)) {
             creature->itemAttributes().addItem(item, _services.game);
         }
@@ -275,10 +277,26 @@ bool Object::removeItem(const std::shared_ptr<Item> &item, bool &last) {
     } else {
         last = true;
         _items.erase(maybeItem);
+        item->setOwner(0);
         if (Creature *creature = dyn_cast<Creature>(this)) {
             creature->itemAttributes().removeItem(item);
         }
     }
+
+    return true;
+}
+
+bool Object::removeItemStack(const std::shared_ptr<Item> &item) {
+    auto maybeItem = find(_items.begin(), _items.end(), item);
+    if (maybeItem == _items.end()) {
+        return false;
+    }
+
+    _items.erase(maybeItem);
+    if (Creature *creature = dyn_cast<Creature>(this)) {
+        creature->itemAttributes().removeItem(item);
+    }
+    item->setOwner(0);
 
     return true;
 }

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -934,6 +934,7 @@ bool Creature::equip(int slot, const std::shared_ptr<Item> &item) {
     }
     _equipment[slot] = item;
     item->setEquipped(true);
+    item->setOwner(_id);
 
     uint32_t prevAppearance = _appearance;
     updateDisguise();

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2701,9 +2701,23 @@ static Variable GiveItem(const std::vector<Variable> &args, const RoutineContext
     auto oGiveTo = getObject(args, 1, ctx);
 
     // Transform
+    auto item = checkItem(oItem);
 
     // Execute
-    throw RoutineNotImplementedException("GiveItem");
+    uint32_t owner = item->owner();
+    if (owner && owner != kObjectInvalid) {
+        auto object = ctx.game.getObjectById(owner);
+        if (object) {
+            if (auto creature = dyn_cast<Creature>(object)) {
+                if (item->isEquipped()) {
+                    creature->unequip(item);
+                }
+            }
+            object->removeItemStack(item);
+        }
+    }
+    oGiveTo->addItem(item);
+    return Variable::ofNull();
 }
 
 static Variable ObjectToString(const std::vector<Variable> &args, const RoutineContext &ctx) {


### PR DESCRIPTION
`GiveItem` routine is supposed to move an item from the current owner to
another object. The routine itself only has an item and a destination
object, so the engine has to track the current owner for every item.

`GiveItem` moves an entire stack of items to avoid splitting it, which
would otherwise require to clone the item.

This fixes Leviathan setup, where `LEV_StripCharacter` script loops over
all items in the target's equipment and inventory and moves them to a
container.