### PR TITLE
[game] Implement the K1 Galaxy Map

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -37,6 +37,7 @@
 #include "gui/container.h"
 #include "gui/conversation.h"
 #include "gui/dialog.h"
+#include "gui/galaxymap.h"
 #include "gui/hud.h"
 #include "gui/ingame.h"
 #include "gui/loadscreen.h"
@@ -125,6 +126,7 @@ public:
         Container,
         PartySelection,
         SaveLoad,
+        GalaxyMap,
         SwoopRace,
         PazaakWager,
         PazaakSetup,
@@ -233,6 +235,7 @@ public:
     void openContainer(const std::shared_ptr<Object> &container);
     void openPartySelection(const PartySelectionContext &ctx);
     void openSaveLoad(SaveLoadMode mode);
+    void openGalaxyMap(int initialPlanet);
 
     // KotOR I Pazaak lifecycle
 
@@ -680,6 +683,7 @@ private:
     std::unique_ptr<ContainerGUI> _container;
     std::unique_ptr<PartySelection> _partySelect;
     std::unique_ptr<SaveLoad> _saveLoad;
+    std::unique_ptr<GalaxyMap> _galaxyMap;
     std::unique_ptr<PazaakWagerGUI> _pazaakWager;
     std::unique_ptr<PazaakSetupGUI> _pazaakSetup;
     std::unique_ptr<PazaakBoardGUI> _pazaakBoard;

