### PR TITLE
[game] Handle "unlimited use" spell items

### DIFF
--- a/include/reone/game/object/item.h
+++ b/include/reone/game/object/item.h
@@ -134,6 +134,7 @@ public:
     int maxDexterityBonus() const { return _maxDexterityBonus; }
     ACBonus acBonusType() const { return _acBonusType; }
     std::optional<SpellType> activateSpell() const { return _activateSpell; }
+    int activateSpellCost() const { return _activateSpellCost; }
     const std::vector<PropertyEntry> &properties() const { return _properties; }
 
     bool hasDisguise() const { return _disguiseAppearance >= 0; }
@@ -199,6 +200,7 @@ private:
     ACBonus _acBonusType {ACBonus::Invalid};
 
     std::optional<SpellType> _activateSpell;
+    int _activateSpellCost {0};
     int _disguiseAppearance {-1};
     std::vector<PropertyEntry> _properties;
     std::optional<uint32_t> _originalOwnerLocalObjectId;

--- a/src/libs/game/action/castspellatobject.cpp
+++ b/src/libs/game/action/castspellatobject.cpp
@@ -77,13 +77,15 @@ void CastSpellAtObjectAction::execute(std::shared_ptr<Action> self, Object &acto
         lock();
 
         bool lastItem = false;
-        if (!_cheat && _item && !caster.removeItem(_item.value(), lastItem)) {
-            // Ran out of items since this action was enqueued. This may happen
-            // in case of shared inventory (not implemented yet).
-            //
-            // Cheats ignore all requirements and do not remove the item.
-            finish(caster);
-            return;
+        if (!_cheat && _item && _item.value()->activateSpellCost()) {
+            if (!caster.removeItem(_item.value(), lastItem)) {
+                // Ran out of items since this action was enqueued. This may happen
+                // in case of shared inventory (not implemented yet).
+                //
+                // Cheats ignore all requirements and do not remove the item.
+                finish(caster);
+                return;
+            }
         }
 
         caster.setMovementType(Creature::MovementType::None);

--- a/src/libs/game/object/item.cpp
+++ b/src/libs/game/object/item.cpp
@@ -120,9 +120,21 @@ void Item::deserializeProperties(const resource::Gff &gff) {
 
         if (prop->readWord(entry.propertyName, "PropertyName")) {
             switch (static_cast<ItemProperty>(entry.propertyName)) {
-            case ItemProperty::ActivateItem:
+            case ItemProperty::ActivateItem: {
                 _activateSpell = static_cast<SpellType>(entry.subtype);
+
+                // CostTable is an index into iprp_costtable.2da: index 3 is
+                // iprp_chargecost.2da table. Other tables are not used.
+                //
+                // CostValue is an index in the corresponding table: index 1 is
+                // a "Single_Use" item. Index 13 is an "Unlimited_Use" item.
+                //
+                // For now, treat everything except "Single_Use" as unlimited.
+                if (entry.costTable == 3 && entry.costValue == 1) {
+                    _activateSpellCost = 1;
+                }
                 break;
+            }
             case ItemProperty::Disguise:
                 _disguiseAppearance = entry.subtype;
                 break;


### PR DESCRIPTION
Unlimited use items must not be removed after spell cast.

The vanilla engine supports `iprp_costtable.2da` and
`iprp_chargecost.2da`. For now, we only care if an item is a single use
or not, so the values are hardcoded.

The patch fixes the sonic emitter on Manaan `manm28an` and `manm28ab`.