### PR TITLE
[game] Give restored modules a runtime identity

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -363,9 +363,10 @@ public:
         return newObject<Module>(*this, _services);
     }
     inline std::shared_ptr<Module> newSavedModule() {
-        // Module is the structural owner of the saved graph, not an entry in
-        // its ObjectId namespace. Retail saves can assign 0 to the Area.
-        return std::make_shared<Module>(0, *this, _services);
+        // The module is not part of the serialized object graph, but it still
+        // needs a live identity: authored OnLoad scripts run with the module
+        // as OBJECT_SELF and may schedule commands back onto it.
+        return newObject<Module>(*this, _services);
     }
     inline std::shared_ptr<Item> newItem() {
         return newObject<Item>(*this, _services);

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -1018,6 +1018,12 @@ bool Game::loadModule(const std::string &name, std::string entry, bool initialSa
             bool restoringSavedWorld = restoresSavedWorld(context);
             bool restoringSavedSession = restoresSavedSession(context);
 
+            // The module itself needs a transient runtime identity even though
+            // it is not serialized. Keep that allocation clear of identities
+            // explicitly owned by the saved IFO graph (notably the Area).
+            if (restoringSavedWorld) {
+                reserveSavedObjectIds(*ifo);
+            }
             _module = restoringSavedWorld ? newSavedModule() : newModule();
             _module->load(name, *ifo, restoringSavedWorld);
             _loadedModules.insert(std::make_pair(name, _module));

--- a/test/game/object.cpp
+++ b/test/game/object.cpp
@@ -5022,7 +5022,7 @@ TEST(SavedRuntimeState, accepts_retail_low_ids_but_rejects_invalid_and_duplicate
     EXPECT_THROW(game.newItem(*saved), ValidationException);
 }
 
-TEST(SavedRuntimeState, keeps_structural_module_outside_the_saved_object_registry) {
+TEST(SavedRuntimeState, gives_structural_module_a_transient_runtime_identity) {
     TestEngine engine;
     engine.init();
     StubConsole console;
@@ -5031,9 +5031,10 @@ TEST(SavedRuntimeState, keeps_structural_module_outside_the_saved_object_registr
     auto module = game.newSavedModule();
     auto area = game.newSavedArea(0);
 
-    EXPECT_EQ(0u, module->id());
+    EXPECT_EQ(2u, module->id());
     EXPECT_EQ(0u, area->id());
-    EXPECT_EQ(1u, engine.gameModule().objectRegistrySize(game));
+    EXPECT_EQ(module, game.getObjectById(module->id()));
+    EXPECT_EQ(2u, engine.gameModule().objectRegistrySize(game));
 }
 
 TEST(SavedRuntimeState, reserves_the_actual_retail_graph_before_owner_local_allocations) {
@@ -5073,11 +5074,12 @@ TEST(SavedRuntimeState, reserves_the_actual_retail_graph_before_owner_local_allo
     auto savedTrigger = game.newTrigger(*trigger);
     auto savedPlaceable = game.newPlaceable(*placeable);
 
-    EXPECT_EQ(0u, module->id());
+    EXPECT_EQ(52u, module->id());
     EXPECT_EQ(0u, savedArea->id());
     EXPECT_EQ(1u, savedTrigger->id());
     EXPECT_EQ(50u, savedPlaceable->id());
-    EXPECT_EQ(52u, engine.gameModule().objectRegistrySize(game));
+    EXPECT_EQ(module, game.getObjectById(module->id()));
+    EXPECT_EQ(53u, engine.gameModule().objectRegistrySize(game));
     EXPECT_THROW(game.newPlaceable(*placeable), ValidationException);
 }
 


### PR DESCRIPTION
## Summary

Restored modules were created with ObjectId 0 and left outside the runtime object registry, so module-owned script actions could not resolve their caller.

Reserve saved object IDs before allocating and registering a transient runtime identity for the module.

## Validation

Adds coverage for restored-module registration, allocator placement and saved-ID collision rejection.

Full suite passes.