### PR TITLE
[game] Partition objects by isDead field for GetObjectByTag routine

### DIFF
--- a/src/libs/game/object/area.cpp
+++ b/src/libs/game/object/area.cpp
@@ -738,10 +738,38 @@ std::shared_ptr<Object> Area::getObjectByTag(const std::string &tag, int nth) co
     auto objects = _objectsByTag.find(tag);
     if (objects == _objectsByTag.end())
         return nullptr;
+
     if (nth >= objects->second.size())
         return nullptr;
 
-    return objects->second[nth];
+    // GetObjectByTag routine requires the array to be partitioned by isDead:
+    // all alive objects should be at the front, and all dead objects should be
+    // at the back of the array.
+    //
+    // We do not actually sort the array, but traverse it in two passes with an
+    // inverted condition.
+
+    // Search "not dead" objects first.
+    size_t i = 0;
+    for (const std::shared_ptr<Object> &object : objects->second) {
+        if (!object->isDead()) {
+            if ((i++) == nth) {
+                return object;
+            }
+        }
+    }
+
+    // Search across dead objects.
+    for (const std::shared_ptr<Object> &object : objects->second) {
+        if (object->isDead()) {
+            if ((i++) == nth) {
+                return object;
+            }
+        }
+    }
+
+    assert(0 && "inconsistent getObjectByTag");
+    return nullptr;
 }
 
 bool Area::landObject(Object &object) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/fixtures/engine.cpp
     ${TESTS_SOURCE_DIR}/game/action.cpp
     ${TESTS_SOURCE_DIR}/game/actionactor.cpp
+    ${TESTS_SOURCE_DIR}/game/area.cpp
     ${TESTS_SOURCE_DIR}/game/assigncommand.cpp
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp

--- a/test/game/area.cpp
+++ b/test/game/area.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object.h"
+#include "reone/game/object/area.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace testing;
+
+namespace {
+
+TEST(Area, get_object_by_tag_should_partition_by_is_dead) {
+    TestEngine &engine = testEngine();
+    engine.init();
+    StubConsole console;
+    Game game(resource::GameID::KotOR, "", engine.options(), engine.services(), console);
+    NiceMock<scene::MockSceneGraph> sceneGraph;
+    ON_CALL(engine.sceneModule().graphs(), get(_))
+        .WillByDefault(ReturnRef(sceneGraph));
+
+    std::string tag = "foo";
+
+    auto area = game.newArea();
+
+    auto alive0 = game.newCreature();
+    alive0->setTag(tag);
+
+    auto dead1 = game.newCreature();
+    dead1->setTag(tag);
+
+    auto alive2 = game.newCreature();
+    alive2->setTag(tag);
+
+    auto dead3 = game.newCreature();
+    dead3->setTag(tag);
+
+    area->add(alive0);
+    area->add(dead1);
+    area->add(alive2);
+    area->add(dead3);
+
+    dead1->damage(1, 0);
+    dead3->damage(1, 0);
+
+    EXPECT_EQ(alive0, area->getObjectByTag(tag, 0));
+    EXPECT_EQ(alive2, area->getObjectByTag(tag, 1));
+    EXPECT_EQ(dead1, area->getObjectByTag(tag, 2));
+    EXPECT_EQ(dead3, area->getObjectByTag(tag, 3));
+}
+
+} // namespace


### PR DESCRIPTION
`tat_m18aa` scripts require this for the Sand Crawler attack
scene. There are multiple waves of Tuskens:

1. `k_ptat_tuskamb` script creates the first wave of 4 x `tat18_tusken04`
objects.

2. `k_ptat_tuskcut2` script calls `GetObjectByTag("tat18_tusken04", 0..4)`
and changes their faction to Hostile.

3. `k_ptat_tuskcut3` script creates another wave of 4 x `tat18_tusken04` objects
- using the same tag because reasons.

4. `k_ptat_tuskcut4` script also calls `GetObjectByTag("tat18_tusken04",
0..4)`, and that routine returns objects of the first wave that are
already dead. Tuskens of the second wave do not change faction.

With the patch, the engine now counts alive objects first, and then
continues the counter for all dead objects. Therefore script (4)
addresses the second wave of Tuskens instead of the first one.