### PR TITLE
[resource] Preserve loaded dialog resref

### DIFF
--- a/src/libs/resource/provider/dialogs.cpp
+++ b/src/libs/resource/provider/dialogs.cpp
@@ -30,7 +30,9 @@ std::shared_ptr<Dialog> Dialogs::doGet(std::string resRef) {
         return nullptr;
     }
     auto dlgParsed = resource::generated::parseDLG(*dlg);
-    return loadDialog(dlgParsed);
+    auto dialog = loadDialog(dlgParsed);
+    dialog->resRef = ResRef(std::move(resRef)).value();
+    return dialog;
 }
 
 std::unique_ptr<Dialog> Dialogs::loadDialog(const resource::generated::DLG &dlg) {

--- a/test/resource/provider/dialogs.cpp
+++ b/test/resource/provider/dialogs.cpp
@@ -89,3 +89,39 @@ TEST(Dialogs, should_preserve_quest_and_plot_xp_fields_from_dlg) {
     EXPECT_EQ(8, dialog->replies[0].plotIndex);
     EXPECT_FLOAT_EQ(0.5f, dialog->replies[0].plotXPPercentage);
 }
+
+TEST(Dialogs, should_preserve_resource_identity) {
+    // given
+
+    auto root = Gff(0xffffffff, {});
+    auto dlgBytes = ByteBuffer();
+    auto dlgStream = MemoryOutputStream(dlgBytes);
+    GffWriter(ResType::Dlg, root).save(dlgStream);
+    auto alternateDlgBytes = dlgBytes;
+
+    auto resources = Resources();
+    auto container = std::make_unique<MemoryResourceContainer>();
+    container->add(ResourceId("sample", ResType::Dlg), std::move(dlgBytes));
+    container->add(ResourceId("alternate", ResType::Dlg), std::move(alternateDlgBytes));
+    resources.add(std::move(container));
+
+    auto gffs = Gffs(resources);
+    auto strings = Strings();
+    auto dialogs = Dialogs(gffs, strings);
+
+    // when
+
+    auto dialog = dialogs.get("SAMPLE");
+    auto cachedDialog = dialogs.get("SAMPLE");
+    auto alternateDialog = dialogs.get("alternate");
+
+    // then
+
+    ASSERT_TRUE(static_cast<bool>(dialog));
+    ASSERT_TRUE(static_cast<bool>(alternateDialog));
+
+    EXPECT_EQ("sample", dialog->resRef);
+    EXPECT_EQ(dialog, cachedDialog);
+    EXPECT_EQ("sample", cachedDialog->resRef);
+    EXPECT_EQ("alternate", alternateDialog->resRef);
+}


### PR DESCRIPTION
## Summary

Preserves the source resref on DLG resources loaded through the dialog provider.

Previously the DLG content was parsed correctly, but the returned `Dialog` did not retain the resource identity it had been loaded under, so `Dialog::resRef` remained empty.

The provider now attaches the normalized resource identity when constructing the loaded dialog. Dialogue parsing and runtime behavior are otherwise unchanged.

## Validation

- provider-level regression proving loaded and cached DLGs report their resref
- equivalent DLG content under distinct resrefs retains distinct identities
- existing parsed dialogue content regression remains unchanged and passes
- discrimination against the previous empty-resref behavior
- full `UnitTests` suite passes
- `git diff --check`