### PR TITLE
[game] Validate a save before giving up the running session

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -328,6 +328,24 @@ public:
     // the slot the player picked is the slot that gets loaded.
     void loadGame(const resource::SaveSlotDescriptor &slot);
 
+    /**
+     * Candidate save load, resolved and validated but not yet committed.
+     *
+     * Everything here is read from the unpublished session, so preparing it
+     * cannot disturb the running game. The decoded records are carried into
+     * restoration rather than parsed a second time once the candidate has been
+     * published.
+     */
+    struct PreparedSaveLoad {
+        std::unique_ptr<resource::SaveSessionState> session;
+        resource::NFO nfo;
+        std::shared_ptr<resource::Gff> saveInfo;
+        std::shared_ptr<resource::Gff> globalVars;
+        std::shared_ptr<resource::Gff> moduleIfo;
+        std::shared_ptr<resource::Gff> partyTable;
+        std::shared_ptr<resource::Gff> inventory;
+    };
+
     std::vector<SavedGame> savedGames() const;
     const std::filesystem::path &gamePath() const { return _path; }
 
@@ -610,8 +628,12 @@ public:
     std::map<int, std::string> parseCustomTokens(
         const resource::Gff &ifoGff) const;
     void replaceCustomTokens(std::map<int, std::string> tokens);
+    PreparedSaveLoad prepareSaveLoad(const resource::SaveSlotDescriptor &slot);
+    void restoreSaveLoad(PreparedSaveLoad prepared);
+    void retireToMainMenu();
+
     void deserializeGlobalVariables(resource::Gff &gvtGff);
