### PR TITLE
[scene] Allow GUI model scenes to prewarm continuous emitters

### DIFF
--- a/include/reone/gui/sceneinitializer.h
+++ b/include/reone/gui/sceneinitializer.h
@@ -50,6 +50,7 @@ public:
     SceneInitializer &aspect(float aspect);
     SceneInitializer &depth(float zNear, float zFar);
     SceneInitializer &perspective(float verticalFov);
+    SceneInitializer &prewarmEmitters();
     SceneInitializer &modelSupplier(const std::function<std::shared_ptr<scene::ModelSceneNode>(scene::ISceneGraph &)> &supplier);
     SceneInitializer &modelScale(float scale);
     SceneInitializer &modelOffset(glm::vec2 offset);
@@ -64,6 +65,7 @@ private:
     float _zNear {graphics::kDefaultClipPlaneNear};
     float _zFar {graphics::kDefaultClipPlaneFar};
     std::optional<float> _perspectiveVerticalFov;
+    bool _prewarmEmitters {false};
     std::function<std::shared_ptr<scene::ModelSceneNode>(scene::ISceneGraph &)> _modelSupplier;
     float _modelScale {1.0f};
     glm::vec2 _modelOffset {0.0f};

--- a/include/reone/scene/node/emitter.h
+++ b/include/reone/scene/node/emitter.h
@@ -54,6 +54,16 @@ public:
     void detonate();
     void rearmSingle();
 
+    /**
+     * Fill a continuous emitter with the particle field it would be carrying
+     * had it already been running, so its first rendered frame shows an
+     * established effect rather than one starting from nothing.
+     *
+     * Only Fountain emitters are populated. Single, Lightning, Explosion and
+     * unsupported modes keep their ordinary lifecycle untouched.
+     */
+    void prewarmContinuousParticles();
+
     float getParticleSize(float time) const { return _particleSize.get(time); };
     glm::vec3 getColor(float time) const { return _color.get(time); };
     float getAlpha(float time) const { return _alpha.get(time); };
@@ -108,7 +118,7 @@ private:
 
     void spawnParticles(float dt);
     void removeExpiredParticles(float dt);
-    void doSpawnParticle();
+    ParticleSceneNode *doSpawnParticle();
     void spawnLightningParticles();
 };
 

--- a/include/reone/scene/node/model.h
+++ b/include/reone/scene/node/model.h
@@ -109,6 +109,15 @@ public:
     void computeAABB();
     void signalEvent(const std::string &name);
 
+    /**
+     * Prewarm every continuous emitter in this model, so a scene that is shown
+     * rather than entered does not have to build its effects up from nothing
+     * in front of the viewer.
+     *
+     * Opt-in: nothing calls this on an ordinary model.
+     */
+    void prewarmEmitters();
+
     bool isPickable() const { return _pickable; }
 
     ModelNodeSceneNode *getNodeByNumber(uint16_t number);

