### PR TITLE
[resource] Detect Linux and MacOS game directory

### DIFF
--- a/src/libs/resource/gameprobe.cpp
+++ b/src/libs/resource/gameprobe.cpp
@@ -16,27 +16,26 @@
  */
 
 #include "reone/resource/gameprobe.h"
-#include "reone/system/exception/validation.h"
 #include "reone/system/fileutil.h"
+#include "reone/system/logutil.h"
 
 namespace reone {
 
 namespace resource {
 
 GameID GameProbe::probe() {
-    // If there is a KotOR executable then game is KotOR
-    auto exePathK1 = findFileIgnoreCase(_gamePath, "swkotor.exe");
-    if (exePathK1) {
-        return GameID::KotOR;
+    auto chitin = findFileIgnoreCase(_gamePath, "chitin.key");
+    if (!chitin) {
+        error("chitin.key is missing");
+        throw std::runtime_error("Unable to determine game ID: " + _gamePath.string());
     }
 
-    // If there is a TSL executable then game is TSL
-    auto exePathK2 = findFileIgnoreCase(_gamePath, "swkotor2.exe");
-    if (exePathK2) {
+    auto k2 = findFileIgnoreCase(_gamePath, "swkotor2.ini");
+    if (k2) {
         return GameID::TSL;
     }
 
-    throw std::runtime_error("Unable to determine game ID: " + _gamePath.string());
+    return GameID::KotOR;
 }
 
 } // namespace resource


### PR DESCRIPTION
`GameProbe` used to look for `swkotor.exe` and `swkotor2.exe` as an
indicator of the game. Native builds of the game for Linux and MacOS
do not have these files

Now we detect the game only by `chitin.key`. TSL is detected by
`swkotor2.ini`.