### PR TITLE
[game] Restore K2 main menu scenes

### DIFF
--- a/doc/k2-main-menu.md
+++ b/doc/k2-main-menu.md
@@ -1,0 +1,91 @@
+# KotOR II main-menu presentation
+
+K2 selects its menu scene from `GBL_MAIN_SITH_LORD`:
+
+| Value | Model | Presentation |
+| --- | --- | --- |
+| 0 | `mainmenu01` | Sion |
+| 1 | `mainmenu02` | Alternate Traya (unused by normal progression) |
+| 2 | `mainmenu03` | Nihilus |
+| 3 | `mainmenu04` | Traya |
+| 4 | `mainmenu05` | Environment and current leader |
+| Other or absent | `mainmenu01` | Sion fallback |
+
+K1 retains its unnumbered `mainmenu`, orthographic projection, 1.4 framing
+scale, and existing camera setup.
+
+## Scene and lifetime
+
+`MainMenu::refreshScene()` rebuilds K2's scene on GUI load and each subsequent
+main-menu entry. Hosts that change the options snapshot can also call it
+explicitly. It replaces only `kSceneMainMenu`, including its node arena and
+render targets. Ordinary `SceneGraph::clear()` only removes roots and therefore
+cannot release the old menu's cameras, emitters, and other allocated nodes.
+
+Replacing a scene also drops the graphics context's framebuffer references
+before their owners are destroyed. Screenshot readback invalidates the cached
+read framebuffer when binding the window; otherwise the next scene blit can
+incorrectly reuse that binding. A driver-free graphics test covers this
+readback/blit sequence. No particle, shader, texture-unit, or uniform-buffer
+behavior is changed.
+
+K2 uses a 22.7259998-degree vertical perspective and near/far planes of
+0.1/10000. Retail first inserts `gui3d_room` as a separate black enclosing
+shell, then adds the selected numbered model at scale one. The room does not
+parent or occlude the numbered model and supplies no menu camera or character
+lighting. The numbered model supplies the authored floor, backdrop, lights,
+continuous emitters, and looping `default` animation. Emitters use the shared
+prewarming support; the menu does not alter their authored density or color.
+
+The camera attaches to the `camerahook` directly below the authored scene root.
+This matters for `mainmenu03`: it also contains a second `camerahook` inside
+Nihilus, which the general duplicate-name lookup would select instead.
+
+The dynamic leader uses `mainmenu05`'s `cutscenedummy` position (approximately
+`(-1.01066, 0.905068, 0)` in the installed retail model), facing -Y. A model
+without that placement hook falls back to `(0, -1, 0)`. The retail `evil`
+animation is available through the PC supermodel chain; it loops on the body
+and propagates to the head. Unsupported actors log a warning and request
+`pause1` instead.
+
+## Durable options
+
+Before resetting a playable K2 session, `Game::openMainMenu()` copies the global
+selector and, for value 4, the current leader's gender, appearance, effective
+body column, and texture variation. Cold startup, character-generation cancel,
+and partial-load recovery do not replace this snapshot with empty runtime state.
+No save slot is inspected to choose the cold-start presentation.
+
+The engine stores these top-level options in its existing `reone.cfg`:
+
+```ini
+k2-menu-selector=4
+k2-menu-gender=0
+k2-menu-appearance=136
+k2-menu-body=1
+k2-menu-texture=1
+```
+
+Body columns are zero-based (`a = 0`, `b = 1`, etc.). The writer replaces only
+the five menu keys and retains unrelated lines, comments, and sections. A
+complete valid leader tuple is required to insert the dynamic creature;
+otherwise value 4 displays the environment alone.
+
+The reconstructed actor comes from `Game::newPresentationCreature()`. It has
+no gameplay registration, Party membership, saved identity, or retained live
+leader reference. Body/texture overrides use the existing Creature model
+builder; equipment objects and weapons are not copied. The tuple setter rejects
+runtime creatures.
+
+## Regression checks
+
+Asset-free tests are in `test/game/mainmenu.cpp`:
+
+```sh
+build/bin/tests --gtest_filter='MenuPresentation.*:MainMenuTest.*'
+```
+
+The existing console command `openmenu main` exercises the same capture,
+retirement, and refresh boundary as other main-menu entries. Headless engine
+runs advance at 60 simulation frames per second, so `pause 1200` observes the
+scene past one complete 16-second `default` animation cycle.

--- a/glsl/f_oit_model.glsl
+++ b/glsl/f_oit_model.glsl
@@ -3,6 +3,7 @@
 
 #include "i_luma.glsl"
 #include "i_math.glsl"
+#include "i_lighting.glsl"
 #include "i_normalmap.glsl"
 #include "i_oit.glsl"
 
