### PR TITLE
[gui] The K1 combat HUD text scale is absolute, not compounded

### DIFF
--- a/src/libs/game/gui/hud.cpp
+++ b/src/libs/game/gui/hud.cpp
@@ -80,17 +80,21 @@ void HUD::onGUILoaded() {
     bindControls();
 
     if (!_game.isTSL()) {
+        // The GUI control tree outlives this wrapper in the GUI cache. Derive
+        // from the live layout inputs so rebuilding a HUD cannot feed the
+        // previous presentation scale back into itself.
+        const float combatTextScale = _gui->scale() * _gui->textScale() * kK1CombatTextScale;
         for (Control *control : {
                  static_cast<Control *>(_controls.LBL_CMBTMODEMSG.get()),
                  static_cast<Control *>(_controls.BTN_CLEARALL.get()),
                  static_cast<Control *>(_controls.BTN_CLEARONE.get()),
                  static_cast<Control *>(_controls.BTN_CLEARONE2.get())}) {
             if (control) {
-                control->setScale(control->scale() * kK1CombatTextScale);
+                control->setScale(combatTextScale);
             }
         }
         if (auto actionDescription = findControl<gui::Label>("LBL_ACTIONDESC")) {
-            actionDescription->setScale(actionDescription->scale() * kK1CombatTextScale);
+            actionDescription->setScale(combatTextScale);
         }
     }
 


### PR DESCRIPTION
## The defect

The K1 combat sequence HUD's text grows with every level load, doubling each
time, until it wraps and clips.

## Cause

`HUD::onGUILoaded` scales by reading the control's own scale back:

```cpp
control->setScale(control->scale() * kK1CombatTextScale);
```

That is a read-modify-write on state the wrapper does not own. The HUD wrapper
is reconstructed on loadgame, reset and new-session, but the control tree it
binds lives in the GUI cache and survives — so each reconstruction multiplies
the previous result again.

An ordinary `warp` preserves the wrapper and shows nothing, which is why this
presents as a level-load bug rather than a HUD one, and why it is easy to miss
when testing by warping.

## Fix

Derive the value from the live layout and text inputs, so applying it to an
already-scaled tree is idempotent. The wrapper and the control tree have
different lifetimes; the operation should not care which one it is looking at.

## Measurement

Three `loadgame` cycles, glyph region of the combat text:

| load | before | after |
|---|---|---|
| 1 | 1203 px, 314x14 | 1203 px, 314x14 |
| 2 | 5207 px, 629x28 | 1203 px, 314x14 |
| 3 | 22770 px, clipped | 1203 px, 314x14 |

After the fix the first and third regions are pixel-identical.

## Note on verification

The measurements above were taken on a downstream branch that carries this file
unchanged from `master` — the block is byte-identical here, and the patch
applies to `master` as-is. I have not built `master` itself, so a CI run is
worth having before merge.