### PR TITLE
[game] Add Galaxy Map state and script routines

### DIFF
--- a/include/reone/game/galaxymapstate.h
+++ b/include/reone/game/galaxymapstate.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/resource/types.h"
+
+namespace reone {
+
+namespace resource {
+class Gff;
+}
+
+namespace game {
+
+/**
+ * Runtime galaxy map planet state, as the galaxy map script routines and the
+ * galaxy map GUI see it.
+ *
+ * The two titles size this differently. K1 takes its planet list from content,
+ * so rows above 15 are valid whenever planetary.2da defines them. K2 always
+ * carries exactly 16 rows, whatever the table says.
+ *
+ * Availability and selectability are independent: a planet can be shown on the
+ * map while remaining an invalid travel destination. Selection follows
+ * availability alone.
+ */
+class GalaxyMapState {
+public:
+    /** Row count K2 always carries, regardless of content. */
+    static constexpr int kTSLRowCount = 16;
+
+    /** Number of legacy planet mask bits per half of PARTYTABLE's GlxyMapPlntMsk. */
+    static constexpr int kPlanetMaskBits = 16;
+
+    /**
+     * Resize to a new game and drop all planet state.
+     *
+     * \param contentRowCount rows content defines, honoured by K1 only
+     */
+    void reset(resource::GameID gameId, int contentRowCount);
+
+    /** Drop all planet state, keeping the row count content established. */
+    void clear();
+
+    int rowCount() const { return static_cast<int>(_available.size()); }
+    bool isValidRow(int row) const { return row >= 0 && row < rowCount(); }
+
+    void setAvailable(int row, bool value);
+    bool available(int row) const;
+    void setSelectable(int row, bool value);
+    bool selectable(int row) const;
+
+    int selectedPlanet() const { return _selected; }
+
+    /**
+     * Select a planet on behalf of the player. An unavailable or out of range
+     * row leaves the previous selection in place.
+     *
+     * \returns whether the selection changed hands
+     */
+    bool trySelectPlanet(int row);
+
+    /** Put back a selection a save carries, without an availability check. */
+    void restoreSelectedPlanet(int row) { _selected = isValidRow(row) ? row : -1; }
+
+    /**
+     * Apply the GalaxyMap struct of a PARTYTABLE. A save missing the struct or
+     * any of its fields leaves planets unavailable, unselectable and nothing
+     * selected.
+     */
+    void loadFromPartyTable(const resource::Gff &ptGff);
+
+private:
+    std::vector<bool> _available;
+    std::vector<bool> _selectable;
+    int _selected {-1};
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -152,6 +152,7 @@ public:
 
     bool isPaused() const { return _paused; }
     bool isTSL() const { return _gameId == resource::GameID::TSL; }
+    resource::GameID gameId() const { return _gameId; }
 
     Camera *getActiveCamera() const;
 
@@ -437,6 +438,8 @@ public:
     void deserializeGlobalVariables(resource::Gff &gvtGff);
     void deserializeParty(resource::Gff &ifoGff);
     void deserializePartyTable(resource::Gff &ptGff);
+    void deserializeGalaxyMap(resource::Gff &ptGff);
+    void resetGalaxyMap();
     void serializePazaakPartyTable(resource::Gff &ptGff) const;
     void deserializePartyMembers(resource::Gff &ptGff);
     void deserializeJournal(const resource::Gff &ptGff);

--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "reone/game/galaxymapstate.h"
 #include "reone/input/event.h"
 
 #include <array>
@@ -155,6 +156,16 @@ public:
 
     // END Experience
 
+    // Galaxy map
+    //
+    // Planet availability, selectability and the current travel destination
+    // are party-wide runtime state, carried in PARTYTABLE.
+
+    GalaxyMapState &galaxyMap() { return _galaxyMap; }
+    const GalaxyMapState &galaxyMap() const { return _galaxyMap; }
+
+    // END Galaxy map
+
     // Inventory
     //
     // KOTOR keeps a single shared party inventory, modelled here as the player
@@ -177,6 +188,7 @@ private:
     bool _solo {false};
     int _gold {0};
     int _xp {0};
+    GalaxyMapState _galaxyMap;
     bool _pazaakDataValid {false};
     size_t _pazaakCardCount {kK1PazaakCardCount};
     PazaakCardCounts _pazaakCardCounts {};

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -184,6 +184,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/event.h
     ${GAME_INCLUDE_DIR}/footstepsounds.h
     ${GAME_INCLUDE_DIR}/floatingtext.h
+    ${GAME_INCLUDE_DIR}/galaxymapstate.h
     ${GAME_INCLUDE_DIR}/game.h
     ${GAME_INCLUDE_DIR}/itemdescription.h
     ${GAME_INCLUDE_DIR}/gui.h
@@ -470,6 +471,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/equipmentrules.cpp
     ${GAME_SOURCE_DIR}/footstepsounds.cpp
     ${GAME_SOURCE_DIR}/floatingtext.cpp
+    ${GAME_SOURCE_DIR}/galaxymapstate.cpp
     ${GAME_SOURCE_DIR}/game.cpp
     ${GAME_SOURCE_DIR}/itemdescription.cpp
     ${GAME_SOURCE_DIR}/gui/actionbar.cpp

--- a/src/libs/game/galaxymapstate.cpp
+++ b/src/libs/game/galaxymapstate.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/galaxymapstate.h"
+
+#include "reone/resource/gff.h"
+
+namespace reone {
+
+namespace game {
+
+void GalaxyMapState::reset(resource::GameID gameId, int contentRowCount) {
+    int rowCount = gameId == resource::GameID::TSL
+                       ? kTSLRowCount
+                       : std::max(0, contentRowCount);
+    _available.assign(rowCount, false);
+    _selectable.assign(rowCount, false);
+    _selected = -1;
+}
+
+void GalaxyMapState::clear() {
+    _available.assign(_available.size(), false);
+    _selectable.assign(_selectable.size(), false);
+    _selected = -1;
+}
+
+void GalaxyMapState::setAvailable(int row, bool value) {
+    if (!isValidRow(row)) {
+        return;
+    }
+    _available[row] = value;
+}
+
+bool GalaxyMapState::available(int row) const {
+    return isValidRow(row) && _available[row];
+}
+
+void GalaxyMapState::setSelectable(int row, bool value) {
+    if (!isValidRow(row)) {
+        return;
+    }
+    _selectable[row] = value;
+}
+
+bool GalaxyMapState::selectable(int row) const {
+    return isValidRow(row) && _selectable[row];
+}
+
+bool GalaxyMapState::trySelectPlanet(int row) {
+    if (!available(row)) {
+        return false;
+    }
+    _selected = row;
+    return true;
+}
+
+void GalaxyMapState::loadFromPartyTable(const resource::Gff &ptGff) {
+    auto galaxyMap = ptGff.findStruct("GlxyMap");
+    if (!galaxyMap) {
+        return;
+    }
+
+    // Both titles pack the planet flags into a single dword: the low half is
+    // availability, the high half selectability. K2 additionally records how
+    // many planets the map carries, which bounds the flags it takes.
+    int maskBits = kPlanetMaskBits;
+    uint32_t numPlanets = 0;
+    if (galaxyMap->readDword(numPlanets, "GlxyMapNumPnts")) {
+        maskBits = std::min<int>(static_cast<int>(numPlanets), kPlanetMaskBits);
+    }
+
+    uint32_t mask = 0;
+    galaxyMap->readDword(mask, "GlxyMapPlntMsk");
+    for (int row = 0; row < std::min(maskBits, rowCount()); ++row) {
+        setAvailable(row, (mask & (1u << row)) != 0);
+        setSelectable(row, (mask & (1u << (row + kPlanetMaskBits))) != 0);
+    }
+
+    int32_t selected = -1;
+    galaxyMap->readInt(selected, "GlxyMapSelPnt");
+    restoreSelectedPlanet(selected);
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -400,6 +400,7 @@ static int getDebugFaction(const std::shared_ptr<Object> &object) {
 
 void Game::init() {
     initConsole();
+    resetGalaxyMap();
     initLocalServices();
     setSceneSurfaces();
     setCursorType(CursorType::Default);
@@ -1013,6 +1014,8 @@ void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
 }
 
 void Game::deserializeParty(resource::Gff &ifoGff) {
+    resetGalaxyMap();
+
     const auto &players = ifoGff.getList("Mod_PlayerList");
     if (players.empty()) {
         return;
@@ -1043,9 +1046,21 @@ void Game::deserializeParty(resource::Gff &ifoGff) {
         _party.setXP(xp);
     }
 
+    deserializeGalaxyMap(*ptGff);
     deserializePartyTable(*ptGff);
     deserializePartyMembers(*ptGff);
     deserializeJournal(*ptGff);
+}
+
+void Game::resetGalaxyMap() {
+    // K1 takes its planet count from content; K2 ignores the table and always
+    // carries sixteen rows.
+    auto planetary = _services.resource.twoDas.get("planetary");
+    _party.galaxyMap().reset(_gameId, planetary ? planetary->getRowCount() : 0);
+}
+
+void Game::deserializeGalaxyMap(resource::Gff &ptGff) {
+    _party.galaxyMap().loadFromPartyTable(ptGff);
 }
 
 void Game::deserializePartyTable(resource::Gff &ptGff) {

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -130,6 +130,7 @@ void Party::reset() {
     _solo = false;
     _gold = 0;
     _xp = 0;
+    _galaxyMap.clear();
     _pazaakDataValid = false;
     _pazaakCardCounts.fill(0);
     _pazaakSideDeck.fill(-1);

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -6059,7 +6059,8 @@ static Variable SetPlanetSelectable(const std::vector<Variable> &args, const Rou
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("SetPlanetSelectable");
+    ctx.game.party().galaxyMap().setSelectable(nPlanet, bSelectable != 0);
+    return {};
 }
 
 static Variable GetPlanetSelectable(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -6069,7 +6070,7 @@ static Variable GetPlanetSelectable(const std::vector<Variable> &args, const Rou
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("GetPlanetSelectable");
+    return Variable::ofInt(ctx.game.party().galaxyMap().selectable(nPlanet) ? 1 : 0);
 }
 
 static Variable SetPlanetAvailable(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -6080,7 +6081,8 @@ static Variable SetPlanetAvailable(const std::vector<Variable> &args, const Rout
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("SetPlanetAvailable");
+    ctx.game.party().galaxyMap().setAvailable(nPlanet, bAvailable != 0);
+    return {};
 }
 
 static Variable GetPlanetAvailable(const std::vector<Variable> &args, const RoutineContext &ctx) {
@@ -6090,12 +6092,12 @@ static Variable GetPlanetAvailable(const std::vector<Variable> &args, const Rout
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("GetPlanetAvailable");
+    return Variable::ofInt(ctx.game.party().galaxyMap().available(nPlanet) ? 1 : 0);
 }
 
 static Variable GetSelectedPlanet(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetSelectedPlanet");
+    return Variable::ofInt(ctx.game.party().galaxyMap().selectedPlanet());
 }
 
 static Variable SoundObjectFadeAndStop(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,8 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/conversation.cpp
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
+    ${TESTS_SOURCE_DIR}/game/galaxymaproutines.cpp
+    ${TESTS_SOURCE_DIR}/game/galaxymapstate.cpp
     ${TESTS_SOURCE_DIR}/game/journal.cpp
     ${TESTS_SOURCE_DIR}/game/messagebus.cpp
     ${TESTS_SOURCE_DIR}/game/minigame.cpp

--- a/test/game/galaxymaproutines.cpp
+++ b/test/game/galaxymaproutines.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "reone/game/game.h"
+#include "reone/game/party.h"
+#include "reone/game/script/routines.h"
+#include "reone/resource/types.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/variable.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace reone::script;
+
+namespace {
+
+/**
+ * A game plus the routine table it is bound to, so a galaxy map routine can be
+ * called the way a compiled script calls it.
+ */
+class RoutineHarness : boost::noncopyable {
+public:
+    RoutineHarness(GameID gameId, int contentRowCount) :
+        _game(gameId, "", testEngine().options(), testEngine().services(), _console),
+        _routines(gameId, &_game, &testEngine().services()) {
+
+        _routines.init();
+        _game.party().galaxyMap().reset(gameId, contentRowCount);
+    }
+
+    Variable call(const std::string &name, std::vector<Variable> args) {
+        Routine &routine = _routines.get(_routines.getIndexByName(name));
+        ExecutionContext execution;
+        execution.routines = &_routines;
+        return routine.invoke(args, execution);
+    }
+
+    GalaxyMapState &galaxyMap() { return _game.party().galaxyMap(); }
+
+private:
+    StubConsole _console;
+    Game _game;
+    Routines _routines;
+};
+
+int callGetInt(RoutineHarness &harness, const std::string &name, int planet) {
+    return harness.call(name, {Variable::ofInt(planet)}).intValue;
+}
+
+void callSet(RoutineHarness &harness, const std::string &name, int planet, int value) {
+    harness.call(name, {Variable::ofInt(planet), Variable::ofInt(value)});
+}
+
+class GalaxyMapRoutines : public ::testing::TestWithParam<GameID> {};
+
+} // namespace
+
+TEST_P(GalaxyMapRoutines, set_and_get_planet_available_round_trip) {
+    RoutineHarness harness(GetParam(), 16);
+
+    callSet(harness, "SetPlanetAvailable", 3, 1);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 3));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetAvailable", 4));
+
+    callSet(harness, "SetPlanetAvailable", 3, 0);
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetAvailable", 3));
+}
+
+TEST_P(GalaxyMapRoutines, set_and_get_planet_selectable_round_trip) {
+    RoutineHarness harness(GetParam(), 16);
+
+    callSet(harness, "SetPlanetSelectable", 3, 1);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetSelectable", 3));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetSelectable", 4));
+
+    callSet(harness, "SetPlanetSelectable", 3, 0);
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetSelectable", 3));
+}
+
+TEST_P(GalaxyMapRoutines, boolean_setters_canonicalize_any_non_zero_value) {
+    RoutineHarness harness(GetParam(), 16);
+
+    callSet(harness, "SetPlanetAvailable", 2, 7);
+    callSet(harness, "SetPlanetSelectable", 2, -3);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 2));
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetSelectable", 2));
+}
+
+TEST_P(GalaxyMapRoutines, availability_and_selectability_are_set_independently) {
+    RoutineHarness harness(GetParam(), 16);
+
+    callSet(harness, "SetPlanetAvailable", 6, 1);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 6));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetSelectable", 6));
+}
+
+TEST_P(GalaxyMapRoutines, get_selected_planet_is_none_until_one_is_selected) {
+    RoutineHarness harness(GetParam(), 16);
+
+    EXPECT_EQ(-1, harness.call("GetSelectedPlanet", {}).intValue);
+
+    harness.galaxyMap().setAvailable(8, true);
+    ASSERT_TRUE(harness.galaxyMap().trySelectPlanet(8));
+
+    EXPECT_EQ(8, harness.call("GetSelectedPlanet", {}).intValue);
+}
+
+TEST_P(GalaxyMapRoutines, rows_zero_and_fifteen_are_valid) {
+    RoutineHarness harness(GetParam(), 16);
+
+    callSet(harness, "SetPlanetAvailable", 0, 1);
+    callSet(harness, "SetPlanetAvailable", 15, 1);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 0));
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 15));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothGames,
+    GalaxyMapRoutines,
+    ::testing::Values(GameID::KotOR, GameID::TSL),
+    [](const ::testing::TestParamInfo<GameID> &info) {
+        return info.param == GameID::TSL ? "TSL" : "KotOR";
+    });
+
+TEST(GalaxyMapRoutinesTSL, rows_outside_zero_to_fifteen_are_rejected) {
+    RoutineHarness harness(GameID::TSL, 16);
+
+    callSet(harness, "SetPlanetAvailable", -1, 1);
+    callSet(harness, "SetPlanetAvailable", 16, 1);
+    callSet(harness, "SetPlanetSelectable", -1, 1);
+    callSet(harness, "SetPlanetSelectable", 16, 1);
+
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetAvailable", -1));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetAvailable", 16));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetSelectable", -1));
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetSelectable", 16));
+}
+
+TEST(GalaxyMapRoutinesKotOR, rows_above_fifteen_work_when_content_defines_them) {
+    RoutineHarness harness(GameID::KotOR, 24);
+
+    callSet(harness, "SetPlanetAvailable", 20, 1);
+    callSet(harness, "SetPlanetSelectable", 20, 1);
+
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetAvailable", 20));
+    EXPECT_EQ(1, callGetInt(harness, "GetPlanetSelectable", 20));
+
+    // And a row content does not define is still rejected.
+    callSet(harness, "SetPlanetAvailable", 24, 1);
+    EXPECT_EQ(0, callGetInt(harness, "GetPlanetAvailable", 24));
+}