--- a/src/libs/gui/sceneinitializer.cpp
+++ b/src/libs/gui/sceneinitializer.cpp
@@ -38,6 +38,9 @@ void SceneInitializer::invoke() {
     _sceneGraph.clear();
     _sceneGraph.addRoot(model);
     _sceneGraph.setAmbientLightColor(_ambientLightColor);
+    if (_prewarmEmitters) {
+        model->prewarmEmitters();
+    }
 
     std::shared_ptr<CameraSceneNode> cameraNode(_sceneGraph.newCamera());
     if (!cameraNode) {
@@ -76,6 +79,11 @@ SceneInitializer &SceneInitializer::depth(float zNear, float zFar) {
 
 SceneInitializer &SceneInitializer::perspective(float verticalFov) {
     _perspectiveVerticalFov = verticalFov;
+    return *this;
+}
+
+SceneInitializer &SceneInitializer::prewarmEmitters() {
+    _prewarmEmitters = true;
     return *this;
 }
 

--- a/src/libs/scene/node/emitter.cpp
+++ b/src/libs/scene/node/emitter.cpp
@@ -155,10 +155,10 @@ void EmitterSceneNode::spawnParticles(float dt) {
     }
 }
 
-void EmitterSceneNode::doSpawnParticle() {
+ParticleSceneNode *EmitterSceneNode::doSpawnParticle() {
     // Take particle from the pool, if available
     if (_particlePool.empty()) {
-        return;
+        return nullptr;
     }
     auto particle = static_cast<ParticleSceneNode *>(_particlePool.front());
     particle->setLifetime(0.0f);
@@ -183,6 +183,41 @@ void EmitterSceneNode::doSpawnParticle() {
     // Remove particle from pool and append it to emitter
     _particlePool.pop_front();
     addChild(*particle);
+
+    return particle;
+}
+
+void EmitterSceneNode::prewarmContinuousParticles() {
+    auto emitter = _modelNode.emitter();
+    if (!emitter || emitter->updateMode != ModelNode::Emitter::UpdateMode::Fountain) {
+        return;
+    }
+    if (_birthrate <= 0.0f || _lifeExpectancy <= 0.0f) {
+        return;
+    }
+
+    // Take the phase where a particle is born exactly as the scene opens. The
+    // ones still alive behind it are then those emitted one, two, three birth
+    // intervals ago, up to the last whose age is still short of the life
+    // expectancy: ceil(birthrate * lifeExpectancy) of them. The pool init()
+    // allocated bounds that, in which case the youngest are the ones seeded.
+    int count = glm::min(kMaxParticles, static_cast<int>(glm::ceil(_birthrate * _lifeExpectancy)));
+    for (int i = 0; i < count; ++i) {
+        auto particle = doSpawnParticle();
+        if (!particle) {
+            break;
+        }
+        // Age by whole birth intervals, not by an even share of the lifetime:
+        // the two agree only when birthrate times life expectancy happens to be
+        // a whole number, and elsewhere an even share invents ages the authored
+        // cadence could never have produced. The oldest lands strictly short of
+        // the life expectancy, so nothing is seeded already expired.
+        particle->update(i * _birthInterval);
+    }
+
+    // The next birth is a full interval away, so the field this leaves behind
+    // is not immediately followed by an extra particle.
+    _birthTimer.reset(_birthInterval);
 }
 
 void EmitterSceneNode::spawnLightningParticles() {

--- a/src/libs/scene/node/model.cpp
+++ b/src/libs/scene/node/model.cpp
@@ -144,6 +144,25 @@ void ModelSceneNode::signalEvent(const std::string &name) {
     }
 }
 
+void ModelSceneNode::prewarmEmitters() {
+    // Collect first: prewarming gives an emitter particle children, and the
+    // walk should not be reading a list it has just grown.
+    std::vector<EmitterSceneNode *> emitters;
+    std::function<void(SceneNode &)> collect = [&collect, &emitters](SceneNode &node) {
+        if (node.type() == SceneNodeType::Emitter) {
+            emitters.push_back(static_cast<EmitterSceneNode *>(&node));
+        }
+        for (auto &child : node.children()) {
+            collect(*child);
+        }
+    };
+    collect(*this);
+
+    for (auto *emitter : emitters) {
+        emitter->prewarmContinuousParticles();
+    }
+}
+
 void ModelSceneNode::attach(const std::string &parentName, SceneNode &node) {
     auto maybeParent = _nodeByName.find(parentName);
     if (maybeParent == _nodeByName.end()) {

--- a/test/scene/emitter.cpp
+++ b/test/scene/emitter.cpp
@@ -6,6 +6,8 @@
 #include "reone/scene/graph.h"
 #include "reone/scene/node/emitter.h"
 #include "reone/scene/node/model.h"
+#include "reone/scene/node/particle.h"
+#include "reone/gui/sceneinitializer.h"
 #include "../fixtures/audio.h"
 #include "../fixtures/graphics.h"
 #include "../fixtures/resource.h"
@@ -186,4 +188,274 @@ TEST(EmitterSceneNode, rearming_single_does_not_affect_fountain_emission) {
     ASSERT_EQ(1, fountain->children().size());
     scene->update(0.05f);
     EXPECT_EQ(2, fountain->children().size());
+}
+
+namespace {
+
+/** The engine modules and scene graph a GUI model scene needs to exist. */
+struct PrewarmScene {
+    GraphicsOptions graphicsOpt;
+    MockRenderPipelineFactory pipelineFactory;
+    TestGraphicsModule graphicsModule;
+    TestAudioModule audioModule;
+    TestResourceModule resourceModule;
+    std::unique_ptr<SceneGraph> graph;
+    std::shared_ptr<ModelSceneNode> model;
+
+    PrewarmScene() {
+        graphicsModule.init();
+        audioModule.init();
+        resourceModule.init();
+        graph = std::make_unique<SceneGraph>(
+            "test",
+            pipelineFactory,
+            graphicsOpt,
+            graphicsModule.services(),
+            audioModule.services(),
+            resourceModule.services());
+    }
+
+    /** Build the GUI scene and hand back its one emitter. */
+    EmitterSceneNode *build(Model &source, bool prewarm) {
+        gui::SceneInitializer initializer(*graph);
+        initializer.modelSupplier([this, &source](ISceneGraph &graph) {
+            model = graph.newModel(source, ModelUsage::GUI);
+            return model;
+        });
+        if (prewarm) {
+            initializer.prewarmEmitters();
+        }
+        initializer.invoke();
+        return static_cast<EmitterSceneNode *>(model->getNodeByName("emitter"));
+    }
+};
+
+/**
+ * A model carrying one emitter of the given mode, emitting at the given
+ * birthrate for the given particle life expectancy.
+ */
+std::shared_ptr<Model> newEmitterModel(
+    const std::string &name,
+    ModelNode::Emitter::UpdateMode updateMode,
+    float birthrate,
+    float lifeExpectancy) {
+
+    auto rootNode = std::make_shared<ModelNode>(
+        0, "root", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+
+    auto emitter = std::make_shared<ModelNode::Emitter>();
+    emitter->updateMode = updateMode;
+    emitter->renderMode = ModelNode::Emitter::RenderMode::Normal;
+
+    auto emitterNode = std::make_shared<ModelNode>(
+        1, "emitter", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
+    emitterNode->setEmitter(emitter);
+    emitterNode->floatTracks()[ControllerTypes::birthrate].add(0.0f, birthrate);
+    emitterNode->floatTracks()[ControllerTypes::lifeExp].add(0.0f, lifeExpectancy);
+    // Authored appearance over a particle's life, so a seeded particle can be
+    // checked against the point in that life it claims to be at.
+    emitterNode->floatTracks()[ControllerTypes::frameStart].add(0.0f, 0.0f);
+    emitterNode->floatTracks()[ControllerTypes::frameEnd].add(0.0f, 10.0f);
+    emitterNode->floatTracks()[ControllerTypes::sizeStart].add(0.0f, 1.0f);
+    emitterNode->floatTracks()[ControllerTypes::sizeMid].add(0.0f, 2.0f);
+    emitterNode->floatTracks()[ControllerTypes::sizeEnd].add(0.0f, 3.0f);
+    emitterNode->floatTracks()[ControllerTypes::alphaStart].add(0.0f, 1.0f);
+    emitterNode->floatTracks()[ControllerTypes::alphaMid].add(0.0f, 0.5f);
+    emitterNode->floatTracks()[ControllerTypes::alphaEnd].add(0.0f, 0.0f);
+    emitterNode->vectorTracks()[ControllerTypes::colorStart].add(0.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+    emitterNode->vectorTracks()[ControllerTypes::colorMid].add(0.0f, glm::vec3(0.0f, 1.0f, 0.0f));
+    emitterNode->vectorTracks()[ControllerTypes::colorEnd].add(0.0f, glm::vec3(0.0f, 0.0f, 1.0f));
+    rootNode->addChild(emitterNode);
+
+    auto model = std::make_shared<Model>(
+        name, 0, rootNode, std::vector<std::shared_ptr<Animation>>(), "", 1.0f);
+    model->init();
+    return model;
+}
+
+std::vector<float> particleLifetimes(const EmitterSceneNode &emitter) {
+    std::vector<float> lifetimes;
+    for (auto &child : emitter.children()) {
+        if (child->type() != SceneNodeType::Particle) {
+            continue;
+        }
+        lifetimes.push_back(static_cast<const ParticleSceneNode *>(child)->lifetime());
+    }
+    std::sort(lifetimes.begin(), lifetimes.end());
+    return lifetimes;
+}
+
+const ParticleSceneNode *oldestParticle(const EmitterSceneNode &emitter) {
+    const ParticleSceneNode *oldest = nullptr;
+    for (auto &child : emitter.children()) {
+        if (child->type() != SceneNodeType::Particle) {
+            continue;
+        }
+        auto particle = static_cast<const ParticleSceneNode *>(child);
+        if (!oldest || particle->lifetime() > oldest->lifetime()) {
+            oldest = particle;
+        }
+    }
+    return oldest;
+}
+
+} // namespace
+
+TEST(EmitterPrewarm, a_gui_scene_that_does_not_opt_in_starts_its_fountain_cold) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("cold", ModelNode::Emitter::UpdateMode::Fountain, 10.0f, 2.0f);
+
+    auto emitter = scene.build(*model, false);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_TRUE(emitter->children().empty());
+}
+
+TEST(EmitterPrewarm, opting_in_seeds_a_fountain_at_its_steady_state_population) {
+    PrewarmScene scene;
+    // Ten a second, each living two seconds: twenty alive once it is running.
+    auto model = newEmitterModel("warm", ModelNode::Emitter::UpdateMode::Fountain, 10.0f, 2.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_EQ(20u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, seeded_particle_ages_are_spread_across_the_authored_lifetime) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("spread", ModelNode::Emitter::UpdateMode::Fountain, 2.0f, 2.0f);
+
+    auto emitter = scene.build(*model, true);
+    ASSERT_TRUE(emitter);
+
+    // Four particles over a two second life: one per half-second birth interval.
+    auto lifetimes = particleLifetimes(*emitter);
+    ASSERT_EQ(4u, lifetimes.size());
+    EXPECT_FLOAT_EQ(0.0f, lifetimes[0]);
+    EXPECT_FLOAT_EQ(0.5f, lifetimes[1]);
+    EXPECT_FLOAT_EQ(1.0f, lifetimes[2]);
+    EXPECT_FLOAT_EQ(1.5f, lifetimes[3]);
+    // None of them is already at the end of its life.
+    EXPECT_LT(lifetimes.back(), 2.0f);
+}
+
+TEST(EmitterPrewarm, a_seeded_particle_looks_like_one_that_lived_that_long) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("aged", ModelNode::Emitter::UpdateMode::Fountain, 1.0f, 2.0f);
+
+    auto emitter = scene.build(*model, true);
+    ASSERT_TRUE(emitter);
+    ASSERT_EQ(2u, emitter->children().size());
+
+    // The older of the two is halfway through its life, so it carries the
+    // authored midpoint of every property that varies over a particle's life.
+    auto oldest = oldestParticle(*emitter);
+    ASSERT_TRUE(oldest);
+    EXPECT_FLOAT_EQ(1.0f, oldest->lifetime());
+    EXPECT_EQ(5, oldest->frame());
+    EXPECT_FLOAT_EQ(2.0f, oldest->size().x);
+    EXPECT_FLOAT_EQ(0.5f, oldest->alpha());
+    EXPECT_LT(glm::length(oldest->color() - glm::vec3(0.0f, 1.0f, 0.0f)), 1e-5f);
+}
+
+TEST(EmitterPrewarm, prewarming_leaves_a_single_emitter_alone) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("single", ModelNode::Emitter::UpdateMode::Single, 10.0f, 2.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    // Its one particle is still the ordinary lifecycle's to create.
+    EXPECT_TRUE(emitter->children().empty());
+
+    scene.graph->update(0.0f);
+    EXPECT_EQ(1u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, emission_carries_on_at_the_authored_cadence_after_prewarming) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("cadence", ModelNode::Emitter::UpdateMode::Fountain, 2.0f, 2.0f);
+
+    auto emitter = scene.build(*model, true);
+    ASSERT_TRUE(emitter);
+    ASSERT_EQ(4u, emitter->children().size());
+
+    // A tick well short of the half-second birth interval must not add one: a
+    // birth timer left at zero by prewarming would fire straight away.
+    scene.graph->update(0.1f);
+    EXPECT_EQ(4u, emitter->children().size());
+
+    // Reaching the interval emits exactly one more, and nothing has expired yet.
+    scene.graph->update(0.4f);
+    EXPECT_EQ(5u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, seeded_ages_follow_the_birth_interval_not_an_even_share_of_the_lifetime) {
+    PrewarmScene scene;
+    // Two a second for three quarters of a second: the product is 1.5, so an
+    // even share of the lifetime and the authored cadence disagree. A running
+    // emitter holds the newborn and the one emitted half a second before it;
+    // sharing the lifetime evenly would instead claim an age of 0.375, which no
+    // emission at this cadence could ever have produced.
+    auto model = newEmitterModel("cadence_phase", ModelNode::Emitter::UpdateMode::Fountain, 2.0f, 0.75f);
+
+    auto emitter = scene.build(*model, true);
+    ASSERT_TRUE(emitter);
+
+    auto lifetimes = particleLifetimes(*emitter);
+    ASSERT_EQ(2u, lifetimes.size());
+    EXPECT_FLOAT_EQ(0.0f, lifetimes[0]);
+    EXPECT_FLOAT_EQ(0.5f, lifetimes[1]);
+    EXPECT_LT(lifetimes.back(), 0.75f);
+}
+
+TEST(EmitterPrewarm, a_fractional_birthrate_still_seeds_whole_birth_intervals) {
+    PrewarmScene scene;
+    // Two and a half a second for a second: three alive, spaced four tenths
+    // apart, the oldest still short of the end of its life.
+    auto model = newEmitterModel("fractional", ModelNode::Emitter::UpdateMode::Fountain, 2.5f, 1.0f);
+
+    auto emitter = scene.build(*model, true);
+    ASSERT_TRUE(emitter);
+
+    auto lifetimes = particleLifetimes(*emitter);
+    ASSERT_EQ(3u, lifetimes.size());
+    EXPECT_FLOAT_EQ(0.0f, lifetimes[0]);
+    EXPECT_FLOAT_EQ(0.4f, lifetimes[1]);
+    EXPECT_FLOAT_EQ(0.8f, lifetimes[2]);
+    EXPECT_LT(lifetimes.back(), 1.0f);
+}
+
+TEST(EmitterPrewarm, no_seeded_particle_is_born_already_expired) {
+    // Across products either side of a whole number, the oldest seeded particle
+    // must still be short of the life expectancy, or it would be removed on the
+    // very first update and the field would open a particle short.
+    const std::vector<std::pair<float, float>> cases {
+        {2.0f, 2.0f},  // exactly 4
+        {2.0f, 0.75f}, // 1.5
+        {4.0f, 1.1f},  // 4.4
+        {2.5f, 1.0f},  // 2.5
+        {3.0f, 1.0f},  // exactly 3
+        {7.0f, 0.3f}   // 2.1
+    };
+    for (const auto &[birthrate, lifeExpectancy] : cases) {
+        PrewarmScene scene;
+        auto model = newEmitterModel("expiry", ModelNode::Emitter::UpdateMode::Fountain, birthrate, lifeExpectancy);
+
+        auto emitter = scene.build(*model, true);
+        ASSERT_TRUE(emitter);
+
+        auto lifetimes = particleLifetimes(*emitter);
+        ASSERT_FALSE(lifetimes.empty()) << "birthrate " << birthrate << " life " << lifeExpectancy;
+        EXPECT_LT(lifetimes.back(), lifeExpectancy)
+            << "birthrate " << birthrate << " life " << lifeExpectancy;
+
+        // Nothing is dropped by the first update, so the field it opens with is
+        // the field it keeps.
+        auto seeded = emitter->children().size();
+        scene.graph->update(0.0f);
+        EXPECT_EQ(seeded, emitter->children().size())
+            << "birthrate " << birthrate << " life " << lifeExpectancy;
+    }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in for GUI model scenes to open with continuous Fountain emitters already populated.

Reone currently starts Fountain emitters with no live particles. For GUI scenes this means a continuous effect visibly builds up after the panel opens, rather than appearing already established on the first frame.

`SceneInitializer::prewarmEmitters()` seeds Fountain emitters with the particles they would contain under their normal authored birth cadence. Particle ages are spaced by whole birth intervals:

`0, T, 2T, ...`

up to the last particle younger than its authored lifetime, capped by the emitter's existing particle pool.

Seeded particles are aged through the normal particle update path, so their frame, size, colour and alpha match their age. The birth timer then resumes one full interval later, avoiding an immediate extra particle.

Only Fountain emitters are prewarmed. Single, Lightning, Explosion and unsupported emitter modes retain their existing lifecycle.

This is an opt-in mechanism for presenting an already-running continuous effect; it does not claim that the original engine achieved the same visual result through prewarming internally. Existing `SceneInitializer` callers are unchanged.
