### PR TITLE
[game] Implement GetLoadFromSaveGame

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -463,6 +463,18 @@ public:
     uint8_t minutesPerHour() const { return _minutesPerHour; }
 
     /**
+     * Whether the world currently being built came from loading a save from
+     * disk, as opposed to a new game or an ordinary module transition.
+     *
+     * Authored scripts read this to skip entry work - spawns, cutscenes,
+     * destruction - whose results the save already holds. It is true only
+     * while the initial module of a save load is being restored, so an
+     * ordinary transition or a revisit to a module the save already knows
+     * reports false.
+     */
+    bool isLoadingFromSaveGame() const { return _loadingFromSaveGame; }
+
+    /**
      * Length of a game day in world-time milliseconds.
      *
      * Mod_MinPerHour shortens the day - an in-game hour lasts that many
@@ -680,6 +692,7 @@ private:
     bool _runtimeSessionPlayable {false};
     bool _cheatUsed {false};
     uint64_t _runtimeSessionGeneration {1};
+    bool _loadingFromSaveGame {false};
     uint64_t _worldTimeMilliseconds {0};
     uint8_t _minutesPerHour {5};
     double _worldTimeFraction {0.0};

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -916,6 +916,15 @@ bool Game::loadModule(const std::string &name, std::string entry, bool initialSa
         ~TransitionGuard() { value = false; }
     } transitionGuard {_transitionInProgress};
 
+    // Restoring a save is the only load an authored script may see as such,
+    // and only while it runs: the flag falls away on completion, on failure
+    // and on the way out of any exception.
+    _loadingFromSaveGame = initialSaveRestore;
+    struct LoadFromSaveGuard {
+        bool &value;
+        ~LoadFromSaveGuard() { value = false; }
+    } loadFromSaveGuard {_loadingFromSaveGame};
+
     // A module transition is a technical Pazaak abort. It must not manufacture
     // a result or invoke the pending continuation.
     abortPazaak();

--- a/src/libs/game/script/routine/impl/main.cpp
+++ b/src/libs/game/script/routine/impl/main.cpp
@@ -2572,7 +2572,7 @@ static Variable RandomName(const std::vector<Variable> &args, const RoutineConte
 
 static Variable GetLoadFromSaveGame(const std::vector<Variable> &args, const RoutineContext &ctx) {
     // Execute
-    throw RoutineNotImplementedException("GetLoadFromSaveGame");
+    return Variable::ofInt(static_cast<int>(ctx.game.isLoadingFromSaveGame()));
 }
 
 static Variable GetName(const std::vector<Variable> &args, const RoutineContext &ctx) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/minigame.cpp
     ${TESTS_SOURCE_DIR}/game/modulename.cpp
     ${TESTS_SOURCE_DIR}/game/modulesnapshot.cpp
+    ${TESTS_SOURCE_DIR}/game/loadfromsavegame.cpp
     ${TESTS_SOURCE_DIR}/game/savegame.cpp
     ${TESTS_SOURCE_DIR}/game/savedgame.cpp
     ${TESTS_SOURCE_DIR}/game/saveload.cpp

--- a/test/game/loadfromsavegame.cpp
+++ b/test/game/loadfromsavegame.cpp
@@ -1,0 +1,186 @@
+/* Copyright (c) 2026 The reone project contributors */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+#include "../fixtures/game.h"
+#include "../fixtures/scene.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object/area.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/savegame.h"
+#include "reone/game/script/routines.h"
+#include "reone/resource/saveworkingstate.h"
+#include "reone/script/executioncontext.h"
+#include "reone/script/variable.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace reone::script;
+using namespace testing;
+
+namespace {
+
+/**
+ * GetLoadFromSaveGame reports whether the world being built came from a save
+ * on disk. Shipped scripts use it to tell that restoration apart from ordinary
+ * entry, and the two games lean opposite ways: K1 callers take the negative
+ * form, guarding entry work such as spawns, cutscenes and destruction that the
+ * save already holds, while K2 callers predominantly take the positive form to
+ * run restore-time fixups. Either way the answer must be true only while a
+ * save is being restored, and false for a new game, an ordinary transition or
+ * a revisit.
+ */
+struct LoadFromSaveGameFixture : TestWithParam<GameID> {
+    void SetUp() override {
+        // testEngine() initializes itself once and is shared by the whole
+        // binary: re-initializing it here would tear down mocks other suites
+        // have already taught, and this default must never outlive what it
+        // points at.
+        ON_CALL(engine.sceneModule().graphs(), get(_))
+            .WillByDefault(ReturnRef(sharedSceneGraph()));
+        EXPECT_CALL(engine.gameModule().portraits(), portraits())
+            .Times(AnyNumber())
+            .WillRepeatedly(ReturnRef(portraitRows));
+
+        game = std::make_unique<Game>(
+            GetParam(), "", engine.options(), engine.services(), console);
+        routines = std::make_unique<Routines>(
+            GetParam(), game.get(), &engine.services());
+        routines->init();
+
+        area = game->newArea();
+        player = game->newCreature();
+        TestGameModule::configureModuleSnapshot(
+            *game, area, player, "module_a", "module_a");
+
+        auto &director = engine.resourceModule().director();
+        EXPECT_CALL(director, committedSaveWorkingState())
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke([this]() { return committed; }));
+        EXPECT_CALL(director, saveSlotDescriptor())
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke([this]() { return sourceSlot; }));
+        EXPECT_CALL(director, adoptSaveWorkingState(_))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke([this](auto state) { committed = std::move(state); }));
+        EXPECT_CALL(director, saveNames())
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(std::set<std::string> {}));
+    }
+
+    /** The routine's answer, the way a compiled script asks for it. */
+    bool routineSaysLoading() {
+        Routine &routine = routines->get(routines->getIndexByName("GetLoadFromSaveGame"));
+        ExecutionContext execution;
+        execution.routines = routines.get();
+        return routine.invoke({}, execution).intValue != 0;
+    }
+
+    /**
+     * Snapshotting the source module happens inside the load, so it is a live
+     * window onto what an authored script would see while the world is built.
+     * The snapshot then reports failure, which unwinds the load without
+     * needing a renderable scene; the sample has already been taken.
+     */
+    void sampleDuringLoad() {
+        observed.reset();
+        SaveOrchestrationSeams seams;
+        seams.captureModule = [this](const Game &, const std::string &) {
+            observed = routineSaysLoading();
+            ModuleSnapshotResult result;
+            result.error = ModuleSnapshotError::EncodingFailure;
+            result.message = "injected snapshot failure";
+            return result;
+        };
+        TestGameModule::configureSaveOrchestration(*game, std::move(seams));
+    }
+
+    static NiceMock<scene::MockSceneGraph> &sharedSceneGraph() {
+        static NiceMock<scene::MockSceneGraph> graph;
+        return graph;
+    }
+
+    TestEngine &engine {testEngine()};
+    StubConsole console;
+    std::vector<Portrait> portraitRows;
+    std::unique_ptr<Game> game;
+    std::unique_ptr<Routines> routines;
+    std::shared_ptr<Area> area;
+    std::shared_ptr<Creature> player;
+    std::shared_ptr<const SaveWorkingState> committed {
+        std::make_shared<const SaveWorkingState>()};
+    SaveSlotDescriptor sourceSlot;
+    std::optional<bool> observed;
+};
+
+} // namespace
+
+TEST_P(LoadFromSaveGameFixture, an_ordinary_running_session_is_not_loading) {
+    EXPECT_FALSE(routineSaysLoading());
+}
+
+// The discriminating case: while a save is being restored, an authored script
+// must be told so.
+TEST_P(LoadFromSaveGameFixture, restoring_a_save_reports_loading) {
+    sampleDuringLoad();
+
+    game->loadModule("module_b", "", /*initialSaveRestore=*/true);
+
+    ASSERT_TRUE(observed) << "the load never reached the sampling point";
+    EXPECT_TRUE(*observed);
+}
+
+TEST_P(LoadFromSaveGameFixture, an_ordinary_module_transition_is_not_loading) {
+    sampleDuringLoad();
+
+    game->loadModule("module_b");
+
+    ASSERT_TRUE(observed) << "the load never reached the sampling point";
+    EXPECT_FALSE(*observed)
+        << "an ordinary transition must not look like a save restore";
+}
+
+// The answer belongs to the load, not to the session that outlives it, and a
+// load that dies partway must not leave the session claiming otherwise.
+TEST_P(LoadFromSaveGameFixture, the_window_closes_when_the_restore_ends) {
+    sampleDuringLoad();
+
+    EXPECT_FALSE(game->loadModule("module_b", "", /*initialSaveRestore=*/true));
+
+    ASSERT_TRUE(observed);
+    ASSERT_TRUE(*observed);
+    EXPECT_FALSE(routineSaysLoading())
+        << "the answer must fall away once the load is over";
+}
+
+TEST_P(LoadFromSaveGameFixture, a_later_restore_still_gets_its_window) {
+    sampleDuringLoad();
+    ASSERT_FALSE(game->loadModule("module_b", "", /*initialSaveRestore=*/true));
+    ASSERT_FALSE(routineSaysLoading());
+
+    sampleDuringLoad();
+    ASSERT_FALSE(game->loadModule("module_c", "", /*initialSaveRestore=*/true));
+
+    ASSERT_TRUE(observed);
+    EXPECT_TRUE(*observed) << "an earlier failure must not consume the window";
+    EXPECT_FALSE(routineSaysLoading());
+}
+
+TEST_P(LoadFromSaveGameFixture, routine_is_registered_with_the_retail_signature) {
+    int index = routines->getIndexByName("GetLoadFromSaveGame");
+    EXPECT_EQ(index, 251);
+    Routine &routine = routines->get(index);
+    EXPECT_EQ(routine.getArgumentCount(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothGames,
+    LoadFromSaveGameFixture,
+    ::testing::Values(GameID::KotOR, GameID::TSL),
+    [](const ::testing::TestParamInfo<GameID> &info) {
+        return info.param == GameID::TSL ? "TSL" : "KotOR";
+    });

--- a/test/game/loadfromsavegame.cpp
+++ b/test/game/loadfromsavegame.cpp
@@ -1,4 +1,11 @@
-/* Copyright (c) 2026 The reone project contributors */
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>


### PR DESCRIPTION
## Summary

Implement `GetLoadFromSaveGame`, which was previously stubbed.

The routine now reports true while the initial module of a disk save is being restored and false for ordinary module transitions and revisits.

## Validation

Adds K1/K2 coverage for the restore window, ordinary transitions and failed-load cleanup.

Full suite passes.
