### PR TITLE
[scene] Render meshes with runtime texture overrides

### DIFF
--- a/src/libs/scene/node/mesh.cpp
+++ b/src/libs/scene/node/mesh.cpp
@@ -195,7 +195,10 @@ bool MeshSceneNode::shouldRender() const {
     if (!mesh || !mesh->render || _alpha == 0.0f) {
         return false;
     }
-    return !_modelNode.isAABBMesh() && !mesh->diffuseMap.empty();
+    // Renderability depends on the diffuse texture effectively bound to this node,
+    // not on whether the model itself authored one. Creature bodies routinely defer
+    // their skin to a runtime override applied through setMainTexture.
+    return !_modelNode.isAABBMesh() && _nodeTextures.diffuse != nullptr;
 }
 
 bool MeshSceneNode::shouldCastShadows() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/resource/sourcelifetimes.cpp
     ${TESTS_SOURCE_DIR}/resource/strings.cpp
     ${TESTS_SOURCE_DIR}/scene/emitter.cpp
+    ${TESTS_SOURCE_DIR}/scene/mesh.cpp
     ${TESTS_SOURCE_DIR}/scene/model.cpp
     ${TESTS_SOURCE_DIR}/script/format/ncsreader.cpp
     ${TESTS_SOURCE_DIR}/script/format/ncswriter.cpp

