### PR TITLE
[game] Reapply "Process more than one action per frame"

### DIFF
--- a/src/libs/game/object.cpp
+++ b/src/libs/game/object.cpp
@@ -446,18 +446,33 @@ void Object::updateDelayedActions(float dt) {
 }
 
 void Object::executeActions(float dt) {
-    if (_actions.empty()) {
-        return;
+    size_t maxActions = _actions.size();
+    for (size_t i = 0; i < maxActions; ++i) {
+        bool repeat = false;
+        for (std::shared_ptr<Action> action : _actions) {
+            if (action->isCompleted()) {
+                continue;
+            }
+
+            _executingAction = action;
+            try {
+                action->execute(action, *this, dt);
+            } catch (...) {
+                _executingAction.reset();
+                throw;
+            }
+
+            _executingAction.reset();
+
+            // Restart iteration from the beginning, because action execution
+            // could add more actions to the queue, and therefore reallocate it.
+            repeat = action->isCompleted();
+            break;
+        }
+        if (!repeat) {
+            break;
+        }
     }
-    std::shared_ptr<Action> action(_actions.front());
-    _executingAction = action;
-    try {
-        action->execute(action, *this, dt);
-    } catch (...) {
-        _executingAction.reset();
-        throw;
-    }
-    _executingAction.reset();
 }
 
 bool Object::hasUserActionsPending(const Action *excluded) const {


### PR DESCRIPTION
We used to execute up to 1 action per frame. With a high dt
multiplier, a single frame takes ~100ms (virtual time, 8x dt). For a
busy queue of multiple actions (script continuations, for example), it
is possible that processing actions one by one will take much longer
than for a queue of a single action.

With DelayCommand actions, it is crucial that they execute in the same
relative order, even when pushed to different queues. With the "1
action per frame" limitation, it is possible that commands in a busy
queue can be delayed for so long, they effectively execute
out-of-order relative to a command in a single action queue, for
example.

This happens with `k_pebn_pophawk` and `k_pebo_carthtlk` when running
with 8x dt multiplier:

  - `k_pebn_pophawk` spawns Carth with a 0.5s delay (module queue).
  - `k_pebo_carthtlk` starts a dialogue with 1.0s delay (trigger queue).

The module queue contains other delayed commands, so it takes a few
frames to process them. The trigger queue only has 1 action, so it can
execute before the module queue actually gets to execute the spawn
command.

Unlike reverted ca2d1acc1 (#315), this patch only processes actions
that were in the queue at the beginning of Object::executeActions. New
actions are processed during the next update cycle.