### PR TITLE
[game] Implement the K2 Galaxy Map

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -237,6 +237,8 @@ public:
     void openPartySelection(const PartySelectionContext &ctx);
     void openSaveLoad(SaveLoadMode mode);
     void openGalaxyMap(int initialPlanet);
+    /** Whether the galaxy map may take the screen over from the given one. */
+    static bool canOpenGalaxyMapFrom(Screen screen);
 
     // KotOR I Pazaak lifecycle
 

--- a/include/reone/game/gui/galaxymap.h
+++ b/include/reone/game/gui/galaxymap.h
@@ -19,6 +19,8 @@
 
 #include "../gui.h"
 
+#include "confirmpopup.h"
+
 namespace reone {
 
 namespace resource {
@@ -50,21 +52,44 @@ class GalaxyMapTestAccess;
  * Everything the panel shows comes from planetary.2da. A row names the GUI
  * control that stands for the planet, the strings describing it, and the model
  * shown in the lower preview.
+ *
+ * K2 authors its own panel and adds two rules of its own: a destination can be
+ * locked out with a reason to show for it, and accepting the location the party
+ * is already at says so instead of travelling.
  */
 class GalaxyMap : public GameGUI {
 public:
-    GalaxyMap(Game &game, ServicesView &services) :
-        GameGUI(game, services) {
-        _resRef = "galaxymap";
-    }
+    GalaxyMap(Game &game, ServicesView &services);
 
     /** Bring the panel in line with the current planet state before it opens. */
-    void prepare();
+    void prepare(int initialPlanet = -1);
+
+    /** Move the choice to the next or previous planet the party can reach. */
+    void selectNextDestination() { selectAdjacentDestination(1); }
+    void selectPreviousDestination() { selectAdjacentDestination(-1); }
+
+    /** Whether the travel script this panel dispatched is still running. */
+    bool isRunningTravelScript() const { return _runningTravelScript; }
 
     bool handle(const input::Event &event) override;
+    void update(float dt) override;
+    void render() override;
 
 private:
     friend class GalaxyMapTestAccess;
+
+    /** What pressing Accept on the current choice comes to. */
+    enum class AcceptOutcome {
+        Nothing,
+        Message,
+        Travel
+    };
+
+    struct AcceptDecision {
+        AcceptOutcome outcome {AcceptOutcome::Nothing};
+        /** String to show when the outcome is a message, -1 when there is none. */
+        int strRef {-1};
+    };
 
     std::shared_ptr<resource::TwoDA> _planetary;
 
@@ -87,6 +112,11 @@ private:
     int _hoveredPlanet {-1};
     bool _accepting {false};
 
+    /** The current physical planet for this opening, for K2 location checking. */
+    int _locationAtOpen {-1};
+    bool _runningTravelScript {false};
+    std::unique_ptr<ConfirmPopup> _popup;
+
     void onGUILoaded() override;
     void onSelectionChanged(const std::string &control, bool selected) override;
 
@@ -100,6 +130,18 @@ private:
     void detachCameras(scene::ModelSceneNode &model);
 
     bool isTravelDestination(int row) const;
+    bool isSelectableOnMap(int row) const;
+    int lockedOutReason(int row) const;
+
+    void applyOpeningSelection(int initialPlanet);
+    int adjacentDestination(int from, int step) const;
+    void selectAdjacentDestination(int step);
+
+    AcceptDecision decideAccept() const;
+    void showMessage(int strRef);
+
+    uint32_t travelScriptCaller() const;
+    void runTravelScript();
 
     void select(int row);
     void refreshPresentation();

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -3586,8 +3586,26 @@ void Game::openSaveLoad(SaveLoadMode mode) {
     changeScreen(Screen::SaveLoad);
 }
 
+bool Game::canOpenGalaxyMapFrom(Screen screen) {
+    switch (screen) {
+    case Screen::None:
+    case Screen::InGame:
+    case Screen::InGameMenu:
+    case Screen::Conversation:
+        return true;
+    default:
+        // Every other screen owns the whole display and has somewhere of its
+        // own to return to. Taking it over would strand it.
+        return false;
+    }
+}
+
 void Game::openGalaxyMap(int initialPlanet) {
-    if (_screen == Screen::GalaxyMap) {
+    if (!canOpenGalaxyMapFrom(_screen)) {
+        return;
+    }
+    if (_galaxyMap && _galaxyMap->isRunningTravelScript()) {
+        // The travel script this panel dispatched must not reopen it.
         return;
     }
     if (!_galaxyMap) {
@@ -3598,11 +3616,12 @@ void Game::openGalaxyMap(int initialPlanet) {
         // whatever is on it.
         return;
     }
-    _party.galaxyMap().trySelectPlanet(initialPlanet);
     stopMovement();
     setRelativeMouseMode(false);
     setCursorType(CursorType::Default);
-    _galaxyMap->prepare();
+    // The panel decides what the routine's planet means: K2 has to record
+    // where the party already is before anything can move the selection.
+    _galaxyMap->prepare(initialPlanet);
     changeScreen(Screen::GalaxyMap);
 }
 

--- a/src/libs/game/gui/galaxymap.cpp
+++ b/src/libs/game/gui/galaxymap.cpp
@@ -33,6 +33,7 @@
 #include "reone/scene/graph.h"
 #include "reone/scene/graphs.h"
 #include "reone/scene/node/model.h"
+#include "reone/script/types.h"
 #include "reone/system/logutil.h"
 
 namespace reone {
@@ -55,6 +56,36 @@ static constexpr float kDisplayClipPlaneFar = 10000.0f;
 static constexpr char kPreviewAnimation[] = "zoomin";
 
 static constexpr char kTravelScript[] = "k_sup_galaxymap";
+
+/** "You are already at that location." */
+static constexpr int kAlreadyAtLocationStrRef = 125629;
+
+namespace {
+
+/** Holds a flag raised for as long as the call it scopes is on the stack. */
+class ScopedFlag : boost::noncopyable {
+public:
+    ScopedFlag(bool &flag) :
+        _flag(flag) {
+        _flag = true;
+    }
+
+    ~ScopedFlag() {
+        _flag = false;
+    }
+
+private:
+    bool &_flag;
+};
+
+} // namespace
+
+GalaxyMap::GalaxyMap(Game &game, ServicesView &services) :
+    GameGUI(game, services) {
+
+    // The two titles author separate panels; K2 has no galaxymap.
+    _resRef = game.isTSL() ? "galaxymap_p" : "galaxymap";
+}
 
 void GalaxyMap::onGUILoaded() {
     _accept = findControl<gui::Button>("BTN_ACCEPT");
@@ -134,13 +165,23 @@ std::shared_ptr<scene::ModelSceneNode> GalaxyMap::getGalaxyModel(scene::ISceneGr
     return _galaxyModelNode;
 }
 
-void GalaxyMap::prepare() {
+void GalaxyMap::prepare(int initialPlanet) {
     _accepting = false;
     _hoveredPlanet = -1;
+    if (_popup) {
+        _popup->hide();
+    }
+    if (_game.isTSL()) {
+        // Only K2 checks the party against where it already is, so only K2
+        // needs to remember that. The soft-selection itself works the same
+        // either way.
+        applyOpeningSelection(initialPlanet);
+    } else {
+        _game.party().galaxyMap().trySelectPlanet(initialPlanet);
+    }
     for (auto &[row, control] : _planetControls) {
-        bool available = _game.party().galaxyMap().available(row);
-        control->setVisible(available);
-        control->setDisabled(!available || !_game.party().galaxyMap().selectable(row));
+        control->setVisible(_game.party().galaxyMap().available(row));
+        control->setDisabled(!isSelectableOnMap(row));
     }
     refreshPresentation();
 }
@@ -229,9 +270,61 @@ void GalaxyMap::detachCameras(scene::ModelSceneNode &model) {
     }
 }
 
-void GalaxyMap::select(int row) {
+void GalaxyMap::applyOpeningSelection(int initialPlanet) {
     auto &galaxyMap = _game.party().galaxyMap();
-    if (!galaxyMap.selectable(row) || !galaxyMap.trySelectPlanet(row)) {
+    // initialPlanet is the current physical planet for this opening, and that
+    // is what the panel soft-selects every time. The persisted destination in
+    // GlxyMapSelPnt is a separate thing: it survives cancelling and may name
+    // somewhere the party has never been, so it does not decide what the map
+    // highlights on opening.
+    _locationAtOpen = initialPlanet;
+    // Selecting is availability-only, and a row it rejects changes nothing:
+    // the persisted destination stays selected. Content relies on that. K2
+    // reaches Onderon before Dxun is on the map yet still names Dxun as the
+    // current location, and the map is expected to keep showing Onderon
+    // rather than go hunting for some other planet to highlight.
+    galaxyMap.trySelectPlanet(initialPlanet);
+}
+
+int GalaxyMap::adjacentDestination(int from, int step) const {
+    const auto &galaxyMap = _game.party().galaxyMap();
+    int rowCount = galaxyMap.rowCount();
+    if (rowCount <= 0) {
+        return from;
+    }
+    // Every planet on the map is a stop, including the ones travel is locked
+    // out of, and the walk wraps around the ends.
+    for (int offset = 1; offset <= rowCount; ++offset) {
+        int row = ((from + step * offset) % rowCount + rowCount) % rowCount;
+        if (galaxyMap.available(row)) {
+            return row;
+        }
+    }
+    return from;
+}
+
+void GalaxyMap::selectAdjacentDestination(int step) {
+    auto &galaxyMap = _game.party().galaxyMap();
+    int row = adjacentDestination(galaxyMap.selectedPlanet(), step);
+    if (row == galaxyMap.selectedPlanet() || !galaxyMap.trySelectPlanet(row)) {
+        return;
+    }
+    refreshPresentation();
+}
+
+bool GalaxyMap::isSelectableOnMap(int row) const {
+    const auto &galaxyMap = _game.party().galaxyMap();
+    if (!galaxyMap.available(row)) {
+        return false;
+    }
+    // Every planet on the K2 map can be picked, including the ones travel is
+    // locked out of: picking one is how the player is told why. K1 authors no
+    // reason to give, so there a planet it cannot travel to stays inert.
+    return _game.isTSL() || galaxyMap.selectable(row);
+}
+
+void GalaxyMap::select(int row) {
+    if (!isSelectableOnMap(row) || !_game.party().galaxyMap().trySelectPlanet(row)) {
         return;
     }
     refreshPresentation();
@@ -241,7 +334,10 @@ void GalaxyMap::refreshPresentation() {
     int row = _game.party().galaxyMap().selectedPlanet();
 
     if (_accept) {
-        _accept->setDisabled(!isTravelDestination(row));
+        // Accept is live whenever pressing it has something to say. On K2 that
+        // takes in a locked out planet and the party's own location, since the
+        // message each of those gives is the whole point of pressing it.
+        _accept->setDisabled(decideAccept().outcome == AcceptOutcome::Nothing);
     }
     updatePlanetControlPresentation();
     refreshPlanetModel(row);
@@ -268,6 +364,35 @@ void GalaxyMap::refreshPresentation() {
 bool GalaxyMap::isTravelDestination(int row) const {
     const auto &galaxyMap = _game.party().galaxyMap();
     return _planetControls.count(row) > 0 && galaxyMap.available(row) && galaxyMap.selectable(row);
+}
+
+int GalaxyMap::lockedOutReason(int row) const {
+    // K1 planetary.2da has no locked out column, so a row never carries one.
+    if (!_planetary || row < 0 || row >= _planetary->getRowCount()) {
+        return -1;
+    }
+    return _planetary->getInt(row, "lockedoutreason", -1);
+}
+
+void GalaxyMap::showMessage(int strRef) {
+    if (strRef < 0) {
+        return;
+    }
+    auto text = _services.resource.strings.getText(strRef);
+    if (text.empty()) {
+        return;
+    }
+    if (!_popup) {
+        auto popup = std::make_unique<ConfirmPopup>(_game, _services);
+        try {
+            popup->init();
+        } catch (const std::exception &e) {
+            error("Galaxy map: unable to load the message popup: " + std::string(e.what()));
+            return;
+        }
+        _popup = std::move(popup);
+    }
+    _popup->show(text);
 }
 
 void GalaxyMap::updatePlanetControlPresentation() {
@@ -298,6 +423,17 @@ void GalaxyMap::onSelectionChanged(const std::string &control, bool selected) {
 }
 
 bool GalaxyMap::handle(const input::Event &event) {
+    if (_popup && _popup->isVisible()) {
+        // The message sits over the map and takes every event until dismissed.
+        if (event.type == input::EventType::KeyDown &&
+            !event.key.repeat &&
+            event.key.code == input::KeyCode::Escape) {
+            _popup->hide();
+            return true;
+        }
+        _popup->handle(event);
+        return true;
+    }
     if (event.type == input::EventType::KeyDown &&
         !event.key.repeat &&
         event.key.code == input::KeyCode::Escape) {
@@ -307,26 +443,83 @@ bool GalaxyMap::handle(const input::Event &event) {
     return GameGUI::handle(event);
 }
 
+void GalaxyMap::update(float dt) {
+    GameGUI::update(dt);
+    if (_popup && _popup->isVisible()) {
+        _popup->update(dt);
+    }
+}
+
+void GalaxyMap::render() {
+    GameGUI::render();
+    if (_popup && _popup->isVisible()) {
+        _popup->render();
+    }
+}
+
 void GalaxyMap::close() {
     // Leaving the map keeps whatever destination was picked: the selection is
     // party state, not something this panel owns until it is accepted.
     _game.openInGame();
 }
 
-void GalaxyMap::accept() {
-    if (_accepting) {
-        return;
-    }
-    int row = _game.party().galaxyMap().selectedPlanet();
-    if (!isTravelDestination(row)) {
-        return;
-    }
-    _accepting = true;
-    close();
+uint32_t GalaxyMap::travelScriptCaller() const {
+    // K2 runs the travel script with an invalid caller; K1 runs it with none.
+    return _game.isTSL() ? script::kObjectInvalid : 0;
+}
+
+void GalaxyMap::runTravelScript() {
+    ScopedFlag running(_runningTravelScript);
     try {
-        _game.scriptRunner().run(kTravelScript);
+        // K2 hands the travel script no caller of its own.
+        _game.scriptRunner().run(kTravelScript, travelScriptCaller());
     } catch (const std::exception &e) {
         error(str(boost::format("Galaxy map: %s failed: %s") % kTravelScript % std::string(e.what())));
+    }
+}
+
+GalaxyMap::AcceptDecision GalaxyMap::decideAccept() const {
+    const auto &galaxyMap = _game.party().galaxyMap();
+    int row = galaxyMap.selectedPlanet();
+
+    if (!_game.isTSL()) {
+        return {isTravelDestination(row) ? AcceptOutcome::Travel : AcceptOutcome::Nothing, -1};
+    }
+    if (row >= 0 && row == _locationAtOpen) {
+        // The party is already there, so say so rather than travel.
+        return {AcceptOutcome::Message, kAlreadyAtLocationStrRef};
+    }
+    if (!galaxyMap.available(row)) {
+        return {AcceptOutcome::Nothing, -1};
+    }
+    if (!galaxyMap.selectable(row)) {
+        // On the map, but travel there is locked out for a reason content gives.
+        return {AcceptOutcome::Message, lockedOutReason(row)};
+    }
+    return {AcceptOutcome::Travel, -1};
+}
+
+void GalaxyMap::accept() {
+    if (_accepting || _runningTravelScript) {
+        return;
+    }
+    auto decision = decideAccept();
+    if (decision.outcome == AcceptOutcome::Nothing) {
+        return;
+    }
+    if (decision.outcome == AcceptOutcome::Message) {
+        showMessage(decision.strRef);
+        return;
+    }
+
+    _accepting = true;
+    if (_game.isTSL()) {
+        // K2 keeps the panel up until the travel script has been handed over.
+        runTravelScript();
+        close();
+    } else {
+        close();
+        runTravelScript();
     }
 }
 

--- a/test/game/galaxymap.cpp
+++ b/test/game/galaxymap.cpp
@@ -31,6 +31,7 @@
 #include "reone/game/script/routines.h"
 #include "reone/scene/node/model.h"
 #include "reone/script/executioncontext.h"
+#include "reone/script/types.h"
 #include "reone/script/variable.h"
 
 using namespace reone;
@@ -71,6 +72,24 @@ public:
     static const std::shared_ptr<ModelSceneNode> &planetModelNode(const GalaxyMap &map) {
         return map._planetModelNode;
     }
+
+    static const std::string &resRef(const GalaxyMap &map) { return map._resRef; }
+
+    static int locationAtOpen(const GalaxyMap &map) { return map._locationAtOpen; }
+    static int lockedOutReason(const GalaxyMap &map, int row) { return map.lockedOutReason(row); }
+    static uint32_t travelScriptCaller(const GalaxyMap &map) { return map.travelScriptCaller(); }
+    static bool acceptTravels(const GalaxyMap &map) {
+        return map.decideAccept().outcome == GalaxyMap::AcceptOutcome::Travel;
+    }
+
+    static bool acceptShowsMessage(const GalaxyMap &map) {
+        return map.decideAccept().outcome == GalaxyMap::AcceptOutcome::Message;
+    }
+
+    static int acceptMessageStrRef(const GalaxyMap &map) { return map.decideAccept().strRef; }
+
+    static void selectNext(GalaxyMap &map) { map.selectNextDestination(); }
+    static void selectPrevious(GalaxyMap &map) { map.selectPreviousDestination(); }
 
     static void select(GalaxyMap &map, int row) { map.select(row); }
     static void accept(GalaxyMap &map) { map.accept(); }
@@ -481,4 +500,524 @@ TEST_F(GalaxyMapFixture, revisiting_a_planet_does_not_stack_cameras_on_its_hook)
 
     EXPECT_EQ(first.get(), GalaxyMapTestAccess::planetModelNode(*_map).get());
     EXPECT_EQ(1u, camerasOnHook(first));
+}
+
+namespace {
+
+/**
+ * A stand-in K2 planetary.2da: sixteen rows, of which the first few carry
+ * planets and one is locked out with a reason.
+ */
+std::shared_ptr<TwoDA> newTSLPlanetary() {
+    auto builder = TwoDA::Builder();
+    builder.columns({"label", "name", "description", "model", "guitag", "lockedoutreason"});
+    builder.row({"Dantooine", "123725", "123726", "planet_06", "LBL_Planet_Dantooine", ""});
+    builder.row({"Dxun", "123721", "123722", "planet_04", "LBL_Planet_Dxun", ""});
+    builder.row({"Ebon_Hawk", "112771", "", "ebon_01", "LBL_EbonHawk", ""});
+    builder.row({"Onderon", "123723", "123724", "planet_05", "LBL_Planet_Onderon", "136291"});
+    for (int row = 4; row < 16; ++row) {
+        builder.row({"Live_Planet", "", "", "", "", ""});
+    }
+    return builder.build();
+}
+
+/** The K2 panel, on its own engine. */
+class TSLGalaxyMapFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _engine.init();
+        _game = std::make_unique<Game>(
+            GameID::TSL, "", _engine.options(), _engine.services(), _console);
+        _game->initLocalServices();
+        _map = std::make_unique<GalaxyMap>(*_game, _engine.services());
+        GalaxyMapTestAccess::setPlanetary(*_map, newTSLPlanetary());
+        _game->party().galaxyMap().reset(GameID::TSL, 0);
+    }
+
+    std::shared_ptr<gui::Button> newButton(std::string tag) {
+        auto button = std::make_shared<gui::Button>(
+            _gui,
+            _engine.sceneModule().graphs(),
+            _engine.graphicsModule().services(),
+            _engine.resourceModule().services());
+        button->setTag(std::move(tag));
+        return button;
+    }
+
+    GalaxyMapState &galaxyMap() { return _game->party().galaxyMap(); }
+
+    TestEngine _engine;
+    StubConsole _console;
+    gui::MockGUI _gui;
+    std::unique_ptr<Game> _game;
+    std::unique_ptr<GalaxyMap> _map;
+};
+
+} // namespace
+
+TEST_F(TSLGalaxyMapFixture, the_panel_is_the_one_k2_authors) {
+    EXPECT_EQ("galaxymap_p", GalaxyMapTestAccess::resRef(*_map));
+}
+
+TEST_F(GalaxyMapFixture, the_panel_is_the_one_k1_authors) {
+    EXPECT_EQ("galaxymap", GalaxyMapTestAccess::resRef(*_map));
+}
+
+TEST_F(TSLGalaxyMapFixture, the_planet_list_is_always_sixteen_rows) {
+    EXPECT_EQ(16, galaxyMap().rowCount());
+}
+
+// Three things are easy to conflate here, so the rows below are named for
+// what they are rather than for any planet:
+//   - the persisted destination, GlxyMapSelPnt, which survives in PARTYTABLE;
+//   - the current physical planet, which the routine passes as initialPlanet;
+//   - the soft-selection, which is what the panel highlights on opening.
+// A retail K2 save taken after choosing a destination and cancelling shows the
+// first two holding different planet ids, so a persisted destination is not
+// evidence of where the party is. Opening still highlights where the party is.
+constexpr int kPhysicalPlanet = 0;
+constexpr int kPersistedDestination = 6;
+
+TEST_F(TSLGalaxyMapFixture, opening_soft_selects_the_current_physical_planet) {
+    galaxyMap().setAvailable(kPhysicalPlanet, true);
+    galaxyMap().setAvailable(kPersistedDestination, true);
+    galaxyMap().setSelectable(kPersistedDestination, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(kPersistedDestination));
+
+    _map->prepare(kPhysicalPlanet);
+
+    EXPECT_EQ(kPhysicalPlanet, GalaxyMapTestAccess::locationAtOpen(*_map));
+    EXPECT_EQ(kPhysicalPlanet, galaxyMap().selectedPlanet());
+}
+
+// Choosing a destination updates the persisted selection at once, cancelling
+// does not roll it back, and opening again soft-selects the physical planet.
+TEST_F(TSLGalaxyMapFixture, cancelling_keeps_the_destination_but_reopening_resets_the_soft_selection) {
+    galaxyMap().setAvailable(kPhysicalPlanet, true);
+    galaxyMap().setAvailable(kPersistedDestination, true);
+    galaxyMap().setSelectable(kPersistedDestination, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(kPersistedDestination));
+
+    _map->prepare(kPhysicalPlanet);
+    ASSERT_EQ(kPhysicalPlanet, galaxyMap().selectedPlanet());
+
+    GalaxyMapTestAccess::select(*_map, kPersistedDestination);
+    EXPECT_EQ(kPersistedDestination, galaxyMap().selectedPlanet());
+
+    auto escape = input::Event::newKeyDown(
+        input::KeyEvent(true, input::KeyCode::Escape, 0, false));
+    ASSERT_TRUE(_map->handle(escape));
+    EXPECT_EQ(kPersistedDestination, galaxyMap().selectedPlanet())
+        << "cancelling must not roll the persisted destination back";
+
+    _map->prepare(kPhysicalPlanet);
+    EXPECT_EQ(kPhysicalPlanet, galaxyMap().selectedPlanet())
+        << "reopening soft-selects the current physical planet again";
+
+    // The party has not moved, so the destination is still somewhere to go.
+    GalaxyMapTestAccess::select(*_map, kPersistedDestination);
+    EXPECT_EQ(kPhysicalPlanet, GalaxyMapTestAccess::locationAtOpen(*_map));
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptTravels(*_map));
+}
+
+// K1 opens the same way: the current physical planet is what comes up each
+// time. Its table is only three rows, so it names its own destination.
+TEST_F(GalaxyMapFixture, k1_reopening_resets_the_soft_selection_to_the_physical_planet) {
+    constexpr int kK1PhysicalPlanet = 0;    // Taris
+    constexpr int kK1PersistedDestination = 2; // Dantooine
+    galaxyMap().setAvailable(kK1PhysicalPlanet, true);
+    galaxyMap().setSelectable(kK1PhysicalPlanet, true);
+    galaxyMap().setAvailable(kK1PersistedDestination, true);
+    galaxyMap().setSelectable(kK1PersistedDestination, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(kK1PersistedDestination));
+
+    _map->prepare(kK1PhysicalPlanet);
+    EXPECT_EQ(kK1PhysicalPlanet, galaxyMap().selectedPlanet());
+
+    GalaxyMapTestAccess::select(*_map, kK1PersistedDestination);
+    ASSERT_EQ(kK1PersistedDestination, galaxyMap().selectedPlanet());
+
+    _map->prepare(kK1PhysicalPlanet);
+    EXPECT_EQ(kK1PhysicalPlanet, galaxyMap().selectedPlanet());
+}
+
+// Selecting is availability-only, so a physical planet that is not on the map
+// is simply not taken, and the persisted destination stays soft-selected. K2
+// content depends on this: the party reaches Onderon while the current
+// location it names is Dxun, which is not on the map yet.
+TEST_F(TSLGalaxyMapFixture, an_unavailable_physical_planet_leaves_the_persisted_destination_alone) {
+    galaxyMap().setAvailable(kPhysicalPlanet, false);
+    galaxyMap().setAvailable(kPersistedDestination, true);
+    galaxyMap().setSelectable(kPersistedDestination, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(kPersistedDestination));
+    // Somewhere the party could be sent, if the panel went looking. It must not.
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+
+    _map->prepare(kPhysicalPlanet);
+
+    EXPECT_EQ(kPhysicalPlanet, GalaxyMapTestAccess::locationAtOpen(*_map));
+    EXPECT_EQ(kPersistedDestination, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, the_chosen_destination_travels_and_the_party_location_says_so) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setAvailable(6, true);
+    galaxyMap().setSelectable(6, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(6));
+
+    _map->prepare(0);
+    // Opening soft-selected Dantooine, where the party is, so the destination
+    // has to be picked again before there is anywhere to travel to.
+    ASSERT_EQ(0, galaxyMap().selectedPlanet());
+
+    // Nar Shaddaa is somewhere else, so accepting it travels.
+    GalaxyMapTestAccess::select(*_map, 6);
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptTravels(*_map));
+
+    // Dantooine is where the party already is, whatever its own flags say.
+    GalaxyMapTestAccess::select(*_map, 0);
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptShowsMessage(*_map));
+    EXPECT_EQ(125629, GalaxyMapTestAccess::acceptMessageStrRef(*_map));
+}
+
+TEST_F(TSLGalaxyMapFixture, changing_the_selection_does_not_move_where_the_party_is) {
+    for (int row : {0, 1, 6}) {
+        galaxyMap().setAvailable(row, true);
+        galaxyMap().setSelectable(row, true);
+    }
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(6));
+
+    _map->prepare(0);
+    ASSERT_EQ(0, GalaxyMapTestAccess::locationAtOpen(*_map));
+
+    GalaxyMapTestAccess::select(*_map, 1);
+    EXPECT_EQ(0, GalaxyMapTestAccess::locationAtOpen(*_map));
+    GalaxyMapTestAccess::select(*_map, 0);
+    EXPECT_EQ(0, GalaxyMapTestAccess::locationAtOpen(*_map));
+    GalaxyMapTestAccess::selectNext(*_map);
+    EXPECT_EQ(0, GalaxyMapTestAccess::locationAtOpen(*_map));
+
+    // Still the planet the routine opened on, so it still says so.
+    GalaxyMapTestAccess::select(*_map, 0);
+    EXPECT_EQ(125629, GalaxyMapTestAccess::acceptMessageStrRef(*_map));
+}
+
+// Travel being locked out of the physical planet does not stop it being the
+// soft-selection: selecting looks at availability alone.
+TEST_F(TSLGalaxyMapFixture, a_locked_out_physical_planet_is_still_soft_selected) {
+    galaxyMap().setAvailable(3, true);
+    galaxyMap().setSelectable(3, true);
+    galaxyMap().setAvailable(0, true);
+    ASSERT_EQ(-1, galaxyMap().selectedPlanet());
+
+    _map->prepare(0);
+
+    EXPECT_EQ(0, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, an_unavailable_physical_planet_selects_nothing_when_nothing_was_selected) {
+    galaxyMap().setAvailable(3, true);
+    galaxyMap().setSelectable(3, true);
+    ASSERT_EQ(-1, galaxyMap().selectedPlanet());
+
+    // Row 0 is not on the map at all, so it cannot be the opening selection,
+    // and row 3 is not hunted down to stand in for it.
+    _map->prepare(0);
+
+    EXPECT_EQ(-1, galaxyMap().selectedPlanet());
+}
+
+TEST_F(GalaxyMapFixture, k1_still_opens_on_the_planet_the_routine_names) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(2, true);
+    galaxyMap().setSelectable(2, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    _map->prepare(2);
+
+    EXPECT_EQ(2, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, opening_records_where_the_party_already_is) {
+    galaxyMap().setAvailable(2, true);
+    galaxyMap().setSelectable(2, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(2));
+
+    _map->prepare(2);
+
+    EXPECT_EQ(2, GalaxyMapTestAccess::locationAtOpen(*_map));
+    // A selection that still stands is kept.
+    EXPECT_EQ(2, galaxyMap().selectedPlanet());
+}
+
+// Content can open the map without naming a planet at all. That names nowhere
+// for the party to be, so the persisted destination is what stays selected.
+TEST_F(TSLGalaxyMapFixture, opening_on_no_planet_leaves_the_persisted_destination_alone) {
+    galaxyMap().setAvailable(3, true);
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+
+    _map->prepare();
+
+    EXPECT_EQ(1, galaxyMap().selectedPlanet());
+    EXPECT_EQ(-1, GalaxyMapTestAccess::locationAtOpen(*_map));
+}
+
+TEST_F(TSLGalaxyMapFixture, opening_with_no_planet_available_selects_nothing) {
+    _map->prepare();
+
+    EXPECT_EQ(-1, galaxyMap().selectedPlanet());
+    EXPECT_EQ(-1, GalaxyMapTestAccess::locationAtOpen(*_map));
+}
+
+TEST_F(TSLGalaxyMapFixture, navigation_walks_the_available_planets_and_wraps_around) {
+    for (int row : {0, 1, 3}) {
+        galaxyMap().setAvailable(row, true);
+        galaxyMap().setSelectable(row, true);
+    }
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    GalaxyMapTestAccess::selectNext(*_map);
+    EXPECT_EQ(1, galaxyMap().selectedPlanet());
+    GalaxyMapTestAccess::selectNext(*_map);
+    EXPECT_EQ(3, galaxyMap().selectedPlanet());
+    GalaxyMapTestAccess::selectNext(*_map);
+    EXPECT_EQ(0, galaxyMap().selectedPlanet());
+
+    GalaxyMapTestAccess::selectPrevious(*_map);
+    EXPECT_EQ(3, galaxyMap().selectedPlanet());
+    GalaxyMapTestAccess::selectPrevious(*_map);
+    EXPECT_EQ(1, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, navigation_stops_at_planets_travel_is_locked_out_of) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    // On the map, but not a valid destination.
+    galaxyMap().setAvailable(3, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    GalaxyMapTestAccess::selectNext(*_map);
+
+    EXPECT_EQ(3, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, navigation_is_safe_with_no_planet_available) {
+    GalaxyMapTestAccess::selectNext(*_map);
+    EXPECT_EQ(-1, galaxyMap().selectedPlanet());
+
+    GalaxyMapTestAccess::selectPrevious(*_map);
+    EXPECT_EQ(-1, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, planet_details_come_from_the_table_row) {
+    EXPECT_EQ("planet_04", GalaxyMapTestAccess::planetModelResRef(*_map, 1));
+    EXPECT_EQ(136291, GalaxyMapTestAccess::lockedOutReason(*_map, 3));
+    // Rows content leaves open carry no reason, and neither do rows off the table.
+    EXPECT_EQ(-1, GalaxyMapTestAccess::lockedOutReason(*_map, 0));
+    EXPECT_EQ(-1, GalaxyMapTestAccess::lockedOutReason(*_map, 16));
+}
+
+TEST_F(TSLGalaxyMapFixture, accepting_where_the_party_already_is_says_so_and_does_not_travel) {
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+    // The routine opens on the planet the party is at, which here is also the
+    // destination it already carries.
+    _map->prepare(1);
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptShowsMessage(*_map));
+    EXPECT_EQ(125629, GalaxyMapTestAccess::acceptMessageStrRef(*_map));
+
+    GalaxyMapTestAccess::accept(*_map);
+
+    // The map stays up and the choice stands.
+    EXPECT_NE(Game::Screen::InGame, _game->currentScreen());
+    EXPECT_EQ(1, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, accepting_a_locked_out_planet_shows_its_reason_and_does_not_travel) {
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    galaxyMap().setAvailable(3, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+    _map->prepare();
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(3));
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptShowsMessage(*_map));
+    EXPECT_EQ(136291, GalaxyMapTestAccess::acceptMessageStrRef(*_map));
+
+    GalaxyMapTestAccess::accept(*_map);
+
+    EXPECT_NE(Game::Screen::InGame, _game->currentScreen());
+}
+
+TEST_F(TSLGalaxyMapFixture, accepting_a_new_reachable_planet_travels_there) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+    _map->prepare();
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(kTravelScript))
+        .Times(1)
+        .WillRepeatedly(Return(nullptr));
+
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptTravels(*_map));
+
+    GalaxyMapTestAccess::accept(*_map);
+    GalaxyMapTestAccess::accept(*_map);
+
+    // K2 leaves the panel only once the travel script has been handed over.
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+    EXPECT_FALSE(_map->isRunningTravelScript());
+}
+
+TEST_F(TSLGalaxyMapFixture, the_travel_script_is_handed_an_invalid_caller) {
+    EXPECT_EQ(script::kObjectInvalid, GalaxyMapTestAccess::travelScriptCaller(*_map));
+}
+
+TEST_F(GalaxyMapFixture, the_k1_travel_script_is_handed_no_caller) {
+    EXPECT_EQ(0u, GalaxyMapTestAccess::travelScriptCaller(*_map));
+}
+
+TEST_F(TSLGalaxyMapFixture, a_failing_travel_script_still_clears_the_running_state) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+    _map->prepare();
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(kTravelScript))
+        .WillRepeatedly(testing::Throw(std::runtime_error("script blew up")));
+
+    GalaxyMapTestAccess::accept(*_map);
+
+    EXPECT_FALSE(_map->isRunningTravelScript());
+}
+
+TEST_F(TSLGalaxyMapFixture, escape_leaves_the_map_without_travelling_or_rolling_back) {
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(1, true);
+    galaxyMap().setSelectable(1, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+    _map->prepare();
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(1));
+    EXPECT_CALL(_engine.resourceModule().scripts(), get(_)).Times(0);
+
+    auto escape = input::Event::newKeyDown(
+        input::KeyEvent(true, input::KeyCode::Escape, 0, false));
+    EXPECT_TRUE(_map->handle(escape));
+
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+    EXPECT_EQ(1, galaxyMap().selectedPlanet());
+}
+
+TEST(GalaxyMapShowGuards, the_map_only_takes_over_a_screen_it_can_return_to) {
+    EXPECT_TRUE(Game::canOpenGalaxyMapFrom(Game::Screen::None));
+    EXPECT_TRUE(Game::canOpenGalaxyMapFrom(Game::Screen::InGame));
+    EXPECT_TRUE(Game::canOpenGalaxyMapFrom(Game::Screen::InGameMenu));
+    EXPECT_TRUE(Game::canOpenGalaxyMapFrom(Game::Screen::Conversation));
+
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::GalaxyMap));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::MainMenu));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::Loading));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::CharacterGeneration));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::SaveLoad));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::Container));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::PartySelection));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::PazaakBoard));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::SwoopRace));
+    EXPECT_FALSE(Game::canOpenGalaxyMapFrom(Game::Screen::Turret));
+}
+
+TEST_F(TSLGalaxyMapFixture, a_panel_that_will_not_load_leaves_the_screen_alone) {
+    _game->openInGame();
+    ASSERT_EQ(Game::Screen::InGame, _game->currentScreen());
+
+    // The GUI provider hands back nothing, so the panel cannot be built.
+    _game->openGalaxyMap(0);
+
+    EXPECT_EQ(Game::Screen::InGame, _game->currentScreen());
+}
+
+TEST_F(TSLGalaxyMapFixture, a_planet_travel_is_locked_out_of_can_still_be_picked_on_the_map) {
+    auto onderon = std::make_shared<gui::Button>(
+        _gui,
+        _engine.sceneModule().graphs(),
+        _engine.graphicsModule().services(),
+        _engine.resourceModule().services());
+    onderon->setTag("LBL_Planet_Onderon");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 3, onderon);
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    // On the map, but not a destination the party can travel to.
+    galaxyMap().setAvailable(3, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+
+    _map->prepare();
+
+    // Picking it is the only way the player is told why it is closed, so the
+    // control has to stay live.
+    EXPECT_TRUE(onderon->isVisible());
+    EXPECT_FALSE(onderon->isDisabled());
+
+    GalaxyMapTestAccess::select(*_map, 3);
+
+    EXPECT_EQ(3, galaxyMap().selectedPlanet());
+    EXPECT_TRUE(GalaxyMapTestAccess::acceptShowsMessage(*_map));
+    EXPECT_EQ(136291, GalaxyMapTestAccess::acceptMessageStrRef(*_map));
+}
+
+TEST_F(GalaxyMapFixture, a_k1_destination_that_cannot_be_travelled_to_stays_inert) {
+    auto dantooine = newButton("LBL_Planet_Dantooine");
+    GalaxyMapTestAccess::setPlanetControl(*_map, 2, dantooine);
+    galaxyMap().setAvailable(2, true);
+
+    _map->prepare();
+
+    // K1 authors no reason to show, so there is nothing to be gained by
+    // letting the player land on it.
+    EXPECT_TRUE(dantooine->isVisible());
+    EXPECT_TRUE(dantooine->isDisabled());
+
+    GalaxyMapTestAccess::select(*_map, 2);
+    EXPECT_EQ(-1, galaxyMap().selectedPlanet());
+}
+
+TEST_F(TSLGalaxyMapFixture, accept_stays_live_for_a_planet_that_only_has_a_reason_to_give) {
+    auto accept = newButton("BTN_ACCEPT");
+    GalaxyMapTestAccess::setAcceptButton(*_map, accept);
+    galaxyMap().setAvailable(0, true);
+    galaxyMap().setSelectable(0, true);
+    galaxyMap().setAvailable(3, true);
+    ASSERT_TRUE(galaxyMap().trySelectPlanet(0));
+    _map->prepare();
+
+    // The party's own location: pressing Accept is how it says so.
+    EXPECT_FALSE(accept->isDisabled());
+
+    // A planet travel is locked out of: pressing Accept is how the reason shows.
+    GalaxyMapTestAccess::select(*_map, 3);
+    EXPECT_FALSE(accept->isDisabled());
+}
+
+TEST_F(TSLGalaxyMapFixture, accept_is_dead_with_nothing_reachable_chosen) {
+    auto accept = newButton("BTN_ACCEPT");
+    GalaxyMapTestAccess::setAcceptButton(*_map, accept);
+
+    _map->prepare();
+
+    ASSERT_EQ(-1, galaxyMap().selectedPlanet());
+    EXPECT_TRUE(accept->isDisabled());
 }


### PR DESCRIPTION
## Summary

Implements the K2 Galaxy Map on top of #306.

- Adds routine 739 / `ShowGalaxyMap` using `galaxymap_p` and K2's fixed 16-row `planetary.2da` contract.
- Names, descriptions, preview models, controls and `lockedoutreason` are table-driven.
- Each open tries to soft-select the current physical planet through the availability-only selection path; the persisted destination is otherwise left alone.
- Available but locked planets remain selectable so Accept can show their authored reason.
- Current location shows strref 125629; valid destinations travel normally.
- Back/Escape closes without travelling.
- Next/previous available-planet traversal is implemented but left unbound pending evidence for the original input.

Travel runs `k_sup_galaxymap` with `script::kObjectInvalid`. Re-entry is guarded while the script runs.

## Testing

82/82 focused Galaxy Map tests; full suite 1691/1691.

Retail K1/K2 fixtures and K2 black-box testing confirm that `GlxyMapSelPnt` persists the chosen destination across Cancel/save, while opening the map soft-selects the current physical planet when available.

## Known limitations

- Galaxy Map renderer parity: #311.
- Multi-line confirmation popup clipping: fixed by #285 and verified with K2 authored messages.
- Missing `zoomin` on several K2 planet models: #312.