--- a/test/scene/mesh.cpp
+++ b/test/scene/mesh.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/graphics/animation.h"
+#include "reone/graphics/model.h"
+#include "reone/graphics/modelnode.h"
+#include "reone/graphics/options.h"
+#include "reone/graphics/texture.h"
+#include "reone/scene/graph.h"
+#include "reone/scene/node/mesh.h"
+#include "reone/scene/node/model.h"
+
+#include "../fixtures/audio.h"
+#include "../fixtures/graphics.h"
+#include "../fixtures/resource.h"
+#include "../fixtures/scene.h"
+
+using namespace reone;
+using namespace reone::audio;
+using namespace reone::graphics;
+using namespace reone::resource;
+using namespace reone::scene;
+
+using testing::_;
+using testing::Return;
+
+namespace {
+
+// Minimal creature-usage model with an arbitrary number of mesh nodes, built
+// through the production scene graph so that MeshSceneNode::init and the
+// setMainTexture propagation path are the real ones.
+struct MeshFixture {
+    GraphicsOptions graphicsOpt;
+    MockRenderPipelineFactory pipelineFactory;
+    TestGraphicsModule graphicsModule;
+    TestAudioModule audioModule;
+    TestResourceModule resourceModule;
+    std::unique_ptr<SceneGraph> scene;
+    std::shared_ptr<ModelNode> rootNode;
+    std::vector<std::shared_ptr<ModelNode::TriangleMesh>> meshes;
+    std::unique_ptr<Model> model;
+    std::shared_ptr<ModelSceneNode> node;
+    std::shared_ptr<Texture> texture;
+
+    MeshFixture() {
+        graphicsModule.init();
+        audioModule.init();
+        resourceModule.init();
+        scene = std::make_unique<SceneGraph>("test", pipelineFactory, graphicsOpt,
+                                             graphicsModule.services(),
+                                             audioModule.services(),
+                                             resourceModule.services());
+        rootNode = std::make_shared<ModelNode>(0, "root_node", glm::vec3(0.0f),
+                                               glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+        texture = std::make_shared<Texture>("some_texture", TextureType::TwoDim, Texture::Properties());
+        EXPECT_CALL(resourceModule.textures(), get(_, _)).WillRepeatedly(Return(texture));
+    }
+
+    // Appends a mesh node to the model root. An empty diffuseMap models the K2
+    // creature bodies that defer their skin to appearance.2da.
+    std::shared_ptr<ModelNode::TriangleMesh> addMesh(int number,
+                                                     const std::string &name,
+                                                     const std::string &diffuseMap,
+                                                     bool render = true) {
+        auto mesh = std::make_shared<ModelNode::TriangleMesh>();
+        mesh->render = render;
+        mesh->diffuseMap = diffuseMap;
+        auto meshNode = std::make_shared<ModelNode>(number, name, glm::vec3(0.0f),
+                                                    glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
+        meshNode->setMesh(mesh);
+        rootNode->addChild(meshNode);
+        meshes.push_back(mesh);
+        return mesh;
+    }
+
+    void build() {
+        model = std::make_unique<Model>("some_model", 0, rootNode,
+                                        std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+        node = std::make_shared<ModelSceneNode>(*model, ModelUsage::Creature, *scene,
+                                                graphicsModule.services(),
+                                                audioModule.services(),
+                                                resourceModule.services());
+        node->init();
+    }
+
+    MeshSceneNode &meshNode(const std::string &name) {
+        auto sceneNode = node->getNodeByName(name);
+        return *static_cast<MeshSceneNode *>(sceneNode);
+    }
+};
+
+} // namespace
+
+TEST(MeshSceneNode, should_render_mesh_with_embedded_diffuse_texture) {
+    // given
+    MeshFixture fixture;
+    fixture.addMesh(1, "body_g", "c_mk1_drd");
+    fixture.build();
+
+    // when
+    auto &mesh = fixture.meshNode("body_g");
+
+    // then
+    EXPECT_TRUE(mesh.shouldRender());
+}
+
+TEST(MeshSceneNode, should_cull_mesh_without_any_diffuse_texture) {
+    // given
+    MeshFixture fixture;
+    fixture.addMesh(1, "body_g", "");
+    fixture.build();
+
+    // when
+    auto &mesh = fixture.meshNode("body_g");
+
+    // then
+    EXPECT_FALSE(mesh.shouldRender());
+}
+
+TEST(MeshSceneNode, should_render_mesh_whose_diffuse_texture_is_supplied_at_runtime) {
+    // given
+    MeshFixture fixture;
+    fixture.addMesh(1, "body_g", "");
+    fixture.build();
+    auto &mesh = fixture.meshNode("body_g");
+    ASSERT_FALSE(mesh.shouldRender());
+
+    // when
+    fixture.node->setMainTexture(fixture.texture.get());
+
+    // then
+    EXPECT_TRUE(mesh.shouldRender());
+}
+
+TEST(MeshSceneNode, should_cull_mesh_with_render_flag_off_despite_runtime_texture) {
+    // given
+    MeshFixture fixture;
+    fixture.addMesh(1, "body_g", "", false);
+    fixture.build();
+
+    // when
+    fixture.node->setMainTexture(fixture.texture.get());
+
+    // then
+    EXPECT_FALSE(fixture.meshNode("body_g").shouldRender());
+}
+
+TEST(MeshSceneNode, should_cull_aabb_mesh_despite_runtime_texture) {
+    // given
+    MeshFixture fixture;
+    auto mesh = fixture.addMesh(1, "walkmesh_g", "");
+    mesh->aabbTree = std::make_shared<ModelNode::AABBTree>();
+    fixture.build();
+
+    // when
+    fixture.node->setMainTexture(fixture.texture.get());
+
+    // then
+    EXPECT_FALSE(fixture.meshNode("walkmesh_g").shouldRender());
+}
+
+TEST(MeshSceneNode, should_propagate_runtime_texture_to_every_mesh_of_a_model) {
+    // given
+    MeshFixture fixture;
+    fixture.addMesh(1, "torso_g", "n_rodian01");
+    fixture.addMesh(2, "head_g", "");
+    fixture.build();
+    ASSERT_TRUE(fixture.meshNode("torso_g").shouldRender());
+    ASSERT_FALSE(fixture.meshNode("head_g").shouldRender());
+
+    // when
+    fixture.node->setMainTexture(fixture.texture.get());
+
+    // then
+    EXPECT_TRUE(fixture.meshNode("torso_g").shouldRender());
+    EXPECT_TRUE(fixture.meshNode("head_g").shouldRender());
+}


### PR DESCRIPTION
## Problem

`MeshSceneNode::shouldRender()` determined visibility using the diffuse texture name authored into the MDL (`mesh->diffuseMap`).

KOTOR II contains many creature models whose render-enabled meshes intentionally have no authored diffuse texture and instead receive their skin at runtime from `appearance.2da` through `setMainTexture()`. Although the runtime texture was successfully bound, those meshes were still culled, because `shouldRender()` checked the original MDL field rather than the effective texture.

Symptoms:

- humanoids rendering as heads only;
- HK-series droids rendering no body;
- partially missing creature models.

## Fix

Determine mesh renderability from the effective bound diffuse texture, `_nodeTextures.diffuse`, instead of `mesh->diffuseMap`. That texture is populated either by `initTextures()` from the model itself or by a later runtime override, so both origins are treated equivalently.

Existing gates for `render == false`, zero alpha, AABB geometry, and genuinely untextured meshes are unchanged. No K2-specific or creature-specific special cases are introduced.
