### PR TITLE
[game] Handle missing leader in FollowLeader action

### DIFF
--- a/src/libs/game/action/followleader.cpp
+++ b/src/libs/game/action/followleader.cpp
@@ -26,8 +26,19 @@ namespace reone {
 namespace game {
 
 void FollowLeaderAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
+    // The party has no leader while it is empty: before it is first populated,
+    // after a module transition resets it, and once the last member is removed
+    // by RemovePartyMember. A FollowLeader action queued on a creature can still
+    // be executed in those windows, so there is nothing to follow and the action
+    // is dropped instead of dereferencing a null leader.
+    auto leader = _game.party().getLeader();
+    if (!leader) {
+        complete();
+        return;
+    }
+
     auto creatureActor = _game.getObjectById<Creature>(actor.id());
-    glm::vec3 destination(_game.party().getLeader()->position());
+    glm::vec3 destination(leader->position());
     float distance2 = creatureActor->getSquareDistanceTo(glm::vec2(destination));
     bool run = distance2 > kDistanceWalk;
 

--- a/test/game/action.cpp
+++ b/test/game/action.cpp
@@ -21,9 +21,11 @@
 #include <set>
 
 #include "../fixtures/engine.h"
+#include "reone/game/action/followleader.h"
 #include "reone/game/action/startconversation.h"
 #include "reone/game/action/usetalentonobject.h"
 #include "reone/game/game.h"
+#include "reone/game/party.h"
 #include "reone/game/script/routines.h"
 #include "reone/resource/types.h"
 #include "reone/script/executioncontext.h"
@@ -231,6 +233,72 @@ TEST(Action, get_is_conversation_active_reports_the_shared_predicate) {
 
     setScreen(game, Game::Screen::Conversation);
     EXPECT_EQ(1, routine.invoke({}, ctx).intValue);
+}
+
+namespace {
+
+// A leader far enough away that a follower still has ground to cover, so an
+// honored FollowLeader stays in progress rather than completing on arrival.
+constexpr float kFarFromLeader = 10.0f * kDefaultFollowDistance;
+
+} // namespace
+
+// E. FollowLeader has no leader to follow while the party is empty - before it
+// is first populated, after a module transition resets it, and once the last
+// member is removed. The action is dropped there instead of dereferencing the
+// absent leader, and nothing else is promoted in its place.
+TEST(Action, follow_leader_is_discarded_when_the_party_has_no_leader) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto follower = makeApproachingSpeaker(game);
+    ASSERT_TRUE(game.party().isEmpty());
+    ASSERT_FALSE(game.party().getLeader());
+
+    auto action = game.newAction<FollowLeaderAction>();
+    action->execute(action, *follower, 1.0f);
+
+    EXPECT_TRUE(action->isCompleted());
+}
+
+// F. The complement of E, and the check that the guard drops nothing it should
+// not: with a leader in the party the action survives and its follower sets
+// about the approach instead of being discarded.
+TEST(Action, follow_leader_survives_when_the_party_has_a_leader) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto leader = game.newCreature();
+    leader->setPosition(glm::vec3(kFarFromLeader, 0.0f, 0.0f));
+    game.party().addMember(kNpcPlayer, leader);
+    ASSERT_EQ(leader, game.party().getLeader());
+
+    auto follower = makeApproachingSpeaker(game);
+
+    auto action = game.newAction<FollowLeaderAction>();
+    action->execute(action, *follower, 1.0f);
+
+    EXPECT_FALSE(action->isCompleted());
+}
+
+// G. Leader-present completion is unchanged too: a follower already within
+// following distance of the leader finishes the action.
+TEST(Action, follow_leader_completes_once_the_follower_is_with_the_leader) {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+
+    auto leader = game.newCreature();
+    game.party().addMember(kNpcPlayer, leader);
+    auto follower = game.newCreature();
+    ASSERT_EQ(leader->position(), follower->position());
+
+    auto action = game.newAction<FollowLeaderAction>();
+    action->execute(action, *follower, 1.0f);
+
+    EXPECT_TRUE(action->isCompleted());
 }
 
 namespace {


### PR DESCRIPTION
## Summary

Prevents `FollowLeaderAction` from dereferencing a missing party leader.

`Party::getLeader()` can return null when the party is empty. A queued `FollowLeader` action can still execute in that state, including before the party is populated, after `Game::reset()` clears it during a module transition, or after the final party member is removed.

The action now completes immediately when no leader exists. No substitute actor is chosen and no party state is created; there is simply nothing to follow, so the action is discarded and the queue can continue.

Leader-present behaviour is unchanged.

## Validation

Focused action coverage verifies:

- no leader: the action completes safely instead of dereferencing null;
- leader present and out of range: the action remains active and the follower begins approaching;
- leader present and in range: the action completes on arrival.

Removing the guard reproduces the original access violation in the no-leader case, while both leader-present cases continue to pass and preserve existing behaviour.

Full validation also confirmed the unrelated `ArrayRef` / `TextBuffer` MSVC debug-STL assertion failures are already present on the same upstream baseline.