### PR TITLE
[game] Serialize LinkedTo flags for triggers

### DIFF
--- a/include/reone/resource/strings.h
+++ b/include/reone/resource/strings.h
@@ -74,6 +74,10 @@ public:
         return _loc;
     }
 
+    const int32_t &id() const {
+        return _id;
+    }
+
 private:
     int32_t _id;
     std::string _ref;

--- a/src/libs/game/modulesnapshot.cpp
+++ b/src/libs/game/modulesnapshot.cpp
@@ -1194,6 +1194,11 @@ std::shared_ptr<Gff> ModuleSnapshotBuilder::writeTrigger(
             .field(Gff::Field::newFloat("PointZ", point.z)).build());
     }
     put(*result, Gff::Field::newList("Geometry", std::move(geometry)));
+    put(*result, Gff::Field::newByte("LinkedToFlags", trigger._linkedToFlags));
+    put(*result, Gff::Field::newCExoString("LinkedTo", trigger._linkedTo));
+    put(*result, Gff::Field::newResRef("LinkedToModule", trigger._linkedToModule));
+    put(*result, Gff::Field::newCExoLocString(
+                     "TransitionDestin", trigger._transitionDestin.id(), trigger._transitionDestin.str()));
     return result;
 }
 


### PR DESCRIPTION
Triggers used to lose their transition properties after serialization.
Steps to reproduce:

1. `warp tat_m18aa` (Dune Sea).
2. Go to Anchorhead  - the transition works.
3. `warp tat_m18aa` again.
4. Transition back to Anchorhead does not work - the trigger lost its `_linkedTo`, `_linkedToFlags` and `_linkedToModule` properties.