### PR TITLE
[game] Restore computer security camera views

### DIFF
--- a/include/reone/game/gui/computer.h
+++ b/include/reone/game/gui/computer.h
@@ -20,6 +20,7 @@
 #include "reone/gui/control/label.h"
 #include "reone/gui/control/listbox.h"
 
+#include "computercam.h"
 #include "conversation.h"
 
 namespace reone {
@@ -29,11 +30,33 @@ namespace game {
 class ComputerGUI : public Conversation {
 public:
     ComputerGUI(Game &game, ServicesView &services) :
-        Conversation(game, services) {
+        Conversation(game, services),
+        _cameraGUI(game, services, [this]() { returnFromCamera(); }) {
         _resRef = guiResRef("computer");
     }
 
+    void init() override;
+    bool handle(const input::Event &event) override;
+    void update(float dt) override;
+    void render() override;
+
+protected:
+    void onStart() override;
+    void onFinish() override;
+    void onLoadEntry() override;
+    void onEntryEnded() override;
+
 private:
+    enum class Presentation {
+        Normal,
+        Camera
+    };
+
+    ComputerCamGUI _cameraGUI;
+    Presentation _presentation {Presentation::Normal};
+
+    void returnFromCamera();
+
     struct Controls {
         std::shared_ptr<gui::Label> LBL_BAR1;
         std::shared_ptr<gui::Label> LBL_BAR2;

--- a/include/reone/game/gui/computercam.h
+++ b/include/reone/game/gui/computercam.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "../gui.h"
+
+namespace reone {
+
+namespace game {
+
+// Transparent presentation only; the owning computer conversation drives it.
+class ComputerCamGUI : public GameGUI {
+public:
+    ComputerCamGUI(Game &game, ServicesView &services, std::function<void()> onReturn);
+
+    bool handle(const input::Event &event) override;
+
+private:
+    std::function<void()> _onReturn;
+
+    void preload(gui::IGUI &gui) override;
+    void onGUILoaded() override;
+};
+
+} // namespace game
+
+} // namespace reone

--- a/include/reone/game/gui/conversation.h
+++ b/include/reone/game/gui/conversation.h
@@ -77,6 +77,9 @@ protected:
 
     void pickReply(int index);
 
+    // Complete the active entry's presentation using the same path as expiry.
+    void endCurrentEntry();
+
     virtual void setReplyLines(std::vector<std::string> lines) = 0;
 
     // How a one-liner presents its entry, alongside setMessage/setReplyLines.
@@ -108,7 +111,6 @@ private:
     void refreshReplies();
 
     void finish();
-    void endCurrentEntry();
 
     int indexOfFirstActive(const std::vector<resource::Dialog::EntryReplyLink> &links);
 

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -208,6 +208,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/gui/chargen/quickorcustom.h
     ${GAME_INCLUDE_DIR}/gui/chargen/skills.h
     ${GAME_INCLUDE_DIR}/gui/computer.h
+    ${GAME_INCLUDE_DIR}/gui/computercam.h
     ${GAME_INCLUDE_DIR}/gui/confirmpopup.h
     ${GAME_INCLUDE_DIR}/gui/container.h
     ${GAME_INCLUDE_DIR}/gui/conversation.h
@@ -505,6 +506,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/chargen/skills.cpp
     ${GAME_SOURCE_DIR}/gui/chargen.cpp
     ${GAME_SOURCE_DIR}/gui/computer.cpp
+    ${GAME_SOURCE_DIR}/gui/computercam.cpp
     ${GAME_SOURCE_DIR}/gui/confirmpopup.cpp
     ${GAME_SOURCE_DIR}/gui/container.cpp
     ${GAME_SOURCE_DIR}/gui/conversation.cpp

--- a/src/libs/game/gui/computer.cpp
+++ b/src/libs/game/gui/computer.cpp
@@ -35,6 +35,59 @@ static void setVisible(const std::shared_ptr<Label> &control, bool visible) {
     }
 }
 
+void ComputerGUI::init() {
+    Conversation::init();
+    _cameraGUI.init();
+}
+
+bool ComputerGUI::handle(const input::Event &event) {
+    if (_presentation == Presentation::Camera) {
+        return _cameraGUI.handle(event);
+    }
+    return Conversation::handle(event);
+}
+
+void ComputerGUI::update(float dt) {
+    Conversation::update(dt);
+    if (_presentation == Presentation::Camera) {
+        _cameraGUI.update(dt);
+    }
+}
+
+void ComputerGUI::render() {
+    if (_presentation == Presentation::Camera) {
+        _cameraGUI.render();
+    } else {
+        Conversation::render();
+    }
+}
+
+void ComputerGUI::onStart() {
+    _presentation = Presentation::Normal;
+}
+
+void ComputerGUI::onFinish() {
+    _presentation = Presentation::Normal;
+}
+
+void ComputerGUI::onLoadEntry() {
+    int cameraId = 0;
+    _presentation = getCamera(cameraId) == CameraType::Static ? Presentation::Camera : Presentation::Normal;
+    if (_presentation == Presentation::Camera) {
+        _cameraGUI.clearSelection();
+    }
+}
+
+void ComputerGUI::onEntryEnded() {
+    _presentation = Presentation::Normal;
+}
+
+void ComputerGUI::returnFromCamera() {
+    if (_presentation == Presentation::Camera) {
+        endCurrentEntry();
+    }
+}
+
 void ComputerGUI::preload(IGUI &gui) {
     GameGUI::preload(gui);
 }

--- a/src/libs/game/gui/computercam.cpp
+++ b/src/libs/game/gui/computercam.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "reone/game/gui/computercam.h"
+
+#include "reone/game/game.h"
+#include "reone/gui/control/label.h"
+
+namespace reone {
+
+namespace game {
+
+ComputerCamGUI::ComputerCamGUI(Game &game, ServicesView &services, std::function<void()> onReturn) :
+    GameGUI(game, services),
+    _onReturn(std::move(onReturn)) {
+    _resRef = game.isTSL() ? guiResRef("computercam") : "computercamera";
+}
+
+void ComputerCamGUI::preload(gui::IGUI &gui) {
+    GameGUI::preload(gui);
+    // Both games author the camera overlay on a 640x480 canvas.
+    gui.setResolution(640, 480);
+}
+
+void ComputerCamGUI::onGUILoaded() {
+    auto returnControl = findControl<gui::Label>("LBL_RETURN");
+    returnControl->setSelectable(true);
+    returnControl->setOnClick(_onReturn);
+}
+
+bool ComputerCamGUI::handle(const input::Event &event) {
+    if (event.type == input::EventType::KeyUp &&
+        (event.key.code == input::KeyCode::Escape || event.key.code == input::KeyCode::Return)) {
+        _onReturn();
+        return true;
+    }
+    return GameGUI::handle(event);
+}
+
+} // namespace game
+
+} // namespace reone

--- a/src/libs/game/gui/conversation.cpp
+++ b/src/libs/game/gui/conversation.cpp
@@ -454,6 +454,9 @@ bool Conversation::isNonPresentationalEntry() const {
 }
 
 void Conversation::endCurrentEntry() {
+    if (!_currentEntry || _entryEnded || _paused) {
+        return;
+    }
     _entryEnded = true;
 
     // Stop voice over, if any

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/d20/class.cpp
     ${TESTS_SOURCE_DIR}/game/d20/spells.cpp
     ${TESTS_SOURCE_DIR}/game/conversation.cpp
+    ${TESTS_SOURCE_DIR}/game/computer.cpp
     ${TESTS_SOURCE_DIR}/game/globalnumber.cpp
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
     ${TESTS_SOURCE_DIR}/game/effect.cpp

--- a/test/game/computer.cpp
+++ b/test/game/computer.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../fixtures/engine.h"
+
+#include "reone/game/console.h"
+#include "reone/game/game.h"
+#include "reone/game/gui/computer.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::gui;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+
+class ComputerConsole : public IConsole {
+public:
+    void registerCommand(std::string, std::string, CommandHandler) override {}
+    void printLine(const std::string &) override {}
+};
+
+class TestComputer : public ComputerGUI {
+public:
+    using ComputerGUI::ComputerGUI;
+
+    int loads {0};
+    int ends {0};
+    int finishes {0};
+    int replyRefreshes {0};
+    std::vector<std::string> replies;
+    const Dialog::EntryReply *entry() const { return _currentEntry; }
+    std::shared_ptr<Object> resolvedOwner() const { return owner(); }
+
+protected:
+    // Exercise real Conversation transitions and GUI delegation without
+    // building the normal terminal's list controls.
+    void onGUILoaded() override {}
+    void setMessage(std::string) override {}
+    void setReplyLines(std::vector<std::string> lines) override {
+        replies = std::move(lines);
+        ++replyRefreshes;
+    }
+    void onLoadEntry() override {
+        ComputerGUI::onLoadEntry();
+        ++loads;
+    }
+    void onEntryEnded() override {
+        ComputerGUI::onEntryEnded();
+        ++ends;
+    }
+    void onFinish() override {
+        ComputerGUI::onFinish();
+        ++finishes;
+    }
+};
+
+std::shared_ptr<Dialog> computerDialog(bool camera = true, bool automatic = false) {
+    auto dialog = std::make_shared<Dialog>();
+    dialog->resRef = "computer_test";
+    dialog->conversationType = ConversationType::Computer;
+    dialog->startEntries.push_back({});
+    dialog->entries.resize(2);
+    dialog->replies.resize(3);
+    auto &first = dialog->entries[0];
+    first.text = "Camera menu";
+    first.cameraId = camera ? 1 : 0;
+    first.delay = 2;
+    first.replies.push_back({});
+    if (!automatic) {
+        Dialog::EntryReplyLink secondReply;
+        secondReply.index = 1;
+        first.replies.push_back(secondReply);
+        dialog->replies[0].text = "Mess Hall";
+        dialog->replies[1].text = "Log out";
+    }
+    Dialog::EntryReplyLink nextEntry;
+    nextEntry.index = 1;
+    dialog->replies[0].entries.push_back(nextEntry);
+    auto &next = dialog->entries[1];
+    next.text = "Main console";
+    next.cameraId = 0;
+    next.delay = 100;
+    Dialog::EntryReplyLink lastReply;
+    lastReply.index = 2;
+    next.replies.push_back(lastReply);
+    dialog->replies[2].text = "Log out";
+    return dialog;
+}
+
+input::Event key(input::KeyCode code) {
+    return input::Event::newKeyUp({false, code, 0, false});
+}
+
+class ComputerGUITest : public TestWithParam<GameID> {
+protected:
+    void SetUp() override {
+        engine.init();
+        game = std::make_unique<Game>(GetParam(), std::filesystem::path {}, engine.options(), engine.services(), console);
+        game->initLocalServices();
+        normal = std::make_shared<NiceMock<MockGUI>>();
+        camera = std::make_shared<NiceMock<MockGUI>>();
+        auto &svc = engine.services();
+        returnControl = std::make_shared<Label>(*camera, svc.scene.graphs, svc.graphics, svc.resource);
+        EXPECT_CALL(*camera, findControl("LBL_RETURN")).WillOnce(Return(returnControl));
+        EXPECT_CALL(*camera, setBackground(_)).Times(0);
+        EXPECT_CALL(engine.guiModule().guis(), get(GetParam() == GameID::KotOR ? "computer" : "computer_p", _))
+            .WillOnce(Return(normal));
+        EXPECT_CALL(engine.guiModule().guis(), get(GetParam() == GameID::KotOR ? "computercamera" : "computercam_p", _))
+            .WillOnce(Invoke([this](const std::string &, std::function<void(IGUI &)> preload) {
+                InSequence sequence;
+                if (GetParam() == GameID::TSL) {
+                    EXPECT_CALL(*camera, setResolution(800, 600));
+                }
+                EXPECT_CALL(*camera, setResolution(640, 480));
+                preload(*camera);
+                return camera;
+            }));
+        computer = std::make_unique<TestComputer>(*game, svc);
+        computer->init();
+    }
+
+    void expectRender(bool cameraActive) {
+        EXPECT_CALL(*normal, render()).Times(cameraActive ? 0 : 1);
+        EXPECT_CALL(*camera, render()).Times(cameraActive ? 1 : 0);
+        computer->render();
+        Mock::VerifyAndClearExpectations(normal.get());
+        Mock::VerifyAndClearExpectations(camera.get());
+    }
+
+    TestEngine engine;
+    ComputerConsole console;
+    std::unique_ptr<Game> game;
+    std::shared_ptr<NiceMock<MockGUI>> normal;
+    std::shared_ptr<NiceMock<MockGUI>> camera;
+    std::shared_ptr<Label> returnControl;
+    std::unique_ptr<TestComputer> computer;
+};
+
+TEST_P(ComputerGUITest, normal_entry_renders_terminal_and_handles_normal_input) {
+    expectRender(false);
+    computer->start(computerDialog(false), nullptr);
+    expectRender(false);
+    EXPECT_CALL(*normal, handle(_)).WillOnce(Return(true));
+    EXPECT_CALL(*camera, handle(_)).Times(0);
+    EXPECT_TRUE(computer->handle(key(input::KeyCode::Tab)));
+}
+
+TEST_P(ComputerGUITest, static_entry_renders_only_camera_and_isolates_input) {
+    computer->start(computerDialog(), nullptr);
+    expectRender(true);
+    EXPECT_CALL(*normal, handle(_)).Times(0);
+    EXPECT_CALL(*camera, handle(_)).Times(2).WillRepeatedly(Return(false));
+    computer->handle(input::Event::newMouseButtonDown({input::MouseButton::Left, true, 1, 100, 100}));
+    computer->handle(key(input::KeyCode::Key1));
+    EXPECT_EQ(computer->loads, 1);
+    EXPECT_EQ(computer->ends, 0);
+}
+
+TEST_P(ComputerGUITest, animated_camera_takes_precedence_over_static_id) {
+    auto dialog = computerDialog();
+    dialog->cameraModel = "camera_model";
+    computer->start(dialog, nullptr);
+    int id = 0;
+    EXPECT_EQ(computer->getCamera(id), CameraType::Animated);
+    expectRender(false);
+}
+
+TEST_P(ComputerGUITest, return_auto_selects_empty_reply_once_without_replaying_scripts) {
+    auto dialog = computerDialog(true, true);
+    dialog->entries[0].script = "camera_entry";
+    dialog->replies[0].script = "empty_reply";
+    dialog->entries[1].script = "next_entry";
+    auto &scripts = engine.resourceModule().scripts();
+    EXPECT_CALL(scripts, get("camera_entry")).WillOnce(Return(nullptr));
+    EXPECT_CALL(scripts, get("empty_reply")).WillOnce(Return(nullptr));
+    EXPECT_CALL(scripts, get("next_entry")).WillOnce(Return(nullptr));
+
+    computer->start(dialog, nullptr);
+    EXPECT_TRUE(computer->handle(key(input::KeyCode::Escape)));
+    EXPECT_EQ(computer->entry(), &dialog->entries[1]);
+    EXPECT_EQ(computer->ends, 1);
+    EXPECT_EQ(computer->loads, 2);
+    expectRender(false);
+
+    // A queued duplicate click on the old camera control cannot advance again.
+    returnControl->handleClick(0, 0, 1);
+    computer->update(3.0f);
+    EXPECT_EQ(computer->ends, 1);
+    EXPECT_EQ(computer->loads, 2);
+}
+
+TEST_P(ComputerGUITest, return_preserves_entry_and_existing_multiple_replies) {
+    auto dialog = computerDialog();
+    computer->start(dialog, nullptr);
+    auto replies = computer->replies;
+    EXPECT_TRUE(returnControl->isSelectable());
+    returnControl->handleClick(0, 0, 1);
+    EXPECT_EQ(computer->entry(), &dialog->entries[0]);
+    EXPECT_EQ(computer->replies, replies);
+    EXPECT_EQ(computer->replyRefreshes, 1);
+    EXPECT_EQ(computer->loads, 1);
+    EXPECT_EQ(computer->ends, 1);
+    expectRender(false);
+    computer->update(3.0f);
+    EXPECT_EQ(computer->ends, 1);
+    computer->handle(key(input::KeyCode::Key1));
+    EXPECT_EQ(computer->entry(), &dialog->entries[1]);
+    EXPECT_EQ(computer->loads, 2);
+}
+
+TEST_P(ComputerGUITest, conversation_timer_expires_camera_with_automatic_reply) {
+    auto dialog = computerDialog(true, true);
+    computer->start(dialog, nullptr);
+    computer->update(1.0f);
+    expectRender(true);
+    computer->update(1.0f);
+    expectRender(false);
+    EXPECT_EQ(computer->entry(), &dialog->entries[1]);
+    EXPECT_EQ(computer->ends, 1);
+    EXPECT_EQ(computer->loads, 2);
+}
+
+TEST_P(ComputerGUITest, conversation_timer_expires_camera_with_multiple_replies) {
+    auto dialog = computerDialog();
+    computer->start(dialog, nullptr);
+    computer->update(2.0f);
+    expectRender(false);
+    EXPECT_EQ(computer->entry(), &dialog->entries[0]);
+    EXPECT_EQ(computer->replies.size(), 2u);
+    EXPECT_EQ(computer->replyRefreshes, 1);
+    EXPECT_EQ(computer->ends, 1);
+    computer->update(20.0f);
+    EXPECT_EQ(computer->ends, 1);
+}
+
+TEST_P(ComputerGUITest, consecutive_camera_entries_keep_the_next_feed_visible) {
+    auto dialog = computerDialog(true, true);
+    dialog->entries[1].cameraId = 3;
+    computer->start(dialog, nullptr);
+    computer->handle(key(input::KeyCode::Return));
+    EXPECT_EQ(computer->entry(), &dialog->entries[1]);
+    EXPECT_EQ(computer->loads, 2);
+    EXPECT_EQ(computer->ends, 1);
+    expectRender(true);
+    computer->handle(key(input::KeyCode::Return));
+    EXPECT_EQ(computer->ends, 2);
+    EXPECT_EQ(computer->replies.size(), 1u);
+    expectRender(false);
+}
+
+TEST_P(ComputerGUITest, paused_entry_cannot_be_completed_by_return_or_timeout) {
+    computer->start(computerDialog(), nullptr);
+    computer->pause();
+    computer->handle(key(input::KeyCode::Return));
+    computer->update(3.0f);
+    expectRender(true);
+    EXPECT_EQ(computer->ends, 0);
+    computer->resume();
+    computer->update(0.0f);
+    expectRender(false);
+    EXPECT_EQ(computer->ends, 1);
+}
+
+TEST_P(ComputerGUITest, finish_without_replies_clears_camera) {
+    auto dialog = computerDialog();
+    dialog->entries[0].replies.clear();
+    computer->start(dialog, nullptr);
+    expectRender(true);
+    computer->handle(key(input::KeyCode::Return));
+    expectRender(false);
+    EXPECT_EQ(computer->finishes, 1);
+    computer->update(3.0f);
+    EXPECT_EQ(computer->finishes, 1);
+}
+
+TEST_P(ComputerGUITest, replacement_and_module_cleanup_clear_camera) {
+    computer->start(computerDialog(), nullptr);
+    expectRender(true);
+    computer->start(computerDialog(false), nullptr);
+    expectRender(false);
+    computer->start(computerDialog(), nullptr);
+    expectRender(true);
+    computer->cleanupForModuleTransition();
+    expectRender(false);
+    // Reuse after transition does not inherit the previous presentation.
+    computer->start(computerDialog(false), nullptr);
+    expectRender(false);
+}
+
+TEST_P(ComputerGUITest, retiring_owner_ends_camera_without_retaining_runtime_object) {
+    auto owner = game->newCreature();
+    computer->start(computerDialog(), owner);
+    EXPECT_EQ(computer->resolvedOwner(), owner);
+    expectRender(true);
+    std::weak_ptr<Object> retiredOwner = owner;
+    game->destroyRuntimeObjectGraph(owner);
+    owner.reset();
+    EXPECT_TRUE(retiredOwner.expired());
+    computer->update(0.0f);
+    EXPECT_FALSE(computer->resolvedOwner());
+    expectRender(false);
+    EXPECT_EQ(computer->finishes, 1);
+}
+
+TEST_P(ComputerGUITest, automatic_reply_script_replacement_preserves_new_conversation) {
+    auto dialog = computerDialog(true, true);
+    dialog->replies[0].script = "replace_dialog";
+    auto replacement = computerDialog(false);
+    EXPECT_CALL(engine.resourceModule().scripts(), get("replace_dialog"))
+        .WillOnce(Invoke([&](const std::string &) {
+            computer->start(replacement, nullptr);
+            return nullptr;
+        }));
+    computer->start(dialog, nullptr);
+    computer->handle(key(input::KeyCode::Return));
+    EXPECT_EQ(computer->entry(), &replacement->entries[0]);
+    EXPECT_EQ(computer->loads, 2);
+    EXPECT_EQ(computer->ends, 1);
+    expectRender(false);
+}
+
+INSTANTIATE_TEST_SUITE_P(RetailGames, ComputerGUITest, Values(GameID::KotOR, GameID::TSL));
+
+} // namespace

--- a/test/game/conversation.cpp
+++ b/test/game/conversation.cpp
@@ -70,6 +70,10 @@ public:
         pickReply(index);
     }
 
+    void setGUIForTest(std::shared_ptr<gui::IGUI> gui) {
+        _gui = std::move(gui);
+    }
+
     void pauseOnFirstEntryLoad() {
         _pauseOnFirstEntryLoad = true;
     }
@@ -226,6 +230,33 @@ protected:
     std::unique_ptr<Game> _game;
     std::unique_ptr<TestConversation> _conversation;
 };
+
+TEST_F(ConversationTest, ordinary_static_dialogue_keeps_its_own_gui) {
+    auto dialog = makeDialog();
+    dialog->entries[0].cameraId = 1;
+    auto gui = std::make_shared<NiceMock<gui::MockGUI>>();
+    _conversation->setGUIForTest(gui);
+    EXPECT_CALL(_engine.guiModule().guis(), get(_, _)).Times(0);
+    _conversation->start(dialog, nullptr);
+    int cameraId = 0;
+    EXPECT_EQ(_conversation->getCamera(cameraId), CameraType::Static);
+    EXPECT_EQ(cameraId, 1);
+    EXPECT_CALL(*gui, render()).Times(1);
+    _conversation->render();
+}
+
+TEST_F(ConversationTest, animated_dialogue_keeps_its_own_gui) {
+    auto dialog = makeDialog();
+    dialog->cameraModel = "camera_model";
+    auto gui = std::make_shared<NiceMock<gui::MockGUI>>();
+    _conversation->setGUIForTest(gui);
+    EXPECT_CALL(_engine.guiModule().guis(), get(_, _)).Times(0);
+    _conversation->start(dialog, nullptr);
+    int cameraId = 0;
+    EXPECT_EQ(_conversation->getCamera(cameraId), CameraType::Animated);
+    EXPECT_CALL(*gui, render()).Times(1);
+    _conversation->render();
+}
 
 TEST_F(ConversationTest, game_pause_is_harmless_without_a_conversation) {
     EXPECT_FALSE(_game->isConversationActive());


### PR DESCRIPTION
## Summary

Computer conversations already selected and rendered authored static
cameras, but the normal opaque computer GUI was drawn over the scene.

Security-camera entries now switch to the shipped transparent camera
presentation while retaining the existing conversation, timer and reply
state.

K1 uses `computercamera`; K2 uses `computercam_p`.

## Validation

- 28 new tests
- 55/55 computer/conversation tests
- 25/25 GUI/camera tests
- 2,036 full-suite tests passed; two unchanged system tests
  (`ArrayRef.std_vector`, `TextBuffer.clear`) reproduce independently on
  this toolchain
- K1 Endar Spire security-camera flows
- K2 Peragus remote-camera flows
- Normal computers, dialogue-camera presentation isolation, third-person
  return and module cleanup
