### PR TITLE
[game] Do not reload the party on RemovePartyMember

### DIFF
--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -5340,14 +5340,7 @@ static Variable RemovePartyMember(const std::vector<Variable> &args, const Routi
     // Transform
 
     // Execute
-    bool removed = false;
-    if (ctx.game.party().isMember(nNPC)) {
-        ctx.game.party().removeMember(nNPC);
-        auto area = ctx.game.module()->area();
-        area->unloadParty();
-        area->reloadParty();
-        removed = true;
-    }
+    bool removed = ctx.game.party().removeMember(nNPC);
     return Variable::ofInt(static_cast<int>(removed));
 }
 


### PR DESCRIPTION
Reloading the whole party causes non-removed members to reload
too. Doing so in `lev_m40ac` causes a post-stunt `k_plev_malak2_e2`
trigger to fire before the player actually transitions to the stunt
module with `k_plev_gostunt` and returns back.

It appears that `RemovePartyMember` is not supposed to destroy the
object as well. In these scripts, `RemovePartyMember` is there to
prevent party members transitioning to the stunt module along with the
player.