### PR TITLE
[game] Handle pause and resume without an active conversation

### DIFF
--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -3241,10 +3241,16 @@ void Game::startDialog(const std::shared_ptr<Object> &owner, const std::string &
 }
 
 void Game::resumeConversation() {
+    if (!_conversation || !isConversationActive()) {
+        return;
+    }
     _conversation->resume();
 }
 
 void Game::pauseConversation() {
+    if (!_conversation || !isConversationActive()) {
+        return;
+    }
     _conversation->pause();
 }
 

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -55,6 +55,7 @@ class Area;
 class Game;
 class Module;
 class Object;
+class Conversation;
 
 class MockCameraStyles : public ICameraStyles, boost::noncopyable {
 public:
@@ -161,6 +162,7 @@ public:
         PazaakSession::MainDeckFactory mainDeckFactory,
         std::function<void(const std::string &, uint32_t)> continuation);
     static void setCurrentScreen(Game &game, int screen);
+    static void setConversation(Game &game, Conversation *conversation);
     static void raiseTimingDiscontinuity(Game &game);
     static void initConsole(Game &game);
     static void setActiveModule(Game &game, bool active);

--- a/test/game/conversation.cpp
+++ b/test/game/conversation.cpp
@@ -23,6 +23,8 @@
 #include "reone/audio/clip.h"
 #include "reone/audio/mixer.h"
 #include "reone/audio/source.h"
+#include "reone/game/action/pauseconversation.h"
+#include "reone/game/action/resumeconversation.h"
 #include "reone/game/console.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/conversation.h"
@@ -214,11 +216,78 @@ protected:
         _conversation->start(makeDialog(-1, true), nullptr);
     }
 
+    void attachConversation(Game::Screen screen) {
+        TestGameModule::setConversation(*_game, _conversation.get());
+        TestGameModule::setCurrentScreen(*_game, static_cast<int>(screen));
+    }
+
     TestEngine _engine;
     StubConsole _console;
     std::unique_ptr<Game> _game;
     std::unique_ptr<TestConversation> _conversation;
 };
+
+TEST_F(ConversationTest, game_pause_is_harmless_without_a_conversation) {
+    EXPECT_FALSE(_game->isConversationActive());
+
+    _game->pauseConversation();
+}
+
+TEST_F(ConversationTest, game_resume_is_harmless_without_a_conversation) {
+    EXPECT_FALSE(_game->isConversationActive());
+
+    _game->resumeConversation();
+}
+
+TEST_F(ConversationTest, pause_and_resume_actions_complete_without_a_conversation) {
+    auto actor = _game->newCreature();
+    auto pause = _game->newAction<PauseConversationAction>();
+    auto resume = _game->newAction<ResumeConversationAction>();
+
+    pause->execute(pause, *actor, 0.0f);
+    resume->execute(resume, *actor, 0.0f);
+
+    EXPECT_TRUE(pause->isCompleted());
+    EXPECT_TRUE(resume->isCompleted());
+}
+
+TEST_F(ConversationTest, queued_pause_and_resume_actions_are_consumed_without_a_conversation) {
+    auto actor = _game->newCreature();
+    actor->addAction(_game->newAction<PauseConversationAction>());
+    actor->addAction(_game->newAction<ResumeConversationAction>());
+
+    actor->update(0.0f);
+    actor->update(0.0f);
+    actor->update(0.0f);
+
+    EXPECT_TRUE(actor->actions().empty());
+}
+
+TEST_F(ConversationTest, game_pause_and_resume_ignore_a_retained_inactive_conversation) {
+    startSilent();
+    attachConversation(Game::Screen::InGame);
+
+    ASSERT_FALSE(_conversation->isPaused());
+    _game->pauseConversation();
+    EXPECT_FALSE(_conversation->isPaused());
+
+    _conversation->pause();
+    ASSERT_TRUE(_conversation->isPaused());
+    _game->resumeConversation();
+    EXPECT_TRUE(_conversation->isPaused());
+}
+
+TEST_F(ConversationTest, game_pause_and_resume_control_an_active_conversation) {
+    startSilent();
+    attachConversation(Game::Screen::Conversation);
+
+    ASSERT_FALSE(_conversation->isPaused());
+    _game->pauseConversation();
+    EXPECT_TRUE(_conversation->isPaused());
+
+    _game->resumeConversation();
+    EXPECT_FALSE(_conversation->isPaused());
+}
 
 TEST_F(ConversationTest, silent_entry_timer_expiry_does_not_advance_while_paused) {
     startSilent();

--- a/test/game/pazaakintegration.cpp
+++ b/test/game/pazaakintegration.cpp
@@ -59,6 +59,10 @@ void reone::game::TestGameModule::setCurrentScreen(Game &game, int screen) {
     game.changeScreen(static_cast<Game::Screen>(screen));
 }
 
+void reone::game::TestGameModule::setConversation(Game &game, Conversation *conversation) {
+    game._conversation = conversation;
+}
+
 void reone::game::TestGameModule::initConsole(Game &game) {
     game.initConsole();
 }


### PR DESCRIPTION
## Summary

Makes conversation pause/resume actions harmless when no conversation is active.

`Game::pauseConversation()` and `resumeConversation()` previously dereferenced the stored conversation pointer unconditionally. These actions can execute when no conversation exists, or after a previously retained conversation has become inactive.

Both methods now return when there is no active conversation. Active conversation pause/resume behavior is unchanged.

## Validation

- no-conversation pause/resume regressions;
- queued actions complete normally without a conversation;
- retained inactive conversations are not modified;
- active pause/resume behavior preserved;
- discrimination against both the original dereference and a pointer-only guard;
- broader UnitTests pass;