--- a/test/game/galaxymapstate.cpp
+++ b/test/game/galaxymapstate.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/game/galaxymapstate.h"
+#include "reone/resource/gff.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+
+namespace {
+
+/** A PARTYTABLE carrying a GalaxyMap struct built from the given fields. */
+std::shared_ptr<Gff> newPartyTable(std::vector<Gff::Field> galaxyMapFields) {
+    auto galaxyMap = std::make_shared<Gff>(0, std::move(galaxyMapFields));
+    return std::make_shared<Gff>(
+        0xffffffff,
+        std::vector<Gff::Field> {
+            Gff::Field::newStruct("GlxyMap", std::move(galaxyMap))});
+}
+
+/** Legacy planet mask: low half availability, high half selectability. */
+uint32_t planetMask(std::initializer_list<int> available, std::initializer_list<int> selectable) {
+    uint32_t mask = 0;
+    for (int row : available) {
+        mask |= 1u << row;
+    }
+    for (int row : selectable) {
+        mask |= 1u << (row + 16);
+    }
+    return mask;
+}
+
+} // namespace
+
+TEST(GalaxyMapState, k1_sizes_its_planet_list_from_content) {
+    GalaxyMapState state;
+    state.reset(GameID::KotOR, 8);
+
+    EXPECT_EQ(8, state.rowCount());
+}
+
+TEST(GalaxyMapState, k1_keeps_rows_above_fifteen_when_content_defines_them) {
+    GalaxyMapState state;
+    state.reset(GameID::KotOR, 24);
+    ASSERT_EQ(24, state.rowCount());
+
+    state.setAvailable(16, true);
+    state.setSelectable(23, true);
+
+    EXPECT_TRUE(state.available(16));
+    EXPECT_TRUE(state.selectable(23));
+    EXPECT_TRUE(state.trySelectPlanet(16));
+    EXPECT_EQ(16, state.selectedPlanet());
+}
+
+TEST(GalaxyMapState, k1_rejects_rows_content_does_not_define) {
+    GalaxyMapState state;
+    state.reset(GameID::KotOR, 3);
+
+    state.setAvailable(3, true);
+    state.setSelectable(3, true);
+
+    EXPECT_FALSE(state.available(3));
+    EXPECT_FALSE(state.selectable(3));
+}
+
+TEST(GalaxyMapState, k2_always_carries_sixteen_rows) {
+    GalaxyMapState state;
+
+    state.reset(GameID::TSL, 3);
+    EXPECT_EQ(16, state.rowCount());
+
+    state.reset(GameID::TSL, 40);
+    EXPECT_EQ(16, state.rowCount());
+
+    state.reset(GameID::TSL, -1);
+    EXPECT_EQ(16, state.rowCount());
+}
+
+TEST(GalaxyMapState, k2_treats_zero_and_fifteen_as_valid_rows) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+
+    state.setAvailable(0, true);
+    state.setAvailable(15, true);
+    state.setSelectable(0, true);
+    state.setSelectable(15, true);
+
+    EXPECT_TRUE(state.available(0));
+    EXPECT_TRUE(state.available(15));
+    EXPECT_TRUE(state.selectable(0));
+    EXPECT_TRUE(state.selectable(15));
+}
+
+TEST(GalaxyMapState, k2_invalid_setters_do_nothing_and_invalid_getters_are_false) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+
+    state.setAvailable(-1, true);
+    state.setAvailable(16, true);
+    state.setSelectable(-1, true);
+    state.setSelectable(16, true);
+
+    EXPECT_FALSE(state.available(-1));
+    EXPECT_FALSE(state.available(16));
+    EXPECT_FALSE(state.selectable(-1));
+    EXPECT_FALSE(state.selectable(16));
+}
+
+TEST(GalaxyMapState, availability_and_selectability_are_independent) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+
+    state.setAvailable(4, true);
+    EXPECT_TRUE(state.available(4));
+    EXPECT_FALSE(state.selectable(4));
+
+    state.setSelectable(5, true);
+    EXPECT_FALSE(state.available(5));
+    EXPECT_TRUE(state.selectable(5));
+}
+
+TEST(GalaxyMapState, selection_follows_availability_alone) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    state.setAvailable(2, true);
+
+    // Available but not selectable is still a selection the map can make.
+    EXPECT_TRUE(state.trySelectPlanet(2));
+    EXPECT_EQ(2, state.selectedPlanet());
+}
+
+TEST(GalaxyMapState, a_failed_selection_leaves_the_previous_one_in_place) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    state.setAvailable(3, true);
+    state.setSelectable(7, true);
+    ASSERT_TRUE(state.trySelectPlanet(3));
+
+    // Unavailable, merely selectable, and out of range rows all fail alike.
+    EXPECT_FALSE(state.trySelectPlanet(7));
+    EXPECT_FALSE(state.trySelectPlanet(9));
+    EXPECT_FALSE(state.trySelectPlanet(-1));
+    EXPECT_FALSE(state.trySelectPlanet(16));
+
+    EXPECT_EQ(3, state.selectedPlanet());
+}
+
+TEST(GalaxyMapState, nothing_is_selected_by_default) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapState, a_reset_drops_planet_state_and_the_selection) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    state.setAvailable(1, true);
+    state.setSelectable(1, true);
+    ASSERT_TRUE(state.trySelectPlanet(1));
+
+    state.reset(GameID::TSL, 0);
+
+    EXPECT_FALSE(state.available(1));
+    EXPECT_FALSE(state.selectable(1));
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, mask_bits_map_to_availability_and_selectability) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    auto ptGff = newPartyTable({
+        Gff::Field::newDword("GlxyMapPlntMsk", planetMask({0, 5, 15}, {5, 15})),
+        Gff::Field::newInt("GlxyMapSelPnt", 5)});
+
+    state.loadFromPartyTable(*ptGff);
+
+    EXPECT_TRUE(state.available(0));
+    EXPECT_TRUE(state.available(5));
+    EXPECT_TRUE(state.available(15));
+    EXPECT_FALSE(state.available(1));
+
+    EXPECT_FALSE(state.selectable(0));
+    EXPECT_TRUE(state.selectable(5));
+    EXPECT_TRUE(state.selectable(15));
+
+    EXPECT_EQ(5, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, a_missing_galaxy_map_struct_leaves_safe_defaults) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    Gff ptGff(0xffffffff, std::vector<Gff::Field> {Gff::Field::newDword("PT_GOLD", 100)});
+
+    state.loadFromPartyTable(ptGff);
+
+    for (int row = 0; row < 16; ++row) {
+        EXPECT_FALSE(state.available(row)) << "row " << row;
+        EXPECT_FALSE(state.selectable(row)) << "row " << row;
+    }
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, missing_fields_leave_safe_defaults) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    auto ptGff = newPartyTable({});
+
+    state.loadFromPartyTable(*ptGff);
+
+    for (int row = 0; row < 16; ++row) {
+        EXPECT_FALSE(state.available(row)) << "row " << row;
+        EXPECT_FALSE(state.selectable(row)) << "row " << row;
+    }
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, a_selected_planet_outside_the_row_range_falls_back_to_none) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    auto ptGff = newPartyTable({
+        Gff::Field::newDword("GlxyMapPlntMsk", planetMask({0}, {0})),
+        Gff::Field::newInt("GlxyMapSelPnt", 40)});
+
+    state.loadFromPartyTable(*ptGff);
+
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, k2_planet_count_bounds_the_flags_taken_from_the_mask) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    auto ptGff = newPartyTable({
+        Gff::Field::newDword("GlxyMapNumPnts", 3),
+        Gff::Field::newDword("GlxyMapPlntMsk", planetMask({1, 9}, {1, 9})),
+        Gff::Field::newInt("GlxyMapSelPnt", 1)});
+
+    state.loadFromPartyTable(*ptGff);
+
+    EXPECT_TRUE(state.available(1));
+    EXPECT_FALSE(state.available(9));
+    EXPECT_FALSE(state.selectable(9));
+    EXPECT_EQ(1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, k1_takes_mask_flags_for_the_rows_content_defines) {
+    GalaxyMapState state;
+    state.reset(GameID::KotOR, 20);
+    auto ptGff = newPartyTable({
+        Gff::Field::newDword("GlxyMapPlntMsk", planetMask({0, 15}, {15})),
+        Gff::Field::newInt("GlxyMapSelPnt", 15)});
+
+    state.loadFromPartyTable(*ptGff);
+
+    EXPECT_TRUE(state.available(0));
+    EXPECT_TRUE(state.available(15));
+    EXPECT_TRUE(state.selectable(15));
+    // Rows beyond the legacy mask stay untouched, and remain settable content.
+    EXPECT_FALSE(state.available(16));
+    state.setAvailable(16, true);
+    EXPECT_TRUE(state.available(16));
+    EXPECT_EQ(15, state.selectedPlanet());
+}
+
+TEST(GalaxyMapState, a_clear_drops_planet_state_but_keeps_the_row_count) {
+    GalaxyMapState state;
+    state.reset(GameID::KotOR, 24);
+    state.setAvailable(20, true);
+    state.setSelectable(20, true);
+    ASSERT_TRUE(state.trySelectPlanet(20));
+
+    state.clear();
+
+    EXPECT_EQ(24, state.rowCount());
+    EXPECT_FALSE(state.available(20));
+    EXPECT_FALSE(state.selectable(20));
+    EXPECT_EQ(-1, state.selectedPlanet());
+}
+
+TEST(GalaxyMapStateLoad, a_full_planet_count_takes_the_whole_mask) {
+    GalaxyMapState state;
+    state.reset(GameID::TSL, 0);
+    // Both titles write the count as a dword, and both write sixteen.
+    auto ptGff = newPartyTable({
+        Gff::Field::newDword("GlxyMapNumPnts", 16),
+        Gff::Field::newDword("GlxyMapPlntMsk", planetMask({3, 15}, {15})),
+        Gff::Field::newInt("GlxyMapSelPnt", 15)});
+
+    state.loadFromPartyTable(*ptGff);
+
+    EXPECT_TRUE(state.available(3));
+    EXPECT_TRUE(state.available(15));
+    EXPECT_FALSE(state.selectable(3));
+    EXPECT_TRUE(state.selectable(15));
+    EXPECT_EQ(15, state.selectedPlanet());
+}


### PR DESCRIPTION
## Summary

Adds Galaxy Map state to `Party` and implements routines 740–744.

- Tracks per-planet availability/selectability and the selected destination.
- K1 sizes state from `planetary.2da`, including rows above 15.
- K2 uses the fixed 16-row contract.
- Loads the legacy `GlxyMap` PARTYTABLE state.
- Selection requires availability only; failed selection preserves the previous row.

`ShowGalaxyMap` (739) remains unimplemented and the GUI comes separately.

## Persistence

`GlxyMapPlntMsk` packs availability in bits 0–15 and selectability in 16–31. Missing state/fields default safely to unavailable/unselectable with no planet selected.

This is load-only; Reone still has no PARTYTABLE writer.

## Testing

Covers both row policies, flag independence, selection behavior, mask decoding/defaults, and routines 740–744 for K1/K2.
