### PR TITLE
[game] Hand control back to the player character

### DIFF
--- a/include/reone/game/party.h
+++ b/include/reone/game/party.h
@@ -133,6 +133,20 @@ public:
     const std::vector<Member> &members() const { return _members; }
 
     const PersistedState &persistedState() const { return _persistedState; }
+
+    /** Roster index of the actor standing in for the PC, or kNpcPlayer. */
+    int controlledNpc() const { return _persistedState.controlledNpc; }
+
+    /**
+     * Hand control to a creature, leaving the rest of the party alone.
+     *
+     * Retail models temporary control as a roster NPC taking the player's
+     * place: the outgoing actor is parked rather than demoted to a companion,
+     * and the companions travelling with it are untouched. The incoming
+     * creature occupies the leading slot exactly once, however it was
+     * represented before.
+     */
+    void setControlledMember(int npc, const std::shared_ptr<Creature> &creature);
     void setPersistedState(PersistedState state);
 
     void setPartyLeader(int npc);

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1764,6 +1764,7 @@ void Game::loadDefaultParty() {
         player->setImmortal(true);
         _party.addMember(kNpcPlayer, player);
         _party.setPlayer(player);
+        _party.setActualPlayer(player);
     }
     if (!member2.empty()) {
         std::shared_ptr<Creature> companion = newCreature();

--- a/src/libs/game/gui/chargen.cpp
+++ b/src/libs/game/gui/chargen.cpp
@@ -374,6 +374,9 @@ void CharacterGeneration::finish() {
         party.reset();
         party.addMember(kNpcPlayer, player);
         party.setPlayer(player);
+        // The canonical PC has to exist before any script hands control to a
+        // stand-in, or there is nothing to hand control back to.
+        party.setActualPlayer(player);
 
         std::string moduleName(!_game.isTSL() ? "end_m01aa" : "001ebo");
         _game.loadModule(moduleName);

--- a/src/libs/game/party.cpp
+++ b/src/libs/game/party.cpp
@@ -17,6 +17,8 @@
 
 #include "reone/game/party.h"
 
+#include <algorithm>
+
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
 #include "reone/system/logutil.h"
@@ -336,6 +338,33 @@ void Party::setPartyLeaderByIndex(int index) {
 
 void Party::setPlayer(const std::shared_ptr<Creature> &player) {
     _player = player;
+}
+
+void Party::setControlledMember(int npc, const std::shared_ptr<Creature> &creature) {
+    // However the incoming creature was represented before, it ends up in the
+    // leading slot once and only once.
+    _members.erase(
+        std::remove_if(
+            _members.begin(), _members.end(),
+            [&npc, &creature](const Member &member) {
+                return member.npc == npc || member.creature == creature;
+            }),
+        _members.end());
+
+    // The actor being relieved stops being a party member rather than becoming
+    // a companion: the canonical PC waits in _actualPlayer and a relieved NPC
+    // waits in the available roster, which is where each is looked up again.
+    if (!_members.empty() && _player && _members.front().creature == _player) {
+        _members.erase(_members.begin());
+    }
+
+    Member member;
+    member.npc = npc;
+    member.creature = creature;
+    _members.insert(_members.begin(), std::move(member));
+
+    _player = creature;
+    _persistedState.controlledNpc = npc;
 }
 
 bool Party::removeMember(int npc) {

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -222,12 +222,22 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
 
     // Execute
     Party &party = ctx.game.party();
-    if (party.getMemberByNPC(nNPC)) {
-        party.setPartyLeader(nNPC);
-        return Variable::ofInt(1);
-    }
 
-    std::shared_ptr<Creature> creature = party.getAvailableMember(nNPC);
+    // The canonical PC is not a roster entry. Retail parks it while another
+    // actor stands in, and -1 asks for it back; the available roster only ever
+    // holds companions.
+    std::shared_ptr<Creature> creature;
+    if (nNPC == kNpcPlayer) {
+        if (party.controlledNpc() == kNpcPlayer) {
+            return Variable::ofInt(1);
+        }
+        creature = party.actualPlayer();
+    } else {
+        if (party.controlledNpc() == nNPC) {
+            return Variable::ofInt(1);
+        }
+        creature = party.getAvailableMember(nNPC);
+    }
     if (!creature) {
         warn("Party: NPC not found: " + std::to_string(nNPC));
         return Variable::ofInt(0);
@@ -243,9 +253,7 @@ static Variable SwitchPlayerCharacter(const std::vector<Variable> &args, const R
         area->unloadParty();
     }
 
-    party.clear();
-    party.addMember(nNPC, creature);
-    party.setPlayer(creature);
+    party.setControlledMember(nNPC, creature);
 
     if (area) {
         area->loadParty(position, facing);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/effect.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymap.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymaproutines.cpp
+    ${TESTS_SOURCE_DIR}/game/partycontrol.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymapstate.cpp
     ${TESTS_SOURCE_DIR}/game/savedruntime.cpp
     ${TESTS_SOURCE_DIR}/game/saveprovenance.cpp

--- a/test/game/partycontrol.cpp
+++ b/test/game/partycontrol.cpp
@@ -1,0 +1,174 @@
+/* Copyright (c) 2026 The reone project contributors */
+
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/party.h"
+#include "reone/game/script/routines.h"
+#include "reone/game/types.h"
+#include "reone/resource/types.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/variable.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace reone::script;
+
+namespace {
+
+/**
+ * A game plus its routine table, so SwitchPlayerCharacter can be called the way
+ * the shipped prologue and Leviathan scripts call it.
+ */
+class ControlHarness : boost::noncopyable {
+public:
+    explicit ControlHarness(GameID gameId) :
+        _game(gameId, "", testEngine().options(), testEngine().services(), _console),
+        _routines(gameId, &_game, &testEngine().services()) {
+        _routines.init();
+    }
+
+    /** A brand new game: no save has ever been loaded. */
+    std::shared_ptr<Creature> startFreshGame() {
+        auto player = _game.newCreature();
+        _game.party().addMember(kNpcPlayer, player);
+        _game.party().setPlayer(player);
+        _game.party().setActualPlayer(player);
+        return player;
+    }
+
+    std::shared_ptr<Creature> addRosterNpc(int npc) {
+        auto creature = _game.newCreature();
+        _game.party().addAvailableMember(npc, creature);
+        return creature;
+    }
+
+    std::shared_ptr<Creature> addCompanion(int npc) {
+        auto creature = addRosterNpc(npc);
+        _game.party().addMember(npc, creature);
+        return creature;
+    }
+
+    int switchTo(int npc) {
+        Routine &routine = _routines.get(
+            _routines.getIndexByName("SwitchPlayerCharacter"));
+        ExecutionContext execution;
+        execution.routines = &_routines;
+        return routine.invoke({Variable::ofInt(npc)}, execution).intValue;
+    }
+
+    Party &party() { return _game.party(); }
+
+    /** How many member entries name this creature. */
+    size_t occurrences(const std::shared_ptr<Creature> &creature) {
+        size_t count = 0;
+        for (const auto &member : _game.party().members()) {
+            if (member.creature == creature) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+private:
+    StubConsole _console;
+    Game _game;
+    Routines _routines;
+};
+
+class PartyControl : public ::testing::TestWithParam<GameID> {};
+
+} // namespace
+
+TEST_P(PartyControl, aFreshGameEstablishesTheCanonicalPlayer) {
+    // given nothing but character generation. Until this holds there is no
+    // canonical PC for a script to hand control back to.
+    ControlHarness harness(GetParam());
+    auto player = harness.startFreshGame();
+
+    EXPECT_EQ(player, harness.party().actualPlayer());
+    EXPECT_EQ(player, harness.party().player());
+    EXPECT_EQ(kNpcPlayer, harness.party().controlledNpc());
+}
+
+TEST_P(PartyControl, controlPassesToARosterNpcAndBackOnAFreshGame) {
+    // given the shipped K2 prologue chain, which never loads a save:
+    //   AddAvailableNPCByTemplate(8, "p_t3m4") -> SwitchPlayerCharacter(8)
+    //   ... -> SwitchPlayerCharacter(-1) -> StartNewModule("101PER")
+    ControlHarness harness(GetParam());
+    auto player = harness.startFreshGame();
+    auto t3 = harness.addRosterNpc(8);
+
+    ASSERT_EQ(1, harness.switchTo(8));
+    EXPECT_EQ(t3, harness.party().player());
+    EXPECT_EQ(t3, harness.party().getLeader());
+    EXPECT_EQ(8, harness.party().controlledNpc());
+
+    // then handing control back restores the canonical PC rather than
+    // transferring the stand-in into the next module
+    ASSERT_EQ(1, harness.switchTo(kNpcPlayer));
+    EXPECT_EQ(player, harness.party().player());
+    EXPECT_EQ(player, harness.party().getLeader());
+    EXPECT_EQ(kNpcPlayer, harness.party().controlledNpc());
+}
+
+TEST_P(PartyControl, unrelatedCompanionsSurviveAControlChange) {
+    // given a companion travelling with the player, as on the Leviathan
+    ControlHarness harness(GetParam());
+    auto player = harness.startFreshGame();
+    auto companion = harness.addCompanion(0);
+    auto breaker = harness.addRosterNpc(5);
+
+    ASSERT_EQ(1, harness.switchTo(5));
+    EXPECT_EQ(1u, harness.occurrences(companion));
+    EXPECT_TRUE(harness.party().isMember(0));
+
+    ASSERT_EQ(1, harness.switchTo(kNpcPlayer));
+    EXPECT_EQ(player, harness.party().getLeader());
+    EXPECT_EQ(1u, harness.occurrences(companion));
+    EXPECT_TRUE(harness.party().isMember(0));
+}
+
+TEST_P(PartyControl, takingControlOfACompanionLeavesItInThePartyOnlyOnce) {
+    // given the incoming actor is already an active companion
+    ControlHarness harness(GetParam());
+    harness.startFreshGame();
+    auto companion = harness.addCompanion(0);
+
+    ASSERT_EQ(1, harness.switchTo(0));
+
+    EXPECT_EQ(companion, harness.party().player());
+    EXPECT_EQ(companion, harness.party().getLeader());
+    EXPECT_EQ(1u, harness.occurrences(companion));
+}
+
+TEST_P(PartyControl, switchingToTheCurrentActorIsANoOp) {
+    ControlHarness harness(GetParam());
+    auto player = harness.startFreshGame();
+
+    // already the canonical PC
+    EXPECT_EQ(1, harness.switchTo(kNpcPlayer));
+    EXPECT_EQ(player, harness.party().player());
+    EXPECT_EQ(1u, harness.party().members().size());
+
+    auto npc = harness.addRosterNpc(4);
+    ASSERT_EQ(1, harness.switchTo(4));
+    EXPECT_EQ(1, harness.switchTo(4));
+    EXPECT_EQ(npc, harness.party().player());
+    EXPECT_EQ(1u, harness.occurrences(npc));
+}
+
+TEST_P(PartyControl, switchingToAnUnknownNpcChangesNothing) {
+    ControlHarness harness(GetParam());
+    auto player = harness.startFreshGame();
+
+    EXPECT_EQ(0, harness.switchTo(9));
+    EXPECT_EQ(player, harness.party().player());
+    EXPECT_EQ(kNpcPlayer, harness.party().controlledNpc());
+}
+
+INSTANTIATE_TEST_SUITE_P(Games, PartyControl,
+                         testing::Values(GameID::KotOR, GameID::TSL));


### PR DESCRIPTION
## Summary

`SwitchPlayerCharacter` treated the PC like an available NPC and rebuilt the active party when switching control. In K2's prologue this made
the switch from T3 back to the PC fail before `101PER`.

Keep the PC separate from the NPC roster and switch only the controlled member while preserving unrelated companions.