### PR TITLE
[graphics] Fix transparent model and emitter semantics

### DIFF
--- a/glsl/f_oit_model.glsl
+++ b/glsl/f_oit_model.glsl
@@ -3,6 +3,7 @@
 
 #include "i_luma.glsl"
 #include "i_math.glsl"
+#include "i_lighting.glsl"
 #include "i_normalmap.glsl"
 #include "i_oit.glsl"
 
@@ -40,10 +41,6 @@ void main() {
     vec4 mainTexSample = texture(sMainTex, uv);
     vec3 diffuseColor = mainTexSample.rgb;
     float diffuseAlpha = mainTexSample.a;
-    if (isFeatureEnabled(FEATURE_PREMULALPHA)) {
-        diffuseAlpha = rgbToLuma(mainTexSample.rgb);
-        diffuseColor *= 1.0 / max(0.0001, diffuseAlpha);
-    }
 
     vec3 normal = getNormal(uv);
 
@@ -55,16 +52,37 @@ void main() {
         discard;
     }
 
-    vec3 lighting;
+    vec3 ambient = vec3(0.0);
+    vec3 diffuse = uSelfIllumColor.rgb;
     if (isFeatureEnabled(FEATURE_LIGHTMAP)) {
         vec4 lightmapSample = texture(sLightmap, fragUV2);
-        lighting = lightmapSample.rgb;
+        diffuse += lightmapSample.rgb;
         if (isFeatureEnabled(FEATURE_WATER)) {
-            lighting = mix(vec3(1.0), lighting, 0.2);
+            diffuse = mix(vec3(1.0), diffuse, 0.2);
         }
-    } else {
-        lighting = vec3(1.0);
+    } else if (!isFeatureEnabled(FEATURE_STATIC)) {
+        ambient += uAmbientColor.rgb * uWorldAmbientColor.rgb;
     }
+    for (int i = 0; i < uNumLights; ++i) {
+        if (isFeatureEnabled(FEATURE_STATIC) && uLights[i].dynamicType != LIGHT_DYNAMIC_TYPE_ALL) {
+            continue;
+        }
+        vec3 lightPos = uLights[i].position.xyz - fragPosWorld.xyz;
+        float lightDist = length(lightPos);
+        if (lightDist > uLights[i].radius * uLights[i].radius) {
+            continue;
+        }
+        vec3 lightDir = lightPos / max(1e-4, lightDist);
+        float diff = max(0.0, dot(normal, lightDir));
+        float attenuation = lightAttenuationQuadratic(uLights[i], lightDist);
+        vec3 lightColor = uLights[i].color.rgb;
+        if (uLights[i].ambientOnly) {
+            ambient += uLights[i].multiplier * attenuation * uAmbientColor.rgb * lightColor;
+        } else {
+            diffuse += uLights[i].multiplier * diff * attenuation * uDiffuseColor.rgb * lightColor;
+        }
+    }
+    vec3 lighting = min(vec3(1.0), ambient + max(vec3(0.0), diffuse));
 
     vec3 objectColor = lighting * uColor.rgb * diffuseColor;
     if (isFeatureEnabled(FEATURE_ENVMAP)) {
@@ -75,6 +93,17 @@ void main() {
     }
     if (isFeatureEnabled(FEATURE_WATER)) {
         objectColor *= uWaterAlpha;
+    }
+
+    if (isFeatureEnabled(FEATURE_PREMULALPHA)) {
+        // Convert the lit SRC_ALPHA contribution, not unlit texture RGB.
+        // Zero-light additive surfaces must contribute neither color nor opacity.
+        objectColor *= objectAlpha;
+        objectAlpha = clamp(rgbToLuma(objectColor), 0.0, 1.0);
+        if (objectAlpha == 0.0) {
+            discard;
+        }
+        objectColor /= objectAlpha;
     }
 
     float w = OIT_weight(gl_FragCoord.z, objectAlpha);

--- a/include/reone/scene/node/emitter.h
+++ b/include/reone/scene/node/emitter.h
@@ -64,9 +64,9 @@ public:
      */
     void prewarmContinuousParticles();
 
-    float getParticleSize(float time) const { return _particleSize.get(time); };
-    glm::vec3 getColor(float time) const { return _color.get(time); };
-    float getAlpha(float time) const { return _alpha.get(time); };
+    float getParticleSize(float time) const { return _particleSize.get(time, _percentStart, _percentMid, _percentEnd); };
+    glm::vec3 getColor(float time) const { return _color.get(time, _percentStart, _percentMid, _percentEnd); };
+    float getAlpha(float time) const { return _alpha.get(time, _percentStart, _percentMid, _percentEnd); };
 
     float lifeExpectancy() const { return _lifeExpectancy; }
     int frameStart() const { return _frameStart; }
@@ -80,12 +80,20 @@ private:
         T mid;
         T end;
 
-        T get(float factor) const {
-            if (factor < 0.5f) {
-                return glm::mix(start, mid, 2.0f * factor);
-            } else {
-                return glm::mix(mid, end, 2.0f * factor - 1.0f);
+        T get(float factor, float percentStart, float percentMid, float percentEnd) const {
+            percentStart = glm::clamp(percentStart, 0.0f, 1.0f);
+            percentMid = glm::clamp(percentMid, 0.0f, 1.0f);
+            percentEnd = glm::clamp(percentEnd, 0.0f, 1.0f);
+            if (factor <= percentStart) {
+                return start;
             }
+            if (percentMid > percentStart && factor < percentMid) {
+                return glm::mix(start, mid, (factor - percentStart) / (percentMid - percentStart));
+            }
+            if (factor < percentEnd && percentEnd > percentMid) {
+                return glm::mix(mid, end, (factor - percentMid) / (percentEnd - percentMid));
+            }
+            return end;
         }
     };
 
@@ -93,7 +101,12 @@ private:
     StartMidEnd<glm::vec3> _color;
     StartMidEnd<float> _alpha;
 
+    float _percentStart {0.0f};
+    float _percentMid {0.5f};
+    float _percentEnd {1.0f};
+
     float _birthrate {0.0f};      /**< rate of particle birth per second */
+    float _randomBirthrate {0.0f}; /**< integral random variation applied by Fountain emitters */
     float _lifeExpectancy {0.0f}; /**< life of each particle in seconds */
     glm::vec2 _size {0.0f};
     int _frameStart {0};
@@ -111,6 +124,7 @@ private:
     int _lightningSubDiv {0};
 
     float _birthInterval {0.0f};
+    float _particleAccumulator {0.0f};
     Timer _birthTimer;
     bool _spawned {false};
 
@@ -119,6 +133,7 @@ private:
     void spawnParticles(float dt);
     void removeExpiredParticles(float dt);
     ParticleSceneNode *doSpawnParticle();
+    int fountainSpawnCount(float elapsed);
     void spawnLightningParticles();
 };
 

--- a/src/libs/scene/node/emitter.cpp
+++ b/src/libs/scene/node/emitter.cpp
@@ -41,6 +41,7 @@ namespace scene {
 
 void EmitterSceneNode::init() {
     _modelNode.floatValueAtTime(ControllerTypes::birthrate, 0.0f, _birthrate);
+    _modelNode.floatValueAtTime(ControllerTypes::randomBirthRate, 0.0f, _randomBirthrate);
     _modelNode.floatValueAtTime(ControllerTypes::lifeExp, 0.0f, _lifeExpectancy);
     _modelNode.floatValueAtTime(ControllerTypes::xSize, 0.0f, _size.x);
     _modelNode.floatValueAtTime(ControllerTypes::ySize, 0.0f, _size.y);
@@ -78,6 +79,9 @@ void EmitterSceneNode::init() {
     _modelNode.floatValueAtTime(ControllerTypes::alphaStart, 0.0f, _alpha.start);
     _modelNode.floatValueAtTime(ControllerTypes::alphaMid, 0.0f, _alpha.mid);
     _modelNode.floatValueAtTime(ControllerTypes::alphaEnd, 0.0f, _alpha.end);
+    _modelNode.floatValueAtTime(ControllerTypes::percentStart, 0.0f, _percentStart);
+    _modelNode.floatValueAtTime(ControllerTypes::percentMid, 0.0f, _percentMid);
+    _modelNode.floatValueAtTime(ControllerTypes::percentEnd, 0.0f, _percentEnd);
 
     if (_birthrate != 0.0f) {
         _birthInterval = 1.0f / _birthrate;
@@ -130,10 +134,13 @@ void EmitterSceneNode::spawnParticles(float dt) {
     switch (emitter->updateMode) {
     case ModelNode::Emitter::UpdateMode::Fountain:
         if (_birthrate != 0.0f) {
-            _birthTimer.update(dt);
-            if (_birthTimer.elapsed()) {
-                doSpawnParticle();
-                _birthTimer.reset(_birthInterval);
+            _particleAccumulator += dt;
+            if (_particleAccumulator >= _birthInterval) {
+                int count = fountainSpawnCount(_particleAccumulator);
+                for (int i = 0; i < count; ++i) {
+                    doSpawnParticle();
+                }
+                _particleAccumulator = 0.0f;
             }
         }
         break;
@@ -156,9 +163,12 @@ void EmitterSceneNode::spawnParticles(float dt) {
 }
 
 ParticleSceneNode *EmitterSceneNode::doSpawnParticle() {
-    // Take particle from the pool, if available
+    // kMaxParticles is the size of one GPU uniform batch, not an emitter
+    // population limit. Retail allocates another particle when its dead list is
+    // empty; SceneGraph likewise owns every particle allocated here and later
+    // splits a large emitter into kMaxParticles-sized draw batches.
     if (_particlePool.empty()) {
-        return nullptr;
+        _particlePool.push_back(_sceneGraph.newParticle(*this).get());
     }
     auto particle = static_cast<ParticleSceneNode *>(_particlePool.front());
     particle->setLifetime(0.0f);
@@ -187,6 +197,20 @@ ParticleSceneNode *EmitterSceneNode::doSpawnParticle() {
     return particle;
 }
 
+int EmitterSceneNode::fountainSpawnCount(float elapsed) {
+    float effectiveRate = _birthrate;
+    int randomRange = static_cast<int>(glm::round(_randomBirthrate));
+    if (randomRange > 0) {
+        bool add = randomInt(0, 1) != 0;
+        int variation = randomInt(0, randomRange - 1);
+        effectiveRate += add ? variation : -variation;
+        effectiveRate = glm::max(0.0f, effectiveRate);
+    }
+
+    int divisor = static_cast<int>(effectiveRate) + 1;
+    return divisor > 0 ? static_cast<int>(elapsed * effectiveRate) % divisor : 0;
+}
+
 void EmitterSceneNode::prewarmContinuousParticles() {
     auto emitter = _modelNode.emitter();
     if (!emitter || emitter->updateMode != ModelNode::Emitter::UpdateMode::Fountain) {
@@ -199,25 +223,26 @@ void EmitterSceneNode::prewarmContinuousParticles() {
     // Take the phase where a particle is born exactly as the scene opens. The
     // ones still alive behind it are then those emitted one, two, three birth
     // intervals ago, up to the last whose age is still short of the life
-    // expectancy: ceil(birthrate * lifeExpectancy) of them. The pool init()
-    // allocated bounds that, in which case the youngest are the ones seeded.
-    int count = glm::min(kMaxParticles, static_cast<int>(glm::ceil(_birthrate * _lifeExpectancy)));
-    for (int i = 0; i < count; ++i) {
-        auto particle = doSpawnParticle();
-        if (!particle) {
-            break;
+    // expectancy: ceil(birthrate * lifeExpectancy) of them.
+    int emissionSlots = static_cast<int>(glm::ceil(_birthrate * _lifeExpectancy));
+    for (int i = 0; i < emissionSlots; ++i) {
+        int count = fountainSpawnCount(_birthInterval);
+        for (int j = 0; j < count; ++j) {
+            auto particle = doSpawnParticle();
+            if (!particle) {
+                break;
+            }
+            // Age by whole birth intervals, not by an even share of the
+            // lifetime: the two agree only when birthrate times life
+            // expectancy is a whole number, and elsewhere an even share
+            // invents ages the authored cadence could never have produced.
+            particle->update(i * _birthInterval);
         }
-        // Age by whole birth intervals, not by an even share of the lifetime:
-        // the two agree only when birthrate times life expectancy happens to be
-        // a whole number, and elsewhere an even share invents ages the authored
-        // cadence could never have produced. The oldest lands strictly short of
-        // the life expectancy, so nothing is seeded already expired.
-        particle->update(i * _birthInterval);
     }
 
     // The next birth is a full interval away, so the field this leaves behind
     // is not immediately followed by an extra particle.
-    _birthTimer.reset(_birthInterval);
+    _particleAccumulator = 0.0f;
 }
 
 void EmitterSceneNode::spawnLightningParticles() {

--- a/src/libs/scene/node/particle.cpp
+++ b/src/libs/scene/node/particle.cpp
@@ -72,7 +72,13 @@ void ParticleSceneNode::updateAnimation(float dt) {
         factor = 0.0f;
     }
 
-    _frame = static_cast<int>(glm::ceil(_emitter.frameStart() + factor * (_emitter.frameEnd() - _emitter.frameStart())));
+    // A zero authored frame rate is a static atlas selection in Odyssey. It
+    // does not mean that the frame range should be spread over particle life.
+    if (_animLength > 0.0f) {
+        _frame = static_cast<int>(glm::ceil(_emitter.frameStart() + factor * (_emitter.frameEnd() - _emitter.frameStart())));
+    } else {
+        _frame = _emitter.frameStart();
+    }
     _size = glm::vec2(_emitter.getParticleSize(factor));
     _color = _emitter.getColor(factor);
     _alpha = _emitter.getAlpha(factor);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/format/tgareader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/tgawriter.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/tpcreader.cpp
+    ${TESTS_SOURCE_DIR}/graphics/shadersemantics.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/txireader.cpp
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp

--- a/test/graphics/shadersemantics.cpp
+++ b/test/graphics/shadersemantics.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+namespace {
+
+std::string readShader(std::string_view name) {
+    auto path = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() / "glsl" / name;
+    std::ifstream stream(path);
+    return std::string(
+        std::istreambuf_iterator<char>(stream),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+TEST(OITModelShader, transparent_material_keeps_authored_alpha_and_lighting) {
+    auto shader = readShader("f_oit_model.glsl");
+    ASSERT_FALSE(shader.empty());
+
+    auto textureAlpha = shader.find("float diffuseAlpha = mainTexSample.a;");
+    auto applyTextureAlpha = shader.find("objectAlpha *= diffuseAlpha;");
+    auto lightLoop = shader.find("for (int i = 0; i < uNumLights; ++i)");
+    auto litColor = shader.find("vec3 objectColor = lighting * uColor.rgb * diffuseColor;");
+    auto applyAuthoredAlpha = shader.find("objectColor *= objectAlpha;");
+    auto encodeContribution = shader.find("objectAlpha = clamp(rgbToLuma(objectColor), 0.0, 1.0);");
+
+    EXPECT_NE(std::string::npos, textureAlpha);
+    EXPECT_NE(std::string::npos, applyTextureAlpha);
+    EXPECT_NE(std::string::npos, lightLoop);
+    EXPECT_NE(std::string::npos, litColor);
+    EXPECT_NE(std::string::npos, applyAuthoredAlpha);
+    EXPECT_NE(std::string::npos, encodeContribution);
+    EXPECT_LT(textureAlpha, applyTextureAlpha);
+    EXPECT_LT(lightLoop, litColor);
+    EXPECT_LT(litColor, applyAuthoredAlpha);
+    EXPECT_LT(applyAuthoredAlpha, encodeContribution);
+
+    // The old path replaced texture alpha with RGB luminance before lighting,
+    // which made a blue additive texture visible even under zero light.
+    EXPECT_EQ(std::string::npos, shader.find("diffuseAlpha = rgbToLuma(mainTexSample.rgb);"));
+}

--- a/test/scene/emitter.cpp
+++ b/test/scene/emitter.cpp
@@ -7,6 +7,7 @@
 #include "reone/scene/node/emitter.h"
 #include "reone/scene/node/model.h"
 #include "reone/scene/node/particle.h"
+#include "reone/system/randomutil.h"
 #include "reone/gui/sceneinitializer.h"
 #include "../fixtures/audio.h"
 #include "../fixtures/graphics.h"
@@ -183,11 +184,11 @@ TEST(EmitterSceneNode, rearming_single_does_not_affect_fountain_emission) {
     ASSERT_TRUE(fountain);
 
     scene->update(0.05f);
-    ASSERT_EQ(1, fountain->children().size());
+    ASSERT_TRUE(fountain->children().empty());
     scene->update(0.05f);
     ASSERT_EQ(1, fountain->children().size());
     scene->update(0.05f);
-    EXPECT_EQ(2, fountain->children().size());
+    EXPECT_EQ(1, fountain->children().size());
 }
 
 namespace {
@@ -238,7 +239,8 @@ std::shared_ptr<Model> newEmitterModel(
     const std::string &name,
     ModelNode::Emitter::UpdateMode updateMode,
     float birthrate,
-    float lifeExpectancy) {
+    float lifeExpectancy,
+    float randomBirthrate = 0.0f) {
 
     auto rootNode = std::make_shared<ModelNode>(
         0, "root", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
@@ -251,6 +253,7 @@ std::shared_ptr<Model> newEmitterModel(
         1, "emitter", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
     emitterNode->setEmitter(emitter);
     emitterNode->floatTracks()[ControllerTypes::birthrate].add(0.0f, birthrate);
+    emitterNode->floatTracks()[ControllerTypes::randomBirthRate].add(0.0f, randomBirthrate);
     emitterNode->floatTracks()[ControllerTypes::lifeExp].add(0.0f, lifeExpectancy);
     // Authored appearance over a particle's life, so a seeded particle can be
     // checked against the point in that life it claims to be at.
@@ -262,6 +265,9 @@ std::shared_ptr<Model> newEmitterModel(
     emitterNode->floatTracks()[ControllerTypes::alphaStart].add(0.0f, 1.0f);
     emitterNode->floatTracks()[ControllerTypes::alphaMid].add(0.0f, 0.5f);
     emitterNode->floatTracks()[ControllerTypes::alphaEnd].add(0.0f, 0.0f);
+    emitterNode->floatTracks()[ControllerTypes::percentStart].add(0.0f, 0.0f);
+    emitterNode->floatTracks()[ControllerTypes::percentMid].add(0.0f, 0.5f);
+    emitterNode->floatTracks()[ControllerTypes::percentEnd].add(0.0f, 1.0f);
     emitterNode->vectorTracks()[ControllerTypes::colorStart].add(0.0f, glm::vec3(1.0f, 0.0f, 0.0f));
     emitterNode->vectorTracks()[ControllerTypes::colorMid].add(0.0f, glm::vec3(0.0f, 1.0f, 0.0f));
     emitterNode->vectorTracks()[ControllerTypes::colorEnd].add(0.0f, glm::vec3(0.0f, 0.0f, 1.0f));
@@ -353,7 +359,7 @@ TEST(EmitterPrewarm, a_seeded_particle_looks_like_one_that_lived_that_long) {
     auto oldest = oldestParticle(*emitter);
     ASSERT_TRUE(oldest);
     EXPECT_FLOAT_EQ(1.0f, oldest->lifetime());
-    EXPECT_EQ(5, oldest->frame());
+    EXPECT_EQ(0, oldest->frame());
     EXPECT_FLOAT_EQ(2.0f, oldest->size().x);
     EXPECT_FLOAT_EQ(0.5f, oldest->alpha());
     EXPECT_LT(glm::length(oldest->color() - glm::vec3(0.0f, 1.0f, 0.0f)), 1e-5f);
@@ -371,6 +377,70 @@ TEST(EmitterPrewarm, prewarming_leaves_a_single_emitter_alone) {
 
     scene.graph->update(0.0f);
     EXPECT_EQ(1u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, steady_state_population_can_exceed_one_gpu_particle_batch) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("large_population", ModelNode::Emitter::UpdateMode::Fountain, 25.0f, 4.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_EQ(100u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, appearance_uses_the_authored_lifecycle_percentages) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("early_midpoint", ModelNode::Emitter::UpdateMode::Fountain, 1.0f, 10.0f);
+    auto sourceEmitter = model->rootNode()->children().front();
+    sourceEmitter->floatTracks().erase(ControllerTypes::percentMid);
+    sourceEmitter->floatTracks()[ControllerTypes::percentMid].add(0.0f, 0.1f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    auto oneSecondOldIt = std::find_if(emitter->children().begin(), emitter->children().end(), [](auto child) {
+        return child->type() == SceneNodeType::Particle &&
+               static_cast<const ParticleSceneNode *>(child)->lifetime() == 1.0f;
+    });
+    ASSERT_NE(emitter->children().end(), oneSecondOldIt);
+    auto oneSecondOld = static_cast<const ParticleSceneNode *>(*oneSecondOldIt);
+    EXPECT_FLOAT_EQ(2.0f, oneSecondOld->size().x);
+    EXPECT_FLOAT_EQ(0.5f, oneSecondOld->alpha());
+    EXPECT_LT(glm::length(oneSecondOld->color() - glm::vec3(0.0f, 1.0f, 0.0f)), 1e-5f);
+}
+
+TEST(EmitterPrewarm, zero_fps_keeps_the_authored_start_frame) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("static_atlas_frame", ModelNode::Emitter::UpdateMode::Fountain, 1.0f, 2.0f);
+    auto sourceEmitter = model->rootNode()->children().front();
+    sourceEmitter->floatTracks().erase(ControllerTypes::frameStart);
+    sourceEmitter->floatTracks()[ControllerTypes::frameStart].add(0.0f, 3.0f);
+    sourceEmitter->floatTracks()[ControllerTypes::fps].add(0.0f, 0.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    auto oldest = oldestParticle(*emitter);
+    ASSERT_TRUE(oldest);
+    EXPECT_EQ(3, oldest->frame());
+}
+
+TEST(EmitterPrewarm, random_birthrate_changes_the_authored_fountain_population) {
+    setRandomSeed(0x4b324d4du);
+    PrewarmScene scene;
+    auto model = newEmitterModel(
+        "random_birthrate",
+        ModelNode::Emitter::UpdateMode::Fountain,
+        10.0f,
+        10.0f,
+        9.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_GT(emitter->children().size(), 0u);
+    EXPECT_LT(emitter->children().size(), 100u);
 }
 
 TEST(EmitterPrewarm, emission_carries_on_at_the_authored_cadence_after_prewarming) {


### PR DESCRIPTION
## Summary

Fixes several shared model/emitter interpretation defects found while validating K2 GUI scenes.

- transparent meshes now retain authored lighting and texture/material alpha;
- emitter population is no longer incorrectly capped by the 64-particle GPU batch size;
- authored lifecycle midpoint, random birth-rate, and zero-FPS atlas semantics are respected.

These are generic rendering corrections with no content-specific particle density, opacity, colour, or shader tuning.

## Validation

- 42 focused renderer/emitter/menu/scene tests pass
- full suite: 2025 passed, 1 existing expected skip
- shader-pack generation passes
- `git diff --check` passes