-    void deserializeParty(resource::Gff &ifoGff);
+    void deserializeParty(resource::Gff &ifoGff, const std::shared_ptr<resource::Gff> &ptGff);
     void publishPartyRuntimeState(
         resource::Gff &ifoGff,
         const std::shared_ptr<resource::Gff> &ptGff,

--- a/include/reone/resource/director.h
+++ b/include/reone/resource/director.h
@@ -77,6 +77,21 @@ public:
 
     /** Mount the exact slot discovered during indexing. */
     virtual void onGameLoad(const SaveSlotDescriptor &slot) = 0;
+
+    /**
+     * Build an unpublished candidate over the exact slot discovered during
+     * indexing.
+     *
+     * Throws if the slot cannot be opened, and mutates nothing when it does:
+     * the committed session stays authoritative until commitGameLoad accepts
+     * the candidate, so a load that cannot proceed leaves the running game
+     * intact rather than stranding it.
+     */
+    virtual std::unique_ptr<SaveSessionState> prepareGameLoad(
+        const SaveSlotDescriptor &slot) = 0;
+
+    /** Publish a prepared candidate, retiring the previous save mounts. */
+    virtual void commitGameLoad(std::unique_ptr<SaveSessionState> candidate) = 0;
     virtual std::optional<Resource> findSaveMetadata(const ResourceId &id) = 0;
     virtual std::optional<Resource> findSaveWorking(const ResourceId &id) = 0;
     virtual std::unordered_set<ResourceId> saveWorkingResourceIds() const = 0;
@@ -132,6 +147,9 @@ public:
     void onNewGame() override;
     void onGameLoad(std::string_view name) override;
     void onGameLoad(const SaveSlotDescriptor &slot) override;
+    std::unique_ptr<SaveSessionState> prepareGameLoad(
+        const SaveSlotDescriptor &slot) override;
+    void commitGameLoad(std::unique_ptr<SaveSessionState> candidate) override;
     std::optional<Resource> findSaveMetadata(const ResourceId &id) override;
     std::optional<Resource> findSaveWorking(const ResourceId &id) override;
     std::unordered_set<ResourceId> saveWorkingResourceIds() const override;

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1062,7 +1062,12 @@ bool Game::loadModule(const std::string &name, std::string entry, bool initialSa
         } catch (const std::exception &e) {
             error("Failed loading module '" + name + "': " + std::string(e.what()));
             if (initialSaveRestore) {
+                // Restoring a save has already retired the session that was
+                // running, so there is nothing to fall back to. Retiring alone
+                // leaves Screen::None, which renders as a black window over a
+                // still-updating engine; send the player somewhere deliberate.
                 retireRuntimeSession();
+                retireToMainMenu();
             } else {
                 retireActiveModuleRuntime();
                 _screen = Screen::None;
@@ -1235,23 +1240,79 @@ void Game::resetGame() {
     _services.resource.director.onNewGame();
 }
 
+/**
+ * Resolve and validate a save without disturbing the running game.
+ *
+ * Every read goes through the unpublished candidate rather than the director,
+ * because the director still answers for the committed session: consulting it
+ * here would validate the save that is already loaded. Records that the loader
+ * treats as mandatory are proven now, so the failures that used to strand a
+ * half-torn-down session are raised while the old one is still authoritative.
+ */
+Game::PreparedSaveLoad Game::prepareSaveLoad(const resource::SaveSlotDescriptor &slot) {
+    PreparedSaveLoad prepared;
+    prepared.session = _services.resource.director.prepareGameLoad(slot);
+
+    prepared.saveInfo = decodeSaveGff(
+        prepared.session->findMetadata(ResourceId("savenfo", ResType::Res)));
+    if (!prepared.saveInfo) {
+        throw ResourceNotFoundException("saveinfo.res not found");
+    }
+    prepared.nfo = resource::parseNFO(*prepared.saveInfo);
+
+    prepared.globalVars = decodeSaveGff(
+        prepared.session->findMetadata(ResourceId("globalvars", ResType::Res)));
+    if (!prepared.globalVars) {
+        throw ResourceNotFoundException("globalvars.res not found");
+    }
+
+    // The remaining records are optional to the loader. Decode what the slot
+    // carries so restoration does not read it again, but do not invent a
+    // requirement: a module IFO absent from the archive still resolves from the
+    // module itself once mounted, and rejecting the save here would refuse one
+    // that loads correctly today.
+    prepared.moduleIfo = decodeSaveGff(
+        prepared.session->findWorking(ResourceId("module", ResType::Ifo)));
+    prepared.partyTable = decodeSaveGff(
+        prepared.session->findMetadata(ResourceId("partytable", ResType::Res)));
+    prepared.inventory = decodeSaveGff(
+        prepared.session->findWorking(ResourceId("inventory", ResType::Res)));
+
+    return prepared;
+}
+
 void Game::loadGame(const resource::SaveSlotDescriptor &slot) {
     info(str(boost::format("Loading savegame '%s'") % slot.directory.filename().string()));
 
-    // Reset game state before loading a new game.
+    // Resolve and validate the replacement before anything is given up. A
+    // throw here leaves the current session and its mounts untouched, so the
+    // player keeps playing instead of being left with nothing to render.
+    auto prepared = prepareSaveLoad(slot);
+
+    // Commit. The old runtime and the old mounts retire together, and only
+    // then does the candidate become authoritative: no runtime ever observes
+    // the other session's resources.
     resetGame();
+    _services.resource.director.commitGameLoad(std::move(prepared.session));
 
-    // Add savegame files to resource resolution.
-    _services.resource.director.onGameLoad(slot);
-
-    auto saveInfo = decodeSaveGff(
-        _services.resource.director.findSaveMetadata(ResourceId("savenfo", ResType::Res)));
-    if (!saveInfo) {
-        throw ResourceNotFoundException("saveinfo.res not found");
+    try {
+        restoreSaveLoad(std::move(prepared));
+    } catch (const std::exception &e) {
+        // Past the commit boundary the previous session no longer exists and
+        // cannot be restored. Retire whatever was half-built and land on a
+        // deliberate screen rather than the blank one an abandoned session
+        // leaves behind.
+        error("Failed restoring savegame '" +
+              slot.directory.filename().string() + "': " + std::string(e.what()));
+        retireToMainMenu();
+        return;
     }
-    NFO nfo = resource::parseNFO(*saveInfo);
+}
+
+void Game::restoreSaveLoad(PreparedSaveLoad prepared) {
+    const NFO &nfo = prepared.nfo;
     _cheatUsed = nfo.cheatUsed;
-    captureSaveResourceShadow({SaveResourceKind::Nfo, {}}, *saveInfo);
+    captureSaveResourceShadow({SaveResourceKind::Nfo, {}}, *prepared.saveInfo);
 
     // Add module files to resource resolution. Since all savegame files are
     // already in scope, this is going to resolve to the last module from the
@@ -1278,16 +1339,15 @@ void Game::loadGame(const resource::SaveSlotDescriptor &slot) {
     }
     _services.game.reputes.replace(std::move(*reputesState));
 
-    // Deserialize global variables
-    auto globalVars = decodeSaveGff(
-        _services.resource.director.findSaveMetadata(ResourceId("globalvars", ResType::Res)));
-    if (!globalVars) {
-        throw ResourceNotFoundException("globalvars.res not found");
-    }
-    deserializeGlobalVariables(*globalVars);
+    // Deserialize global variables, proven present while the candidate was
+    // still unpublished.
+    deserializeGlobalVariables(*prepared.globalVars);
 
-    // Deserialize party.
-    std::shared_ptr<Gff> ifo(_services.resource.gffs.get("module", ResType::Ifo));
+    // Deserialize party. The archive usually carries its own module IFO; when
+    // it does not, the mounted module still supplies one.
+    std::shared_ptr<Gff> ifo = prepared.moduleIfo
+                                   ? prepared.moduleIfo
+                                   : _services.resource.gffs.get("module", ResType::Ifo);
     if (!ifo) {
         throw ResourceNotFoundException("Module IFO not found");
     }
@@ -1318,14 +1378,13 @@ void Game::loadGame(const resource::SaveSlotDescriptor &slot) {
             reserveSavedObjectIds(*git);
         }
     }
-    deserializeParty(*ifo);
+    deserializeParty(*ifo, prepared.partyTable);
 
     // Once the player is loaded, deserialize player's inventory.
-    if (auto inventoryGff = decodeSaveGff(
-            _services.resource.director.findSaveWorking(ResourceId("inventory", ResType::Res)))) {
+    if (prepared.inventory) {
         captureSaveResourceShadow(
-            {SaveResourceKind::Inventory, {}}, *inventoryGff);
-        deserializeInventory(*inventoryGff);
+            {SaveResourceKind::Inventory, {}}, *prepared.inventory);
+        deserializeInventory(*prepared.inventory);
     }
 
     // Warp to the last module.
@@ -1377,10 +1436,8 @@ void Game::deserializeGlobalVariables(resource::Gff &gvtGff) {
     }
 }
 
-void Game::deserializeParty(resource::Gff &ifoGff) {
+void Game::deserializeParty(resource::Gff &ifoGff, const std::shared_ptr<Gff> &ptGff) {
     resetGalaxyMap();
-    auto ptGff = decodeSaveGff(
-        _services.resource.director.findSaveMetadata(ResourceId("partytable", ResType::Res)));
 
     std::shared_ptr<Gff> pcGff;
     const auto &players = ifoGff.getList("Mod_PlayerList");
@@ -2824,6 +2881,23 @@ void Game::withLoadingScreen(const std::string &imageResRef, const std::function
     changeScreen(Screen::Loading);
     render();
     block();
+}
+
+/**
+ * Terminal destination for a load that failed after the commit boundary.
+ *
+ * openMainMenu retires whatever was half-built and drops the candidate mounts
+ * with it, so nothing of either session survives. It gives up early when the
+ * menu GUI cannot be loaded, which would leave the screen wherever the
+ * abandoned session left it; record the intended destination regardless, so a
+ * missing menu resource is its own visible failure rather than an engine that
+ * renders nothing while still running.
+ */
+void Game::retireToMainMenu() {
+    openMainMenu();
+    if (_screen == Screen::None) {
+        _screen = Screen::MainMenu;
+    }
 }
 
 void Game::openMainMenu() {

--- a/src/libs/resource/director.cpp
+++ b/src/libs/resource/director.cpp
@@ -124,8 +124,18 @@ void ResourceDirector::onGameLoad(std::string_view name) {
     commitSaveSession(buildSaveSession(name));
 }
 
+/** Prepare and commit in one step, for callers that need no commit boundary. */
 void ResourceDirector::onGameLoad(const SaveSlotDescriptor &slot) {
-    commitSaveSession(buildSaveSession(slot));
+    commitGameLoad(prepareGameLoad(slot));
+}
+
+std::unique_ptr<SaveSessionState> ResourceDirector::prepareGameLoad(
+    const SaveSlotDescriptor &slot) {
+    return buildSaveSession(slot);
+}
+
+void ResourceDirector::commitGameLoad(std::unique_ptr<SaveSessionState> candidate) {
+    commitSaveSession(std::move(candidate));
 }
 
 void ResourceDirector::commitSaveSession(std::unique_ptr<SaveSessionState> candidate) {

--- a/test/fixtures/resource.h
+++ b/test/fixtures/resource.h
@@ -190,6 +190,10 @@ public:
     MOCK_METHOD(void, onNewGame, (), (override));
     MOCK_METHOD(void, onGameLoad, (std::string_view name), (override));
     MOCK_METHOD(void, onGameLoad, (const SaveSlotDescriptor &slot), (override));
+    MOCK_METHOD(std::unique_ptr<SaveSessionState>, prepareGameLoad,
+                (const SaveSlotDescriptor &slot), (override));
+    MOCK_METHOD(void, commitGameLoad,
+                (std::unique_ptr<SaveSessionState> candidate), (override));
     MOCK_METHOD(std::optional<Resource>, findSaveMetadata, (const ResourceId &id), (override));
     MOCK_METHOD(std::optional<Resource>, findSaveWorking, (const ResourceId &id), (override));
     MOCK_METHOD(std::unordered_set<ResourceId>, saveWorkingResourceIds, (), (const, override));

--- a/test/game/savegame.cpp
+++ b/test/game/savegame.cpp
@@ -13,6 +13,8 @@
 #include "reone/game/object/creature.h"
 #include "reone/game/object/module.h"
 #include "reone/graphics/format/tgareader.h"
+#include "reone/resource/exception/notfound.h"
+#include "reone/resource/format/gffwriter.h"
 #include "reone/resource/saveworkingstate.h"
 #include "reone/system/stream/memoryinput.h"
 
@@ -741,3 +743,248 @@ TEST(SaveSessionState, unsaved_session_has_real_empty_committed_state_and_no_slo
 }
 
 } // namespace
+
+namespace {
+
+/// Installation holding one structurally complete save slot on disk.
+// The load transaction is part of the shared Game lifecycle, so both games
+// must observe the same commit boundary.
+struct LoadTransactionFixture : TestWithParam<GameID> {
+    test::TmpDir root {"reone_e3g_load_transaction"};
+    TestEngine engine;
+    NiceMock<scene::MockSceneGraph> sceneGraph;
+    StubConsole console;
+    std::unique_ptr<Game> game;
+    std::shared_ptr<Area> area;
+    std::shared_ptr<Creature> player;
+    std::vector<Portrait> portraitRows;
+    SaveSlotDescriptor slot;
+
+    void SetUp() override {
+        engine.init();
+        ON_CALL(engine.sceneModule().graphs(), get(_))
+            .WillByDefault(ReturnRef(sceneGraph));
+        portraitRows.push_back({"po_live_player", 0, -1, -1, true, 0});
+        EXPECT_CALL(engine.gameModule().portraits(), portraits())
+            .Times(AnyNumber())
+            .WillRepeatedly(ReturnRef(portraitRows));
+
+        game = std::make_unique<Game>(
+            GetParam(), root.path, engine.options(), engine.services(), console);
+        area = game->newArea();
+        player = game->newCreature();
+        TestGameModule::configureModuleSnapshot(
+            *game, area, player, "module_a", "module_a");
+
+        // The engine has to be somewhere recognisable for "the screen did not
+        // change" to mean anything.
+        TestGameModule::setCurrentScreen(
+            *game, static_cast<int>(Game::Screen::InGame));
+
+        auto directory = root.path / "saves" / "000002 - Game1";
+        std::filesystem::create_directories(directory);
+        test::writeErf(directory / "SAVEGAME.sav", ErfWriter::FileType::ERF, {});
+        slot = SaveSlotDescriptor {directory, directory / "SAVEGAME.sav"};
+    }
+};
+
+} // namespace
+
+TEST_P(LoadTransactionFixture, aPreCommitFailureLeavesTheRunningSessionAuthoritative) {
+    // given a load whose candidate cannot even be opened
+    auto &director = engine.resourceModule().director();
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Throw(ResourceNotFoundException("Save directory not found")));
+
+    // nothing may be committed or retired on the way out
+    EXPECT_CALL(director, commitGameLoad(_)).Times(0);
+    EXPECT_CALL(director, onNewGame()).Times(0);
+    EXPECT_CALL(director, onModuleLoad(_)).Times(0);
+
+    auto generation = TestGameModule::runtimeSessionGeneration(*game);
+    auto *modulePtr = game->module().get();
+    auto *playerPtr = game->party().player().get();
+    auto screen = game->currentScreen();
+
+    // when
+    EXPECT_THROW(game->loadGame(slot), ResourceNotFoundException);
+
+    // then the session the player was in is still the one that is running
+    EXPECT_EQ(generation, TestGameModule::runtimeSessionGeneration(*game));
+    EXPECT_EQ(modulePtr, game->module().get());
+    EXPECT_EQ(playerPtr, game->party().player().get());
+    EXPECT_EQ(screen, game->currentScreen());
+    EXPECT_NE(Game::Screen::None, game->currentScreen());
+}
+
+TEST_P(LoadTransactionFixture, aMissingRequiredSaveRecordFailsBeforeTheCommitBoundary) {
+    // given a slot whose archive opens but which carries no savenfo.res.
+    // Validating it only after the reset is what used to strand the engine.
+    auto &director = engine.resourceModule().director();
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Invoke([this](const SaveSlotDescriptor &descriptor) {
+            return std::make_unique<SaveSessionState>(descriptor);
+        }));
+    EXPECT_CALL(director, commitGameLoad(_)).Times(0);
+    EXPECT_CALL(director, onNewGame()).Times(0);
+
+    auto generation = TestGameModule::runtimeSessionGeneration(*game);
+    auto *modulePtr = game->module().get();
+
+    // when
+    EXPECT_THROW(game->loadGame(slot), ResourceNotFoundException);
+
+    // then
+    EXPECT_EQ(generation, TestGameModule::runtimeSessionGeneration(*game));
+    EXPECT_EQ(modulePtr, game->module().get());
+}
+
+TEST_P(LoadTransactionFixture, preparationConsumesTheDiscoveredDescriptorVerbatim) {
+    // given the slot discovered by indexing. Reducing it to a name here would
+    // let the loader resolve a different directory than the list offered.
+    auto &director = engine.resourceModule().director();
+    std::filesystem::path seen;
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Invoke([&](const SaveSlotDescriptor &descriptor) {
+            seen = descriptor.directory;
+            throw ResourceNotFoundException("stop after capturing identity");
+            return std::unique_ptr<SaveSessionState>();
+        }));
+    EXPECT_CALL(director, onGameLoad(An<std::string_view>())).Times(0);
+
+    // when
+    EXPECT_THROW(game->loadGame(slot), ResourceNotFoundException);
+
+    // then
+    EXPECT_EQ(slot.directory, seen);
+}
+
+TEST_P(LoadTransactionFixture, aFailedLoadDoesNotPreventALaterOne) {
+    // given one rejected candidate followed by another attempt
+    auto &director = engine.resourceModule().director();
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Throw(ResourceNotFoundException("Save directory not found")))
+        .WillOnce(Throw(ResourceNotFoundException("Save directory not found")));
+
+    EXPECT_THROW(game->loadGame(slot), ResourceNotFoundException);
+
+    // when the player tries again
+    // then the second attempt still reaches preparation rather than finding a
+    // half-dismantled engine
+    EXPECT_THROW(game->loadGame(slot), ResourceNotFoundException);
+    EXPECT_EQ("module_a", game->module()->name());
+}
+
+TEST_P(LoadTransactionFixture, aPostCommitFailureLandsOnADeliberateScreen) {
+    // given a candidate good enough to commit, which then fails while the
+    // destination module is being mounted. The previous session is already
+    // gone at that point and cannot be brought back, so the only question is
+    // whether the engine ends up somewhere intentional.
+    auto nfo = Gff::Builder()
+                   .field(Gff::Field::newCExoString("LASTMODULE", "module_b"))
+                   .field(Gff::Field::newCExoString("AREANAME", "module_b"))
+                   .build();
+    auto nfoBytes = GffWriter(GffFileFormat::v32("NFO "), *nfo).toBytes();
+    std::ofstream nfoFile(slot.directory / "savenfo.res", std::ios::binary);
+    nfoFile.write(nfoBytes.data(), static_cast<std::streamsize>(nfoBytes.size()));
+    nfoFile.close();
+
+    auto globals = Gff::Builder().build();
+    auto globalBytes = GffWriter(GffFileFormat::v32("GVT "), *globals).toBytes();
+    std::ofstream globalFile(slot.directory / "globalvars.res", std::ios::binary);
+    globalFile.write(globalBytes.data(), static_cast<std::streamsize>(globalBytes.size()));
+    globalFile.close();
+
+    auto &director = engine.resourceModule().director();
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Invoke([](const SaveSlotDescriptor &descriptor) {
+            return std::make_unique<SaveSessionState>(descriptor);
+        }));
+    EXPECT_CALL(director, commitGameLoad(_)).Times(1);
+    EXPECT_CALL(director, onModuleLoad(_))
+        .WillRepeatedly(Throw(ResourceNotFoundException("module not found")));
+
+    // when the failure lands after the commit boundary
+    EXPECT_NO_THROW(game->loadGame(slot));
+
+    // then nothing of either session is left half-built, and the engine is not
+    // sitting on the blank screen an abandoned session renders as
+    EXPECT_EQ(Game::Screen::MainMenu, game->currentScreen());
+    EXPECT_NE(Game::Screen::None, game->currentScreen());
+    EXPECT_FALSE(game->module());
+    EXPECT_FALSE(game->hasPlayableRuntimeSession());
+}
+
+TEST_P(LoadTransactionFixture, aCommittedLoadReplacesTheRunningSessionInOrder) {
+    // given a candidate that gets past validation
+    auto nfo = Gff::Builder()
+                   .field(Gff::Field::newCExoString("LASTMODULE", "module_b"))
+                   .field(Gff::Field::newCExoString("AREANAME", "module_b"))
+                   .build();
+    auto nfoBytes = GffWriter(GffFileFormat::v32("NFO "), *nfo).toBytes();
+    std::ofstream nfoFile(slot.directory / "savenfo.res", std::ios::binary);
+    nfoFile.write(nfoBytes.data(), static_cast<std::streamsize>(nfoBytes.size()));
+    nfoFile.close();
+
+    auto globals = Gff::Builder().build();
+    auto globalBytes = GffWriter(GffFileFormat::v32("GVT "), *globals).toBytes();
+    std::ofstream globalFile(slot.directory / "globalvars.res", std::ios::binary);
+    globalFile.write(globalBytes.data(), static_cast<std::streamsize>(globalBytes.size()));
+    globalFile.close();
+
+    auto *modulePtr = game->module().get();
+    auto generation = TestGameModule::runtimeSessionGeneration(*game);
+
+    // The candidate is built while the old session is still authoritative, the
+    // old session is retired next, and only then is the candidate published.
+    // Recorded as call order rather than a strict sequence: retiring to the
+    // safe terminal state resets the game a second time, which a saturating
+    // InSequence expectation would reject.
+    int step = 0;
+    int prepared = 0;
+    int retired = 0;
+    int committed = 0;
+
+    auto &director = engine.resourceModule().director();
+    EXPECT_CALL(director, prepareGameLoad(_))
+        .WillOnce(Invoke([&](const SaveSlotDescriptor &descriptor) {
+            prepared = ++step;
+            return std::make_unique<SaveSessionState>(descriptor);
+        }));
+    EXPECT_CALL(director, onNewGame())
+        .Times(AnyNumber())
+        .WillRepeatedly(Invoke([&]() {
+            if (retired == 0) {
+                retired = ++step;
+            }
+        }));
+    EXPECT_CALL(director, commitGameLoad(_))
+        .WillOnce(Invoke([&](std::unique_ptr<SaveSessionState>) {
+            committed = ++step;
+        }));
+    EXPECT_CALL(director, onModuleLoad(_))
+        .WillRepeatedly(Throw(ResourceNotFoundException("module not found")));
+
+    // when the load reaches the commit boundary
+    EXPECT_NO_THROW(game->loadGame(slot));
+
+    // then the session that was running has genuinely been replaced rather
+    // than merely disturbed
+    EXPECT_NE(generation, TestGameModule::runtimeSessionGeneration(*game));
+    EXPECT_NE(modulePtr, game->module().get());
+
+    // validation precedes retirement, retirement precedes publication
+    ASSERT_GT(prepared, 0);
+    ASSERT_GT(retired, 0);
+    ASSERT_GT(committed, 0);
+    EXPECT_LT(prepared, retired);
+    EXPECT_LT(retired, committed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothGames,
+    LoadTransactionFixture,
+    ::testing::Values(GameID::KotOR, GameID::TSL),
+    [](const ::testing::TestParamInfo<GameID> &info) {
+        return info.param == GameID::TSL ? "TSL" : "KotOR";
+    });


### PR DESCRIPTION
## Summary

`Game::loadGame` reset the running game before the selected save had been validated. If opening the save failed, the current session was already gone and the game could be left without a playable runtime.

The selected save is now validated before the running session is retired. If validation fails, the current session remains intact. If loading fails after that commit point, the game returns to the main menu rather than leaving a partially restored runtime.

## Validation

Adds K1/K2 coverage for failed-load preservation, successful replacement and post-commit failure handling.

Full suite passes. Live K1/K2 smoke confirms a rejected save leaves the current session playable and a valid save still loads normally.