### PR TITLE
[game] Validate CloseDoor target

### DIFF
--- a/include/reone/game/action/closedoor.h
+++ b/include/reone/game/action/closedoor.h
@@ -23,11 +23,13 @@ namespace reone {
 
 namespace game {
 
+class Door;
+
 class CloseDoorAction : public Action {
 public:
     CloseDoorAction(Game &game,
                     ServicesView &services,
-                    std::shared_ptr<Object> door) :
+                    std::shared_ptr<Door> door) :
         Action(game, services, ActionType::CloseDoor),
         _door(std::move(door)) {
     }
@@ -39,7 +41,7 @@ public:
     void execute(std::shared_ptr<Action> self, Object &actor, float dt) override;
 
 private:
-    std::shared_ptr<Object> _door;
+    std::shared_ptr<Door> _door;
 };
 
 } // namespace game

--- a/src/libs/game/action/closedoor.cpp
+++ b/src/libs/game/action/closedoor.cpp
@@ -27,11 +27,10 @@ namespace game {
 
 void CloseDoorAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     auto creatureActor = _game.getObjectById<Creature>(actor.id());
-    auto door = std::dynamic_pointer_cast<Door>(_door);
 
-    bool reached = !creatureActor || creatureActor->navigateTo(door->position(), true, kDefaultMaxObjectDistance, dt);
+    bool reached = !creatureActor || creatureActor->navigateTo(_door->position(), true, kDefaultMaxObjectDistance, dt);
     if (reached) {
-        door->close();
+        _door->close();
         complete();
     }
 }

--- a/src/libs/game/script/routine/impl/action.cpp
+++ b/src/libs/game/script/routine/impl/action.cpp
@@ -258,9 +258,10 @@ static Variable ActionCloseDoor(const std::vector<Variable> &args, const Routine
     auto oDoor = getObject(args, 0, ctx);
 
     // Transform
+    auto door = checkDoor(oDoor);
 
     // Execute
-    auto action = ctx.game.newAction<CloseDoorAction>(std::move(oDoor));
+    auto action = ctx.game.newAction<CloseDoorAction>(std::move(door));
     getCaller(ctx)->addAction(std::move(action));
     return Variable::ofNull();
 }

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -4096,3 +4096,116 @@ TEST(RemoveHeartbeat, is_not_registered_for_kotor_one) {
     k2.init();
     EXPECT_EQ("RemoveHeartbeat", k2.get(kRemoveHeartbeatRoutine).name());
 }
