### PR TITLE
[game] Resolve save slots by discovered filesystem identity

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -320,9 +320,10 @@ public:
     void scheduleModuleTransition(const std::string &moduleName, const std::string &entry);
     void scheduleModuleTransitionWithMovies(const std::string &moduleName, const std::string &entry, std::vector<std::string> movies);
 
-    // Load a savegame. Name must be one of savegame directores returned by
-    // ResourceDirector::saveNames().
-    void loadGame(std::string_view name);
+    // Load a savegame. The slot is the durable identity discovered by
+    // discoverSavedGames(); it is mounted verbatim rather than re-resolved, so
+    // the slot the player picked is the slot that gets loaded.
+    void loadGame(const resource::SaveSlotDescriptor &slot);
 
     std::vector<SavedGame> savedGames() const;
     const std::filesystem::path &gamePath() const { return _path; }

--- a/include/reone/game/savedgame.h
+++ b/include/reone/game/savedgame.h
@@ -38,6 +38,18 @@ struct SavedGame {
     std::optional<ByteBuffer> screenshot;
 };
 
+/**
+ * Resolve the installation's save root.
+ *
+ * Retail ships this directory under either casing, so it must be discovered
+ * rather than spelled. Indexing, deletion and writing all have to agree with
+ * ResourceDirector on the one directory a slot lives in: resolving it
+ * separately lets the list offer a save the loader cannot mount. Falls back to
+ * the canonical name when no directory exists yet, so a first save can create
+ * it.
+ */
+std::filesystem::path savedGamesDirectory(const std::filesystem::path &gamePath);
+
 /** Discover structurally usable durable slots below one installation root. */
 std::vector<SavedGame> discoverSavedGames(const std::filesystem::path &gamePath);
 

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -66,7 +66,17 @@ public:
     virtual void init() = 0;
     virtual void onModuleLoad(const std::string &name) = 0;
     virtual void onNewGame() = 0;
+    /**
+     * Mount a save resolved by name below the game path.
+     *
+     * Convenience for callers that only hold a name. It re-resolves the
+     * directory, so it does not carry durable slot identity: code that already
+     * discovered a slot must pass the descriptor overload instead.
+     */
     virtual void onGameLoad(std::string_view name) = 0;
+
+    /** Mount the exact slot discovered during indexing. */
+    virtual void onGameLoad(const SaveSlotDescriptor &slot) = 0;
     virtual std::optional<Resource> findSaveMetadata(const ResourceId &id) = 0;
     virtual std::optional<Resource> findSaveWorking(const ResourceId &id) = 0;
     virtual std::unordered_set<ResourceId> saveWorkingResourceIds() const = 0;
@@ -121,6 +131,7 @@ public:
     void onModuleLoad(const std::string &name) override;
     void onNewGame() override;
     void onGameLoad(std::string_view name) override;
+    void onGameLoad(const SaveSlotDescriptor &slot) override;
     std::optional<Resource> findSaveMetadata(const ResourceId &id) override;
     std::optional<Resource> findSaveWorking(const ResourceId &id) override;
     std::unordered_set<ResourceId> saveWorkingResourceIds() const override;
@@ -171,6 +182,8 @@ private:
     void loadK1GlobalResources();
     void loadLiveResources();
     std::unique_ptr<SaveSessionState> buildSaveSession(std::string_view name);
+    std::unique_ptr<SaveSessionState> buildSaveSession(const SaveSlotDescriptor &slot);
+    void commitSaveSession(std::unique_ptr<SaveSessionState> candidate);
 
     void loadModuleResources(const std::string &name);
     void loadModuleResourcesFromPolicy(const std::string &name);

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1187,14 +1187,14 @@ void Game::resetGame() {
     _services.resource.director.onNewGame();
 }
 
