### PR TITLE
[game] Keep world time in retail milliseconds

### DIFF
--- a/include/reone/game/action/movetolocation.h
+++ b/include/reone/game/action/movetolocation.h
@@ -29,8 +29,12 @@ public:
     struct ForcedState {
         uint32_t areaId {kSavedRuntimeInvalidObjectId};
         bool active {false};
-        uint32_t expiryDay {0};
-        uint32_t expiryTime {0};
+        /**
+         * Absolute deadline in world milliseconds. The retail record stores a
+         * day/time pair; it is composed on restore and split again on save, so
+         * the running action never rebuilds a calendar.
+         */
+        uint64_t expiryMilliseconds {0};
     };
 
     MoveToLocationAction(Game &game,

--- a/include/reone/game/action/movetoobject.h
+++ b/include/reone/game/action/movetoobject.h
@@ -30,8 +30,12 @@ public:
         uint32_t areaId {kSavedRuntimeInvalidObjectId};
         glm::vec2 offset {0.0f};
         bool active {false};
-        uint32_t expiryDay {0};
-        uint32_t expiryTime {0};
+        /**
+         * Absolute deadline in world milliseconds. The retail record stores a
+         * day/time pair; it is composed on restore and split again on save, so
+         * the running action never rebuilds a calendar.
+         */
+        uint64_t expiryMilliseconds {0};
     };
 
     MoveToObjectAction(Game &game,

--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -449,9 +449,47 @@ public:
     void bindSavedRuntimeState();
     void publishSavedRuntimeState();
 
-    uint32_t worldTimeDay() const { return _worldTimeDay; }
-    uint32_t worldTimeOfDay() const { return _worldTimeOfDay; }
+    /**
+     * World time as absolute elapsed world/simulation milliseconds.
+     *
+     * This is the canonical runtime clock. It advances with simulation dt and
+     * is never rescaled; Mod_MinPerHour only changes how the calendar divides
+     * it. Retail saves store a day and a time of day instead, so that split
+     * happens at the save and load boundaries and nowhere else.
+     */
+    uint64_t worldTimeMilliseconds() const { return _worldTimeMilliseconds; }
+
     uint8_t minutesPerHour() const { return _minutesPerHour; }
+
+    /**
+     * Length of a game day in world-time milliseconds.
+     *
+     * Mod_MinPerHour shortens the day - an in-game hour lasts that many
+     * minutes of world time - it does not change the rate at which the clock
+     * advances. Matches CWorldTimer, where m_nMillisecondsInDay =
+     * MinutesPerHour * 60 * 1000 * HOURS_IN_DAY and the raw timer accumulates
+     * elapsed time.
+     */
+    uint32_t millisecondsPerWorldDay() const {
+        return static_cast<uint32_t>(_minutesPerHour == 0 ? 5 : _minutesPerHour) *
+               60u * 1000u * 24u;
+    }
+
+    /**
+     * Calendar day, derived from the canonical clock. Calendar time is a real
+     * engine concept - day/night cycles, NPC schedules, waiting - and not just
+     * a detail of the save format.
+     */
+    uint32_t worldTimeDay() const {
+        return static_cast<uint32_t>(
+            _worldTimeMilliseconds / millisecondsPerWorldDay());
+    }
+
+    /** World milliseconds elapsed within the current calendar day. */
+    uint32_t worldTimeOfDay() const {
+        return static_cast<uint32_t>(
+            _worldTimeMilliseconds % millisecondsPerWorldDay());
+    }
     std::optional<float> remainingEffectDuration(const EffectInstance &effect) const;
 
     template <class T>
@@ -641,9 +679,7 @@ private:
     bool _runtimeSessionPlayable {false};
     bool _cheatUsed {false};
     uint64_t _runtimeSessionGeneration {1};
-    static constexpr uint32_t kMillisecondsPerDay = 24u * 60u * 60u * 1000u;
-    uint32_t _worldTimeDay {0};
-    uint32_t _worldTimeOfDay {0};
+    uint64_t _worldTimeMilliseconds {0};
     uint8_t _minutesPerHour {5};
     double _worldTimeFraction {0.0};
     double _playedTimeFraction {0.0};

--- a/include/reone/game/object/module.h
+++ b/include/reone/game/object/module.h
@@ -130,6 +130,12 @@ private:
 
     struct PublishedSavedEvent {
         size_t savedIndex {0};
+        /**
+         * Absolute due time in world milliseconds, composed once from the
+         * record's day/time pair when the queue is published. Dispatch then
+         * compares clocks without rebuilding a calendar every frame.
+         */
+        uint64_t dueMilliseconds {0};
         std::shared_ptr<SavedScriptContinuation> continuation;
         bool delivered {false};
     };

--- a/src/libs/game/action/movetolocation.cpp
+++ b/src/libs/game/action/movetolocation.cpp
@@ -29,12 +29,6 @@ namespace reone {
 
 namespace game {
 
-namespace {
-
-constexpr uint32_t kMillisecondsPerDay = 24u * 60u * 60u * 1000u;
-
-}
-
 void MoveToLocationAction::execute(std::shared_ptr<Action> self, Object &actor, float dt) {
     if (!_destination) {
         complete();
@@ -52,18 +46,14 @@ void MoveToLocationAction::execute(std::shared_ptr<Action> self, Object &actor, 
         if (auto module = _game.module(); module && module->area()) {
             _forcedState.areaId = module->area()->id();
         }
-        uint64_t now = static_cast<uint64_t>(_game.worldTimeDay()) * kMillisecondsPerDay +
-                       _game.worldTimeOfDay();
-        uint64_t expiry = now + static_cast<uint64_t>(
-            std::llround(std::max(0.0f, _timeout) * 1000.0f));
-        _forcedState.expiryDay = static_cast<uint32_t>(expiry / kMillisecondsPerDay);
-        _forcedState.expiryTime = static_cast<uint32_t>(expiry % kMillisecondsPerDay);
+        _forcedState.expiryMilliseconds = _game.worldTimeMilliseconds() +
+            static_cast<uint64_t>(
+                std::llround(std::max(0.0f, _timeout) * 1000.0f));
     }
 
     if (_force && _forcedState.active) {
-        bool expired = _game.worldTimeDay() > _forcedState.expiryDay ||
-                       (_game.worldTimeDay() == _forcedState.expiryDay &&
-                        _game.worldTimeOfDay() >= _forcedState.expiryTime);
+        bool expired =
+            _game.worldTimeMilliseconds() >= _forcedState.expiryMilliseconds;
         if (expired) {
             actor.setPosition(destination);
             if (auto module = _game.module(); module && module->area() &&
@@ -88,8 +78,7 @@ std::optional<SavedActionRecord> MoveToLocationAction::saveFacingState() const {
         (_force && (!std::isfinite(_timeout) ||
                     (!_forcedState.active && _timeout <= 0.0f))) ||
         (_force && _forcedState.active &&
-         ((_forcedState.expiryDay == 0 && _forcedState.expiryTime == 0) ||
-          _forcedState.expiryTime >= kMillisecondsPerDay))) {
+         _forcedState.expiryMilliseconds == 0)) {
         return std::nullopt;
     }
 
@@ -102,6 +91,18 @@ std::optional<SavedActionRecord> MoveToLocationAction::saveFacingState() const {
     if (areaId == kSavedRuntimeInvalidObjectId) {
         return std::nullopt;
     }
+
+    // Split the absolute deadline into the retail pair at the serialization
+    // boundary. A zero absolute deadline is rejected above, so an armed forced
+    // move never serializes as the unarmed (0, 0) encoding.
+    const bool forcedActive = _force && _forcedState.active;
+    const uint64_t millisecondsPerDay = _game.millisecondsPerWorldDay();
+    const uint32_t expiryDay = forcedActive
+        ? static_cast<uint32_t>(_forcedState.expiryMilliseconds / millisecondsPerDay)
+        : 0;
+    const uint32_t expiryTime = forcedActive
+        ? static_cast<uint32_t>(_forcedState.expiryMilliseconds % millisecondsPerDay)
+        : 0;
 
     SavedActionRecord result = originalSavedAction().value_or(SavedActionRecord {});
     result.actionId = 1;
@@ -120,8 +121,8 @@ std::optional<SavedActionRecord> MoveToLocationAction::saveFacingState() const {
         {2, _force && !_forcedState.active ? _timeout : 0.0f},
         {2, 0.0f},
         {2, 0.0f},
-        {1, static_cast<int32_t>(_force && _forcedState.active ? _forcedState.expiryDay : 0)},
-        {1, static_cast<int32_t>(_force && _forcedState.active ? _forcedState.expiryTime : 0)},
+        {1, static_cast<int32_t>(expiryDay)},
+        {1, static_cast<int32_t>(expiryTime)},
     };
     return result;
 }

--- a/src/libs/game/action/movetoobject.cpp
+++ b/src/libs/game/action/movetoobject.cpp
@@ -29,12 +29,6 @@ namespace reone {
 
 namespace game {
 
-namespace {
-
-constexpr uint32_t kMillisecondsPerDay = 24u * 60u * 60u * 1000u;
-
-}
-
 MoveToObjectAction::MoveToObjectAction(
     Game &game, ServicesView &services, std::shared_ptr<Object> moveTo,
     bool run, float range, bool force, float timeout) :
@@ -78,20 +72,16 @@ void MoveToObjectAction::execute(std::shared_ptr<Action> self, Object &actor, fl
         if (auto module = _game.module(); module && module->area()) {
             _forcedState.areaId = module->area()->id();
         }
-        uint64_t now = static_cast<uint64_t>(_game.worldTimeDay()) * kMillisecondsPerDay +
-                       _game.worldTimeOfDay();
-        uint64_t expiry = now + static_cast<uint64_t>(
-            std::llround(std::max(0.0f, _timeout) * 1000.0f));
-        _forcedState.expiryDay = static_cast<uint32_t>(expiry / kMillisecondsPerDay);
-        _forcedState.expiryTime = static_cast<uint32_t>(expiry % kMillisecondsPerDay);
+        _forcedState.expiryMilliseconds = _game.worldTimeMilliseconds() +
+            static_cast<uint64_t>(
+                std::llround(std::max(0.0f, _timeout) * 1000.0f));
     }
 
     auto dest = _moveTo ? _moveTo->position() : _forcedState.destination;
 
     if (_force && _forcedState.active) {
-        bool expired = _game.worldTimeDay() > _forcedState.expiryDay ||
-                       (_game.worldTimeDay() == _forcedState.expiryDay &&
-                        _game.worldTimeOfDay() >= _forcedState.expiryTime);
+        bool expired =
+            _game.worldTimeMilliseconds() >= _forcedState.expiryMilliseconds;
         if (expired) {
             actor.setPosition(_forcedState.destination);
             if (auto module = _game.module(); module && module->area() &&
@@ -131,6 +121,15 @@ std::optional<SavedActionRecord> MoveToObjectAction::saveFacingState() const {
         if (areaId == kSavedRuntimeInvalidObjectId) {
             return std::nullopt;
         }
+        // Split the absolute deadline into the retail pair at the
+        // serialization boundary.
+        const uint64_t millisecondsPerDay = _game.millisecondsPerWorldDay();
+        const uint32_t expiryDay = _forcedState.active
+            ? static_cast<uint32_t>(_forcedState.expiryMilliseconds / millisecondsPerDay)
+            : 0;
+        const uint32_t expiryTime = _forcedState.active
+            ? static_cast<uint32_t>(_forcedState.expiryMilliseconds % millisecondsPerDay)
+            : 0;
         int32_t flags = (_run ? 1 : 0) | (_forcedState.active ? 0 : 4);
         result.actionId = 1;
         result.declaredParameterCount = 13;
@@ -140,8 +139,8 @@ std::optional<SavedActionRecord> MoveToObjectAction::saveFacingState() const {
             {1, flags}, {2, _range}, {1, int32_t {0}},
             {2, _forcedState.active ? 0.0f : _timeout},
             {2, _forcedState.offset.x}, {2, _forcedState.offset.y},
-            {1, static_cast<int32_t>(_forcedState.active ? _forcedState.expiryDay : 0)},
-            {1, static_cast<int32_t>(_forcedState.active ? _forcedState.expiryTime : 0)},
+            {1, static_cast<int32_t>(expiryDay)},
+            {1, static_cast<int32_t>(expiryTime)},
         };
         return result;
     }

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1157,8 +1157,7 @@ void Game::retireRuntimeSession() {
     _reservedSavedObjectIds.clear();
     _nextObjectId = kFirstRuntimeObjectId;
     _effectIds.reset();
-    _worldTimeDay = 0;
-    _worldTimeOfDay = 0;
+    _worldTimeMilliseconds = 0;
     _minutesPerHour = 5;
     _worldTimeFraction = 0.0;
 
@@ -1978,12 +1977,8 @@ void Game::prepareSavedRuntimeNamespace(const resource::Gff &ifo) {
             throw ValidationException("Invalid Mod_Effect_NxtId");
         }
     }
-    _worldTimeDay = ifo.getUint("Mod_CalendarDay");
-    _worldTimeOfDay = ifo.getUint("Mod_TimeOfDay");
-    if (_worldTimeOfDay >= kMillisecondsPerDay) {
-        throw ValidationException("Invalid Mod_TimeOfDay");
-    }
-
+    // Mod_MinPerHour first: it defines the day length that Mod_TimeOfDay is
+    // measured against.
     uint32_t minutesPerHour = ifo.getUint("Mod_MinPerHour");
     if (minutesPerHour > std::numeric_limits<uint8_t>::max()) {
         throw ValidationException("Invalid Mod_MinPerHour");
@@ -1991,6 +1986,16 @@ void Game::prepareSavedRuntimeNamespace(const resource::Gff &ifo) {
     _minutesPerHour = minutesPerHour == 0
                           ? 5
                           : static_cast<uint8_t>(minutesPerHour);
+
+    // Compose the canonical clock from the retail day/time pair. An oversized
+    // time of day carries into later days rather than being rejected, as
+    // CWorldTimer::GetWorldTime does: saves written before the day length
+    // became Mod_MinPerHour-derived hold a time of day on the old fixed
+    // 24-hour scale, and must still load. Both fields are Dwords, so the
+    // composition cannot overflow the 64-bit clock.
+    uint64_t day = ifo.getUint("Mod_CalendarDay");
+    uint64_t timeOfDay = ifo.getUint("Mod_TimeOfDay");
+    _worldTimeMilliseconds = day * millisecondsPerWorldDay() + timeOfDay;
     _worldTimeFraction = 0.0;
 }
 
@@ -2041,21 +2046,20 @@ void Game::advanceWorldTime(float dt) {
     if (dt <= 0.0f) {
         return;
     }
+    // One second of simulation is one thousand world milliseconds.
+    // Mod_MinPerHour shortens the day, it does not accelerate the clock:
+    // CWorldTimer accumulates elapsed time into m_nSnapshotTime and only
+    // derives the day boundary from m_nMillisecondsInDay. Scaling the rate
+    // here instead made every duration measured in world time short by
+    // 60 / Mod_MinPerHour.
     double gameMilliseconds =
-        _worldTimeFraction +
-        static_cast<double>(dt) * 60000.0 /
-            static_cast<double>(_minutesPerHour);
+        _worldTimeFraction + static_cast<double>(dt) * 1000.0;
     uint64_t wholeMilliseconds =
         static_cast<uint64_t>(std::floor(gameMilliseconds));
     _worldTimeFraction =
         gameMilliseconds - static_cast<double>(wholeMilliseconds);
 
-    uint64_t timeOfDay =
-        static_cast<uint64_t>(_worldTimeOfDay) + wholeMilliseconds;
-    _worldTimeDay += static_cast<uint32_t>(
-        timeOfDay / kMillisecondsPerDay);
-    _worldTimeOfDay = static_cast<uint32_t>(
-        timeOfDay % kMillisecondsPerDay);
+    _worldTimeMilliseconds += wholeMilliseconds;
 }
 
 std::optional<float> Game::remainingEffectDuration(
@@ -2067,19 +2071,18 @@ std::optional<float> Game::remainingEffectDuration(
         return std::max(0.0f, effect.duration);
     }
 
-    uint64_t now =
-        static_cast<uint64_t>(_worldTimeDay) * kMillisecondsPerDay +
-        _worldTimeOfDay;
+    // Save-facing expiry provenance, converted once here at the restoration
+    // boundary. Live effects then count down in world seconds and never
+    // reconstruct a calendar day again.
     uint64_t expiry =
-        static_cast<uint64_t>(effect.expiryDay) * kMillisecondsPerDay +
+        static_cast<uint64_t>(effect.expiryDay) * millisecondsPerWorldDay() +
         effect.expiryTime;
-    if (expiry <= now) {
+    if (expiry <= _worldTimeMilliseconds) {
         return 0.0f;
     }
-    double realSeconds =
-        static_cast<double>(expiry - now) *
-        static_cast<double>(_minutesPerHour) / 60000.0;
-    return static_cast<float>(realSeconds);
+    double remainingSeconds =
+        static_cast<double>(expiry - _worldTimeMilliseconds) / 1000.0;
+    return static_cast<float>(remainingSeconds);
 }
 
 void Game::renderGUI() {

--- a/src/libs/game/modulesnapshot.cpp
+++ b/src/libs/game/modulesnapshot.cpp
@@ -58,7 +58,6 @@ using resource::Gff;
 using resource::ResType;
 
 constexpr uint32_t kNcsHeaderSize = 13;
-constexpr uint32_t kMillisecondsPerDay = 24u * 60u * 60u * 1000u;
 
 std::shared_ptr<Gff> emptyRecord(uint32_t type) {
     return Gff::Builder().type(type).build();
@@ -174,17 +173,18 @@ std::shared_ptr<Gff> effectToGff(
     uint32_t expiryDay = effect.expiryDay;
     uint32_t expiryTime = effect.expiryTime;
     if (effect.durationType() == DurationType::Temporary && effect.remainingDuration) {
-        if (!game || game->minutesPerHour() == 0) {
+        // A Game is still needed to read the canonical clock. Mod_MinPerHour
+        // no longer enters the conversion: it only sets the day length that
+        // splits the absolute expiry into the retail day/time pair.
+        if (!game) {
             throw ValidationException("temporary effect lacks a game-time conversion context");
         }
-        uint64_t now = static_cast<uint64_t>(game->worldTimeDay()) * kMillisecondsPerDay +
-                       game->worldTimeOfDay();
         uint64_t delta = static_cast<uint64_t>(std::llround(
-            std::max(0.0f, *effect.remainingDuration) * 60000.0 /
-            game->minutesPerHour()));
-        uint64_t expiry = now + delta;
-        expiryDay = static_cast<uint32_t>(expiry / kMillisecondsPerDay);
-        expiryTime = static_cast<uint32_t>(expiry % kMillisecondsPerDay);
+            std::max(0.0f, *effect.remainingDuration) * 1000.0));
+        uint64_t expiry = game->worldTimeMilliseconds() + delta;
+        uint64_t millisecondsPerDay = game->millisecondsPerWorldDay();
+        expiryDay = static_cast<uint32_t>(expiry / millisecondsPerDay);
+        expiryTime = static_cast<uint32_t>(expiry % millisecondsPerDay);
     } else if (!effect.hasSerializableTemporalProvenance()) {
         throw ValidationException("temporary effect lacks save-facing expiry provenance");
     }
@@ -870,24 +870,21 @@ void ModuleSnapshotBuilder::appendRuntimeDelayedEvents(
                 " delayedIndex=" + std::to_string(index));
         }
 
-        // Object::_delayed counts stable-frame simulation seconds. EventQueue
-        // stores an absolute world timestamp, whose rate is controlled by
-        // Mod_MinPerHour. Snapshotting reads but never resets the live Timer.
+        // Object::_delayed counts stable-frame simulation seconds and the
+        // canonical clock counts world milliseconds, so the two share a unit.
+        // EventQueue stores an absolute timestamp as a day/time pair, split
+        // here at the serialization boundary. Snapshotting reads but never
+        // resets the live Timer.
         const double remainingSeconds = delayed.timer
                                             ? std::max(0.0f, delayed.timer->remaining())
                                             : 0.0f;
-        const double worldMilliseconds =
-            remainingSeconds * 60000.0 /
-            static_cast<double>(std::max<uint8_t>(1, _game._minutesPerHour));
-        const uint64_t now =
-            static_cast<uint64_t>(_game._worldTimeDay) * kMillisecondsPerDay +
-            _game._worldTimeOfDay;
-        const uint64_t absolute = now +
-            static_cast<uint64_t>(std::floor(worldMilliseconds));
+        const uint64_t absolute = _game._worldTimeMilliseconds +
+            static_cast<uint64_t>(std::floor(remainingSeconds * 1000.0));
+        const uint64_t millisecondsPerDay = _game.millisecondsPerWorldDay();
 
         SavedEventRecord event;
-        event.day = static_cast<uint32_t>(absolute / kMillisecondsPerDay);
-        event.time = static_cast<uint32_t>(absolute % kMillisecondsPerDay);
+        event.day = static_cast<uint32_t>(absolute / millisecondsPerDay);
+        event.time = static_cast<uint32_t>(absolute % millisecondsPerDay);
         event.object = SavedObjectReference(owner.id());
         event.caller = SavedObjectReference(owner.id());
         event.eventId = static_cast<uint32_t>(SavedEventType::Timed);
@@ -1496,8 +1493,10 @@ std::shared_ptr<Gff> ModuleSnapshotBuilder::buildIfo(
     put(*result, Gff::Field::newFloat("Mod_Entry_Z", module._info.entryPosition.z));
     put(*result, Gff::Field::newFloat("Mod_Entry_Dir_X", -std::sin(module._info.entryFacing)));
     put(*result, Gff::Field::newFloat("Mod_Entry_Dir_Y", std::cos(module._info.entryFacing)));
-    put(*result, Gff::Field::newDword("Mod_CalendarDay", _game._worldTimeDay));
-    put(*result, Gff::Field::newDword("Mod_TimeOfDay", _game._worldTimeOfDay));
+    // Split the canonical clock into the retail pair. Records written here are
+    // therefore always normalized: Mod_TimeOfDay is below one day length.
+    put(*result, Gff::Field::newDword("Mod_CalendarDay", _game.worldTimeDay()));
+    put(*result, Gff::Field::newDword("Mod_TimeOfDay", _game.worldTimeOfDay()));
     put(*result, Gff::Field::newByte("Mod_MinPerHour", _game._minutesPerHour));
     put(*result, Gff::Field::newDword64("Mod_Effect_NxtId", _game._effectIds.nextId()));
     put(*result, Gff::Field::newStruct("SWVarTable", writeLocals(module)));

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -455,6 +455,12 @@ void Module::publishSavedEventQueue() {
 
         PublishedSavedEvent event;
         event.savedIndex = index;
+        // Both fields are Dwords and a day is at most 255 * 60 * 1000 * 24 ms,
+        // so the composition cannot overflow the 64-bit clock.
+        event.dueMilliseconds =
+            static_cast<uint64_t>(savedEvent.day) *
+                _game.millisecondsPerWorldDay() +
+            savedEvent.time;
         if (savedEvent.eventId == static_cast<uint32_t>(SavedEventType::Timed)) {
             auto situation = std::get_if<SerializedScriptSituation>(
                 &savedEvent.payload);
@@ -478,11 +484,7 @@ void Module::dispatchDueSavedEvents() {
         if (published.delivered) {
             continue;
         }
-        const auto &savedEvent = _savedEventQueue.events[published.savedIndex];
-        bool due = savedEvent.day < _game.worldTimeDay() ||
-                   (savedEvent.day == _game.worldTimeDay() &&
-                    savedEvent.time <= _game.worldTimeOfDay());
-        if (due) {
+        if (published.dueMilliseconds <= _game.worldTimeMilliseconds()) {
             deliverSavedEvent(published);
         }
     }

--- a/src/libs/game/savedruntime.cpp
+++ b/src/libs/game/savedruntime.cpp
@@ -237,9 +237,13 @@ std::optional<SavedMoveToPoint> decodeMoveToPoint(const SavedActionRecord &recor
     bool timed = (flags & 4) != 0;
     bool ordinary = !timed && day == 0 && time == 0 && result.timeout == 0.0f;
     result.forcedPending = timed && result.timeout > 0.0f && day == 0 && time == 0;
+    // Only non-negative day/time are required. A time of day larger than the
+    // current day length is unnormalized, not invalid: records written before
+    // the day length became Mod_MinPerHour-derived used a fixed 24-hour scale,
+    // and composing them into absolute milliseconds carries the excess into
+    // later days. Snapshots written from here on are always normalized.
     result.forcedActive = !timed && (day != 0 || time != 0) &&
-                          result.timeout == 0.0f && day >= 0 && time >= 0 &&
-                          static_cast<uint32_t>(time) < 24u * 60u * 60u * 1000u;
+                          result.timeout == 0.0f && day >= 0 && time >= 0;
     bool valid =
         std::isfinite(result.destination.x) && std::isfinite(result.destination.y) &&
         std::isfinite(result.destination.z) && std::isfinite(result.range) &&
@@ -567,8 +571,10 @@ std::shared_ptr<Action> SavedActionRecord::toRuntimeAction(
             MoveToLocationAction::ForcedState state;
             state.areaId = decoded->area.id;
             state.active = decoded->forcedActive;
-            state.expiryDay = decoded->expiryDay;
-            state.expiryTime = decoded->expiryTime;
+            state.expiryMilliseconds =
+                static_cast<uint64_t>(decoded->expiryDay) *
+                    game.millisecondsPerWorldDay() +
+                decoded->expiryTime;
             auto location = std::make_shared<Location>(decoded->destination, 0.0f);
             auto action = game.newAction<MoveToLocationAction>(
                 std::move(location), decoded->run,
@@ -585,8 +591,10 @@ std::shared_ptr<Action> SavedActionRecord::toRuntimeAction(
         state.destination = decoded->destination;
         state.areaId = decoded->area.id;
         state.active = decoded->forcedActive;
-        state.expiryDay = decoded->expiryDay;
-        state.expiryTime = decoded->expiryTime;
+        state.expiryMilliseconds =
+            static_cast<uint64_t>(decoded->expiryDay) *
+                game.millisecondsPerWorldDay() +
+            decoded->expiryTime;
         auto action = game.newAction<MoveToObjectAction>(
             std::move(target), decoded->run, decoded->range,
             decoded->forcedPending ? decoded->timeout : 0.0f, state);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/galaxymaproutines.cpp
     ${TESTS_SOURCE_DIR}/game/partycontrol.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymapstate.cpp
+    ${TESTS_SOURCE_DIR}/game/worldtime.cpp
     ${TESTS_SOURCE_DIR}/game/savedruntime.cpp
     ${TESTS_SOURCE_DIR}/game/saveprovenance.cpp
     ${TESTS_SOURCE_DIR}/game/savedsituation.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -237,6 +237,10 @@ public:
     static void initSnapshotLocalServices(Game &game);
     static void setSnapshotWorldTime(
         Game &game, uint32_t day, uint32_t time, uint8_t minutesPerHour);
+    /** Change the calendar scale without disturbing the canonical clock. */
+    static void setSnapshotMinutesPerHour(Game &game, uint8_t minutesPerHour);
+    static void advanceWorldTime(Game &game, float dt);
+    static void prepareWorldTimeFromIfo(Game &game, const resource::Gff &ifo);
     static void deserializeSnapshotRuntimeState(
         Object &object, const resource::Gff &gff);
     static void setSnapshotObjectId(Object &object, uint32_t objectId);

--- a/test/game/modulesnapshot.cpp
+++ b/test/game/modulesnapshot.cpp
@@ -97,8 +97,15 @@ void reone::game::TestGameModule::initSnapshotLocalServices(Game &game) {
 
 void reone::game::TestGameModule::setSnapshotWorldTime(
     Game &game, uint32_t day, uint32_t time, uint8_t minutesPerHour) {
-    game._worldTimeDay = day;
-    game._worldTimeOfDay = time;
+    // Compose the canonical clock the same way the load boundary does: the day
+    // length has to be known before the pair means anything.
+    game._minutesPerHour = minutesPerHour;
+    game._worldTimeMilliseconds =
+        static_cast<uint64_t>(day) * game.millisecondsPerWorldDay() + time;
+}
+
+void reone::game::TestGameModule::setSnapshotMinutesPerHour(
+    Game &game, uint8_t minutesPerHour) {
     game._minutesPerHour = minutesPerHour;
 }
 
@@ -378,7 +385,9 @@ TEST_F(SnapshotFixture, writes_and_reopens_complete_deterministic_module_state) 
     auto effect = EffectInstance::fromGff(
         *playerRecord->getList("EffectList").front());
     EXPECT_EQ(effect.expiryDay, 3u);
-    EXPECT_EQ(effect.expiryTime, 241000u);
+    // Twenty seconds remaining. World-time milliseconds are real milliseconds,
+    // as in CWorldTimer, so this is 1000 + 20 * 1000.
+    EXPECT_EQ(effect.expiryTime, 21000u);
     ASSERT_TRUE(game.remainingEffectDuration(effect));
     EXPECT_FLOAT_EQ(*game.remainingEffectDuration(effect), 20.0f);
     Creature e2Creature(player->id() + 1000, "", game, engine.services());
@@ -1179,8 +1188,8 @@ TEST_F(SnapshotFixture, runtime_delays_export_as_retail_timed_events_with_remain
     const auto &event = queue.events.front();
     EXPECT_EQ(event.eventId, static_cast<uint32_t>(SavedEventType::Timed));
     EXPECT_EQ(event.day, 3u);
-    // Six simulation seconds at five real minutes per game hour.
-    EXPECT_EQ(event.time, 73000u);
+    // Six simulation seconds. World-time milliseconds are real milliseconds.
+    EXPECT_EQ(event.time, 7000u);
     EXPECT_EQ(event.object.id, player->id());
     EXPECT_EQ(event.caller.id, player->id());
     const auto *situation = std::get_if<SerializedScriptSituation>(&event.payload);
@@ -1190,7 +1199,9 @@ TEST_F(SnapshotFixture, runtime_delays_export_as_retail_timed_events_with_remain
 }
 
 TEST_F(SnapshotFixture, runtime_delays_preserve_stable_time_order_and_fail_closed) {
-    TestGameModule::setSnapshotWorldTime(game, 2, 86390000, 10);
+    // One real second before the end of a game day. At Mod_MinPerHour=10 a day
+    // is 10 * 60 * 1000 * 24 ms, so the 2 s and 4 s delays cross midnight.
+    TestGameModule::setSnapshotWorldTime(game, 2, 10u * 60u * 1000u * 24u - 1000u, 10);
     auto delayed = [&](Object &owner, float seconds, int value) {
         auto program = std::make_shared<script::ScriptProgram>("ordered_delay");
         program->add(script::Instruction(script::InstructionType::RETN));
@@ -1213,11 +1224,11 @@ TEST_F(SnapshotFixture, runtime_delays_preserve_stable_time_order_and_fail_close
     auto queue = SavedEventQueue::fromGff(*readGff(result.snapshot->ifoBytes));
     ASSERT_EQ(queue.events.size(), 3);
     EXPECT_EQ(queue.events[0].day, 3u);
-    EXPECT_EQ(queue.events[0].time, 2000u);
+    EXPECT_EQ(queue.events[0].time, 1000u);
     EXPECT_EQ(queue.events[0].object.id, player->id());
-    EXPECT_EQ(queue.events[1].time, 2000u);
+    EXPECT_EQ(queue.events[1].time, 1000u);
     EXPECT_EQ(queue.events[1].object.id, door->id());
-    EXPECT_EQ(queue.events[2].time, 14000u);
+    EXPECT_EQ(queue.events[2].time, 3000u);
 
     door->delayAction(
         std::make_shared<UnserializableAction>(game, engine.services()), 3.0f);
@@ -1256,6 +1267,31 @@ TEST_F(SnapshotFixture, due_delay_is_inert_on_restore_and_delivered_exactly_once
     EXPECT_EQ(game.module()->pendingSavedEventCount(), 0u);
     TestGameModule::dispatchSnapshotEvents(*game.module());
     EXPECT_EQ(game.module()->pendingSavedEventCount(), 0u);
+}
+
+TEST_F(SnapshotFixture, writes_a_normalized_calendar_pair_split_from_the_absolute_clock) {
+    // The runtime clock is absolute milliseconds; the IFO stores a day and a
+    // time of day. The split happens here, at the serialization boundary, so
+    // every record written is normalized regardless of where the clock stands.
+    constexpr uint8_t kMinutesPerHour = 2;
+    const uint32_t millisecondsPerDay = kMinutesPerHour * 60u * 1000u * 24u;
+    TestGameModule::setSnapshotWorldTime(
+        game, 6, millisecondsPerDay - 1000u, kMinutesPerHour);
+    TestGameModule::advanceWorldTime(game, 3.0f);
+
+    auto result = ModuleSnapshotBuilder(game, "module003").build();
+    ASSERT_TRUE(result) << result.message;
+    auto ifo = readGff(result.snapshot->ifoBytes);
+
+    EXPECT_EQ(ifo->getUint("Mod_MinPerHour"), kMinutesPerHour);
+    EXPECT_EQ(ifo->getUint("Mod_CalendarDay"), 7u);
+    EXPECT_EQ(ifo->getUint("Mod_TimeOfDay"), 2000u);
+    EXPECT_LT(ifo->getUint("Mod_TimeOfDay"), millisecondsPerDay);
+    // And the pair recomposes to exactly the clock that produced it.
+    EXPECT_EQ(static_cast<uint64_t>(ifo->getUint("Mod_CalendarDay")) *
+                      millisecondsPerDay +
+                  ifo->getUint("Mod_TimeOfDay"),
+              game.worldTimeMilliseconds());
 }
 
 TEST_F(SnapshotFixture, pending_start_conversation_is_a_supported_transition_snapshot_action) {

--- a/test/game/savedruntime.cpp
+++ b/test/game/savedruntime.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include "../fixtures/engine.h"
+#include "../fixtures/game.h"
 
 #include "reone/game/action.h"
 #include "reone/game/action/attackobject.h"
@@ -657,8 +658,9 @@ TEST(SavedAction, move_to_location_imports_ordinary_pending_and_active_forced_ti
     ASSERT_TRUE(active);
     EXPECT_TRUE(active->isForced());
     EXPECT_TRUE(active->forcedState().active);
-    EXPECT_EQ(active->forcedState().expiryDay, 7u);
-    EXPECT_EQ(active->forcedState().expiryTime, 12345u);
+    // The retail pair is composed into an absolute deadline on restore.
+    EXPECT_EQ(active->forcedState().expiryMilliseconds,
+              7ull * game.millisecondsPerWorldDay() + 12345ull);
     auto reexported = active->saveFacingState();
     ASSERT_TRUE(reexported);
     EXPECT_EQ(std::get<int32_t>(reexported->parameters[5].payload), 1);
@@ -751,6 +753,112 @@ TEST(SavedAction, active_forced_move_preserves_absolute_world_time) {
     EXPECT_FLOAT_EQ(std::get<float>(exported->parameters[8].payload), 0.0f);
     EXPECT_EQ(std::get<int32_t>(exported->parameters[11].payload), 4);
     EXPECT_EQ(std::get<int32_t>(exported->parameters[12].payload), 12345);
+}
+
+TEST(SavedAction, forced_move_deadline_round_trips_across_a_day_boundary) {
+    // The runtime holds one absolute deadline; the retail record holds a
+    // day/time pair. Splitting on save and composing on load must be lossless
+    // even when the deadline sits on the far side of a day boundary.
+    for (GameID id : {GameID::KotOR, GameID::TSL}) {
+        TestEngine &engine = testEngine();
+        StubConsole console;
+        Game game(id, "", engine.options(), engine.services(), console);
+        auto area = game.newArea();
+        auto location = std::make_shared<Location>(glm::vec3(1.0f, 2.0f, 3.0f), 0.0f);
+
+        const uint64_t deadline =
+            3ull * game.millisecondsPerWorldDay() + 4567ull;
+        MoveToLocationAction::ForcedState state;
+        state.areaId = area->id();
+        state.active = true;
+        state.expiryMilliseconds = deadline;
+        auto runtime = game.newAction<MoveToLocationAction>(
+            location, false, true, 0.0f, state);
+
+        auto exported = runtime->saveFacingState();
+        ASSERT_TRUE(exported);
+        // Written records are always normalized.
+        EXPECT_EQ(std::get<int32_t>(exported->parameters[11].payload), 3);
+        EXPECT_EQ(std::get<int32_t>(exported->parameters[12].payload), 4567);
+
+        ASSERT_TRUE(exported->bindObjectReferences(game));
+        auto restored = std::dynamic_pointer_cast<MoveToLocationAction>(
+            exported->toRuntimeAction(game));
+        ASSERT_TRUE(restored);
+        EXPECT_TRUE(restored->forcedState().active);
+        EXPECT_EQ(restored->forcedState().expiryMilliseconds, deadline);
+    }
+}
+
+TEST(SavedAction, forced_move_accepts_an_unnormalized_legacy_time_of_day) {
+    // Records written before the day length became Mod_MinPerHour-derived hold
+    // a time of day on the old fixed 24-hour scale, which overflows the current
+    // day length. That is unnormalized, not invalid: it must still restore.
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    auto area = game.newArea();
+    constexpr uint32_t kLegacyTimeOfDay = 24u * 60u * 60u * 1000u - 1u;
+    ASSERT_GT(kLegacyTimeOfDay, game.millisecondsPerWorldDay());
+
+    auto record = SavedActionRecord::fromGff(
+        *moveToPointAction(area->id(), glm::vec3(8.0f), 1, 0.0f, 2,
+                           static_cast<int32_t>(kLegacyTimeOfDay)));
+    ASSERT_TRUE(record.bindObjectReferences(game));
+    auto restored = std::dynamic_pointer_cast<MoveToLocationAction>(
+        record.toRuntimeAction(game));
+    ASSERT_TRUE(restored);
+    EXPECT_TRUE(restored->forcedState().active);
+    EXPECT_EQ(restored->forcedState().expiryMilliseconds,
+              2ull * game.millisecondsPerWorldDay() + kLegacyTimeOfDay);
+
+    // And re-exporting it normalizes the pair.
+    auto exported = restored->saveFacingState();
+    ASSERT_TRUE(exported);
+    EXPECT_GT(std::get<int32_t>(exported->parameters[11].payload), 2);
+    EXPECT_LT(static_cast<uint32_t>(std::get<int32_t>(exported->parameters[12].payload)),
+              game.millisecondsPerWorldDay());
+}
+
+TEST(SavedRuntimePublication, should_compare_event_due_times_on_the_absolute_clock) {
+    // An unnormalized record whose Time exceeds one day length is due two days
+    // later, not on the next calendar rollover. A lexicographic day/time
+    // comparison fires it a whole day early.
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game(GameID::KotOR, "", engine.options(), engine.services(), console);
+    NiceMock<scene::MockSceneGraph> sceneGraph;
+    ON_CALL(engine.sceneModule().graphs(), get(_)).WillByDefault(ReturnRef(sceneGraph));
+
+    auto ifo = Gff::Builder()
+                   .field(Gff::Field::newDword("Mod_CalendarDay", 4))
+                   .field(Gff::Field::newDword("Mod_TimeOfDay", 0))
+                   .field(Gff::Field::newDword("Mod_MinPerHour", 5))
+                   .build();
+    game.prepareSavedRuntimeNamespace(*ifo);
+    const uint32_t millisecondsPerDay = game.millisecondsPerWorldDay();
+    auto module = game.newModule();
+
+    auto queue = Gff::Builder()
+                     .field(Gff::Field::newList(
+                         "EventQueue",
+                         {event(5, 4, 2u * millisecondsPerDay, minimalEffect())}))
+                     .build();
+    module->deserializeSavedEventQueue(*queue);
+    module->bindSavedEventQueue();
+    module->publishSavedEventQueue();
+    ASSERT_EQ(module->pendingSavedEventCount(), 1);
+
+    // One day on: a lexicographic comparison would call this due already.
+    TestGameModule::setSnapshotWorldTime(game, 5, 0, 5);
+    module->dispatchDueSavedEvents();
+    EXPECT_EQ(module->pendingSavedEventCount(), 1)
+        << "an event two day lengths out must not fire after one";
+
+    TestGameModule::setSnapshotWorldTime(game, 6, 0, 5);
+    module->dispatchDueSavedEvents();
+    EXPECT_EQ(module->pendingSavedEventCount(), 0);
+    EXPECT_EQ(module->effects().size(), 1);
 }
 
 TEST(SavedAction, runtime_do_command_exports_retail_action_37_situation) {
@@ -987,7 +1095,9 @@ TEST(SavedRuntimePublication, should_publish_supported_events_without_dispatchin
     EffectInstance expiring;
     expiring.subType = static_cast<uint16_t>(DurationType::Temporary);
     expiring.expiryDay = 4;
-    expiring.expiryTime = 60100;
+    // Five real seconds after the current world time of 100. World-time
+    // milliseconds are real milliseconds, as in CWorldTimer.
+    expiring.expiryTime = 5100;
     auto remaining = game.remainingEffectDuration(expiring);
     ASSERT_TRUE(remaining);
     EXPECT_FLOAT_EQ(*remaining, 5.0f);

--- a/test/game/worldtime.cpp
+++ b/test/game/worldtime.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <algorithm>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "../fixtures/game.h"
+
+#include "reone/game/action/movetolocation.h"
+#include "reone/game/effect.h"
+#include "reone/game/game.h"
+#include "reone/game/location.h"
+#include "reone/game/object/creature.h"
+#include "reone/resource/gff.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+void reone::game::TestGameModule::advanceWorldTime(Game &game, float dt) {
+    game.advanceWorldTime(dt);
+}
+
+void reone::game::TestGameModule::prepareWorldTimeFromIfo(Game &game, const Gff &ifo) {
+    game.prepareSavedRuntimeNamespace(ifo);
+}
+
+namespace {
+
+// The world clock is part of the shared Game contract, so both games must
+// agree. Every shipped K2 module and 113 of 117 K1 modules carry
+// Mod_MinPerHour = 2, so both were affected identically; the parameters below
+// pin that neither game lets Mod_MinPerHour change the rate of the clock.
+struct WorldTimeFixture : TestWithParam<GameID> {
+    WorldTimeFixture() :
+        game(GetParam(), "", engine.options(), engine.services(), console) {
+    }
+
+    void advance(float seconds, float step = 1.0f) {
+        for (float elapsed = 0.0f; elapsed < seconds; elapsed += step) {
+            TestGameModule::advanceWorldTime(game, std::min(step, seconds - elapsed));
+        }
+    }
+
+    uint64_t absoluteWorldTime() const { return game.worldTimeMilliseconds(); }
+
+    TestEngine &engine {testEngine()};
+    StubConsole console;
+    Game game;
+};
+
+} // namespace
+
+// The canonical runtime clock counts absolute world/simulation milliseconds.
+// One second of simulation is a thousand of them. Mod_MinPerHour shortens the
+// day; it must not change the rate at which the clock advances. Before this was
+// fixed the clock ran at 60 / Mod_MinPerHour times simulation time, so every
+// duration measured against it expired 12x-30x early. Day and time of day are
+// derived views over that clock, and are split out only when saving.
+
+TEST_P(WorldTimeFixture, advances_one_millisecond_per_millisecond_of_simulation) {
+    for (uint8_t minutesPerHour : {1, 2, 5, 60}) {
+        TestGameModule::setSnapshotWorldTime(game, 0, 0, minutesPerHour);
+        TestGameModule::advanceWorldTime(game, 0.001f);
+        EXPECT_EQ(absoluteWorldTime(), 1u)
+            << "1 ms of simulation dt must advance the clock by 1 ms at Mod_MinPerHour="
+            << static_cast<int>(minutesPerHour);
+    }
+}
+
+TEST_P(WorldTimeFixture, advances_at_real_time_rate_regardless_of_minutes_per_hour) {
+    for (uint8_t minutesPerHour : {1, 2, 5, 60}) {
+        TestGameModule::setSnapshotWorldTime(game, 0, 0, minutesPerHour);
+        advance(1.0f);
+        EXPECT_EQ(absoluteWorldTime(), 1000u)
+            << "one real second must be 1000 world milliseconds at Mod_MinPerHour="
+            << static_cast<int>(minutesPerHour);
+    }
+}
+
+TEST_P(WorldTimeFixture, changing_the_day_length_does_not_move_the_canonical_clock) {
+    // Retail K1 ships danm14aa at Mod_MinPerHour=1 while 113 other modules use
+    // 2, so the calendar scale genuinely differs between modules. Rescaling the
+    // calendar must reinterpret the elapsed clock, never displace it.
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    advance(600.0f, 60.0f);
+    const uint64_t elapsed = absoluteWorldTime();
+    ASSERT_EQ(elapsed, 600u * 1000u);
+
+    for (uint8_t minutesPerHour : {1, 5, 60}) {
+        TestGameModule::setSnapshotMinutesPerHour(game, minutesPerHour);
+        EXPECT_EQ(absoluteWorldTime(), elapsed)
+            << "absolute world time must survive a day-length change to "
+            << static_cast<int>(minutesPerHour);
+        // The derived calendar view is free to change, but must stay coherent.
+        EXPECT_LT(game.worldTimeOfDay(), game.millisecondsPerWorldDay());
+        EXPECT_EQ(static_cast<uint64_t>(game.worldTimeDay()) *
+                          game.millisecondsPerWorldDay() +
+                      game.worldTimeOfDay(),
+                  elapsed);
+    }
+}
+
+TEST_P(WorldTimeFixture, derives_the_calendar_pair_from_the_canonical_clock) {
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    const uint32_t millisecondsPerDay = game.millisecondsPerWorldDay();
+
+    // Two and a half days in.
+    advance(2.5f * static_cast<float>(millisecondsPerDay) / 1000.0f, 60.0f);
+    EXPECT_EQ(game.worldTimeDay(), 2u);
+    EXPECT_NEAR(static_cast<double>(game.worldTimeOfDay()),
+                millisecondsPerDay / 2.0, 1000.0);
+}
+
+TEST_P(WorldTimeFixture, accumulates_sub_millisecond_remainders_without_drift) {
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    for (int i = 0; i < 1000; ++i) {
+        TestGameModule::advanceWorldTime(game, 1.0f / 3000.0f);
+    }
+    // 1000 steps of 1/3000 s is 1/3 s; allow one millisecond of rounding.
+    EXPECT_NEAR(static_cast<double>(absoluteWorldTime()), 333.0, 1.0);
+}
+
+TEST_P(WorldTimeFixture, day_length_follows_minutes_per_hour) {
+    // CWorldTimer::SetMinutesPerHour: m_nMillisecondsInDay =
+    // MinutesPerHour * 60 * MILLISECONDS_IN_SECOND * HOURS_IN_DAY.
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    EXPECT_EQ(game.millisecondsPerWorldDay(), 2u * 60u * 1000u * 24u);
+
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 5);
+    EXPECT_EQ(game.millisecondsPerWorldDay(), 5u * 60u * 1000u * 24u);
+}
+
+TEST_P(WorldTimeFixture, rolls_the_calendar_after_one_game_day_of_real_time) {
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    // A game day at Mod_MinPerHour=2 is 2 * 60 * 24 = 2880 real seconds.
+    advance(2879.0f, 60.0f);
+    EXPECT_EQ(game.worldTimeDay(), 0u);
+
+    advance(2.0f);
+    EXPECT_EQ(game.worldTimeDay(), 1u);
+    EXPECT_LT(game.worldTimeOfDay(), game.millisecondsPerWorldDay());
+}
+
+TEST_P(WorldTimeFixture, forced_move_timeout_expires_after_the_scripted_real_duration) {
+    TestGameModule::setSnapshotWorldTime(game, 0, 0, 2);
+    auto actor = game.newCreature();
+    actor->setPosition({0.0f, 0.0f, 0.0f});
+    // No module or scene graph in this fixture, so keep the action off the
+    // navigation path. The forced-timeout branch runs before navigateTo and is
+    // what this test is about.
+    actor->setMovementRestricted(true);
+
+    auto destination = std::make_shared<Location>(glm::vec3 {100.0f, 0.0f, 0.0f}, 0.0f);
+    auto action = game.newAction<MoveToLocationAction>(destination, false, true, 30.0f);
+
+    // Arm the deadline, then hold the clock just short of the timeout.
+    action->execute(action, *actor, 0.0f);
+    advance(29.0f);
+    action->execute(action, *actor, 0.0f);
+    EXPECT_FALSE(action->isCompleted())
+        << "a 30 second forced move must not expire after 29 real seconds";
+    EXPECT_LT(glm::length(actor->position()), 1.0f);
+
+    advance(2.0f);
+    action->execute(action, *actor, 0.0f);
+    EXPECT_TRUE(action->isCompleted());
+    EXPECT_NEAR(actor->position().x, 100.0f, 0.001f);
+}
+
+TEST_P(WorldTimeFixture, temporary_effect_expiry_round_trips_as_a_real_duration) {
+    for (uint8_t minutesPerHour : {2, 5}) {
+        TestGameModule::setSnapshotWorldTime(game, 0, 0, minutesPerHour);
+
+        EffectInstance instance;
+        instance.effect = game.newEffect<Effect>(EffectType::Haste);
+        instance.subType = 1; // DurationType::Temporary
+        instance.duration = 45.0f;
+        instance.remainingDuration = 45.0f;
+        instance.expiryDay = 0;
+        instance.expiryTime = static_cast<uint32_t>(45.0f * 1000.0f);
+
+        auto remaining = game.remainingEffectDuration(instance);
+        ASSERT_TRUE(remaining);
+        EXPECT_NEAR(*remaining, 45.0f, 0.001f)
+            << "expiry is stored in world milliseconds, which are real milliseconds";
+
+        advance(20.0f);
+        remaining = game.remainingEffectDuration(instance);
+        ASSERT_TRUE(remaining);
+        EXPECT_NEAR(*remaining, 25.0f, 0.05f);
+    }
+}
+
+TEST_P(WorldTimeFixture, composes_the_canonical_clock_from_the_saved_calendar_pair) {
+    auto ifo = Gff::Builder().type(0xffffffff)
+        .field(Gff::Field::newDword("Mod_CalendarDay", 3))
+        .field(Gff::Field::newDword("Mod_TimeOfDay", 1234u))
+        .field(Gff::Field::newDword("Mod_MinPerHour", 2))
+        .build();
+
+    ASSERT_NO_THROW(TestGameModule::prepareWorldTimeFromIfo(game, *ifo));
+    EXPECT_EQ(game.minutesPerHour(), 2);
+    EXPECT_EQ(game.worldTimeMilliseconds(),
+              3ull * (2u * 60u * 1000u * 24u) + 1234ull);
+    // And the derived view reproduces exactly what was saved.
+    EXPECT_EQ(game.worldTimeDay(), 3u);
+    EXPECT_EQ(game.worldTimeOfDay(), 1234u);
+}
+
+TEST_P(WorldTimeFixture, out_of_range_saved_time_of_day_carries_into_the_calendar) {
+    // Saves written before the day length became Mod_MinPerHour-derived hold a
+    // time of day on the old fixed 24-hour scale. Carry it, as
+    // CWorldTimer::GetWorldTime does, rather than rejecting the save.
+    constexpr uint32_t kLegacyTimeOfDay = 24u * 60u * 60u * 1000u - 1u;
+    auto ifo = Gff::Builder().type(0xffffffff)
+        .field(Gff::Field::newDword("Mod_CalendarDay", 3))
+        .field(Gff::Field::newDword("Mod_TimeOfDay", kLegacyTimeOfDay))
+        .field(Gff::Field::newDword("Mod_MinPerHour", 2))
+        .build();
+
+    ASSERT_NO_THROW(TestGameModule::prepareWorldTimeFromIfo(game, *ifo));
+    EXPECT_EQ(game.minutesPerHour(), 2);
+    // Nothing is discarded: the oversized time simply lands further along.
+    EXPECT_EQ(game.worldTimeMilliseconds(),
+              3ull * (2u * 60u * 1000u * 24u) + kLegacyTimeOfDay);
+    // The derived view is normalized, so anything written from here on is too.
+    EXPECT_LT(game.worldTimeOfDay(), game.millisecondsPerWorldDay());
+    EXPECT_GT(game.worldTimeDay(), 3u);
+}
+
+TEST_P(WorldTimeFixture, calendar_pair_round_trips_across_a_day_boundary) {
+    // One second before the end of a day, then two seconds of simulation.
+    TestGameModule::setSnapshotWorldTime(
+        game, 4, 2u * 60u * 1000u * 24u - 1000u, 2);
+    advance(2.0f);
+    ASSERT_EQ(game.worldTimeDay(), 5u);
+    ASSERT_EQ(game.worldTimeOfDay(), 1000u);
+
+    const uint64_t before = game.worldTimeMilliseconds();
+    auto ifo = Gff::Builder().type(0xffffffff)
+        .field(Gff::Field::newDword("Mod_CalendarDay", game.worldTimeDay()))
+        .field(Gff::Field::newDword("Mod_TimeOfDay", game.worldTimeOfDay()))
+        .field(Gff::Field::newDword("Mod_MinPerHour", game.minutesPerHour()))
+        .build();
+
+    ASSERT_NO_THROW(TestGameModule::prepareWorldTimeFromIfo(game, *ifo));
+    EXPECT_EQ(game.worldTimeMilliseconds(), before)
+        << "splitting on save and composing on load must be lossless";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothGames,
+    WorldTimeFixture,
+    ::testing::Values(GameID::KotOR, GameID::TSL),
+    [](const ::testing::TestParamInfo<GameID> &info) {
+        return info.param == GameID::TSL ? "TSL" : "KotOR";
+    });


### PR DESCRIPTION
## Summary

Fix world time issue resulting in NPC apparent flickering/warping.

* `Mod_MinPerHour` now controls day length instead of clock speed
* use absolute world milliseconds for runtime timing, forced-move deadlines, and restored events
* preserve retail save fields and normalize legacy/unnormalized times on save

This fixes the 30x-fast clock on normal `Mod_MinPerHour = 2` modules, including Dantooine ambient NPCs timing out and teleporting between waypoints.

## Testing

* Added world-time, save/load, forced-move, event-queue, and legacy-time regression coverage
* Verified in K1: ambient NPCs walk normally between waypoints