+
+
+namespace {
+
+// Door action routine numbers, registered for both games.
+constexpr int kActionOpenDoor = 43;
+constexpr int kActionCloseDoor = 44;
+
+// Invoke a door action routine the way a script does: by number, with the
+// caller the engine would have supplied.
+script::Variable invokeDoorRoutine(
+    Routines &routines,
+    int routine,
+    const std::shared_ptr<Object> &caller,
+    const std::shared_ptr<Object> &target) {
+
+    script::ExecutionContext ctx;
+    ctx.args.emplace_back(script::ArgKind::Caller, script::Variable::ofObject(caller->id()));
+    return routines.get(routine).invoke({script::Variable::ofObject(target->id())}, ctx);
+}
+
+struct DoorTargetFixture {
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game {GameID::KotOR, "", engine.options(), engine.services(), console};
+    Routines routines {GameID::KotOR, &game, &engine.services()};
+
+    DoorTargetFixture() {
+        testSceneGraph(engine);
+        routines.init();
+    }
+};
+
+} // namespace
+
+// A non-door target is rejected by argument validation, so nothing is queued on
+// the caller. ActionCloseDoor takes a generic object in nwscript, so a script
+// can name anything at all here.
+TEST(CloseDoorTarget, should_reject_a_non_door_target) {
+    DoorTargetFixture fixture;
+    auto caller = makeMovingCreature(fixture.game, fixture.engine);
+    auto notADoor = fixture.game.newPlaceable();
+
+    auto result = invokeDoorRoutine(fixture.routines, kActionCloseDoor, caller, notADoor);
+
+    EXPECT_EQ(script::VariableType::Void, result.type);
+    EXPECT_TRUE(caller->actions().empty());
+}
+
+// The same rejection for a caller that is not a creature. Without validation
+// this is the path that skipped the approach and went straight to closing the
+// target, so it has to be covered separately from the creature case.
+TEST(CloseDoorTarget, should_reject_a_non_door_target_for_a_non_creature_caller) {
+    DoorTargetFixture fixture;
+    auto caller = fixture.game.newPlaceable();
+    auto notADoor = fixture.game.newPlaceable();
+
+    invokeDoorRoutine(fixture.routines, kActionCloseDoor, caller, notADoor);
+
+    EXPECT_TRUE(caller->actions().empty());
+}
+
+// A real door is queued and closed as before.
+TEST(CloseDoorTarget, should_close_a_door_the_actor_has_reached) {
+    DoorTargetFixture fixture;
+    auto door = makePlainDoor(fixture.game, fixture.engine);
+    auto caller = makeMovingCreature(fixture.game, fixture.engine);
+    door->open();
+    ASSERT_TRUE(door->isOpen());
+
+    invokeDoorRoutine(fixture.routines, kActionCloseDoor, caller, door);
+    ASSERT_EQ(1u, caller->actions().size());
+    auto action = caller->actions().front();
+
+    action->execute(action, *caller, 1.0f);
+
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_FALSE(door->isOpen());
+    EXPECT_EQ(DoorState::Closed, door->state());
+}
+
+// Out of range the action stays in progress and the door is left alone, which
+// is what separates an honored action from a dropped one.
+TEST(CloseDoorTarget, should_keep_approaching_a_door_that_is_out_of_reach) {
+    DoorTargetFixture fixture;
+    auto door = makePlainDoor(fixture.game, fixture.engine, /*locked=*/false, /*onOpen=*/"",
+                              glm::vec3(50.0f, 0.0f, 0.0f));
+    auto caller = makeMovingCreature(fixture.game, fixture.engine);
+    caller->setMovementRestricted(true);
+    door->open();
+
+    invokeDoorRoutine(fixture.routines, kActionCloseDoor, caller, door);
+    ASSERT_EQ(1u, caller->actions().size());
+    auto action = caller->actions().front();
+
+    action->execute(action, *caller, 1.0f);
+
+    EXPECT_FALSE(action->isCompleted());
+    EXPECT_TRUE(door->isOpen());
+}
+
+// Both door routines apply the same validation to the same bad target.
+TEST(CloseDoorTarget, opens_and_closes_reject_a_non_door_target_alike) {
+    DoorTargetFixture fixture;
+    auto caller = makeMovingCreature(fixture.game, fixture.engine);
+    auto notADoor = fixture.game.newPlaceable();
+
+    invokeDoorRoutine(fixture.routines, kActionOpenDoor, caller, notADoor);
+    EXPECT_TRUE(caller->actions().empty());
+
+    invokeDoorRoutine(fixture.routines, kActionCloseDoor, caller, notADoor);
+    EXPECT_TRUE(caller->actions().empty());
+}


### PR DESCRIPTION
## Summary

Validates the target of `ActionCloseDoor` before queueing the action.

Unlike `ActionOpenDoor`, the close-door routine accepted any object and only cast it to `Door` during execution. Passing an existing non-door object therefore left a null `Door` pointer that was later dereferenced — through `door->position()` for a creature actor, and through `door->close()` for any other actor.

`ActionCloseDoor` now uses the same `checkDoor` validation as `ActionOpenDoor`, and `CloseDoorAction` stores a typed door target, so the cast disappears and an invalid target is no longer representable once the action exists. Rejection reuses the existing routine argument handling, which logs a script warning and returns the default void value.

## Validation

- Wrong-type targets are rejected without queueing, for both creature and non-creature callers.
- Valid door closing behaviour is unchanged: an actor in range closes the door and the action completes, while an actor still approaching keeps the action active and leaves the door alone.
- `ActionOpenDoor` and `ActionCloseDoor` are checked to reject the same non-door target alike.
- Discrimination: restoring the previous behaviour reproduces the failure — the bad target is queued, and executing it faults with an access violation on both actor paths.
- Broader suite: 1068 passing vs 1063 on the same baseline (+5 tests).

Existing `ArrayRef` / `TextBuffer` MSVC debug-STL failures reproduce on the unchanged baseline and were excluded from both runs.