@@ -40,10 +41,6 @@ void main() {
     vec4 mainTexSample = texture(sMainTex, uv);
     vec3 diffuseColor = mainTexSample.rgb;
     float diffuseAlpha = mainTexSample.a;
-    if (isFeatureEnabled(FEATURE_PREMULALPHA)) {
-        diffuseAlpha = rgbToLuma(mainTexSample.rgb);
-        diffuseColor *= 1.0 / max(0.0001, diffuseAlpha);
-    }
 
     vec3 normal = getNormal(uv);
 
@@ -55,16 +52,37 @@ void main() {
         discard;
     }
 
-    vec3 lighting;
+    vec3 ambient = vec3(0.0);
+    vec3 diffuse = uSelfIllumColor.rgb;
     if (isFeatureEnabled(FEATURE_LIGHTMAP)) {
         vec4 lightmapSample = texture(sLightmap, fragUV2);
-        lighting = lightmapSample.rgb;
+        diffuse += lightmapSample.rgb;
         if (isFeatureEnabled(FEATURE_WATER)) {
-            lighting = mix(vec3(1.0), lighting, 0.2);
+            diffuse = mix(vec3(1.0), diffuse, 0.2);
         }
-    } else {
-        lighting = vec3(1.0);
+    } else if (!isFeatureEnabled(FEATURE_STATIC)) {
+        ambient += uAmbientColor.rgb * uWorldAmbientColor.rgb;
     }
+    for (int i = 0; i < uNumLights; ++i) {
+        if (isFeatureEnabled(FEATURE_STATIC) && uLights[i].dynamicType != LIGHT_DYNAMIC_TYPE_ALL) {
+            continue;
+        }
+        vec3 lightPos = uLights[i].position.xyz - fragPosWorld.xyz;
+        float lightDist = length(lightPos);
+        if (lightDist > uLights[i].radius * uLights[i].radius) {
+            continue;
+        }
+        vec3 lightDir = lightPos / max(1e-4, lightDist);
+        float diff = max(0.0, dot(normal, lightDir));
+        float attenuation = lightAttenuationQuadratic(uLights[i], lightDist);
+        vec3 lightColor = uLights[i].color.rgb;
+        if (uLights[i].ambientOnly) {
+            ambient += uLights[i].multiplier * attenuation * uAmbientColor.rgb * lightColor;
+        } else {
+            diffuse += uLights[i].multiplier * diff * attenuation * uDiffuseColor.rgb * lightColor;
+        }
+    }
+    vec3 lighting = min(vec3(1.0), ambient + max(vec3(0.0), diffuse));
 
     vec3 objectColor = lighting * uColor.rgb * diffuseColor;
     if (isFeatureEnabled(FEATURE_ENVMAP)) {
@@ -75,6 +93,17 @@ void main() {
     }
     if (isFeatureEnabled(FEATURE_WATER)) {
         objectColor *= uWaterAlpha;
+    }
+
+    if (isFeatureEnabled(FEATURE_PREMULALPHA)) {
+        // Convert the lit SRC_ALPHA contribution, not unlit texture RGB.
+        // Zero-light additive surfaces must contribute neither color nor opacity.
+        objectColor *= objectAlpha;
+        objectAlpha = clamp(rgbToLuma(objectColor), 0.0, 1.0);
+        if (objectAlpha == 0.0) {
+            discard;
+        }
+        objectColor /= objectAlpha;
     }
 
     float w = OIT_weight(gl_FragCoord.z, objectAlpha);

--- a/include/reone/game/gui/mainmenu.h
+++ b/include/reone/game/gui/mainmenu.h
@@ -31,15 +31,21 @@ namespace reone {
 
 namespace game {
 
+class Creature;
+
 class MainMenu : public GameGUI {
 public:
     MainMenu(Game &game, ServicesView &services);
 
     void onModuleSelected(const std::string &name);
+    // Rebuild K2 from the durable options snapshot on every menu entry.
+    // Also callable after a host updates the persisted presentation state.
+    void refreshScene();
 
     const std::string &musicResRef() const { return _musicResRef; }
 
 private:
+    friend class MainMenuTestAccess;
     struct Controls {
         std::shared_ptr<gui::Button> BTN_EXIT;
         std::shared_ptr<gui::Button> BTN_LOADGAME;
@@ -62,6 +68,7 @@ private:
     Controls _controls;
 
     std::string _musicResRef;
+    std::shared_ptr<Creature> _leader;
 
 protected:
     void preload(gui::IGUI &gui) override;

--- a/include/reone/game/menupresentation.h
+++ b/include/reone/game/menupresentation.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace reone::game {
+
+// Visual values only: never an object ID, Party binding, or live creature.
+struct CreaturePresentation {
+    int gender {0};
+    int appearance {0};
+    int bodyVariation {0}; // appearance.2da model/tex column: a = 0
+    int textureVariation {1};
+};
+
+struct MenuPresentation {
+    int selector {0};
+    std::optional<CreaturePresentation> leader;
+
+    static int validateSelector(int value) { return value >= 0 && value <= 4 ? value : 0; }
+    std::string modelResRef(bool tsl) const;
+    static MenuPresentation load(const std::filesystem::path &path);
+    void save(const std::filesystem::path &path) const;
+};
+
+} // namespace reone::game

--- a/include/reone/game/object/creature.h
+++ b/include/reone/game/object/creature.h
@@ -33,6 +33,7 @@
 #include "../d20/attributes.h"
 #include "../d20/itemattributes.h"
 #include "../object.h"
+#include "../menupresentation.h"
 #include "../runtimeref.h"
 #include "../pathfinder.h"
 
@@ -151,6 +152,8 @@ public:
     Gender gender() const { return _gender; }
     ModelType modelType() const { return _modelType; }
     int appearance() const { return _appearance; }
+    CreaturePresentation presentation() const;
+    void setPresentation(const CreaturePresentation &presentation);
     uint16_t portraitId() const { return _portraitId; }
     std::shared_ptr<graphics::Texture> portrait() const { return _portrait; }
     float walkSpeed() const { return _walkSpeed; }
@@ -457,6 +460,7 @@ private:
     bool _noPermDeath {false};
     bool _notReorienting {false};
     uint8_t _bodyVariation {0};
+    std::optional<CreaturePresentation> _presentation;
     uint8_t _textureVar {0};
     bool _partyInteract {false};
     int32_t _walkRate {0};

--- a/include/reone/game/options.h
+++ b/include/reone/game/options.h
@@ -20,6 +20,7 @@
 #include "reone/audio/options.h"
 #include "reone/system/types.h"
 #include "reone/graphics/options.h"
+#include "menupresentation.h"
 
 namespace reone {
 
@@ -30,6 +31,8 @@ struct GameOptions {
     bool developer {false};
     bool neo {false};
     uint8_t clientDifficulty {1}; // Easy=0, Normal=1, Difficult=2, Default=3
+    MenuPresentation menuPresentation;
+    std::filesystem::path configurationPath; // Empty for embedded/test hosts.
 };
 
 struct OptionsView {

--- a/include/reone/scene/graphs.h
+++ b/include/reone/scene/graphs.h
@@ -49,6 +49,8 @@ public:
     virtual ~ISceneGraphs() = default;
 
     virtual void reserve(std::string name) = 0;
+    // Replace one scene, releasing its node arena as well as its roots.
+    virtual void reset(std::string name) = 0;
 
     virtual ISceneGraph &get(const std::string &name) = 0;
 
@@ -71,6 +73,7 @@ public:
     }
 
     void reserve(std::string name) override;
+    void reset(std::string name) override;
 
     ISceneGraph &get(const std::string &name) override;
 

--- a/include/reone/scene/node/emitter.h
+++ b/include/reone/scene/node/emitter.h
@@ -64,9 +64,9 @@ public:
      */
     void prewarmContinuousParticles();
 
-    float getParticleSize(float time) const { return _particleSize.get(time); };
-    glm::vec3 getColor(float time) const { return _color.get(time); };
-    float getAlpha(float time) const { return _alpha.get(time); };
+    float getParticleSize(float time) const { return _particleSize.get(time, _percentStart, _percentMid, _percentEnd); };
+    glm::vec3 getColor(float time) const { return _color.get(time, _percentStart, _percentMid, _percentEnd); };
+    float getAlpha(float time) const { return _alpha.get(time, _percentStart, _percentMid, _percentEnd); };
 
     float lifeExpectancy() const { return _lifeExpectancy; }
     int frameStart() const { return _frameStart; }
@@ -80,12 +80,20 @@ private:
         T mid;
         T end;
 
-        T get(float factor) const {
-            if (factor < 0.5f) {
-                return glm::mix(start, mid, 2.0f * factor);
-            } else {
-                return glm::mix(mid, end, 2.0f * factor - 1.0f);
+        T get(float factor, float percentStart, float percentMid, float percentEnd) const {
+            percentStart = glm::clamp(percentStart, 0.0f, 1.0f);
+            percentMid = glm::clamp(percentMid, 0.0f, 1.0f);
+            percentEnd = glm::clamp(percentEnd, 0.0f, 1.0f);
+            if (factor <= percentStart) {
+                return start;
             }
+            if (percentMid > percentStart && factor < percentMid) {
+                return glm::mix(start, mid, (factor - percentStart) / (percentMid - percentStart));
+            }
+            if (factor < percentEnd && percentEnd > percentMid) {
+                return glm::mix(mid, end, (factor - percentMid) / (percentEnd - percentMid));
+            }
+            return end;
         }
     };
 
@@ -93,7 +101,12 @@ private:
     StartMidEnd<glm::vec3> _color;
     StartMidEnd<float> _alpha;
 
+    float _percentStart {0.0f};
+    float _percentMid {0.5f};
+    float _percentEnd {1.0f};
+
     float _birthrate {0.0f};      /**< rate of particle birth per second */
+    float _randomBirthrate {0.0f}; /**< integral random variation applied by Fountain emitters */
     float _lifeExpectancy {0.0f}; /**< life of each particle in seconds */
     glm::vec2 _size {0.0f};
     int _frameStart {0};
@@ -111,6 +124,7 @@ private:
     int _lightningSubDiv {0};
 
     float _birthInterval {0.0f};
+    float _particleAccumulator {0.0f};
     Timer _birthTimer;
     bool _spawned {false};
 
@@ -119,6 +133,7 @@ private:
     void spawnParticles(float dt);
     void removeExpiredParticles(float dt);
     ParticleSceneNode *doSpawnParticle();
+    int fountainSpawnCount(float elapsed);
     void spawnLightningParticles();
 };
 

--- a/src/apps/engine/optionsparser.cpp
+++ b/src/apps/engine/optionsparser.cpp
@@ -99,6 +99,8 @@ std::unique_ptr<Options> OptionsParser::parse() {
 
     options->game.path = vars.count("game") > 0 ? std::filesystem::path(vars["game"].as<std::string>()) : std::filesystem::current_path();
     options->game.developer = vars["dev"].as<bool>();
+    options->game.configurationPath = std::filesystem::absolute(kConfigFilename);
+    options->game.menuPresentation = game::MenuPresentation::load(options->game.configurationPath);
     options->graphics.width = vars["width"].as<int>();
     options->graphics.height = vars["height"].as<int>();
     options->graphics.winScale = vars["winscale"].as<int>();

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -17,6 +17,7 @@ set(GAME_INCLUDE_DIR ${REONE_INCLUDE_DIR}/reone/game)
 set(GAME_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/libs/game)
 
 set(GAME_HEADERS
+    ${GAME_INCLUDE_DIR}/menupresentation.h
     ${GAME_INCLUDE_DIR}/action.h
     ${GAME_INCLUDE_DIR}/action/attackobject.h
     ${GAME_INCLUDE_DIR}/action/barkstring.h
@@ -355,6 +356,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/visualeffects.h)
 
 set(GAME_SOURCES
+    ${GAME_SOURCE_DIR}/menupresentation.cpp
     ${GAME_SOURCE_DIR}/action.cpp
     ${GAME_SOURCE_DIR}/action/attackobject.cpp
     ${GAME_SOURCE_DIR}/action/barkstring.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -624,7 +624,7 @@ void Game::initConsole() {
     registerConsoleCommand("campos", "set free camera position", &Game::consoleCamPos);
     registerConsoleCommand("camlook", "aim free camera at a point", &Game::consoleCamLook);
     registerConsoleCommand("camstatus", "print free camera viewpoint commands", &Game::consoleCamStatus);
-    registerConsoleCommand("openmenu", "open an in-game menu tab", &Game::consoleOpenMenu);
+    registerConsoleCommand("openmenu", "open the main menu or an in-game menu tab", &Game::consoleOpenMenu);
     registerConsoleCommand("openchargen", "open a character-generation screen", &Game::consoleOpenCharacterGeneration);
     registerConsoleCommand("skipmovie", "skip the active movie", &Game::consoleSkipMovie);
     registerConsoleCommand("showbark", "show a timed HUD bark message", &Game::consoleShowBark);
@@ -3882,9 +3882,26 @@ void Game::retireToMainMenu() {
 }
 
 void Game::openMainMenu() {
+    // Only a committed playable session may replace the durable menu snapshot.
+    // Cold startup and recovery from a partial load must not erase it.
+    if (isTSL() && _runtimeSessionPlayable) {
+        MenuPresentation state;
+        state.selector = MenuPresentation::validateSelector(getGlobalNumber("GBL_MAIN_SITH_LORD"));
+        if (state.selector == 4) {
+            if (auto leader = _party.getLeader()) state.leader = leader->presentation();
+        }
+        _options.game.menuPresentation = state;
+        try {
+            state.save(_options.game.configurationPath);
+        } catch (const std::exception &ex) {
+            warn(std::string("Could not persist main menu presentation: ") + ex.what());
+        }
+    }
     resetGame();
     if (!_mainMenu) {
         _mainMenu = tryLoadGUI<MainMenu>();
+    } else {
+        _mainMenu->refreshScene();
     }
     if (!_mainMenu) {
         return;
@@ -5697,9 +5714,13 @@ void Game::consoleWarp(const ConsoleArgs &args) {
 }
 
 void Game::consoleOpenMenu(const ConsoleArgs &args) {
-    consoleCheckUsage(args, 1, 1, "equipment|equipment-items|inventory|character|abilities|party|messages|journal|map|options");
+    consoleCheckUsage(args, 1, 1, "main|equipment|equipment-items|inventory|character|abilities|party|messages|journal|map|options");
 
     std::string_view name(args[1].value());
+    if (boost::iequals(name, "main")) {
+        openMainMenu();
+        return;
+    }
     if (boost::iequals(name, "equipment-items")) {
         setCursorType(CursorType::Default);
         _inGame->openEquipmentItems();

--- a/src/libs/game/gui/mainmenu.cpp
+++ b/src/libs/game/gui/mainmenu.cpp
@@ -21,12 +21,15 @@
 #include "reone/game/di/services.h"
 #include "reone/game/game.h"
 #include "reone/game/party.h"
+#include "reone/game/object/creature.h"
 #include "reone/game/types.h"
 #include "reone/graphics/di/services.h"
+#include "reone/graphics/model.h"
 #include "reone/gui/sceneinitializer.h"
 #include "reone/resource/provider/models.h"
 #include "reone/scene/di/services.h"
 #include "reone/scene/graphs.h"
+#include "reone/scene/node/camera.h"
 #include "reone/scene/types.h"
 #include "reone/system/logutil.h"
 
@@ -125,6 +128,7 @@ void MainMenu::setButtonColors(Control &control) {
 
 void MainMenu::setup3DView() {
     if (_game.isTSL()) {
+        refreshScene();
         return;
     }
 
@@ -141,6 +145,88 @@ void MainMenu::setup3DView() {
         .invoke();
 
     _controls.LBL_3DVIEW->setSceneName(kSceneMainMenu);
+}
+
+void MainMenu::refreshScene() {
+    if (!_game.isTSL() || !_controls.LBL_3DVIEW) return;
+
+    if (_controls.LB_MODULES && _controls.LB_MODULES->isVisible()) {
+        _controls.LB_MODULES->setVisible(false);
+        for (auto &button : {_controls.BTN_EXIT, _controls.BTN_LOADGAME,
+                 _controls.BTN_MOVIES, _controls.BTN_NEWGAME, _controls.BTN_OPTIONS,
+                 _controls.BTN_MUSIC}) {
+            button->setVisible(true);
+        }
+        _controls.BTN_WARP->setVisible(_game.options().game.developer);
+        _controls.LBL_GAMELOGO->setVisible(true);
+    }
+    _controls.LBL_3DVIEW->setVisible(true);
+
+    // clear() drops roots but keeps the node arena. Replace only this scene so
+    // repeated returns also release obsolete emitters, cameras and listeners.
+    _leader.reset();
+    _services.scene.graphs.reset(kSceneMainMenu);
+    auto &sceneGraph = _services.scene.graphs.get(kSceneMainMenu);
+    const auto &state = _game.options().game.menuPresentation;
+    const auto &extent = _controls.LBL_3DVIEW->extent();
+    auto model = _services.resource.models.get(state.modelResRef(true));
+    if (!model) return;
+    auto environment = sceneGraph.newModel(*model, ModelUsage::GUI);
+    if (!environment) return;
+    SceneInitializer(sceneGraph)
+        .aspect(extent.width / static_cast<float>(extent.height))
+        .depth(0.1f, 10000.0f)
+        .perspective(glm::radians(22.7259998f))
+        .modelScale(1.0f)
+        .prewarmEmitters()
+        .modelSupplier([environment](ISceneGraph &) { return environment; })
+        .invoke();
+    if (auto room = _services.resource.models.get("gui3d_room")) {
+        sceneGraph.clear();
+        sceneGraph.addRoot(sceneGraph.newModel(*room, ModelUsage::Room));
+        sceneGraph.addRoot(environment);
+    }
+    // mainmenu03 also has a character-local camerahook. Select the scene's
+    // direct child by number, avoiding the duplicate-name lookup entirely.
+    if (auto camera = sceneGraph.camera()) {
+        for (const auto &child : model->rootNode()->children()) {
+            if (child->name() == "camerahook") {
+                environment->getNodeByNumber(child->number())->addChild(camera->get());
+                break;
+            }
+        }
+    }
+    environment->playAnimation("default", nullptr, AnimationProperties::fromFlags(AnimationFlags::loop));
+    _controls.LBL_3DVIEW->setSceneName(kSceneMainMenu);
+
+    if (MenuPresentation::validateSelector(state.selector) == 4 && state.leader) {
+        try {
+            _leader = _game.newPresentationCreature(kSceneMainMenu);
+            _leader->setPresentation(*state.leader);
+            auto placement = environment->getNodeByName("cutscenedummy");
+            _leader->setPosition(placement ? glm::vec3(placement->absoluteTransform()[3]) : glm::vec3(0.0f, -1.0f, 0.0f));
+            // The authored menu actor faces -Y, toward the camera.
+            _leader->setFacing(glm::pi<float>());
+            _leader->loadAppearance();
+            auto node = std::static_pointer_cast<ModelSceneNode>(_leader->sceneNode());
+            if (node) {
+                // Resolve through the supermodel and propagate to the head,
+                // without any runtime action or AI state.
+                auto animation = node->model().getAnimation("evil") ? "evil" : "pause1";
+                if (std::string_view(animation) != "evil") {
+                    warn("Main menu leader model has no evil animation");
+                }
+                node->playAnimation(animation, nullptr,
+                    AnimationProperties::fromFlags(AnimationFlags::loop | AnimationFlags::propagate));
+                sceneGraph.addRoot(node);
+            } else {
+                _leader.reset();
+            }
+        } catch (const std::exception &ex) {
+            _leader.reset();
+            warn(std::string("Could not build main menu leader: ") + ex.what());
+        }
+    }
 }
 
 std::shared_ptr<ModelSceneNode> MainMenu::getKotorModel(ISceneGraph &sceneGraph) {

--- a/src/libs/game/menupresentation.cpp
+++ b/src/libs/game/menupresentation.cpp
@@ -83,6 +83,8 @@ void MenuPresentation::save(const std::filesystem::path &path) const {
         output << line;
         if (!input.eof()) output << '\n';
     }
+    // Windows cannot replace the configuration while our read handle is open.
+    if (input.is_open()) input.close();
     auto temporary = path;
     temporary += ".menu.tmp";
     std::ofstream file(temporary, std::ios::binary | std::ios::trunc);

--- a/src/libs/game/menupresentation.cpp
+++ b/src/libs/game/menupresentation.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "reone/game/menupresentation.h"
+
+#include <array>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+
+namespace reone::game {
+namespace {
+const std::array<std::string, 5> keys {
+    "k2-menu-selector", "k2-menu-gender", "k2-menu-appearance",
+    "k2-menu-body", "k2-menu-texture"};
+
+std::string trim(const std::string &s) {
+    auto begin = s.find_first_not_of(" \t\r");
+    return begin == std::string::npos ? "" : s.substr(begin, s.find_last_not_of(" \t\r") - begin + 1);
+}
+
+std::optional<size_t> menuKey(const std::string &line) {
+    auto key = trim(line.substr(0, line.find('=')));
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (key == keys[i]) return i;
+    }
+    return std::nullopt;
+}
+} // namespace
+
+std::string MenuPresentation::modelResRef(bool tsl) const {
+    if (!tsl) return "mainmenu";
+    return "mainmenu0" + std::to_string(validateSelector(selector) + 1);
+}
+
+MenuPresentation MenuPresentation::load(const std::filesystem::path &path) {
+    MenuPresentation result;
+    std::ifstream input(path);
+    std::map<size_t, int> values;
+    for (std::string line; std::getline(input, line);) {
+        if (trim(line).rfind("[", 0) == 0) break; // These are top-level engine options.
+        auto key = menuKey(line);
+        if (!key || line.find('=') == std::string::npos) continue;
+        std::istringstream value(line.substr(line.find('=') + 1));
+        int number;
+        if (value >> number) values[*key] = number;
+    }
+    result.selector = validateSelector(values[0]);
+    if (values.count(1) && values.count(2) && values.count(3) && values.count(4) &&
+        values[1] >= 0 && values[1] <= 4 && values[2] >= 0 && values[2] <= 65535 &&
+        values[3] >= 0 && values[3] < 26 && values[4] >= 0 && values[4] <= 255) {
+        result.leader = CreaturePresentation {values[1], values[2], values[3], values[4]};
+    }
+    return result;
+}
+
+void MenuPresentation::save(const std::filesystem::path &path) const {
+    if (path.empty()) return;
+    std::ifstream input(path, std::ios::binary);
+    if (!input && std::filesystem::exists(path)) {
+        throw std::runtime_error("Cannot read menu configuration: " + path.string());
+    }
+    std::ostringstream output;
+    output << keys[0] << '=' << validateSelector(selector) << '\n';
+    if (leader) {
+        output << keys[1] << '=' << leader->gender << '\n'
+               << keys[2] << '=' << leader->appearance << '\n'
+               << keys[3] << '=' << leader->bodyVariation << '\n'
+               << keys[4] << '=' << leader->textureVariation << '\n';
+    }
+    // Retain every unrelated byte, including comments, sections, and unknown keys.
+    bool topLevel = true;
+    for (std::string line; std::getline(input, line);) {
+        if (trim(line).rfind("[", 0) == 0) topLevel = false;
+        if (topLevel && menuKey(line)) continue;
+        output << line;
+        if (!input.eof()) output << '\n';
+    }
+    auto temporary = path;
+    temporary += ".menu.tmp";
+    std::ofstream file(temporary, std::ios::binary | std::ios::trunc);
+    file << output.str();
+    file.close();
+    if (!file) throw std::runtime_error("Cannot write menu configuration: " + temporary.string());
+    std::filesystem::rename(temporary, path);
+}
+} // namespace reone::game

--- a/src/libs/game/object/creature.cpp
+++ b/src/libs/game/object/creature.cpp
@@ -3351,6 +3351,35 @@ void Creature::finalizeModel(ModelSceneNode &body) {
     }
 }
 
+CreaturePresentation Creature::presentation() const {
+    if (_presentation) return *_presentation;
+    CreaturePresentation result;
+    result.gender = static_cast<int>(_gender);
+    result.appearance = _appearance;
+    auto body = getEquippedItem(InventorySlots::body);
+    if (body && !body->baseBodyVariation().empty()) {
+        auto variation = boost::to_lower_copy(body->baseBodyVariation());
+        result.bodyVariation = variation.front() - 'a';
+        result.textureVariation = body->textureVariation();
+    }
+    return result;
+}
+
+void Creature::setPresentation(const CreaturePresentation &presentation) {
+    if (!isPresentationOnly()) {
+        throw std::logic_error("Visual tuples require a presentation-only creature");
+    }
+    if (presentation.appearance < 0 || presentation.appearance > 65535 ||
+        presentation.gender < 0 || presentation.gender > static_cast<int>(Gender::None) ||
+        presentation.bodyVariation < 0 || presentation.bodyVariation >= 26 ||
+        presentation.textureVariation < 0 || presentation.textureVariation > 255) {
+        throw std::invalid_argument("Invalid creature presentation");
+    }
+    _presentation = presentation;
+    _appearance = presentation.appearance;
+    _gender = static_cast<Gender>(presentation.gender);
+}
+
 std::string Creature::getBodyModelName() const {
     std::string column;
 
@@ -3358,7 +3387,9 @@ std::string Creature::getBodyModelName() const {
         column = "model";
 
         std::shared_ptr<Item> bodyItem(getEquippedItem(InventorySlots::body));
-        if (bodyItem) {
+        if (_presentation) {
+            column += static_cast<char>('a' + _presentation->bodyVariation);
+        } else if (bodyItem) {
             std::string baseBodyVar(bodyItem->baseBodyVariation());
             column += baseBodyVar;
         } else {
@@ -3387,7 +3418,9 @@ std::string Creature::getBodyTextureName() const {
     if (_modelType == Creature::ModelType::Character) {
         column = "tex";
 
-        if (bodyItem) {
+        if (_presentation) {
+            column += static_cast<char>('a' + _presentation->bodyVariation);
+        } else if (bodyItem) {
             std::string baseBodyVar(bodyItem->baseBodyVariation());
             column += baseBodyVar;
         } else {
@@ -3408,8 +3441,9 @@ std::string Creature::getBodyTextureName() const {
 
     if (_modelType == Creature::ModelType::Character) {
         bool texFound = false;
-        if (bodyItem) {
-            std::string tmp(str(boost::format("%s%02d") % texName % bodyItem->textureVariation()));
+        if (_presentation || bodyItem) {
+            auto variation = _presentation ? _presentation->textureVariation : bodyItem->textureVariation();
+            std::string tmp(str(boost::format("%s%02d") % texName % variation));
             std::shared_ptr<Texture> texture(_services.resource.textures.get(tmp, TextureUsage::MainTex));
             if (texture) {
                 texName = std::move(tmp);

--- a/src/libs/graphics/context.cpp
+++ b/src/libs/graphics/context.cpp
@@ -202,6 +202,7 @@ std::shared_ptr<Texture> Context::captureScreen(int width, int height) {
     pixels->resize(static_cast<size_t>(3) * width * height);
     // GUI scene controls render through child framebuffers and may leave one
     // bound for reading. A screenshot is the composed window back buffer.
+    _readFramebuffer.reset();
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
     glReadBuffer(GL_BACK);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);

--- a/src/libs/scene/graphs.cpp
+++ b/src/libs/scene/graphs.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "reone/scene/graphs.h"
+#include "reone/graphics/context.h"
+#include "reone/graphics/di/services.h"
 
 namespace reone {
 
@@ -25,6 +27,10 @@ void SceneGraphs::reserve(std::string name) {
     if (_scenes.count(name) > 0) {
         return;
     }
+    reset(std::move(name));
+}
+
+void SceneGraphs::reset(std::string name) {
     auto scene = std::make_unique<SceneGraph>(
         name,
         _renderPipelineFactory,
@@ -33,7 +39,13 @@ void SceneGraphs::reserve(std::string name) {
         _audioSvc,
         _resourceSvc);
 
-    _scenes.insert(std::make_pair(name, std::move(scene)));
+    if (_scenes.count(name)) {
+        // The graphics context caches references to framebuffer objects. Drop
+        // those bindings before destroying a scene's render targets.
+        _graphicsSvc.context.resetReadFramebuffer();
+        _graphicsSvc.context.resetDrawFramebuffer();
+    }
+    _scenes[name] = std::move(scene);
 }
 
 ISceneGraph &SceneGraphs::get(const std::string &name) {

--- a/src/libs/scene/node/emitter.cpp
+++ b/src/libs/scene/node/emitter.cpp
@@ -41,6 +41,7 @@ namespace scene {
 
 void EmitterSceneNode::init() {
     _modelNode.floatValueAtTime(ControllerTypes::birthrate, 0.0f, _birthrate);
+    _modelNode.floatValueAtTime(ControllerTypes::randomBirthRate, 0.0f, _randomBirthrate);
     _modelNode.floatValueAtTime(ControllerTypes::lifeExp, 0.0f, _lifeExpectancy);
     _modelNode.floatValueAtTime(ControllerTypes::xSize, 0.0f, _size.x);
     _modelNode.floatValueAtTime(ControllerTypes::ySize, 0.0f, _size.y);
@@ -78,6 +79,9 @@ void EmitterSceneNode::init() {
     _modelNode.floatValueAtTime(ControllerTypes::alphaStart, 0.0f, _alpha.start);
     _modelNode.floatValueAtTime(ControllerTypes::alphaMid, 0.0f, _alpha.mid);
     _modelNode.floatValueAtTime(ControllerTypes::alphaEnd, 0.0f, _alpha.end);
+    _modelNode.floatValueAtTime(ControllerTypes::percentStart, 0.0f, _percentStart);
+    _modelNode.floatValueAtTime(ControllerTypes::percentMid, 0.0f, _percentMid);
+    _modelNode.floatValueAtTime(ControllerTypes::percentEnd, 0.0f, _percentEnd);
 
     if (_birthrate != 0.0f) {
         _birthInterval = 1.0f / _birthrate;
@@ -130,10 +134,13 @@ void EmitterSceneNode::spawnParticles(float dt) {
     switch (emitter->updateMode) {
     case ModelNode::Emitter::UpdateMode::Fountain:
         if (_birthrate != 0.0f) {
-            _birthTimer.update(dt);
-            if (_birthTimer.elapsed()) {
-                doSpawnParticle();
-                _birthTimer.reset(_birthInterval);
+            _particleAccumulator += dt;
+            if (_particleAccumulator >= _birthInterval) {
+                int count = fountainSpawnCount(_particleAccumulator);
+                for (int i = 0; i < count; ++i) {
+                    doSpawnParticle();
+                }
+                _particleAccumulator = 0.0f;
             }
         }
         break;
@@ -156,9 +163,12 @@ void EmitterSceneNode::spawnParticles(float dt) {
 }
 
 ParticleSceneNode *EmitterSceneNode::doSpawnParticle() {
-    // Take particle from the pool, if available
+    // kMaxParticles is the size of one GPU uniform batch, not an emitter
+    // population limit. Retail allocates another particle when its dead list is
+    // empty; SceneGraph likewise owns every particle allocated here and later
+    // splits a large emitter into kMaxParticles-sized draw batches.
     if (_particlePool.empty()) {
-        return nullptr;
+        _particlePool.push_back(_sceneGraph.newParticle(*this).get());
     }
     auto particle = static_cast<ParticleSceneNode *>(_particlePool.front());
     particle->setLifetime(0.0f);
@@ -187,6 +197,20 @@ ParticleSceneNode *EmitterSceneNode::doSpawnParticle() {
     return particle;
 }
 
+int EmitterSceneNode::fountainSpawnCount(float elapsed) {
+    float effectiveRate = _birthrate;
+    int randomRange = static_cast<int>(glm::round(_randomBirthrate));
+    if (randomRange > 0) {
+        bool add = randomInt(0, 1) != 0;
+        int variation = randomInt(0, randomRange - 1);
+        effectiveRate += add ? variation : -variation;
+        effectiveRate = glm::max(0.0f, effectiveRate);
+    }
+
+    int divisor = static_cast<int>(effectiveRate) + 1;
+    return divisor > 0 ? static_cast<int>(elapsed * effectiveRate) % divisor : 0;
+}
+
 void EmitterSceneNode::prewarmContinuousParticles() {
     auto emitter = _modelNode.emitter();
     if (!emitter || emitter->updateMode != ModelNode::Emitter::UpdateMode::Fountain) {
@@ -199,25 +223,26 @@ void EmitterSceneNode::prewarmContinuousParticles() {
     // Take the phase where a particle is born exactly as the scene opens. The
     // ones still alive behind it are then those emitted one, two, three birth
     // intervals ago, up to the last whose age is still short of the life
-    // expectancy: ceil(birthrate * lifeExpectancy) of them. The pool init()
-    // allocated bounds that, in which case the youngest are the ones seeded.
-    int count = glm::min(kMaxParticles, static_cast<int>(glm::ceil(_birthrate * _lifeExpectancy)));
-    for (int i = 0; i < count; ++i) {
-        auto particle = doSpawnParticle();
-        if (!particle) {
-            break;
+    // expectancy: ceil(birthrate * lifeExpectancy) of them.
+    int emissionSlots = static_cast<int>(glm::ceil(_birthrate * _lifeExpectancy));
+    for (int i = 0; i < emissionSlots; ++i) {
+        int count = fountainSpawnCount(_birthInterval);
+        for (int j = 0; j < count; ++j) {
+            auto particle = doSpawnParticle();
+            if (!particle) {
+                break;
+            }
+            // Age by whole birth intervals, not by an even share of the
+            // lifetime: the two agree only when birthrate times life
+            // expectancy is a whole number, and elsewhere an even share
+            // invents ages the authored cadence could never have produced.
+            particle->update(i * _birthInterval);
         }
-        // Age by whole birth intervals, not by an even share of the lifetime:
-        // the two agree only when birthrate times life expectancy happens to be
-        // a whole number, and elsewhere an even share invents ages the authored
-        // cadence could never have produced. The oldest lands strictly short of
-        // the life expectancy, so nothing is seeded already expired.
-        particle->update(i * _birthInterval);
     }
 
     // The next birth is a full interval away, so the field this leaves behind
     // is not immediately followed by an extra particle.
-    _birthTimer.reset(_birthInterval);
+    _particleAccumulator = 0.0f;
 }
 
 void EmitterSceneNode::spawnLightningParticles() {

--- a/src/libs/scene/node/particle.cpp
+++ b/src/libs/scene/node/particle.cpp
@@ -72,7 +72,13 @@ void ParticleSceneNode::updateAnimation(float dt) {
         factor = 0.0f;
     }
 
-    _frame = static_cast<int>(glm::ceil(_emitter.frameStart() + factor * (_emitter.frameEnd() - _emitter.frameStart())));
+    // A zero authored frame rate is a static atlas selection in Odyssey. It
+    // does not mean that the frame range should be spread over particle life.
+    if (_animLength > 0.0f) {
+        _frame = static_cast<int>(glm::ceil(_emitter.frameStart() + factor * (_emitter.frameEnd() - _emitter.frameStart())));
+    } else {
+        _frame = _emitter.frameStart();
+    }
     _size = glm::vec2(_emitter.getParticleSize(factor));
     _color = _emitter.getColor(factor);
     _alpha = _emitter.getAlpha(factor);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/conversation.cpp
     ${TESTS_SOURCE_DIR}/game/globalnumber.cpp
+    ${TESTS_SOURCE_DIR}/game/mainmenu.cpp
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
     ${TESTS_SOURCE_DIR}/game/effect.cpp
     ${TESTS_SOURCE_DIR}/game/entrylifecycle.cpp
@@ -92,6 +93,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/transitioncandidate.cpp
     ${TESTS_SOURCE_DIR}/game/turret.cpp
     ${TESTS_SOURCE_DIR}/graphics/aabb.cpp
+    ${TESTS_SOURCE_DIR}/graphics/context.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/bwmreader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/mdlmdxreader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/tgareader.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/graphics/format/tgareader.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/tgawriter.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/tpcreader.cpp
+    ${TESTS_SOURCE_DIR}/graphics/shadersemantics.cpp
     ${TESTS_SOURCE_DIR}/graphics/format/txireader.cpp
     ${TESTS_SOURCE_DIR}/graphics/keyframetrack.cpp
     ${TESTS_SOURCE_DIR}/graphics/walkmesh.cpp

--- a/test/fixtures/game.h
+++ b/test/fixtures/game.h
@@ -66,6 +66,7 @@ class Game;
 class Item;
 class Module;
 class SaveLoad;
+class MainMenu;
 class Conversation;
 class Object;
 class StaticCamera;
@@ -328,6 +329,7 @@ public:
     static void setSnapshotModuleName(Game &game, std::string name);
     static bool hasPendingSave(const Game &game);
     static void setRuntimeSessionPlayable(Game &game, bool playable);
+    static MainMenu &installMainMenu(Game &game);
     static void clearSnapshotModule(Game &game);
     static void clearSnapshotArea(Game &game);
     static void clearSnapshotPlayers(Game &game);

--- a/test/fixtures/scene.h
+++ b/test/fixtures/scene.h
@@ -104,6 +104,7 @@ public:
 class MockSceneGraphs : public ISceneGraphs, boost::noncopyable {
 public:
     MOCK_METHOD(void, reserve, (std::string name), (override));
+    MOCK_METHOD(void, reset, (std::string name), (override));
     MOCK_METHOD(ISceneGraph &, get, (const std::string &name), (override));
     MOCK_METHOD(std::set<std::string>, sceneNames, (), (const override));
 };

--- a/test/game/mainmenu.cpp
+++ b/test/game/mainmenu.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <fstream>
+
+#include "../fixtures/engine.h"
+#include "reone/game/game.h"
+#include "reone/game/gui/mainmenu.h"
+#include "reone/game/object/creature.h"
+#include "reone/graphics/animation.h"
+#include "reone/graphics/camera.h"
+#include "reone/graphics/model.h"
+#include "reone/resource/2da.h"
+#include "reone/scene/graph.h"
+#include "reone/scene/graphs.h"
+#include "reone/scene/node/camera.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::graphics;
+using namespace reone::resource;
+using namespace reone::scene;
+using namespace testing;
+
+namespace reone::game {
+class MainMenuTestAccess {
+public:
+    static void bind(MainMenu &menu, std::shared_ptr<gui::IGUI> gui, std::shared_ptr<gui::Label> label) {
+        menu._gui = std::move(gui);
+        menu._controls.LBL_3DVIEW = std::move(label);
+    }
+    static void setup(MainMenu &menu) { menu.setup3DView(); }
+    static std::shared_ptr<Creature> leader(MainMenu &menu) { return menu._leader; }
+};
+
+MainMenu &TestGameModule::installMainMenu(Game &game) {
+    game._mainMenu = std::make_unique<MainMenu>(game, game._services);
+    return *game._mainMenu;
+}
+} // namespace reone::game
+
+namespace {
+class MenuGraph : public SceneGraph {
+public:
+    using SceneGraph::SceneGraph;
+    std::vector<std::weak_ptr<ModelSceneNode>> roots;
+    void clear() override {
+        roots.clear();
+        SceneGraph::clear();
+    }
+    void addRoot(std::shared_ptr<ModelSceneNode> node) override {
+        roots.push_back(node);
+        SceneGraph::addRoot(std::move(node));
+    }
+};
+
+std::shared_ptr<Model> model(const std::string &name) {
+    auto root = std::make_shared<ModelNode>(0, "root", glm::vec3(0.0f), glm::quat(1, 0, 0, 0), true, nullptr);
+    auto hook = std::make_shared<ModelNode>(1, "camerahook", glm::vec3(0, -5, 1), glm::quat(1, 0, 0, 0), true, root.get());
+    root->addChild(hook);
+    auto placement = std::make_shared<ModelNode>(2, "cutscenedummy", glm::vec3(-1, 1, 0), glm::quat(0, 0, 0, 1), true, root.get());
+    root->addChild(placement);
+    // Nihilus embeds a second camera inside its character subtree.
+    auto closeup = std::make_shared<ModelNode>(3, "camerahook", glm::vec3(0, 0, 1.6f), glm::quat(1, 0, 0, 0), true, placement.get());
+    placement->addChild(closeup);
+    auto clip = std::make_shared<Animation>("evil", 16.0f, 0.0f, "root", root, std::vector<Animation::Event>());
+    auto loop = std::make_shared<Animation>("default", 16.0f, 0.0f, "root", root, std::vector<Animation::Event>());
+    auto result = std::make_shared<Model>(name, 0, root, std::vector<std::shared_ptr<Animation>> {clip, loop}, "", 1.0f);
+    result->init();
+    return result;
+}
+
+class MainMenuTest : public Test {
+protected:
+    void SetUp() override {
+        engine.init();
+        resetGraph();
+        ON_CALL(engine.sceneModule().graphs(), get(_)).WillByDefault(ReturnRef(mainGraph));
+        ON_CALL(engine.sceneModule().graphs(), get(kSceneMainMenu)).WillByDefault(Invoke([this](const auto &) -> ISceneGraph & { return *graph; }));
+        ON_CALL(engine.sceneModule().graphs(), reset(kSceneMainMenu)).WillByDefault(Invoke([this](const auto &) { resetGraph(); }));
+        for (int i = 0; i < 5; ++i) {
+            auto name = MenuPresentation {i, std::nullopt}.modelResRef(true);
+            models.push_back(model(name));
+            ON_CALL(engine.resourceModule().models(), get(name)).WillByDefault(Return(models.back()));
+        }
+        models.push_back(model("mainmenu"));
+        ON_CALL(engine.resourceModule().models(), get("mainmenu")).WillByDefault(Return(models.back()));
+        models.push_back(model("body"));
+        ON_CALL(engine.resourceModule().models(), get("body")).WillByDefault(Return(models.back()));
+        std::shared_ptr<TwoDA> appearance = TwoDA::Builder().columns({"modeltype", "modela", "modelb", "normalhead"})
+            .row({"B", "body", "body", "-1"}).build();
+        ON_CALL(engine.resourceModule().twoDas(), get("appearance")).WillByDefault(Return(appearance));
+        create(GameID::TSL);
+    }
+    void resetGraph() {
+        graph = std::make_unique<MenuGraph>(kSceneMainMenu, engine.sceneModule().renderPipelineFactory(),
+            engine.options().graphics, engine.graphicsModule().services(), engine.audioModule().services(),
+            engine.resourceModule().services());
+    }
+    void create(GameID id) {
+        game = std::make_unique<Game>(id, "", engine.options(), engine.services(), console);
+        menu = &TestGameModule::installMainMenu(*game);
+        gui = std::make_shared<NiceMock<gui::MockGUI>>();
+        label = std::make_shared<gui::Label>(*gui, engine.sceneModule().graphs(),
+            engine.graphicsModule().services(), engine.resourceModule().services());
+        gui::Control::Extent extent;
+        extent.width = 800;
+        extent.height = 600;
+        label->setExtent(extent);
+        MainMenuTestAccess::bind(*menu, gui, label);
+    }
+    TestEngine engine;
+    StubConsole console;
+    NiceMock<MockSceneGraph> mainGraph;
+    std::vector<std::shared_ptr<Model>> models;
+    std::unique_ptr<MenuGraph> graph;
+    std::shared_ptr<gui::MockGUI> gui;
+    std::shared_ptr<gui::Label> label;
+    std::unique_ptr<Game> game;
+    MainMenu *menu {nullptr};
+};
+
+TEST(MenuPresentation, selector_mapping_and_missing_state) {
+    EXPECT_EQ("mainmenu01", MenuPresentation {}.modelResRef(true));
+    for (int value : {-100, -1, 0, 1, 2, 3, 4, 5, 255}) {
+        MenuPresentation state {value, std::nullopt};
+        EXPECT_EQ("mainmenu0" + std::to_string(value >= 0 && value <= 4 ? value + 1 : 1), state.modelResRef(true));
+        EXPECT_EQ("mainmenu", state.modelResRef(false));
+    }
+    EXPECT_EQ(0, MenuPresentation::load({}).selector);
+}
+
+TEST(MenuPresentation, round_trip_preserves_unrelated_configuration_bytes) {
+    auto path = std::filesystem::temp_directory_path() / ("reone-menu-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".cfg");
+    const std::string unrelated = "# user comment\r\nwidth = 1920\r\nunknown = hello\n[extra]\nsetting=42";
+    {
+        std::ofstream file(path, std::ios::binary);
+        file << unrelated;
+    }
+    EXPECT_EQ(0, MenuPresentation::load(path).selector);
+    MenuPresentation state {4, CreaturePresentation {1, 42, 8, 3}};
+    state.save(path);
+    auto loaded = MenuPresentation::load(path);
+    EXPECT_EQ(4, loaded.selector);
+    ASSERT_TRUE(loaded.leader);
+    EXPECT_EQ(1, loaded.leader->gender);
+    EXPECT_EQ(42, loaded.leader->appearance);
+    EXPECT_EQ(8, loaded.leader->bodyVariation);
+    EXPECT_EQ(3, loaded.leader->textureVariation);
+    loaded.save(path);
+    std::ifstream input(path, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(input)), {});
+    EXPECT_EQ(unrelated, content.substr(content.find("# user comment")));
+    MenuPresentation {99, std::nullopt}.save(path);
+    EXPECT_EQ(0, MenuPresentation::load(path).selector);
+    EXPECT_FALSE(MenuPresentation::load(path).leader);
+    std::filesystem::remove(path);
+}
+
+TEST_F(MainMenuTest, returning_to_retained_menu_captures_before_teardown_and_refreshes) {
+    menu->refreshScene();
+    ASSERT_EQ(1u, graph->roots.size());
+    auto previous = graph->roots.front();
+    for (int selector : {2, 3, 0, 99}) {
+        auto runtime = game->newCreature();
+        game->party().addMember(kNpcPlayer, runtime);
+        game->setGlobalNumber("GBL_MAIN_SITH_LORD", selector);
+        TestGameModule::setRuntimeSessionPlayable(*game, true);
+        game->openMainMenu();
+        EXPECT_EQ(MenuPresentation::validateSelector(selector), engine.options().game.menuPresentation.selector);
+        EXPECT_TRUE(game->globalNumbers().empty());
+        EXPECT_TRUE(game->party().isEmpty());
+        EXPECT_FALSE(game->getObjectById(runtime->id()));
+        EXPECT_TRUE(previous.expired());
+        ASSERT_EQ(1u, graph->roots.size());
+        EXPECT_EQ(engine.options().game.menuPresentation.modelResRef(true), graph->roots.front().lock()->model().name());
+        EXPECT_FALSE(MainMenuTestAccess::leader(*menu));
+        previous = graph->roots.front();
+    }
+}
+
+TEST_F(MainMenuTest, leader_is_copied_to_exactly_one_presentation_and_released_on_refresh) {
+    for (auto gender : {Gender::Male, Gender::Female, Gender::None}) {
+        auto runtime = game->newCreature();
+        runtime->setGender(gender);
+        runtime->setAppearance(0);
+        game->party().addMember(kNpcPlayer, runtime);
+        game->setGlobalNumber("GBL_MAIN_SITH_LORD", 4);
+        TestGameModule::setRuntimeSessionPlayable(*game, true);
+        std::weak_ptr<Creature> oldRuntime = runtime;
+        runtime.reset();
+        game->openMainMenu();
+        EXPECT_TRUE(oldRuntime.expired());
+        auto leader = MainMenuTestAccess::leader(*menu);
+        ASSERT_TRUE(leader);
+        EXPECT_TRUE(leader->isPresentationOnly());
+        EXPECT_FALSE(game->getObjectById(leader->id()));
+        EXPECT_TRUE(game->party().isEmpty());
+        EXPECT_EQ(gender, leader->gender());
+        EXPECT_EQ(glm::vec3(-1, 1, 0), leader->position());
+        EXPECT_NEAR(glm::pi<float>(), std::abs(leader->getFacing()), 0.0001f);
+        ASSERT_EQ(2u, graph->roots.size());
+        EXPECT_TRUE(graph->roots.back().lock()->isAnimationPlaying("evil"));
+        std::weak_ptr<Creature> oldLeader = leader;
+        auto oldModel = graph->roots.back();
+        leader.reset();
+        menu->refreshScene();
+        EXPECT_TRUE(oldLeader.expired());
+        EXPECT_TRUE(oldModel.expired());
+        EXPECT_EQ(2u, graph->roots.size());
+    }
+    engine.options().game.menuPresentation.selector = 2;
+    menu->refreshScene();
+    EXPECT_FALSE(MainMenuTestAccess::leader(*menu));
+    EXPECT_EQ(1u, graph->roots.size());
+}
+
+TEST_F(MainMenuTest, cold_entry_keeps_persisted_state_and_k1_keeps_its_original_model) {
+    engine.options().game.menuPresentation.selector = 3;
+    game->openMainMenu();
+    EXPECT_EQ("mainmenu04", graph->roots.front().lock()->model().name());
+    ASSERT_TRUE(graph->camera());
+    auto camera = graph->camera()->get().camera();
+    ASSERT_TRUE(camera);
+    auto expected = glm::perspective(glm::radians(22.7259998f), 800.0f / 600.0f, 0.1f, 10000.0f);
+    EXPECT_EQ(expected, camera->projection());
+    EXPECT_EQ(glm::vec3(0, -5, 1), glm::vec3(graph->camera()->get().absoluteTransform()[3]));
+    auto environment = graph->roots.front().lock();
+    environment->update(16.1f);
+    EXPECT_TRUE(environment->isAnimationPlaying("default"));
+    create(GameID::KotOR);
+    MainMenuTestAccess::setup(*menu);
+    ASSERT_EQ(1u, graph->roots.size());
+    auto malak = graph->roots.front();
+    EXPECT_EQ("mainmenu", malak.lock()->model().name());
+    ASSERT_TRUE(graph->camera());
+    camera = graph->camera()->get().camera();
+    ASSERT_TRUE(camera);
+    float aspect = 800.0f / 600.0f;
+    expected = glm::ortho(-aspect * 1.4f, aspect * 1.4f, -1.4f, 1.4f, kDefaultClipPlaneNear, 10.0f);
+    EXPECT_EQ(expected, camera->projection());
+    menu->refreshScene();
+    EXPECT_EQ(malak.lock(), graph->roots.front().lock());
+}
+
+TEST_F(MainMenuTest, missing_variant_resource_drops_previous_scene_and_leader) {
+    engine.options().game.menuPresentation = {4, CreaturePresentation {}};
+    menu->refreshScene();
+    ASSERT_EQ(2u, graph->roots.size());
+    auto oldModel = graph->roots.back();
+    engine.options().game.menuPresentation.selector = 3;
+    ON_CALL(engine.resourceModule().models(), get("mainmenu04")).WillByDefault(Return(nullptr));
+    menu->refreshScene();
+    EXPECT_TRUE(graph->roots.empty());
+    EXPECT_TRUE(oldModel.expired());
+    EXPECT_FALSE(MainMenuTestAccess::leader(*menu));
+}
+
+TEST_F(MainMenuTest, selector_four_without_a_complete_leader_tuple_shows_environment_only) {
+    engine.options().game.menuPresentation = {4, std::nullopt};
+    menu->refreshScene();
+    EXPECT_EQ(1u, graph->roots.size());
+    EXPECT_FALSE(MainMenuTestAccess::leader(*menu));
+}
+
+TEST_F(MainMenuTest, visual_tuple_cannot_be_applied_to_a_runtime_creature) {
+    EXPECT_THROW(game->newCreature()->setPresentation({}), std::logic_error);
+}
+
+TEST_F(MainMenuTest, captures_effective_body_visuals_without_copying_equipment) {
+    std::shared_ptr<TwoDA> baseItems = TwoDA::Builder()
+        .columns({"equipableslots", "bodyvar", "ammunitiontype"})
+        .row({"2", "b", "0"}).build();
+    ON_CALL(engine.resourceModule().twoDas(), get("baseitems")).WillByDefault(Return(baseItems));
+    auto uti = Gff::Builder()
+        .field(Gff::Field::newInt("BaseItem", 0))
+        .field(Gff::Field::newByte("TextureVar", 3)).build();
+    auto clothing = game->newItem(*uti, SerializedIdentityContext::templateResource("clothes"));
+    auto runtime = game->newCreature();
+    TestGameModule::setSnapshotEquipment(*runtime, InventorySlots::body, clothing);
+    game->party().addMember(kNpcPlayer, runtime);
+    game->setGlobalNumber("GBL_MAIN_SITH_LORD", 4);
+    TestGameModule::setRuntimeSessionPlayable(*game, true);
+    game->openMainMenu();
+    const auto &snapshot = engine.options().game.menuPresentation;
+    ASSERT_TRUE(snapshot.leader);
+    EXPECT_EQ(1, snapshot.leader->bodyVariation);
+    EXPECT_EQ(3, snapshot.leader->textureVariation);
+    auto leader = MainMenuTestAccess::leader(*menu);
+    ASSERT_TRUE(leader);
+    EXPECT_FALSE(leader->getEquippedItem(InventorySlots::body));
+    EXPECT_FALSE(game->getObjectById(clothing->id()));
+    EXPECT_EQ(2u, graph->roots.size());
+}
+
+TEST_F(MainMenuTest, replacing_one_scene_releases_its_arena_without_touching_gameplay) {
+    SceneGraphs scenes(engine.sceneModule().renderPipelineFactory(), engine.options().graphics,
+        engine.graphicsModule().services(), engine.audioModule().services(), engine.resourceModule().services());
+    scenes.reserve(kSceneMain);
+    scenes.reserve(kSceneMainMenu);
+    auto &main = scenes.get(kSceneMain);
+    auto gameplay = main.newModel(*models.front(), ModelUsage::Creature);
+    main.addRoot(gameplay);
+    EXPECT_CALL(engine.graphicsModule().context(), resetReadFramebuffer()).Times(5);
+    EXPECT_CALL(engine.graphicsModule().context(), resetDrawFramebuffer()).Times(5);
+    std::weak_ptr<ModelSceneNode> previous;
+    for (int i = 0; i < 5; ++i) {
+        scenes.reset(kSceneMainMenu);
+        EXPECT_TRUE(previous.expired());
+        EXPECT_EQ(&main, &scenes.get(kSceneMain));
+        auto node = scenes.get(kSceneMainMenu).newModel(*models.front(), ModelUsage::GUI);
+        scenes.get(kSceneMainMenu).addRoot(node);
+        previous = node;
+    }
+}
+} // namespace

--- a/test/game/mainmenu.cpp
+++ b/test/game/mainmenu.cpp
@@ -158,6 +158,7 @@ TEST(MenuPresentation, round_trip_preserves_unrelated_configuration_bytes) {
     loaded.save(path);
     std::ifstream input(path, std::ios::binary);
     std::string content((std::istreambuf_iterator<char>(input)), {});
+    input.close(); // Release the Windows read handle before saving again.
     EXPECT_EQ(unrelated, content.substr(content.find("# user comment")));
     MenuPresentation {99, std::nullopt}.save(path);
     EXPECT_EQ(0, MenuPresentation::load(path).selector);

--- a/test/graphics/context.cpp
+++ b/test/graphics/context.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gtest/gtest.h>
+
+#include "reone/graphics/context.h"
+#include "reone/graphics/framebuffer.h"
+
+using namespace reone::graphics;
+
+namespace {
+// Exercise the real binding cache without a window, driver, or retail assets.
+struct ReadbackGL {
+    decltype(glad_glBindFramebuffer) bind {glad_glBindFramebuffer};
+    decltype(glad_glReadBuffer) read {glad_glReadBuffer};
+    decltype(glad_glPixelStorei) store {glad_glPixelStorei};
+    decltype(glad_glReadPixels) pixels {glad_glReadPixels};
+    ~ReadbackGL() {
+        glad_glBindFramebuffer = bind;
+        glad_glReadBuffer = read;
+        glad_glPixelStorei = store;
+        glad_glReadPixels = pixels;
+    }
+};
+
+TEST(GraphicsContext, readback_invalidates_read_framebuffer_binding) {
+    ReadbackGL restore;
+    static int bindings;
+    bindings = 0;
+    glad_glBindFramebuffer = [](GLenum target, GLuint) {
+        EXPECT_EQ(GL_READ_FRAMEBUFFER, target);
+        ++bindings;
+    };
+    glad_glReadBuffer = [](GLenum) {};
+    glad_glPixelStorei = [](GLenum, GLint) {};
+    glad_glReadPixels = [](GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, void *) {};
+
+    GraphicsOptions options;
+    Context context(options);
+    Framebuffer scene;
+    context.bindReadFramebuffer(scene, 0);
+    EXPECT_EQ(1, bindings);
+    context.captureScreen(1, 1);
+    EXPECT_EQ(2, bindings);
+    // The next scene blit must rebind its source, not read the window because
+    // the cache still claims that source was left bound before the screenshot.
+    context.bindReadFramebuffer(scene, 0);
+    EXPECT_EQ(3, bindings);
+}
+} // namespace

--- a/test/graphics/shadersemantics.cpp
+++ b/test/graphics/shadersemantics.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+namespace {
+
+std::string readShader(std::string_view name) {
+    auto path = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() / "glsl" / name;
+    std::ifstream stream(path);
+    return std::string(
+        std::istreambuf_iterator<char>(stream),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+TEST(OITModelShader, transparent_material_keeps_authored_alpha_and_lighting) {
+    auto shader = readShader("f_oit_model.glsl");
+    ASSERT_FALSE(shader.empty());
+
+    auto textureAlpha = shader.find("float diffuseAlpha = mainTexSample.a;");
+    auto applyTextureAlpha = shader.find("objectAlpha *= diffuseAlpha;");
+    auto lightLoop = shader.find("for (int i = 0; i < uNumLights; ++i)");
+    auto litColor = shader.find("vec3 objectColor = lighting * uColor.rgb * diffuseColor;");
+    auto applyAuthoredAlpha = shader.find("objectColor *= objectAlpha;");
+    auto encodeContribution = shader.find("objectAlpha = clamp(rgbToLuma(objectColor), 0.0, 1.0);");
+
+    EXPECT_NE(std::string::npos, textureAlpha);
+    EXPECT_NE(std::string::npos, applyTextureAlpha);
+    EXPECT_NE(std::string::npos, lightLoop);
+    EXPECT_NE(std::string::npos, litColor);
+    EXPECT_NE(std::string::npos, applyAuthoredAlpha);
+    EXPECT_NE(std::string::npos, encodeContribution);
+    EXPECT_LT(textureAlpha, applyTextureAlpha);
+    EXPECT_LT(lightLoop, litColor);
+    EXPECT_LT(litColor, applyAuthoredAlpha);
+    EXPECT_LT(applyAuthoredAlpha, encodeContribution);
+
+    // The old path replaced texture alpha with RGB luminance before lighting,
+    // which made a blue additive texture visible even under zero light.
+    EXPECT_EQ(std::string::npos, shader.find("diffuseAlpha = rgbToLuma(mainTexSample.rgb);"));
+}

--- a/test/scene/emitter.cpp
+++ b/test/scene/emitter.cpp
@@ -7,6 +7,7 @@
 #include "reone/scene/node/emitter.h"
 #include "reone/scene/node/model.h"
 #include "reone/scene/node/particle.h"
+#include "reone/system/randomutil.h"
 #include "reone/gui/sceneinitializer.h"
 #include "../fixtures/audio.h"
 #include "../fixtures/graphics.h"
@@ -183,11 +184,11 @@ TEST(EmitterSceneNode, rearming_single_does_not_affect_fountain_emission) {
     ASSERT_TRUE(fountain);
 
     scene->update(0.05f);
-    ASSERT_EQ(1, fountain->children().size());
+    ASSERT_TRUE(fountain->children().empty());
     scene->update(0.05f);
     ASSERT_EQ(1, fountain->children().size());
     scene->update(0.05f);
-    EXPECT_EQ(2, fountain->children().size());
+    EXPECT_EQ(1, fountain->children().size());
 }
 
 namespace {
@@ -238,7 +239,8 @@ std::shared_ptr<Model> newEmitterModel(
     const std::string &name,
     ModelNode::Emitter::UpdateMode updateMode,
     float birthrate,
-    float lifeExpectancy) {
+    float lifeExpectancy,
+    float randomBirthrate = 0.0f) {
 
     auto rootNode = std::make_shared<ModelNode>(
         0, "root", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, nullptr);
@@ -251,6 +253,7 @@ std::shared_ptr<Model> newEmitterModel(
         1, "emitter", glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), true, rootNode.get());
     emitterNode->setEmitter(emitter);
     emitterNode->floatTracks()[ControllerTypes::birthrate].add(0.0f, birthrate);
+    emitterNode->floatTracks()[ControllerTypes::randomBirthRate].add(0.0f, randomBirthrate);
     emitterNode->floatTracks()[ControllerTypes::lifeExp].add(0.0f, lifeExpectancy);
     // Authored appearance over a particle's life, so a seeded particle can be
     // checked against the point in that life it claims to be at.
@@ -262,6 +265,9 @@ std::shared_ptr<Model> newEmitterModel(
     emitterNode->floatTracks()[ControllerTypes::alphaStart].add(0.0f, 1.0f);
     emitterNode->floatTracks()[ControllerTypes::alphaMid].add(0.0f, 0.5f);
     emitterNode->floatTracks()[ControllerTypes::alphaEnd].add(0.0f, 0.0f);
+    emitterNode->floatTracks()[ControllerTypes::percentStart].add(0.0f, 0.0f);
+    emitterNode->floatTracks()[ControllerTypes::percentMid].add(0.0f, 0.5f);
+    emitterNode->floatTracks()[ControllerTypes::percentEnd].add(0.0f, 1.0f);
     emitterNode->vectorTracks()[ControllerTypes::colorStart].add(0.0f, glm::vec3(1.0f, 0.0f, 0.0f));
     emitterNode->vectorTracks()[ControllerTypes::colorMid].add(0.0f, glm::vec3(0.0f, 1.0f, 0.0f));
     emitterNode->vectorTracks()[ControllerTypes::colorEnd].add(0.0f, glm::vec3(0.0f, 0.0f, 1.0f));
@@ -353,7 +359,7 @@ TEST(EmitterPrewarm, a_seeded_particle_looks_like_one_that_lived_that_long) {
     auto oldest = oldestParticle(*emitter);
     ASSERT_TRUE(oldest);
     EXPECT_FLOAT_EQ(1.0f, oldest->lifetime());
-    EXPECT_EQ(5, oldest->frame());
+    EXPECT_EQ(0, oldest->frame());
     EXPECT_FLOAT_EQ(2.0f, oldest->size().x);
     EXPECT_FLOAT_EQ(0.5f, oldest->alpha());
     EXPECT_LT(glm::length(oldest->color() - glm::vec3(0.0f, 1.0f, 0.0f)), 1e-5f);
@@ -371,6 +377,70 @@ TEST(EmitterPrewarm, prewarming_leaves_a_single_emitter_alone) {
 
     scene.graph->update(0.0f);
     EXPECT_EQ(1u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, steady_state_population_can_exceed_one_gpu_particle_batch) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("large_population", ModelNode::Emitter::UpdateMode::Fountain, 25.0f, 4.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_EQ(100u, emitter->children().size());
+}
+
+TEST(EmitterPrewarm, appearance_uses_the_authored_lifecycle_percentages) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("early_midpoint", ModelNode::Emitter::UpdateMode::Fountain, 1.0f, 10.0f);
+    auto sourceEmitter = model->rootNode()->children().front();
+    sourceEmitter->floatTracks().erase(ControllerTypes::percentMid);
+    sourceEmitter->floatTracks()[ControllerTypes::percentMid].add(0.0f, 0.1f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    auto oneSecondOldIt = std::find_if(emitter->children().begin(), emitter->children().end(), [](auto child) {
+        return child->type() == SceneNodeType::Particle &&
+               static_cast<const ParticleSceneNode *>(child)->lifetime() == 1.0f;
+    });
+    ASSERT_NE(emitter->children().end(), oneSecondOldIt);
+    auto oneSecondOld = static_cast<const ParticleSceneNode *>(*oneSecondOldIt);
+    EXPECT_FLOAT_EQ(2.0f, oneSecondOld->size().x);
+    EXPECT_FLOAT_EQ(0.5f, oneSecondOld->alpha());
+    EXPECT_LT(glm::length(oneSecondOld->color() - glm::vec3(0.0f, 1.0f, 0.0f)), 1e-5f);
+}
+
+TEST(EmitterPrewarm, zero_fps_keeps_the_authored_start_frame) {
+    PrewarmScene scene;
+    auto model = newEmitterModel("static_atlas_frame", ModelNode::Emitter::UpdateMode::Fountain, 1.0f, 2.0f);
+    auto sourceEmitter = model->rootNode()->children().front();
+    sourceEmitter->floatTracks().erase(ControllerTypes::frameStart);
+    sourceEmitter->floatTracks()[ControllerTypes::frameStart].add(0.0f, 3.0f);
+    sourceEmitter->floatTracks()[ControllerTypes::fps].add(0.0f, 0.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    auto oldest = oldestParticle(*emitter);
+    ASSERT_TRUE(oldest);
+    EXPECT_EQ(3, oldest->frame());
+}
+
+TEST(EmitterPrewarm, random_birthrate_changes_the_authored_fountain_population) {
+    setRandomSeed(0x4b324d4du);
+    PrewarmScene scene;
+    auto model = newEmitterModel(
+        "random_birthrate",
+        ModelNode::Emitter::UpdateMode::Fountain,
+        10.0f,
+        10.0f,
+        9.0f);
+
+    auto emitter = scene.build(*model, true);
+
+    ASSERT_TRUE(emitter);
+    EXPECT_GT(emitter->children().size(), 0u);
+    EXPECT_LT(emitter->children().size(), 100u);
 }
 
 TEST(EmitterPrewarm, emission_carries_on_at_the_authored_cadence_after_prewarming) {


### PR DESCRIPTION
## Summary

Restores K2's authored 3D main-menu scenes, including Sion, Nihilus, Traya, and the late-game player presentation.

Adds retail-compatible menu selection and persistence, refreshes the scene on each menu entry, reconstructs the dynamic leader as a presentation-only creature, and composes the numbered scene with the authored `gui3d_room` shell.

K1's existing Malak menu path is unchanged.

Depends on the shared graphics corrections in the preceding PR.

## Validation

- K2 Sion, Nihilus and Traya validated live
- male and female player-menu presentations validated
- invalid-selector fallback, repeated menu return and restart persistence validated
- K1 Malak remains visually unchanged
- full suite: 2025 passed, 1 existing expected skip
- `git diff --check` passes