### PR TITLE
[game] Run OnUsed scripts on locked containers

### DIFF
--- a/include/reone/game/object/placeable.h
+++ b/include/reone/game/object/placeable.h
@@ -66,7 +66,7 @@ public:
     // Scripts
 
     void onOpen(uint32_t triggererId);
-    void runOnUsed(std::shared_ptr<Object> usedBy);
+    void runOnUsed(uint32_t usedBy);
     void runOnInvDisturbed(uint32_t triggerrer, InventoryDisturbType type, uint32_t item);
 
     // END Scripts

--- a/src/libs/game/action/opencontainer.cpp
+++ b/src/libs/game/action/opencontainer.cpp
@@ -31,19 +31,23 @@ void OpenContainerAction::execute(std::shared_ptr<Action> self, Object &actor, f
         complete();
         return;
     }
+
+    auto &creatureActor = cast<Creature>(actor);
+    bool reached = creatureActor.navigateTo(_object->position(), true, kDefaultMaxObjectDistance, dt);
+    if (!reached) {
+        return;
+    }
+
     if (auto *placeable = dyn_cast<Placeable>(_object.get())) {
+        placeable->runOnUsed(actor.id());
         if (placeable->isLocked()) {
             complete();
             return;
         }
     }
 
-    auto &creatureActor = cast<Creature>(actor);
-    bool reached = creatureActor.navigateTo(_object->position(), true, kDefaultMaxObjectDistance, dt);
-    if (reached) {
-        _game.openContainer(_object);
-        complete();
-    }
+    _game.openContainer(_object);
+    complete();
 }
 
 } // namespace game

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -370,14 +370,12 @@ void Module::onPlaceableClick(const std::shared_ptr<Placeable> &placeable) {
 
     if (placeable->hasInventory()) {
         partyLeader->clearAllActions();
-        if (!placeable->isLocked()) {
-            partyLeader->addAction(_game.newAction<OpenContainerAction>(placeable));
-        }
+        partyLeader->addAction(_game.newAction<OpenContainerAction>(placeable));
     } else if (!placeable->conversation().empty()) {
         partyLeader->clearAllActions();
         partyLeader->addAction(_game.newAction<StartConversationAction>(placeable, ""));
     } else {
-        placeable->runOnUsed(std::move(partyLeader));
+        placeable->runOnUsed(partyLeader->id());
     }
 }
 

--- a/src/libs/game/object/placeable.cpp
+++ b/src/libs/game/object/placeable.cpp
@@ -226,7 +226,7 @@ void Placeable::onOpen(uint32_t triggererId) {
          {script::ArgKind::LastOpenedBy, Variable::ofObject(triggererId)}});
 }
 
-void Placeable::runOnUsed(std::shared_ptr<Object> usedBy) {
+void Placeable::runOnUsed(uint32_t usedBy) {
     if (_onUsed.empty()) {
         return;
     }
@@ -235,8 +235,7 @@ void Placeable::runOnUsed(std::shared_ptr<Object> usedBy) {
     args.emplace_back(script::ArgKind::Caller, Variable::ofObject(_id));
 
     if (usedBy) {
-        args.emplace_back(script::ArgKind::LastUsedBy,
-                          Variable::ofObject(usedBy->id()));
+        args.emplace_back(script::ArgKind::LastUsedBy, Variable::ofObject(usedBy));
     }
 
     _game.scriptRunner().run(_onUsed, args);

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -3219,11 +3219,15 @@ static Variable SetLocked(const std::vector<Variable> &args, const RoutineContex
     auto bLocked = getInt(args, 1);
 
     // Transform
-    auto target = checkDoor(oTarget);
     bool locked = static_cast<bool>(bLocked);
 
     // Execute
-    target->setLocked(locked);
+    if (auto door = dyn_cast<Door>(oTarget)) {
+        door->setLocked(locked);
+    } else if (auto placeable = dyn_cast<Placeable>(oTarget)) {
+        placeable->setLocked(locked);
+    }
+
     return Variable::ofNull();
 }
 

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -5063,7 +5063,7 @@ TEST(RemoveHeartbeat, should_leave_the_other_event_scripts_on_the_object_alone) 
     fixture.tickHeartbeat();
     ASSERT_TRUE(placeable->getOnHeartbeat().empty());
 
-    placeable->runOnUsed(nullptr);
+    placeable->runOnUsed(0);
 
     EXPECT_EQ(1, dispatchesOf("k_plc_used"));
 }


### PR DESCRIPTION
Before the patch, `Module::onPlaceableClick` completely skipped locked
containers. This does not work for the spice container on the Ebon
Hawk in K1. Spice container is locked, but attempting to open it
should trigger its `OnLoad`, which starts a dialogue to enter the code.

With the patch, we use `OpenContainerAction` on both locked and unlocked
containers. The player character navigates to the container before
calling `OnUsed`. If the container is locked, it returns early and does
not open the container.