-void Game::loadGame(std::string_view name) {
-    info(str(boost::format("Loading savegame '%s'") % name));
+void Game::loadGame(const resource::SaveSlotDescriptor &slot) {
+    info(str(boost::format("Loading savegame '%s'") % slot.directory.filename().string()));
 
     // Reset game state before loading a new game.
     resetGame();
 
     // Add savegame files to resource resolution.
-    _services.resource.director.onGameLoad(name);
+    _services.resource.director.onGameLoad(slot);
 
     auto saveInfo = decodeSaveGff(
         _services.resource.director.findSaveMetadata(ResourceId("savenfo", ResType::Res)));
@@ -4821,11 +4821,13 @@ void Game::consoleOpenCloseDoor(const ConsoleArgs &args) {
 void Game::consoleListGames(const ConsoleArgs &args) {
     consoleCheckUsage(args, 0, 0, "");
 
+    // Indices must address the same list consoleLoadGame indexes.
     std::stringstream ss;
     unsigned index = 0;
     const char *newline = "";
-    for (const std::string &name : _saveNames) {
-        ss << newline << "[" << index++ << "] " << name;
+    for (const auto &save : savedGames()) {
+        ss << newline << "[" << index++ << "] "
+           << save.descriptor.directory.filename().string();
         newline = "\n";
     }
     _console.printLine(ss.str());
@@ -4834,13 +4836,11 @@ void Game::consoleListGames(const ConsoleArgs &args) {
 void Game::consoleLoadGame(const ConsoleArgs &args) {
     consoleCheckUsage(args, 1, 1, "save_id");
     size_t id = *args.get<size_t>(1);
-    const auto &_saveNames = _services.resource.director.saveNames();
-    if (id >= _saveNames.size()) {
+    auto saves = savedGames();
+    if (id >= saves.size()) {
         throw std::runtime_error("Invalid savegame id");
     }
-    auto name = _saveNames.begin();
-    std::advance(name, id);
-    loadGame(*name);
+    loadGame(saves[id].descriptor);
 }
 
 void Game::consoleSaveGame(const ConsoleArgs &args) {

--- a/src/libs/game/gui/saveload.cpp
+++ b/src/libs/game/gui/saveload.cpp
@@ -430,10 +430,10 @@ void SaveLoad::loadGame(uint32_t number) {
     auto save = findSave(number);
     if (!save) return;
     try {
-        // Game::loadGame consumes the normalized keys exposed by
-        // ResourceDirector::saveNames(), not the display-cased disk name.
-        _game.loadGame(boost::to_lower_copy(
-            save->descriptor.directory.filename().string()));
+        // Hand over the slot discovered by indexing. Reducing it to a name here
+        // would make the loader resolve the directory a second time, and the
+        // entity it found need not be the one the player selected.
+        _game.loadGame(save->descriptor);
     } catch (const std::exception &e) {
         warn("Unable to load selected save: " + std::string(e.what()));
         showStatus("The selected game could not be loaded.");

--- a/src/libs/game/savedgame.cpp
+++ b/src/libs/game/savedgame.cpp
@@ -15,6 +15,8 @@ namespace game {
 
 namespace {
 
+constexpr char kSavesDirectoryName[] = "saves";
+
 std::optional<uint32_t> parseSlot(const std::string &name) {
     if (name.size() < 6 ||
         !std::all_of(name.begin(), name.begin() + 6,
@@ -78,9 +80,60 @@ SavedGame readSlot(
 
 } // namespace
 
+std::filesystem::path savedGamesDirectory(const std::filesystem::path &gamePath) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(gamePath, ec)) {
+        return gamePath / kSavesDirectoryName;
+    }
+
+    auto foldsToSaves = [](const std::string &name) {
+        static const std::string canonical {kSavesDirectoryName};
+        if (name.size() != canonical.size()) {
+            return false;
+        }
+        return std::equal(
+            name.begin(), name.end(), canonical.begin(),
+            [](unsigned char lhs, unsigned char rhs) {
+                return std::tolower(lhs) == std::tolower(rhs);
+            });
+    };
+
+    std::vector<std::filesystem::path> roots;
+    for (const auto &entry : std::filesystem::directory_iterator(gamePath, ec)) {
+        if (entry.is_directory(ec) && foldsToSaves(entry.path().filename().string())) {
+            roots.push_back(entry.path());
+        }
+    }
+    if (roots.empty()) {
+        return gamePath / kSavesDirectoryName;
+    }
+    std::sort(roots.begin(), roots.end());
+
+    auto chosen = roots.front();
+    for (const auto &root : roots) {
+        if (root.filename().string() == kSavesDirectoryName) {
+            chosen = root;
+            break;
+        }
+    }
+
+    // A second save root is not cosmetic: every slot below the roots that lose
+    // is invisible to the list, and saves written here will not be found by
+    // anything that resolved differently. Say so rather than quietly picking.
+    for (const auto &root : roots) {
+        if (root == chosen) {
+            continue;
+        }
+        warn("Save root '" + root.filename().string() + "' is shadowed by '" +
+             chosen.filename().string() + "': saves stored there are not listed. " +
+             "Merge them into '" + chosen.filename().string() + "' to recover them");
+    }
+    return chosen;
+}
+
 std::vector<SavedGame> discoverSavedGames(const std::filesystem::path &gamePath) {
     std::vector<SavedGame> result;
-    auto savesPath = gamePath / "saves";
+    auto savesPath = savedGamesDirectory(gamePath);
     if (!std::filesystem::is_directory(savesPath)) return result;
 
     // Numeric identity is authoritative. If external tools left duplicates,
@@ -133,7 +186,7 @@ bool deleteSavedGame(
     const std::filesystem::path &gamePath,
     const resource::SaveSlotDescriptor &slot) {
     std::error_code ec;
-    auto saves = std::filesystem::weakly_canonical(gamePath / "saves", ec);
+    auto saves = std::filesystem::weakly_canonical(savedGamesDirectory(gamePath), ec);
     if (ec) return false;
     auto target = std::filesystem::weakly_canonical(slot.directory, ec);
     if (ec || target.parent_path() != saves || target == saves ||

--- a/src/libs/game/savegame.cpp
+++ b/src/libs/game/savegame.cpp
@@ -11,6 +11,7 @@
 
 #include "reone/resource/director.h"
 #include "reone/game/portraits.h"
+#include "reone/game/savedgame.h"
 #include "reone/graphics/context.h"
 #include "reone/graphics/format/tgawriter.h"
 #include "reone/system/fileutil.h"
@@ -397,7 +398,7 @@ SaveMetadataInput Game::buildSaveMetadata(const SaveRequest &request) const {
 resource::SaveSlotDescriptor Game::saveTarget(const SaveRequest &request) const {
     std::ostringstream prefix;
     prefix << std::setw(6) << std::setfill('0') << request.slot;
-    auto saves = _path / "saves";
+    auto saves = savedGamesDirectory(_path);
     // Retail keeps the user-entered title in SAVEGAMENAME. Manual directory
     // suffixes use the allocation sequence after reserved quick/autosave slots.
     // Existing exact slot directories are retained below for overwrite identity.

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -121,8 +121,14 @@ void ResourceDirector::onModuleLoad(const std::string &name) {
  * leaves the active session and cache untouched.
  */
 void ResourceDirector::onGameLoad(std::string_view name) {
-    auto candidate = buildSaveSession(name);
+    commitSaveSession(buildSaveSession(name));
+}
 
+void ResourceDirector::onGameLoad(const SaveSlotDescriptor &slot) {
+    commitSaveSession(buildSaveSession(slot));
+}
+
+void ResourceDirector::commitSaveSession(std::unique_ptr<SaveSessionState> candidate) {
     _resources.clearOwner(ResourceOwner::SaveSlot);
     _saveSession = std::move(candidate);
     _gffs.clear();
@@ -751,11 +757,28 @@ std::unique_ptr<SaveSessionState> ResourceDirector::buildSaveSession(std::string
         throw ResourceNotFoundException("savegame.sav not found");
     }
 
-    SaveSlotDescriptor descriptor {
-        *savePath,
-        *savegamePath,
-    };
-    return std::make_unique<SaveSessionState>(std::move(descriptor));
+    return buildSaveSession(SaveSlotDescriptor {*savePath, *savegamePath});
+}
+
+/**
+ * Build a candidate over an already discovered slot.
+ *
+ * The descriptor is the durable identity: mounting it verbatim keeps the entity
+ * the list offered and the entity the loader opens the same one, which a second
+ * lookup by name cannot guarantee once the directory has changed underneath or
+ * holds entries differing only by case.
+ */
+std::unique_ptr<SaveSessionState> ResourceDirector::buildSaveSession(const SaveSlotDescriptor &slot) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(slot.directory, ec)) {
+        throw ResourceNotFoundException(
+            str(boost::format("Save directory not found: %s") % slot.directory.string()));
+    }
+    if (!std::filesystem::is_regular_file(slot.archive, ec)) {
+        throw ResourceNotFoundException(
+            str(boost::format("savegame.sav not found: %s") % slot.archive.string()));
+    }
+    return std::make_unique<SaveSessionState>(slot);
 }
 
 } // namespace resource

--- a/src/libs/system/fileutil.cpp
+++ b/src/libs/system/fileutil.cpp
@@ -18,6 +18,7 @@
 #include "reone/system/fileutil.h"
 
 #include "reone/system/exception/filenotfound.h"
+#include "reone/system/logutil.h"
 
 namespace reone {
 
@@ -31,24 +32,69 @@ static bool splitRelativePath(std::string_view relPath, std::vector<std::string>
     return true;
 }
 
-std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
-    std::vector<std::string> tokens;
-    if (!splitRelativePath(relPath, tokens)) {
-        throw FileNotFoundException((dir / relPath).string());
-    }
-
+/**
+ * Resolve one path component below dir, ignoring case.
+ *
+ * The contract, in order:
+ *
+ *  - An exact match wins. On the case-insensitive filesystems the games shipped
+ *    for this is the only reachable outcome, so it is never ambiguous.
+ *  - A unique case-folded match resolves to its real path. This is what the
+ *    helper exists for: retail data ships under whatever casing the original
+ *    installer used.
+ *  - Several case-folded matches with no exact match is a genuine ambiguity.
+ *    The requested name designates more than one filesystem entity and nothing
+ *    at this layer can know which was meant.
+ *
+ * Only the on-disk entry is folded; the requested name is expected to already
+ * be lowercase, and a name that is not stays unmatched.
+ *
+ * The ambiguous case still resolves rather than failing, because mod installs
+ * and archive extraction do produce collisions ("Override" beside "override")
+ * and refusing them would strand installations that work today. It is reported
+ * instead of being swallowed, and the winner is chosen by name so that every
+ * consumer asking the same question gets the same answer rather than whatever
+ * the directory happened to yield first. That ordering is a tie-break for
+ * reproducibility only: it is not a claim about which entity is correct.
+ */
+static std::optional<std::filesystem::path> resolveComponentIgnoreCase(
+    const std::filesystem::path &dir,
+    const std::string &name) {
+    std::vector<std::filesystem::path> folded;
     for (auto &entry : std::filesystem::directory_iterator(dir)) {
-        auto filename = boost::to_lower_copy(entry.path().filename().string());
-        if (filename == tokens[0]) {
-            if (tokens.size() == 1) {
-                return entry.path();
-            }
-            auto subPath = relPath.substr(tokens[0].length() + 1);
-            return getFileIgnoreCase(entry.path(), subPath);
+        auto filename = entry.path().filename().string();
+        if (filename == name) {
+            return entry.path();
+        }
+        if (boost::to_lower_copy(filename) == name) {
+            folded.push_back(entry.path());
         }
     }
+    if (folded.empty()) {
+        return std::nullopt;
+    }
+    std::sort(folded.begin(), folded.end());
+    if (folded.size() > 1) {
+        std::string candidates;
+        for (const auto &candidate : folded) {
+            if (!candidates.empty()) {
+                candidates += ", ";
+            }
+            candidates += candidate.filename().string();
+        }
+        warn("Ambiguous case-insensitive lookup of '" + name + "' in " +
+             dir.string() + ": " + candidates + " differ only by case; using '" +
+             folded.front().filename().string() + "'");
+    }
+    return folded.front();
+}
 
-    throw FileNotFoundException((dir / relPath).string());
+std::filesystem::path getFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
+    auto path = findFileIgnoreCase(dir, relPath);
+    if (!path) {
+        throw FileNotFoundException((dir / relPath).string());
+    }
+    return *path;
 }
 
 std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::path &dir, std::string_view relPath) {
@@ -57,18 +103,14 @@ std::optional<std::filesystem::path> findFileIgnoreCase(const std::filesystem::p
         return std::nullopt;
     }
 
-    for (auto &entry : std::filesystem::directory_iterator(dir)) {
-        auto filename = boost::to_lower_copy(entry.path().filename().string());
-        if (filename == tokens[0]) {
-            if (tokens.size() == 1) {
-                return entry.path();
-            }
-            auto subPath = relPath.substr(tokens[0].length() + 1);
-            return findFileIgnoreCase(entry.path(), subPath);
-        }
+    auto resolved = resolveComponentIgnoreCase(dir, tokens[0]);
+    if (!resolved) {
+        return std::nullopt;
     }
-
-    return std::nullopt;
+    if (tokens.size() == 1) {
+        return resolved;
+    }
+    return findFileIgnoreCase(*resolved, relPath.substr(tokens[0].length() + 1));
 }
 
 bool isValidResRef(std::string_view name, size_t maxLen) {

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -189,6 +189,7 @@ public:
     MOCK_METHOD(void, onModuleLoad, (const std::string &name), (override));
     MOCK_METHOD(void, onNewGame, (), (override));
     MOCK_METHOD(void, onGameLoad, (std::string_view name), (override));
+    MOCK_METHOD(void, onGameLoad, (const SaveSlotDescriptor &slot), (override));
     MOCK_METHOD(std::optional<Resource>, findSaveMetadata, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, findSaveWorking, (const ResourceId &id), (override));
     MOCK_METHOD(std::unordered_set<ResourceId>, saveWorkingResourceIds, (), (const, override));

--- a/test/game/runtimesession.cpp
+++ b/test/game/runtimesession.cpp
@@ -219,7 +219,12 @@ TEST(RuntimeSession, retirement_preserves_save_wide_logical_and_resource_state) 
     game.party().addMember(kNpcPlayer, player);
     game.party().setPlayer(player);
 
-    EXPECT_CALL(engine.resourceModule().director(), onGameLoad(_)).Times(0);
+    EXPECT_CALL(engine.resourceModule().director(),
+                onGameLoad(An<std::string_view>()))
+        .Times(0);
+    EXPECT_CALL(engine.resourceModule().director(),
+                onGameLoad(An<const resource::SaveSlotDescriptor &>()))
+        .Times(0);
     EXPECT_CALL(engine.resourceModule().director(), onModuleLoad(_)).Times(0);
     EXPECT_CALL(engine.audioModule().mixer(), stopAll()).Times(1);
     EXPECT_CALL(sceneGraph, clear()).Times(1);

--- a/test/game/savedgame.cpp
+++ b/test/game/savedgame.cpp
@@ -219,3 +219,136 @@ TEST_F(SaveBrowserTest, deletesOnlyTheExactValidatedSlotDirectory) {
 }
 
 } // namespace
+
+namespace {
+
+/// Installation root whose save directory casing the test chooses.
+class SaveRootCasingTest : public Test {
+protected:
+    std::filesystem::path _root;
+
+    void SetUp() override {
+        static std::atomic_uint64_t sequence {0};
+        _root = std::filesystem::temp_directory_path() /
+                ("reone_saveroot_" + std::to_string(++sequence));
+        std::filesystem::create_directories(_root);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(_root, ec);
+    }
+
+    std::filesystem::path addSlot(
+        const std::string &savesDirectoryName,
+        const std::string &directoryName,
+        bool complete = true) {
+        auto directory = _root / savesDirectoryName / directoryName;
+        std::filesystem::create_directories(directory);
+        std::ofstream(directory / "SAVEGAME.sav", std::ios::binary).put('x');
+        if (!complete) {
+            return directory;
+        }
+        auto nfo = Gff::Builder()
+                       .field(Gff::Field::newCExoString("AREANAME", "Upper City"))
+                       .field(Gff::Field::newCExoString("LASTMODULE", "tar_m02aa"))
+                       .field(Gff::Field::newCExoString("PCNAME", "Revan"))
+                       .field(Gff::Field::newDword("TIMEPLAYED", 3723))
+                       .field(Gff::Field::newCExoString("SAVEGAMENAME", "Test Save"))
+                       .build();
+        auto bytes = GffWriter(GffFileFormat::v32("NFO "), *nfo).toBytes();
+        std::ofstream nfoFile(directory / "savenfo.res", std::ios::binary);
+        nfoFile.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        return directory;
+    }
+};
+
+} // namespace
+
+TEST_F(SaveRootCasingTest, discoversSlotsUnderAnUppercaseSaveRoot) {
+    // given a retail installation that ships "Saves" rather than "saves", as
+    // K2 does. Spelling the directory instead of discovering it leaves the
+    // list empty on a case-sensitive filesystem.
+    addSlot("Saves", "000002 - Game1");
+
+    // when
+    auto saves = discoverSavedGames(_root);
+
+    // then
+    ASSERT_EQ(1u, saves.size());
+    EXPECT_EQ(2u, saves.front().slot);
+    EXPECT_EQ("000002 - Game1", saves.front().descriptor.directory.filename().string());
+}
+
+TEST_F(SaveRootCasingTest, discoversSlotsUnderALowercaseSaveRoot) {
+    // given
+    addSlot("saves", "000002 - Game1");
+
+    // when
+    auto saves = discoverSavedGames(_root);
+
+    // then
+    ASSERT_EQ(1u, saves.size());
+    EXPECT_EQ("000002 - Game1", saves.front().descriptor.directory.filename().string());
+}
+
+TEST_F(SaveRootCasingTest, prefersTheExactlyNamedSaveRootWhenSeveralCasingsExist) {
+    // given both casings on disk. Indexing, deletion and writing each resolve
+    // the save root independently: if they disagree the list offers a slot the
+    // loader cannot mount, which is what strands a load with no session.
+    addSlot("saves", "000002 - Game1");
+    addSlot("Saves", "000003 - Game2");
+
+    // A case-insensitive filesystem cannot hold both spellings at once, so the
+    // second slot lands below the first root and there is no ambiguity left to
+    // resolve. Ask the filesystem rather than the platform: Windows can be
+    // configured per-directory either way.
+    std::error_code ec;
+    if (std::filesystem::equivalent(_root / "saves", _root / "Saves", ec) && !ec) {
+        GTEST_SKIP() << "filesystem is case-insensitive: both save roots are "
+                        "one directory, so no case collision exists to resolve";
+    }
+
+    // when
+    auto resolved = savedGamesDirectory(_root);
+    auto saves = discoverSavedGames(_root);
+
+    // then the canonically spelled root wins, and discovery agrees with it
+    EXPECT_EQ("saves", resolved.filename().string());
+    ASSERT_EQ(1u, saves.size());
+    EXPECT_EQ(2u, saves.front().slot);
+    EXPECT_EQ(resolved, saves.front().descriptor.directory.parent_path());
+}
+
+TEST_F(SaveRootCasingTest, resolvesTheCanonicalRootWhenNoSaveDirectoryExistsYet) {
+    // given a fresh installation, so a first save still has somewhere to go
+    // when
+    auto resolved = savedGamesDirectory(_root);
+
+    // then
+    EXPECT_EQ("saves", resolved.filename().string());
+    EXPECT_EQ(_root, resolved.parent_path());
+    EXPECT_TRUE(discoverSavedGames(_root).empty());
+}
+
+TEST_F(SaveRootCasingTest, stillRejectsIncompleteSlotsUnderAnUppercaseSaveRoot) {
+    // given a slot missing savenfo.res
+    addSlot("Saves", "000002 - Game1", /*complete=*/false);
+
+    // when / then case-safe discovery must not weaken structural validation
+    EXPECT_TRUE(discoverSavedGames(_root).empty());
+}
+
+TEST_F(SaveRootCasingTest, deletesAValidatedSlotUnderAnUppercaseSaveRoot) {
+    // given deletion validates containment against the resolved save root
+    auto directory = addSlot("Saves", "000002 - Game1");
+    auto saves = discoverSavedGames(_root);
+    ASSERT_EQ(1u, saves.size());
+
+    // when
+    bool deleted = deleteSavedGame(_root, saves.front().descriptor);
+
+    // then
+    EXPECT_TRUE(deleted);
+    EXPECT_FALSE(std::filesystem::exists(directory));
+}

--- a/test/system/fileutil.cpp
+++ b/test/system/fileutil.cpp
@@ -139,3 +139,66 @@ TEST(FileUtilities, should_reject_unsafe_path_components) {
     EXPECT_FALSE(isSafePathComponent("bad<name>"));
     EXPECT_FALSE(isSafePathComponent("bad\"name"));
 }
+
+/// Temporary directory holding entries that differ only by case.
+struct TmpCaseClash {
+    std::filesystem::path root;
+
+    explicit TmpCaseClash(const std::vector<std::string> &names) {
+        root = std::filesystem::temp_directory_path() / "reone_test_file_util_case_clash";
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+        for (const auto &name : names) {
+            std::filesystem::create_directories(root / name);
+        }
+    }
+
+    ~TmpCaseClash() {
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+    }
+};
+
+TEST(FileUtilities, resolves_an_exact_match_ahead_of_other_casings) {
+    // given both casings on disk
+    TmpCaseClash tree({"saves", "Saves"});
+
+    // when
+    auto resolved = findFileIgnoreCase(tree.root, "saves");
+
+    // then the exactly named entry wins rather than whichever the directory
+    // happened to yield first
+    ASSERT_TRUE(resolved);
+    EXPECT_EQ("saves", resolved->filename().string());
+}
+
+TEST(FileUtilities, resolves_case_clashing_entries_deterministically) {
+    // given only folded matches, so there is nothing exact to prefer.
+    // Directory iteration order is unspecified, so without a tie-break two
+    // consumers asking the same question could disagree about which entry a
+    // name refers to, and one could offer a file the other cannot find.
+    TmpCaseClash tree({"Saves", "SAVES"});
+
+    // when
+    auto first = findFileIgnoreCase(tree.root, "saves");
+    ASSERT_TRUE(first);
+
+    // then
+    for (int i = 0; i < 16; ++i) {
+        auto repeated = findFileIgnoreCase(tree.root, "saves");
+        ASSERT_TRUE(repeated);
+        EXPECT_EQ(*first, *repeated);
+    }
+}
+
+TEST(FileUtilities, resolves_a_single_folded_match_to_its_real_path) {
+    // given retail data ships under whatever casing the installer used
+    TmpCaseClash tree({"Saves"});
+
+    // when
+    auto resolved = findFileIgnoreCase(tree.root, "saves");
+
+    // then
+    ASSERT_TRUE(resolved);
+    EXPECT_EQ("Saves", resolved->filename().string());
+}


### PR DESCRIPTION
## Summary

On Linux, save discovery and loading could resolve different `saves` / `Saves` directories. This could make K2 saves disappear entirely, or cause the UI to list a slot from one directory while the loader opened another.

Save discovery, deletion and writing now use the same case-safe resolver, and loading carries the discovered `SaveSlotDescriptor` through instead of resolving the slot name again.

Exact-case matches win. Ambiguous case-folded matches are warned and resolved deterministically.

## Validation

Adds K1/K2 coverage for upper/lowercase save roots, exact-match preference, fresh-install fallback, incomplete slots and deletion.

Full suite passes, with live Linux K1/K2 validation.