### PR TITLE
[gui] Composite embedded scenes between border fill and frame

### DIFF
--- a/include/reone/gui/control.h
+++ b/include/reone/gui/control.h
@@ -21,6 +21,7 @@
 #include "reone/graphics/types.h"
 
 #include "reone/resource/parser/gff/gui.h"
+#include "controlrender.h"
 #include "types.h"
 
 namespace reone {
@@ -270,7 +271,12 @@ protected:
     void renderBorder(const Border &border,
                       const glm::ivec2 &offset,
                       const glm::ivec2 &size,
-                      scene::IRenderPass &pass);
+                      scene::IRenderPass &pass,
+                      BorderRenderPart part = BorderRenderPart::All);
+
+    void renderScene(const glm::ivec2 &screenSize,
+                     const glm::ivec2 &offset,
+                     scene::IRenderPass &pass);
 
     void renderText(const std::vector<std::string> &lines,
                     const glm::ivec2 &offset,

--- a/include/reone/gui/controlrender.h
+++ b/include/reone/gui/controlrender.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/system/arrayref.h"
+
+namespace reone {
+
+namespace gui {
+
+/** Which parts of a Border a single render call should draw. */
+enum class BorderRenderPart {
+    /** The whole border: the fill behind it and the frame around it. */
+    All,
+    /** Only the fill a border paints inside its frame. */
+    Fill,
+    /** Only the edges and corners a border draws around that fill. */
+    Frame
+};
+
+/**
+ * Draw a control's layers in composition order.
+ *
+ * A control hosting a 3D scene has to put that scene inside its border rather
+ * than beside it: over the fill the border paints as a backdrop, but under the
+ * frame it draws around the outside. Treating a border as one indivisible
+ * layer forces a choice between the two, and either way something authored is
+ * lost - an opaque fill buries the scene, or the scene covers the frame.
+ *
+ * Both passes walk the same borders, so a control showing its HILIGHT state
+ * cannot end up filled by one state and framed by the other.
+ *
+ * A control with no scene keeps drawing its borders whole and then its text,
+ * exactly as before.
+ */
+template <typename Border, typename RenderBorder, typename RenderScene, typename RenderText>
+void renderControlLayers(
+    ArrayRef<const Border *> borders,
+    bool hasScene,
+    RenderBorder renderBorder,
+    RenderScene renderScene,
+    RenderText renderText) {
+
+    if (!hasScene) {
+        for (const auto *border : borders) {
+            renderBorder(*border, BorderRenderPart::All);
+        }
+        renderText();
+        return;
+    }
+
+    for (const auto *border : borders) {
+        renderBorder(*border, BorderRenderPart::Fill);
+    }
+    renderScene();
+    for (const auto *border : borders) {
+        renderBorder(*border, BorderRenderPart::Frame);
+    }
+    renderText();
+}
+
+} // namespace gui
+
+} // namespace reone

--- a/src/libs/gui/control.cpp
+++ b/src/libs/gui/control.cpp
@@ -207,49 +207,71 @@ void Control::render(const glm::ivec2 &screenSize,
         return;
     }
     glm::ivec2 size(_extent.width, _extent.height);
+
+    // The borders this control is currently showing, in the order they stack:
+    // its own border, its HILIGHT border, or - where the hilight is authored to
+    // sit over the border rather than replace it - both.
+    std::array<const Border *, 2> borderStorage;
+    size_t borderCount = 0;
     if (_border && (!_selected || _hilightOverBorder || !_hilight)) {
-        renderBorder(*_border, offset, size, pass);
+        borderStorage[borderCount++] = _border.get();
     }
     if (_selected && _hilight) {
-        renderBorder(*_hilight, offset, size, pass);
+        borderStorage[borderCount++] = _hilight.get();
     }
-    if (!_textLines.empty()) {
-        renderText(_textLines, offset, size, pass);
-    }
-    if (!_sceneName.empty()) {
-        std::optional<std::reference_wrapper<Texture>> output;
-        _graphicsSvc.context.withBlendMode(BlendMode::None, [this, &output]() {
-            output = _sceneGraphs.get(_sceneName).render({_extent.width, _extent.height});
+
+    renderControlLayers(
+        ArrayRef<const Border *>(borderStorage.data(), borderCount),
+        !_sceneName.empty(),
+        [this, &offset, &size, &pass](const Border &border, BorderRenderPart part) {
+            renderBorder(border, offset, size, pass, part);
+        },
+        [this, &screenSize, &offset, &pass]() {
+            renderScene(screenSize, offset, pass);
+        },
+        [this, &offset, &size, &pass]() {
+            if (!_textLines.empty()) {
+                renderText(_textLines, offset, size, pass);
+            }
         });
-        _graphicsSvc.uniforms.setGlobals([&screenSize](auto &globals) {
-            globals.reset();
-            globals.projection = glm::ortho(
-                0.0f,
-                static_cast<float>(screenSize.x),
-                static_cast<float>(screenSize.y),
-                0.0f, 0.0f, 100.0f);
-            globals.projectionInv = glm::inverse(globals.projection);
-        });
-        _graphicsSvc.context.withDepthTestMode(DepthTestMode::None, [this, &offset, &pass, &output]() {
-            pass.drawImage(
-                *output,
-                {_extent.left + offset.x, _extent.top + offset.y},
-                {_extent.width, _extent.height});
-        });
-    }
+}
+
+void Control::renderScene(const glm::ivec2 &screenSize,
+                          const glm::ivec2 &offset,
+                          IRenderPass &pass) {
+    std::optional<std::reference_wrapper<Texture>> output;
+    _graphicsSvc.context.withBlendMode(BlendMode::None, [this, &output]() {
+        output = _sceneGraphs.get(_sceneName).render({_extent.width, _extent.height});
+    });
+    _graphicsSvc.uniforms.setGlobals([&screenSize](auto &globals) {
+        globals.reset();
+        globals.projection = glm::ortho(
+            0.0f,
+            static_cast<float>(screenSize.x),
+            static_cast<float>(screenSize.y),
+            0.0f, 0.0f, 100.0f);
+        globals.projectionInv = glm::inverse(globals.projection);
+    });
+    _graphicsSvc.context.withDepthTestMode(DepthTestMode::None, [this, &offset, &pass, &output]() {
+        pass.drawImage(
+            *output,
+            {_extent.left + offset.x, _extent.top + offset.y},
+            {_extent.width, _extent.height});
+    });
 }
 
 void Control::renderBorder(const Border &border,
                            const glm::ivec2 &offset,
                            const glm::ivec2 &size,
-                           IRenderPass &pass) {
+                           IRenderPass &pass,
+                           BorderRenderPart part) {
     _graphicsSvc.context.useProgram(_graphicsSvc.shaderRegistry.get(ShaderProgramId::mvpTexture));
 
     glm::vec3 color(getBorderColor());
     glm::mat4 transform(1.0f);
     glm::mat3x4 uv(1.0f);
 
-    if (border.fill) {
+    if (part != BorderRenderPart::Frame && border.fill) {
         if (border.fillTransform == Border::FillTransform::Rotate180) {
             uv = glm::mat3x4(
                 glm::vec4(-1.0f, 0.0f, 0.0f, 0.0f),
@@ -269,7 +291,7 @@ void Control::renderBorder(const Border &border,
         });
     }
 
-    if (border.edge) {
+    if (part != BorderRenderPart::Fill && border.edge) {
         int width = size.x - 2 * border.dimension;
         int height = size.y - 2 * border.dimension;
 
@@ -327,7 +349,7 @@ void Control::renderBorder(const Border &border,
         }
     }
 
-    if (border.corner) {
+    if (part != BorderRenderPart::Fill && border.corner) {
         int x = _extent.left + offset.x;
         int y = _extent.top + offset.y;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/format/txireader.cpp
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp
+    ${TESTS_SOURCE_DIR}/gui/controlrender.cpp
     ${TESTS_SOURCE_DIR}/json/gff.cpp
     ${TESTS_SOURCE_DIR}/resource/archivevalidation.cpp
     ${TESTS_SOURCE_DIR}/resource/extractresources.cpp

--- a/test/gui/controlrender.cpp
+++ b/test/gui/controlrender.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/gui/controlrender.h"
+
+using namespace reone;
+using namespace reone::gui;
+
+namespace {
+
+/** Stands in for Control::Border, distinguishable by name in a trace. */
+struct FakeBorder {
+    std::string name;
+};
+
+/** What a render produced, in the order it produced it. */
+struct RenderTrace {
+    std::vector<std::string> layers;
+    std::vector<std::string> fillBorders;
+    std::vector<std::string> frameBorders;
+};
+
+RenderTrace trace(std::vector<const FakeBorder *> borders, bool hasScene) {
+    RenderTrace result;
+    renderControlLayers<FakeBorder>(
+        ArrayRef<const FakeBorder *>(borders.data(), borders.size()),
+        hasScene,
+        [&result](const FakeBorder &border, BorderRenderPart part) {
+            switch (part) {
+            case BorderRenderPart::All:
+                result.layers.push_back("border:" + border.name);
+                break;
+            case BorderRenderPart::Fill:
+                result.layers.push_back("fill:" + border.name);
+                result.fillBorders.push_back(border.name);
+                break;
+            case BorderRenderPart::Frame:
+                result.layers.push_back("frame:" + border.name);
+                result.frameBorders.push_back(border.name);
+                break;
+            }
+        },
+        [&result]() { result.layers.push_back("scene"); },
+        [&result]() { result.layers.push_back("text"); });
+    return result;
+}
+
+} // namespace
+
+TEST(ControlRender, a_scene_is_composited_between_the_border_fill_and_its_frame) {
+    FakeBorder border {"normal"};
+
+    auto rendered = trace({&border}, true);
+
+    EXPECT_EQ(
+        (std::vector<std::string> {"fill:normal", "scene", "frame:normal", "text"}),
+        rendered.layers);
+}
+
+TEST(ControlRender, a_control_without_a_scene_draws_its_border_whole_then_its_text) {
+    FakeBorder border {"normal"};
+
+    auto rendered = trace({&border}, false);
+
+    EXPECT_EQ((std::vector<std::string> {"border:normal", "text"}), rendered.layers);
+}
+
+TEST(ControlRender, a_hilighted_scene_control_is_filled_and_framed_by_the_hilight) {
+    // A control showing its HILIGHT state instead of its own border.
+    FakeBorder hilight {"hilight"};
+
+    auto rendered = trace({&hilight}, true);
+
+    EXPECT_EQ(
+        (std::vector<std::string> {"fill:hilight", "scene", "frame:hilight", "text"}),
+        rendered.layers);
+    EXPECT_EQ(rendered.fillBorders, rendered.frameBorders);
+}
+
+TEST(ControlRender, splitting_a_border_cannot_mix_the_normal_and_hilight_states) {
+    // A hilight authored to sit over the border rather than replace it: both
+    // are showing, so both are split, and neither borrows from the other.
+    FakeBorder normal {"normal"};
+    FakeBorder hilight {"hilight"};
+
+    auto rendered = trace({&normal, &hilight}, true);
+
+    EXPECT_EQ(
+        (std::vector<std::string> {
+            "fill:normal",
+            "fill:hilight",
+            "scene",
+            "frame:normal",
+            "frame:hilight",
+            "text"}),
+        rendered.layers);
+    // Whatever was filled is exactly what gets framed, in the same order.
+    EXPECT_EQ((std::vector<std::string> {"normal", "hilight"}), rendered.fillBorders);
+    EXPECT_EQ(rendered.fillBorders, rendered.frameBorders);
+}
+
+TEST(ControlRender, a_scene_control_with_no_border_still_draws_its_scene_under_its_text) {
+    auto rendered = trace({}, true);
+
+    EXPECT_EQ((std::vector<std::string> {"scene", "text"}), rendered.layers);
+}
+
+TEST(ControlRender, a_borderless_control_without_a_scene_draws_only_its_text) {
+    auto rendered = trace({}, false);
+
+    EXPECT_EQ((std::vector<std::string> {"text"}), rendered.layers);
+}


### PR DESCRIPTION
## Summary

Corrects compositing for GUI controls that host embedded 3D scenes.

A scene-bearing control has authored border content on both sides of the scene:

* the border `fill` acts as the backdrop;
* the border `edge` and `corner` drawables form the frame around it.

Treating the border as one indivisible layer forces the wrong result in one direction or the other. Drawing the whole border before the scene keeps background fills behind models, but allows the 3D scene to cover its frame. Drawing the whole border afterward preserves the frame, but an opaque fill can cover the model itself.

Scene-bearing controls now render:

`fill → scene → edge/corner → text`

Controls without embedded scenes retain their existing:

`border → text`

behavior.

The effective normal/HILIGHT border state is selected once and reused for both passes, so fill and frame cannot accidentally come from different states. Authored hilights that layer with the normal border continue to do so; both are split consistently rather than borrowing components from one another.

This is generic control compositing. There are no screen, control-name, resource or GalaxyMap-specific cases.