--- a/include/reone/game/gui/galaxymap.h
+++ b/include/reone/game/gui/galaxymap.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "../gui.h"
+
+namespace reone {
+
+namespace resource {
+class TwoDA;
+}
+
+namespace gui {
+
+class Button;
+class Label;
+
+} // namespace gui
+
+namespace scene {
+
+class ISceneGraph;
+class ModelSceneNode;
+
+} // namespace scene
+
+namespace game {
+
+class GalaxyMapTestAccess;
+
+/**
+ * The galaxy map panel: the party picks its next destination here, and
+ * accepting one hands over to the travel script.
+ *
+ * Everything the panel shows comes from planetary.2da. A row names the GUI
+ * control that stands for the planet, the strings describing it, and the model
+ * shown in the lower preview.
+ */
+class GalaxyMap : public GameGUI {
+public:
+    GalaxyMap(Game &game, ServicesView &services) :
+        GameGUI(game, services) {
+        _resRef = "galaxymap";
+    }
+
+    /** Bring the panel in line with the current planet state before it opens. */
+    void prepare();
+
+    bool handle(const input::Event &event) override;
+
+private:
+    friend class GalaxyMapTestAccess;
+
+    std::shared_ptr<resource::TwoDA> _planetary;
+
+    std::shared_ptr<gui::Button> _accept;
+    std::shared_ptr<gui::Button> _back;
+    std::shared_ptr<gui::Label> _name;
+    std::shared_ptr<gui::Label> _description;
+    std::shared_ptr<gui::Label> _galaxyDisplay;
+    std::shared_ptr<gui::Label> _planetDisplay;
+
+    /** Planet control per planetary.2da row, for the rows the panel authors one. */
+    std::map<int, std::shared_ptr<gui::Button>> _planetControls;
+
+    std::shared_ptr<scene::ModelSceneNode> _galaxyModelNode;
+    std::shared_ptr<scene::ModelSceneNode> _planetModelNode;
+    /** Preview models are kept once loaded, so revisiting a planet is free. */
+    std::map<std::string, std::shared_ptr<scene::ModelSceneNode>> _planetModelNodes;
+    std::string _planetModelResRef;
+
+    int _hoveredPlanet {-1};
+    bool _accepting {false};
+
+    void onGUILoaded() override;
+    void onSelectionChanged(const std::string &control, bool selected) override;
+
+    void bindPlanetControls();
+    void setupGalaxyDisplay();
+    std::shared_ptr<scene::ModelSceneNode> getGalaxyModel(scene::ISceneGraph &sceneGraph);
+
+    std::string planetModelResRef(int row) const;
+    void refreshPlanetModel(int row);
+    void showPlanetPreview(scene::ModelSceneNode &node);
+    void detachCameras(scene::ModelSceneNode &model);
+
+    bool isTravelDestination(int row) const;
+
+    void select(int row);
+    void refreshPresentation();
+    void updatePlanetControlPresentation();
+
+    void close();
+    void accept();
+};
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -209,6 +209,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/container.h
     ${GAME_INCLUDE_DIR}/gui/conversation.h
     ${GAME_INCLUDE_DIR}/gui/dialog.h
+    ${GAME_INCLUDE_DIR}/gui/galaxymap.h
     ${GAME_INCLUDE_DIR}/gui/generated/areatrans.h
     ${GAME_INCLUDE_DIR}/gui/generated/areatransition.h
     ${GAME_INCLUDE_DIR}/gui/generated/chemical.h
@@ -501,6 +502,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/container.cpp
     ${GAME_SOURCE_DIR}/gui/conversation.cpp
     ${GAME_SOURCE_DIR}/gui/dialog.cpp
+    ${GAME_SOURCE_DIR}/gui/galaxymap.cpp
     ${GAME_SOURCE_DIR}/gui/hud.cpp
     ${GAME_SOURCE_DIR}/gui/ingame/abilities.cpp
     ${GAME_SOURCE_DIR}/gui/ingame/character.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -197,6 +197,8 @@ static const char *screenName(Game::Screen screen) {
         return "PartySelection";
     case Game::Screen::SaveLoad:
         return "SaveLoad";
+    case Game::Screen::GalaxyMap:
+        return "GalaxyMap";
     case Game::Screen::SwoopRace:
         return "SwoopRace";
     case Game::Screen::PazaakWager:
@@ -3535,6 +3537,26 @@ void Game::openSaveLoad(SaveLoadMode mode) {
     changeScreen(Screen::SaveLoad);
 }
 
+void Game::openGalaxyMap(int initialPlanet) {
+    if (_screen == Screen::GalaxyMap) {
+        return;
+    }
+    if (!_galaxyMap) {
+        _galaxyMap = tryLoadGUI<GalaxyMap>();
+    }
+    if (!_galaxyMap) {
+        // A panel that will not load must not take the screen away from
+        // whatever is on it.
+        return;
+    }
+    _party.galaxyMap().trySelectPlanet(initialPlanet);
+    stopMovement();
+    setRelativeMouseMode(false);
+    setCursorType(CursorType::Default);
+    _galaxyMap->prepare();
+    changeScreen(Screen::GalaxyMap);
+}
+
 void Game::serializePazaakPartyTable(resource::Gff &ptGff) const {
     auto replaceField = [&ptGff](resource::Gff::Field replacement) {
         auto &fields = ptGff.fields();
@@ -4074,6 +4096,8 @@ GameGUI *Game::getScreenGUI() const {
         return _partySelect.get();
     case Screen::SaveLoad:
         return _saveLoad.get();
+    case Screen::GalaxyMap:
+        return _galaxyMap.get();
     case Screen::SwoopRace:
         return nullptr; // race skeleton has no HUD yet
     case Screen::PazaakWager:

--- a/src/libs/game/gui/galaxymap.cpp
+++ b/src/libs/game/gui/galaxymap.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2020-2023 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/gui/galaxymap.h"
+
+#include "reone/game/di/services.h"
+#include "reone/game/game.h"
+#include "reone/game/party.h"
+#include "reone/game/script/runner.h"
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/label.h"
+#include "reone/gui/sceneinitializer.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/di/services.h"
+#include "reone/resource/provider/2das.h"
+#include "reone/resource/provider/models.h"
+#include "reone/resource/strings.h"
+#include "reone/scene/di/services.h"
+#include "reone/scene/graph.h"
+#include "reone/scene/graphs.h"
+#include "reone/scene/node/model.h"
+#include "reone/system/logutil.h"
+
+namespace reone {
+
+namespace game {
+
+static constexpr char kSceneGalaxy[] = "galaxymap.galaxy";
+static constexpr char kScenePlanet[] = "galaxymap.planet";
+
+static constexpr char kGalaxyModelResRef[] = "galaxy";
+static constexpr char kCameraHookNodeName[] = "camerahook";
+
+// The panel's two displays are authored as perspective views through the
+// camerahook of their own model, not as flat previews.
+static constexpr float kDisplayVerticalFov = glm::radians(22.7259998f);
+static constexpr float kDisplayClipPlaneNear = 0.1f;
+static constexpr float kDisplayClipPlaneFar = 10000.0f;
+
+/** One-shot intro the preview model plays whenever it becomes the destination. */
+static constexpr char kPreviewAnimation[] = "zoomin";
+
+static constexpr char kTravelScript[] = "k_sup_galaxymap";
+
+void GalaxyMap::onGUILoaded() {
+    _accept = findControl<gui::Button>("BTN_ACCEPT");
+    _back = findControl<gui::Button>("BTN_BACK");
+    _name = findControl<gui::Label>("LBL_PLANETNAME");
+    _description = findControl<gui::Label>("LBL_DESC");
+    _galaxyDisplay = findControl<gui::Label>("3D_PlanetDisplay");
+    _planetDisplay = findControl<gui::Label>("3D_PlanetModel");
+
+    if (_accept) {
+        _accept->setOnClick([this]() { accept(); });
+    }
+    if (_back) {
+        _back->setOnClick([this]() { close(); });
+    }
+    if (_planetDisplay) {
+        // The display control authors placeholder text the preview replaces.
+        _planetDisplay->setTextMessage("");
+        _services.scene.graphs.reserve(kScenePlanet);
+    }
+
+    _planetary = _services.resource.twoDas.get("planetary");
+    bindPlanetControls();
+    setupGalaxyDisplay();
+}
+
+void GalaxyMap::bindPlanetControls() {
+    if (!_planetary) {
+        return;
+    }
+    // A planetary row that names no control, or names one this panel does not
+    // author, simply has no destination on the map.
+    for (int row = 0; row < _planetary->getRowCount(); ++row) {
+        auto tag = _planetary->getString(row, "guitag");
+        if (tag.empty()) {
+            continue;
+        }
+        auto control = std::dynamic_pointer_cast<gui::Button>(_gui->findControl(tag));
+        if (!control) {
+            continue;
+        }
+        _planetControls.emplace(row, control);
+        control->setOnClick([this, row]() { select(row); });
+    }
+}
+
+void GalaxyMap::setupGalaxyDisplay() {
+    if (!_galaxyDisplay) {
+        return;
+    }
+    _services.scene.graphs.reserve(kSceneGalaxy);
+    auto &sceneGraph = _services.scene.graphs.get(kSceneGalaxy);
+    const auto &extent = _galaxyDisplay->extent();
+    float aspect = extent.width / static_cast<float>(extent.height);
+    gui::SceneInitializer(sceneGraph)
+        .aspect(aspect)
+        .depth(kDisplayClipPlaneNear, kDisplayClipPlaneFar)
+        .perspective(kDisplayVerticalFov)
+        // The galaxy is a continuous field the player is dropped straight into,
+        // so it opens already populated rather than filling in over its
+        // particles' lifetimes.
+        .prewarmEmitters()
+        .modelSupplier(std::bind(&GalaxyMap::getGalaxyModel, this, std::placeholders::_1))
+        .cameraFromModelNode(kCameraHookNodeName)
+        .invoke();
+    if (_galaxyModelNode) {
+        _galaxyDisplay->setSceneName(kSceneGalaxy);
+    }
+}
+
+std::shared_ptr<scene::ModelSceneNode> GalaxyMap::getGalaxyModel(scene::ISceneGraph &sceneGraph) {
+    auto model = _services.resource.models.get(kGalaxyModelResRef);
+    if (!model) {
+        return nullptr;
+    }
+    _galaxyModelNode = sceneGraph.newModel(*model, scene::ModelUsage::GUI);
+    return _galaxyModelNode;
+}
+
+void GalaxyMap::prepare() {
+    _accepting = false;
+    _hoveredPlanet = -1;
+    for (auto &[row, control] : _planetControls) {
+        bool available = _game.party().galaxyMap().available(row);
+        control->setVisible(available);
+        control->setDisabled(!available || !_game.party().galaxyMap().selectable(row));
+    }
+    refreshPresentation();
+}
+
+std::string GalaxyMap::planetModelResRef(int row) const {
+    if (!_planetary || row < 0 || row >= _planetary->getRowCount()) {
+        return "";
+    }
+    return _planetary->getString(row, "model");
+}
+
+void GalaxyMap::showPlanetPreview(scene::ModelSceneNode &node) {
+    // The intro is a one-shot animation, so a preview that is already carrying
+    // it has to be told to start over rather than merely asked to play again.
+    if (!node.restartAnimation(kPreviewAnimation)) {
+        node.playAnimation(kPreviewAnimation);
+    }
+}
+
+void GalaxyMap::refreshPlanetModel(int row) {
+    if (!_planetDisplay) {
+        return;
+    }
+
+    auto resRef = planetModelResRef(row);
+    if (_planetModelNode && resRef == _planetModelResRef) {
+        showPlanetPreview(*_planetModelNode);
+        return;
+    }
+
+    _planetModelNode.reset();
+    _planetModelResRef.clear();
+    _planetDisplay->setSceneName("");
+    if (resRef.empty()) {
+        return;
+    }
+
+    auto &sceneGraph = _services.scene.graphs.get(kScenePlanet);
+    auto cached = _planetModelNodes.find(resRef);
+    if (cached != _planetModelNodes.end()) {
+        _planetModelNode = cached->second;
+    } else {
+        auto model = _services.resource.models.get(resRef);
+        if (!model) {
+            return;
+        }
+        _planetModelNode = sceneGraph.newModel(*model, scene::ModelUsage::GUI);
+        _planetModelNodes.emplace(resRef, _planetModelNode);
+    }
+    _planetModelResRef = resRef;
+
+    detachCameras(*_planetModelNode);
+
+    const auto &extent = _planetDisplay->extent();
+    float aspect = extent.width / static_cast<float>(extent.height);
+    auto modelNode = _planetModelNode;
+    gui::SceneInitializer(sceneGraph)
+        .aspect(aspect)
+        .depth(kDisplayClipPlaneNear, kDisplayClipPlaneFar)
+        .perspective(kDisplayVerticalFov)
+        .modelSupplier([modelNode](scene::ISceneGraph &) { return modelNode; })
+        .cameraFromModelNode(kCameraHookNodeName)
+        .invoke();
+
+    showPlanetPreview(*_planetModelNode);
+    _planetDisplay->setSceneName(kScenePlanet);
+}
+
+void GalaxyMap::detachCameras(scene::ModelSceneNode &model) {
+    // Initializing a scene parents its camera to the model's hook, so a preview
+    // taken from the cache is still carrying the camera from the last time it
+    // was shown. Left in place, revisiting a planet would hang another camera
+    // off the same hook every time.
+    auto hook = model.getNodeByName(kCameraHookNodeName);
+    if (!hook) {
+        return;
+    }
+    std::vector<scene::SceneNode *> cameras;
+    for (auto *child : hook->children()) {
+        if (child->type() == scene::SceneNodeType::Camera) {
+            cameras.push_back(child);
+        }
+    }
+    for (auto *camera : cameras) {
+        hook->removeChild(*camera);
+    }
+}
+
+void GalaxyMap::select(int row) {
+    auto &galaxyMap = _game.party().galaxyMap();
+    if (!galaxyMap.selectable(row) || !galaxyMap.trySelectPlanet(row)) {
+        return;
+    }
+    refreshPresentation();
+}
+
+void GalaxyMap::refreshPresentation() {
+    int row = _game.party().galaxyMap().selectedPlanet();
+
+    if (_accept) {
+        _accept->setDisabled(!isTravelDestination(row));
+    }
+    updatePlanetControlPresentation();
+    refreshPlanetModel(row);
+
+    if (!_planetary || row < 0 || row >= _planetary->getRowCount()) {
+        if (_name) {
+            _name->setTextMessage("");
+        }
+        if (_description) {
+            _description->setTextMessage("");
+        }
+        return;
+    }
+    int nameRef = _planetary->getInt(row, "name", -1);
+    int descriptionRef = _planetary->getInt(row, "description", -1);
+    if (_name) {
+        _name->setTextMessage(nameRef >= 0 ? _services.resource.strings.getText(nameRef) : "");
+    }
+    if (_description) {
+        _description->setTextMessage(descriptionRef >= 0 ? _services.resource.strings.getText(descriptionRef) : "");
+    }
+}
+
+bool GalaxyMap::isTravelDestination(int row) const {
+    const auto &galaxyMap = _game.party().galaxyMap();
+    return _planetControls.count(row) > 0 && galaxyMap.available(row) && galaxyMap.selectable(row);
+}
+
+void GalaxyMap::updatePlanetControlPresentation() {
+    int selectedPlanet = _game.party().galaxyMap().selectedPlanet();
+    // The chosen destination keeps the authored HILIGHT state the panel gives a
+    // control under the cursor, so it stays visibly picked while the cursor
+    // wanders over the other planets.
+    for (auto &[row, control] : _planetControls) {
+        control->setSelected(row == selectedPlanet || row == _hoveredPlanet);
+    }
+}
+
+void GalaxyMap::onSelectionChanged(const std::string &control, bool selected) {
+    GameGUI::onSelectionChanged(control, selected);
+
+    auto hovered = std::find_if(_planetControls.begin(), _planetControls.end(), [&control](const auto &entry) {
+        return entry.second->tag() == control;
+    });
+    if (hovered == _planetControls.end()) {
+        return;
+    }
+    if (selected) {
+        _hoveredPlanet = hovered->first;
+    } else if (_hoveredPlanet == hovered->first) {
+        _hoveredPlanet = -1;
+    }
+    updatePlanetControlPresentation();
+}
+
+bool GalaxyMap::handle(const input::Event &event) {
+    if (event.type == input::EventType::KeyDown &&
+        !event.key.repeat &&
+        event.key.code == input::KeyCode::Escape) {
+        close();
+        return true;
+    }
+    return GameGUI::handle(event);
+}
+
+void GalaxyMap::close() {
+    // Leaving the map keeps whatever destination was picked: the selection is
+    // party state, not something this panel owns until it is accepted.
+    _game.openInGame();
+}
+
+void GalaxyMap::accept() {
+    if (_accepting) {
+        return;
+    }
+    int row = _game.party().galaxyMap().selectedPlanet();
+    if (!isTravelDestination(row)) {
+        return;
+    }
+    _accepting = true;
+    close();
+    try {
+        _game.scriptRunner().run(kTravelScript);
+    } catch (const std::exception &e) {
+        error(str(boost::format("Galaxy map: %s failed: %s") % kTravelScript % std::string(e.what())));
+    }
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -6062,7 +6062,8 @@ static Variable ShowGalaxyMap(const std::vector<Variable> &args, const RoutineCo
     // Transform
 
     // Execute
-    throw RoutineNotImplementedException("ShowGalaxyMap");
+    ctx.game.openGalaxyMap(nPlanet);
+    return {};
 }
 
 static Variable SetPlanetSelectable(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/globalnumber.cpp
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
     ${TESTS_SOURCE_DIR}/game/effect.cpp
+    ${TESTS_SOURCE_DIR}/game/galaxymap.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymaproutines.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymapstate.cpp
     ${TESTS_SOURCE_DIR}/game/savedruntime.cpp

--- a/test/game/galaxymap.cpp
+++ b/test/game/galaxymap.cpp
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "reone/game/game.h"
+#include "reone/game/gui/galaxymap.h"
+#include "reone/game/party.h"
+#include "reone/graphics/animation.h"
+#include "reone/graphics/model.h"
+#include "reone/gui/control/button.h"
+#include "reone/gui/control/label.h"
+#include "reone/resource/2da.h"
+#include "reone/scene/graph.h"
+#include "reone/game/script/routines.h"
+#include "reone/scene/node/model.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/variable.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::graphics;
+using namespace reone::resource;
+using namespace reone::scene;
+
+using testing::_;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace reone::game {
+
+/** Reaches the panel internals a running GUI would otherwise have to build. */
+class GalaxyMapTestAccess {
+public:
+    static void setPlanetary(GalaxyMap &map, std::shared_ptr<TwoDA> planetary) {
+        map._planetary = std::move(planetary);
+    }
+
+    static void setPlanetControl(GalaxyMap &map, int row, std::shared_ptr<gui::Button> control) {
+        map._planetControls[row] = std::move(control);
+    }
+
+    static void setPlanetDisplay(GalaxyMap &map, std::shared_ptr<gui::Label> display) {
+        map._planetDisplay = std::move(display);
+    }
+
+    static void setAcceptButton(GalaxyMap &map, std::shared_ptr<gui::Button> accept) {
+        map._accept = std::move(accept);
+    }
+
+    static std::string planetModelResRef(const GalaxyMap &map, int row) {
+        return map.planetModelResRef(row);
+    }
+
+    static const std::shared_ptr<ModelSceneNode> &planetModelNode(const GalaxyMap &map) {
+        return map._planetModelNode;
+    }
+
+    static void select(GalaxyMap &map, int row) { map.select(row); }
+    static void accept(GalaxyMap &map) { map.accept(); }
+    static void refreshPresentation(GalaxyMap &map) { map.refreshPresentation(); }
+    static void updatePlanetControlPresentation(GalaxyMap &map) { map.updatePlanetControlPresentation(); }
+
+    static void selectionChanged(GalaxyMap &map, const std::string &control, bool selected) {
+        map.onSelectionChanged(control, selected);
+    }
+};
+
+} // namespace reone::game
+
+namespace {
+
+constexpr char kTravelScript[] = "k_sup_galaxymap";
+
+/**
+ * A stand-in planetary.2da: a planet with a preview model, one with none, and a
+ * second planet whose preview differs, so model swaps and reuse can be told
+ * apart.
+ */
+std::shared_ptr<TwoDA> newPlanetary() {
+    return TwoDA::Builder()
+        .columns({"label", "name", "description", "model", "guitag"})
+        .row({"Taris", "1", "2", "planet_01", "LBL_Planet_Taris"})
+        .row({"Ebon_Hawk", "3", "", "", ""})
+        .row({"Dantooine", "4", "5", "planet_02", "LBL_Planet_Dantooine"})
+        .build();
+}
+
+/** A model carrying the one-shot preview intro, over one second. */
+std::shared_ptr<Model> newPreviewModel(const std::string &name, bool withCameraHook = false) {
+    auto rootNode = std::make_shared<ModelNode>(
+        0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
+    if (withCameraHook) {
+        auto hook = std::make_shared<ModelNode>(
+            1, "camerahook", glm::vec3(0.0f, -5.0f, 0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
+        rootNode->addChild(hook);
+    }
+    auto animRootNode = std::make_shared<ModelNode>(
+        0, "root_node", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), false, nullptr);
+    animRootNode->vectorTracks()[ControllerTypes::position].add(0.0f, glm::vec3(0.0f));
+    animRootNode->vectorTracks()[ControllerTypes::position].add(1.0f, glm::vec3(4.0f, 0.0f, 0.0f));
+    auto animation = std::make_shared<Animation>(
+        "zoomin", 1.0f, 0.0f, "root_node", animRootNode, std::vector<Animation::Event>());
+    auto model = std::make_shared<Model>(
+        name, 0, rootNode, std::vector<std::shared_ptr<Animation>> {animation}, "", 1.0f);
+    model->init();
+    return model;
+}
+
+/**
+ * A galaxy map hosted on its own engine, so the expectations one test sets on
+ * the resource mocks never reach another.
+ */
+class GalaxyMapFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _engine.init();
+        _game = std::make_unique<Game>(
+            GameID::KotOR, "", _engine.options(), _engine.services(), _console);
+        // Brings up the routine table and the script runner the travel dispatch
+        // goes through.
+        _game->initLocalServices();
+        _map = std::make_unique<GalaxyMap>(*_game, _engine.services());
+        GalaxyMapTestAccess::setPlanetary(*_map, newPlanetary());
+        _game->party().galaxyMap().reset(GameID::KotOR, 3);
+    }
+
+    /** Attach a real scene graph, so previews are real animated scene nodes. */
+    void useRealSceneGraph() {
+        _sceneGraph = std::make_unique<SceneGraph>(
+            "galaxymap.planet",
+            _engine.sceneModule().renderPipelineFactory(),
+            _engine.options().graphics,
+            _engine.graphicsModule().services(),
+            _engine.audioModule().services(),
+            _engine.resourceModule().services());
+        ON_CALL(_engine.sceneModule().graphs(), get(_)).WillByDefault(ReturnRef(*_sceneGraph));
+        EXPECT_CALL(_engine.sceneModule().graphs(), get(_)).Times(testing::AnyNumber());
+    }
+
+    std::shared_ptr<gui::Button> newButton(std::string tag) {
+        auto button = std::make_shared<gui::Button>(
+            _gui,
+            _engine.sceneModule().graphs(),
+            _engine.graphicsModule().services(),
+            _engine.resourceModule().services());
+        button->setTag(std::move(tag));
+        return button;
+    }
+
+    std::shared_ptr<gui::Label> newDisplayLabel() {
+        auto label = std::make_shared<gui::Label>(
+            _gui,
+            _engine.sceneModule().graphs(),
+            _engine.graphicsModule().services(),
+            _engine.resourceModule().services());
+        gui::Control::Extent extent;
+        extent.width = 256;
+        extent.height = 256;
+        label->setExtent(std::move(extent));
+        return label;
+    }
+
+    GalaxyMapState &galaxyMap() { return _game->party().galaxyMap(); }
+
+    TestEngine _engine;
+    StubConsole _console;
+    gui::MockGUI _gui;
+    std::unique_ptr<Game> _game;
+    std::unique_ptr<GalaxyMap> _map;
+    std::unique_ptr<SceneGraph> _sceneGraph;
+};
+
+} // namespace
+
+TEST_F(GalaxyMapFixture, preview_model_comes_from_the_selected_planetary_row) {
+    EXPECT_EQ("planet_01", GalaxyMapTestAccess::planetModelResRef(*_map, 0));
+    EXPECT_EQ("planet_02", GalaxyMapTestAccess::planetModelResRef(*_map, 2));
+}
+
+TEST_F(GalaxyMapFixture, rows_without_a_preview_model_and_rows_off_the_table_have_none) {
+    EXPECT_EQ("", GalaxyMapTestAccess::planetModelResRef(*_map, 1));
+    EXPECT_EQ("", GalaxyMapTestAccess::planetModelResRef(*_map, -1));
+    EXPECT_EQ("", GalaxyMapTestAccess::planetModelResRef(*_map, 3));
+}
+
+TEST_F(GalaxyMapFixture, only_available_destinations_are_shown_and_only_selectable_ones_are_live) {
+    auto taris = newButton("LBL_Planet_Taris");
+    auto dantooine = newButton("LBL_Planet_Dantooine");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+    GalaxyMapTestAccess::setPlanetControl(*_map, 2, dantooine);
+
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    // Available but not a valid destination: shown, but not open to travel.
+    galaxyMap().setAvailable(2, true);
+
+    _map->prepare();
+
+    EXPECT_TRUE(taris->isVisible());
+    EXPECT_FALSE(taris->isDisabled());
+    EXPECT_TRUE(dantooine->isVisible());
+    EXPECT_TRUE(dantooine->isDisabled());
+}
+
+TEST_F(GalaxyMapFixture, a_destination_content_never_made_available_stays_hidden) {
+    auto taris = newButton("LBL_Planet_Taris");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+
+    _map->prepare();
+
+    EXPECT_FALSE(taris->isVisible());
+    EXPECT_TRUE(taris->isDisabled());
+}
+
+TEST_F(GalaxyMapFixture, choosing_a_destination_persists_it_immediately) {
+    auto taris = newButton("LBL_Planet_Taris");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+
+    GalaxyMapTestAccess::select(*_map, 0);
+
+    EXPECT_EQ(0, galaxyMap().selectedPlanet());
+}
+
+TEST_F(GalaxyMapFixture, an_unselectable_destination_leaves_the_previous_choice_alone) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    GalaxyMapTestAccess::select(*_map, 0);
+    ASSERT_EQ(0, galaxyMap().selectedPlanet());
+
+    // Shown, but locked out of travel.
+    galaxyMap().setAvailable(2, true);
+    GalaxyMapTestAccess::select(*_map, 2);
+
+    EXPECT_EQ(0, galaxyMap().selectedPlanet());
+}
+
+TEST_F(GalaxyMapFixture, the_chosen_destination_carries_the_selected_state) {
+    auto taris = newButton("LBL_Planet_Taris");
+    auto dantooine = newButton("LBL_Planet_Dantooine");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+    GalaxyMapTestAccess::setPlanetControl(*_map, 2, dantooine);
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setAvailable(2, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    GalaxyMapTestAccess::updatePlanetControlPresentation(*_map);
+    EXPECT_TRUE(taris->isSelected());
+    EXPECT_FALSE(dantooine->isSelected());
+
+    // The cursor moving over another planet lights it up without taking the
+    // chosen destination's own state away.
+    GalaxyMapTestAccess::selectionChanged(*_map, "LBL_Planet_Dantooine", true);
+    EXPECT_TRUE(taris->isSelected());
+    EXPECT_TRUE(dantooine->isSelected());
+
+    GalaxyMapTestAccess::selectionChanged(*_map, "LBL_Planet_Dantooine", false);
+    EXPECT_TRUE(taris->isSelected());
+    EXPECT_FALSE(dantooine->isSelected());
+}
+
+TEST_F(GalaxyMapFixture, the_preview_follows_the_chosen_destination) {
+    useRealSceneGraph();
+    auto planet01 = newPreviewModel("planet_01");
+    auto planet02 = newPreviewModel("planet_02");
+    ON_CALL(_engine.resourceModule().models(), get("planet_01")).WillByDefault(Return(planet01));
+    ON_CALL(_engine.resourceModule().models(), get("planet_02")).WillByDefault(Return(planet02));
+    EXPECT_CALL(_engine.resourceModule().models(), get(_)).Times(testing::AnyNumber());
+    GalaxyMapTestAccess::setPlanetDisplay(*_map, newDisplayLabel());
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(2, true);
+    galaxyMap().setSelectable(2, true);
+
+    GalaxyMapTestAccess::select(*_map, 0);
+    auto first = GalaxyMapTestAccess::planetModelNode(*_map);
+    ASSERT_NE(nullptr, first);
+
+    GalaxyMapTestAccess::select(*_map, 2);
+    auto second = GalaxyMapTestAccess::planetModelNode(*_map);
+    ASSERT_NE(nullptr, second);
+    EXPECT_NE(first.get(), second.get());
+}
+
+TEST_F(GalaxyMapFixture, choosing_the_same_destination_again_restarts_its_preview) {
+    useRealSceneGraph();
+    auto planet01 = newPreviewModel("planet_01");
+    ON_CALL(_engine.resourceModule().models(), get("planet_01")).WillByDefault(Return(planet01));
+    EXPECT_CALL(_engine.resourceModule().models(), get(_)).Times(testing::AnyNumber());
+    GalaxyMapTestAccess::setPlanetDisplay(*_map, newDisplayLabel());
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+
+    GalaxyMapTestAccess::select(*_map, 0);
+    auto node = GalaxyMapTestAccess::planetModelNode(*_map);
+    ASSERT_NE(nullptr, node);
+
+    // Let the one-shot intro run out, the way it does while the panel sits open.
+    node->update(1.0f);
+    ASSERT_TRUE(node->isAnimationFinished());
+
+    GalaxyMapTestAccess::select(*_map, 0);
+
+    // The same model is still the preview, and its intro is playing from the top.
+    EXPECT_EQ(node.get(), GalaxyMapTestAccess::planetModelNode(*_map).get());
+    ASSERT_FALSE(node->animationChannels().empty());
+    EXPECT_FLOAT_EQ(0.0f, node->animationChannels().front().time);
+    EXPECT_FALSE(node->isAnimationFinished());
+}
+
+TEST_F(GalaxyMapFixture, revisiting_a_destination_reuses_its_cached_preview_and_restarts_it) {
+    useRealSceneGraph();
+    auto planet01 = newPreviewModel("planet_01");
+    auto planet02 = newPreviewModel("planet_02");
+    ON_CALL(_engine.resourceModule().models(), get("planet_01")).WillByDefault(Return(planet01));
+    ON_CALL(_engine.resourceModule().models(), get("planet_02")).WillByDefault(Return(planet02));
+    // A revisited planet is served from the cache, so its model is fetched once.
+    EXPECT_CALL(_engine.resourceModule().models(), get("planet_01")).Times(1);
+    EXPECT_CALL(_engine.resourceModule().models(), get("planet_02")).Times(1);
+    GalaxyMapTestAccess::setPlanetDisplay(*_map, newDisplayLabel());
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(2, true);
+    galaxyMap().setSelectable(2, true);
+
+    GalaxyMapTestAccess::select(*_map, 0);
+    auto first = GalaxyMapTestAccess::planetModelNode(*_map);
+    ASSERT_NE(nullptr, first);
+    first->update(1.0f);
+    ASSERT_TRUE(first->isAnimationFinished());
+
+    GalaxyMapTestAccess::select(*_map, 2);
+    GalaxyMapTestAccess::select(*_map, 0);
+
+    EXPECT_EQ(first.get(), GalaxyMapTestAccess::planetModelNode(*_map).get());
+    ASSERT_FALSE(first->animationChannels().empty());
+    EXPECT_FLOAT_EQ(0.0f, first->animationChannels().front().time);
+    EXPECT_FALSE(first->isAnimationFinished());
+}
+
+TEST_F(GalaxyMapFixture, escape_leaves_the_map_without_travelling) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    auto escape = input::Event::newKeyDown(
+        input::KeyEvent(true, input::KeyCode::Escape, 0, false));
+
+    EXPECT_TRUE(_map->handle(escape));
+
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+    // Backing out is not a rollback: the destination the player picked stands.
+    EXPECT_EQ(0, galaxyMap().selectedPlanet());
+}
+
+TEST_F(GalaxyMapFixture, accepting_a_destination_runs_the_travel_script_once) {
+    auto taris = newButton("LBL_Planet_Taris");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(kTravelScript))
+        .Times(1)
+        .WillRepeatedly(Return(nullptr));
+
+    GalaxyMapTestAccess::accept(*_map);
+    // A second press while the travel script is on its way must not send it again.
+    GalaxyMapTestAccess::accept(*_map);
+
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+}
+
+TEST_F(GalaxyMapFixture, accepting_an_unselectable_destination_does_not_travel) {
+    auto dantooine = newButton("LBL_Planet_Dantooine");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 2, dantooine);
+    galaxyMap().setAvailable(2, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(2));
+
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    GalaxyMapTestAccess::accept(*_map);
+}
+
+TEST_F(GalaxyMapFixture, accepting_with_nothing_chosen_does_not_travel) {
+    ASSERT_EQ(-1, galaxyMap().selectedPlanet());
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    GalaxyMapTestAccess::accept(*_map);
+}
+
+TEST_F(GalaxyMapFixture, accept_is_live_only_for_a_destination_that_can_be_travelled_to) {
+    auto taris = newButton("LBL_Planet_Taris");
+    auto accept = newButton("BTN_ACCEPT");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 0, taris);
+    GalaxyMapTestAccess::setAcceptButton(*_map, accept);
+
+    GalaxyMapTestAccess::refreshPresentation(*_map);
+    EXPECT_TRUE(accept->isDisabled());
+
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    GalaxyMapTestAccess::select(*_map, 0);
+    EXPECT_FALSE(accept->isDisabled());
+}
+
+TEST_F(GalaxyMapFixture, the_show_galaxy_map_routine_reaches_the_panel_and_leaves_the_screen_alone_if_it_will_not_load) {
+    _game->openInGame();
+    ASSERT_EQ(Game::Screen::InGame, _game->currentScreen());
+
+    Routines routines(GameID::KotOR, _game.get(), &_engine.services());
+    routines.init();
+    script::Routine &routine = routines.get(routines.getIndexByName("ShowGalaxyMap"));
+    ASSERT_EQ("ShowGalaxyMap", routine.name());
+
+    script::ExecutionContext execution;
+    execution.routines = &routines;
+
+    // The routine used to throw as unimplemented. It now reaches the panel, and
+    // the GUI provider here hands back nothing, so the screen it could not
+    // replace is the screen that stays.
+    EXPECT_NO_THROW(routine.invoke({script::Variable::ofInt(0)}, execution));
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+}
+
+TEST_F(GalaxyMapFixture, revisiting_a_planet_does_not_stack_cameras_on_its_hook) {
+    useRealSceneGraph();
+    auto planet01 = newPreviewModel("planet_01", /*withCameraHook=*/true);
+    auto planet02 = newPreviewModel("planet_02", /*withCameraHook=*/true);
+    ON_CALL(_engine.resourceModule().models(), get("planet_01")).WillByDefault(Return(planet01));
+    ON_CALL(_engine.resourceModule().models(), get("planet_02")).WillByDefault(Return(planet02));
+    EXPECT_CALL(_engine.resourceModule().models(), get(_)).Times(testing::AnyNumber());
+    GalaxyMapTestAccess::setPlanetDisplay(*_map, newDisplayLabel());
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(2, true);
+    galaxyMap().setSelectable(2, true);
+
+    GalaxyMapTestAccess::select(*_map, 0);
+    auto first = GalaxyMapTestAccess::planetModelNode(*_map);
+    ASSERT_NE(nullptr, first);
+
+    auto camerasOnHook = [](const std::shared_ptr<ModelSceneNode> &model) {
+        auto hook = model->getNodeByName("camerahook");
+        if (!hook) {
+            return size_t {0};
+        }
+        size_t count = 0;
+        for (auto *child : hook->children()) {
+            if (child->type() == SceneNodeType::Camera) {
+                ++count;
+            }
+        }
+        return count;
+    };
+    ASSERT_EQ(1u, camerasOnHook(first));
+
+    // Away and back: the cached preview is initialized a second time, and the
+    // camera the first initialization hung off its hook must not still be there.
+    GalaxyMapTestAccess::select(*_map, 2);
+    GalaxyMapTestAccess::select(*_map, 0);
+
+    EXPECT_EQ(first.get(), GalaxyMapTestAccess::planetModelNode(*_map).get());
+    EXPECT_EQ(1u, camerasOnHook(first));
+}


### PR DESCRIPTION
## Summary

Implements routine 739 (`ShowGalaxyMap`) for K1 and adds the panel behind it. The planet state and routines 740–744 it reads are already merged.

- Everything shown comes from `planetary.2da`: the control standing for each planet, its name and description, and its preview model. A row naming no control — or one this panel does not author — simply has no destination, and rows the shipped table defines above 15 are destinations like any other.
- Unreached destinations are hidden; reached-but-untravellable ones are shown and inert.
- Choosing a destination persists it immediately, and the chosen one keeps the control's authored HILIGHT state while the cursor wanders over the others.
- Accept validates the destination and dispatches `k_sup_galaxymap` exactly once.

K2 is not included here.