### PR TITLE
[game] Move equipment application out of the GUI

### DIFF
--- a/include/reone/game/equipmentoperation.h
+++ b/include/reone/game/equipmentoperation.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "equipmentrules.h"
+
+namespace reone::game {
+
+/** An ordinary gameplay result, independent of command delivery by a screen. */
+enum class EquipmentOperationOutcome {
+    Applied,
+    Unchanged,
+    Rejected,
+    Failed
+};
+
+/**
+ * Apply a selection using existing equipment and inventory operations.
+ * A null item explicitly requests clearing the slot. All non-null objects must
+ * be exact live objects in game; item must belong to sourceInventory.
+ *
+ * Recoverable equip rejection returns the taken candidate to sourceInventory.
+ * A previously cleared paired hand stays in that inventory. Exceptions from
+ * core split/transfer/effect operations propagate; this is not an atomic rollback
+ * boundary over those operations.
+ */
+EquipmentOperationOutcome applyEquipmentOperation(
+    Game &game,
+    Creature &subject,
+    Object &sourceInventory,
+    const std::shared_ptr<Item> &item,
+    int requestedSlot);
+
+} // namespace reone::game

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -181,6 +181,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/effect/visual.h
     ${GAME_INCLUDE_DIR}/effect/vpregenmodifier.h
     ${GAME_INCLUDE_DIR}/effect/whirlwind.h
+    ${GAME_INCLUDE_DIR}/equipmentoperation.h
     ${GAME_INCLUDE_DIR}/equipmentrules.h
     ${GAME_INCLUDE_DIR}/event.h
     ${GAME_INCLUDE_DIR}/runtimeref.h
@@ -481,6 +482,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/effect.cpp
     ${GAME_SOURCE_DIR}/effect/source.cpp
     ${GAME_SOURCE_DIR}/event.cpp
+    ${GAME_SOURCE_DIR}/equipmentoperation.cpp
     ${GAME_SOURCE_DIR}/equipmentrules.cpp
     ${GAME_SOURCE_DIR}/footstepsounds.cpp
     ${GAME_SOURCE_DIR}/floatingtext.cpp

--- a/src/libs/game/equipmentoperation.cpp
+++ b/src/libs/game/equipmentoperation.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/equipmentoperation.h"
+
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/object/item.h"
+
+namespace reone::game {
+
+EquipmentOperationOutcome applyEquipmentOperation(
+    Game &game,
+    Creature &subject,
+    Object &sourceInventory,
+    const std::shared_ptr<Item> &item,
+    int requestedSlot) {
+    auto live = [&game](const Object &object) {
+        return object.isRuntimeLive() &&
+               game.getObjectById(object.id()).get() == &object;
+    };
+    if (!live(subject) || !live(sourceInventory))
+        return EquipmentOperationOutcome::Rejected;
+
+    // Accept only the slots exposed by the ordinary equipment screen.
+    switch (requestedSlot) {
+    case InventorySlots::implant:
+    case InventorySlots::head:
+    case InventorySlots::hands:
+    case InventorySlots::leftArm:
+    case InventorySlots::body:
+    case InventorySlots::rightArm:
+    case InventorySlots::leftWeapon:
+    case InventorySlots::belt:
+    case InventorySlots::rightWeapon:
+    case InventorySlots::leftWeapon2:
+    case InventorySlots::rightWeapon2:
+        break;
+    default:
+        return EquipmentOperationOutcome::Rejected;
+    }
+    if (item && (!live(*item) || item->isEquipped() ||
+                 item->owner() != sourceInventory.id() ||
+                 std::find(sourceInventory.items().begin(), sourceInventory.items().end(), item) == sourceInventory.items().end()))
+        return EquipmentOperationOutcome::Rejected;
+
+    auto decision = evaluateEquipmentCandidate(subject, requestedSlot, item.get());
+    if (!decision.valid)
+        return EquipmentOperationOutcome::Rejected;
+    auto equipped = subject.getEquippedItem(decision.actualSlot);
+    bool clearPaired = decision.action == EquipmentCandidateAction::ClearMainHandAndOffHand ||
+                       decision.action == EquipmentCandidateAction::EquipAndClearOffHand;
+    auto paired = clearPaired ? subject.getEquippedItem(decision.pairedSlot) : nullptr;
+    if ((equipped && !live(*equipped)) || (paired && !live(*paired)))
+        return EquipmentOperationOutcome::Rejected;
+    if (equipped == item && !paired)
+        return EquipmentOperationOutcome::Unchanged;
+
+    if (item) {
+        auto candidate = takeEquipmentCandidate(game, sourceInventory, item);
+        if (!candidate)
+            return EquipmentOperationOutcome::Failed;
+        if (paired && !subject.moveEquippedItemTo(paired, sourceInventory)) {
+            sourceInventory.addItem(candidate);
+            return EquipmentOperationOutcome::Failed;
+        }
+        bool applied = equipped
+            ? subject.replaceEquipment(decision.actualSlot, candidate, sourceInventory)
+            : subject.equip(decision.actualSlot, candidate);
+        if (!applied) {
+            sourceInventory.addItem(candidate);
+            return EquipmentOperationOutcome::Failed;
+        }
+    } else {
+        if (equipped && !subject.moveEquippedItemTo(equipped, sourceInventory))
+            return EquipmentOperationOutcome::Failed;
+        if (paired && !subject.moveEquippedItemTo(paired, sourceInventory))
+            return EquipmentOperationOutcome::Failed;
+    }
+    return EquipmentOperationOutcome::Applied;
+}
+
+} // namespace reone::game

--- a/src/libs/game/equipmentoperation.cpp
+++ b/src/libs/game/equipmentoperation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 The reone project contributors
+ * Copyright (c) 2020-2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,8 +79,8 @@ EquipmentOperationOutcome applyEquipmentOperation(
             return EquipmentOperationOutcome::Failed;
         }
         bool applied = equipped
-            ? subject.replaceEquipment(decision.actualSlot, candidate, sourceInventory)
-            : subject.equip(decision.actualSlot, candidate);
+                           ? subject.replaceEquipment(decision.actualSlot, candidate, sourceInventory)
+                           : subject.equip(decision.actualSlot, candidate);
         if (!applied) {
             sourceInventory.addItem(candidate);
             return EquipmentOperationOutcome::Failed;

--- a/src/libs/game/gui/ingame/equip.cpp
+++ b/src/libs/game/gui/ingame/equip.cpp
@@ -19,6 +19,7 @@
 
 #include "reone/game/di/services.h"
 #include "reone/game/equipmentrules.h"
+#include "reone/game/equipmentoperation.h"
 #include "reone/game/game.h"
 #include "reone/game/gui/ingame.h"
 #include "reone/game/itemdescription.h"
@@ -303,7 +304,7 @@ void Equipment::confirmCandidateItem(const std::string &item) {
 
     std::shared_ptr<Creature> player(_game.party().player());
     std::shared_ptr<Item> itemObj;
-    if (item != kNoneItemTag) {
+    if (player && item != kNoneItemTag) {
         for (auto &playerItem : player->items()) {
             if (playerItem->tag() == item) {
                 itemObj = playerItem;
@@ -311,45 +312,13 @@ void Equipment::confirmCandidateItem(const std::string &item) {
             }
         }
     }
-    std::shared_ptr<Creature> partyLeader(_game.party().getLeader());
-    EquipmentCandidateDecision decision(evaluateEquipmentCandidate(*partyLeader, getInventorySlot(_selectedSlot), itemObj.get()));
-    if (!decision.valid)
+    if (!player || (item != kNoneItemTag && !itemObj))
         return;
-
-    int slot = decision.actualSlot;
-    std::shared_ptr<Item> equipped(partyLeader->getEquippedItem(slot));
-
-    bool clearPairedOffHand = decision.action == EquipmentCandidateAction::ClearMainHandAndOffHand ||
-                              decision.action == EquipmentCandidateAction::EquipAndClearOffHand;
-    std::shared_ptr<Item> pairedOffHand(clearPairedOffHand ? partyLeader->getEquippedItem(decision.pairedSlot) : nullptr);
-
-    bool clearAction = decision.action == EquipmentCandidateAction::ClearSlot ||
-                       decision.action == EquipmentCandidateAction::ClearMainHandAndOffHand;
-    bool equipmentChanged = equipped != itemObj || pairedOffHand;
-    if (equipmentChanged) {
-        if (itemObj) {
-            auto candidate = takeEquipmentCandidate(_game, *player, itemObj);
-            if (!candidate) return;
-            if (pairedOffHand) {
-                partyLeader->moveEquippedItemTo(pairedOffHand, *player);
-            }
-            bool equippedCandidate = equipped
-                                         ? partyLeader->replaceEquipment(
-                                               slot, candidate, *player)
-                                         : partyLeader->equip(slot, candidate);
-            if (!equippedCandidate) {
-                player->addItem(candidate);
-            }
-        } else {
-            if (equipped) {
-                partyLeader->moveEquippedItemTo(equipped, *player);
-            }
-            if (pairedOffHand) {
-                partyLeader->moveEquippedItemTo(pairedOffHand, *player);
-            }
-        }
-    }
-    if (equipmentChanged || clearAction) {
+    auto subject = _game.party().getLeader();
+    if (!subject)
+        return;
+    auto outcome = applyEquipmentOperation(_game, *subject, *player, itemObj, getInventorySlot(_selectedSlot));
+    if (outcome != EquipmentOperationOutcome::Rejected) {
         updateEquipment();
         selectSlot(Slot::None);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/conversation.cpp
     ${TESTS_SOURCE_DIR}/game/globalnumber.cpp
     ${TESTS_SOURCE_DIR}/game/interaction.cpp
+    ${TESTS_SOURCE_DIR}/game/equipmentoperation.cpp
     ${TESTS_SOURCE_DIR}/game/effect.cpp
     ${TESTS_SOURCE_DIR}/game/entrylifecycle.cpp
     ${TESTS_SOURCE_DIR}/game/galaxymap.cpp

--- a/test/game/equipmentoperation.cpp
+++ b/test/game/equipmentoperation.cpp
@@ -132,28 +132,30 @@ TEST_F(EquipmentOperation, clears_paired_hand_for_restricted_weapons_and_support
     for (int baseItem : {1, 6}) {
         for (auto slots : {std::pair {InventorySlots::rightWeapon, InventorySlots::leftWeapon},
                            std::pair {InventorySlots::rightWeapon2, InventorySlots::leftWeapon2}}) {
-            auto subject = game.newCreature();
-            auto owner = game.newCreature();
-            auto main = makeItem(game, "main", 8, 1);
-            auto off = makeItem(game, "off", 3, 1);
-            auto baton = makeItem(game, "restricted", baseItem, 1);
+            Game alternate(GameID::TSL, "", engine.options(), engine.services(), console);
+            Game &operationGame = slots.first == InventorySlots::rightWeapon2 ? alternate : game;
+            auto subject = operationGame.newCreature();
+            auto owner = operationGame.newCreature();
+            auto main = makeItem(operationGame, "main", 8, 1);
+            auto off = makeItem(operationGame, "off", 3, 1);
+            auto baton = makeItem(operationGame, "restricted", baseItem, 1);
             ASSERT_TRUE(subject->equip(slots.first, main));
             ASSERT_TRUE(subject->equip(slots.second, off));
             owner->addItem(baton);
             EXPECT_EQ(EquipmentOperationOutcome::Applied,
-                      applyEquipmentOperation(game, *subject, *owner, baton, slots.first));
+                      applyEquipmentOperation(operationGame, *subject, *owner, baton, slots.first));
             EXPECT_FALSE(subject->getEquippedItem(slots.second));
             EXPECT_EQ(baton, subject->getEquippedItem(slots.first));
             EXPECT_EQ(2u, owner->items().size());
             EXPECT_EQ(owner->id(), main->owner());
             EXPECT_EQ(owner->id(), off->owner());
             EXPECT_EQ(EquipmentOperationOutcome::Applied,
-                      applyEquipmentOperation(game, *subject, *owner, nullptr, slots.first));
+                      applyEquipmentOperation(operationGame, *subject, *owner, nullptr, slots.first));
             EXPECT_EQ(3u, owner->items().size());
             EXPECT_EQ(EquipmentOperationOutcome::Applied,
-                      applyEquipmentOperation(game, *subject, *owner, main, slots.first));
+                      applyEquipmentOperation(operationGame, *subject, *owner, main, slots.first));
             EXPECT_EQ(EquipmentOperationOutcome::Applied,
-                      applyEquipmentOperation(game, *subject, *owner, off, slots.second));
+                      applyEquipmentOperation(operationGame, *subject, *owner, off, slots.second));
             EXPECT_EQ(1u, owner->items().size());
             EXPECT_EQ(owner->id(), baton->owner());
         }

--- a/test/game/equipmentoperation.cpp
+++ b/test/game/equipmentoperation.cpp
@@ -66,9 +66,14 @@ std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int st
     return item;
 }
 
+class EquipmentEngine : public TestEngine {
+public:
+    EquipmentEngine() { init(); }
+};
+
 class EquipmentOperation : public Test {
 protected:
-    TestEngine &engine = testEngine();
+    EquipmentEngine engine;
     StubConsole console;
     Game game {GameID::KotOR, "", engine.options(), engine.services(), console};
     void SetUp() override {

--- a/test/game/equipmentoperation.cpp
+++ b/test/game/equipmentoperation.cpp
@@ -15,15 +15,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include "../fixtures/engine.h"
 #include "reone/game/equipmentoperation.h"
+#include "../fixtures/engine.h"
 #include "reone/game/game.h"
 #include "reone/game/object/creature.h"
 #include "reone/game/object/item.h"
 #include "reone/resource/2da.h"
 #include "reone/resource/gff.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace reone;
 using namespace reone::game;
@@ -41,6 +41,8 @@ std::shared_ptr<TwoDA> makeLightsaberBaseItemsTable() {
             builder.row({"1.5", "2", "2", "2", "4", "48", "w_stunbaton", "1", "1", "1", "-1", ""});
         } else if (i == 3) {
             builder.row({"1.5", "2", "2", "2", "6", "48", "w_vbroswrd", "1", "1", "2", "-1", ""});
+        } else if (i == 6) {
+            builder.row({"1.5", "2", "2", "2", "8", "48", "w_dblsbr", "1", "1", "3", "-1", ""});
         } else if (i == 8) {
             builder.row({"1.5", "2", "2", "2", "8", "48", "w_lghtsbr", "1", "1", "2", "-1", ""});
         } else if (i == 12) {
@@ -64,7 +66,6 @@ std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int st
     return item;
 }
 
-
 class EquipmentOperation : public Test {
 protected:
     TestEngine &engine = testEngine();
@@ -72,10 +73,11 @@ protected:
     Game game {GameID::KotOR, "", engine.options(), engine.services(), console};
     void SetUp() override {
         EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
-            .Times(AnyNumber()).WillRepeatedly(Return(makeLightsaberBaseItemsTable()));
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(makeLightsaberBaseItemsTable()));
     }
 };
-}
+} // namespace
 
 TEST_F(EquipmentOperation, equips_replaces_and_returns_items_to_explicit_inventory) {
     auto owner = game.newCreature();
@@ -85,20 +87,20 @@ TEST_F(EquipmentOperation, equips_replaces_and_returns_items_to_explicit_invento
     owner->addItem(first);
     owner->addItem(second);
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, first, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, first, InventorySlots::rightWeapon));
     EXPECT_EQ(subject->id(), first->owner());
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, second, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, second, InventorySlots::rightWeapon));
     EXPECT_EQ(owner->id(), first->owner());
     EXPECT_EQ(subject->id(), second->owner());
     EXPECT_EQ(second, subject->getEquippedItem(InventorySlots::rightWeapon));
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
     EXPECT_EQ(2u, owner->items().size());
     EXPECT_TRUE(subject->equipment().empty());
     EXPECT_TRUE(subject->items().empty());
     EXPECT_EQ(EquipmentOperationOutcome::Unchanged,
-        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
 }
 
 TEST_F(EquipmentOperation, preserves_stacked_candidates_and_clears_both_hands) {
@@ -107,18 +109,18 @@ TEST_F(EquipmentOperation, preserves_stacked_candidates_and_clears_both_hands) {
     auto stack = makeItem(game, "saber", 8, 3);
     owner->addItem(stack);
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
+              applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
     EXPECT_TRUE(subject->getEquippedItem(InventorySlots::rightWeapon));
     EXPECT_FALSE(subject->getEquippedItem(InventorySlots::leftWeapon));
     EXPECT_EQ(2, stack->stackSize());
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
+              applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
     auto off = subject->getEquippedItem(InventorySlots::leftWeapon);
     ASSERT_TRUE(off);
     EXPECT_NE(stack, off);
     EXPECT_EQ(1, stack->stackSize());
     EXPECT_EQ(EquipmentOperationOutcome::Applied,
-        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
     EXPECT_TRUE(subject->equipment().empty());
     EXPECT_EQ(1u, owner->items().size());
     EXPECT_EQ(3, stack->stackSize());
@@ -126,24 +128,35 @@ TEST_F(EquipmentOperation, preserves_stacked_candidates_and_clears_both_hands) {
     EXPECT_FALSE(off->isRuntimeLive()); // merge consumes the exact split incarnation
 }
 
-TEST_F(EquipmentOperation, clears_paired_hand_for_a_stun_baton_and_supports_alternate_slots) {
-    for (auto slots : {std::pair {InventorySlots::rightWeapon, InventorySlots::leftWeapon},
-                       std::pair {InventorySlots::rightWeapon2, InventorySlots::leftWeapon2}}) {
-        auto subject = game.newCreature();
-        auto owner = game.newCreature();
-        auto main = makeItem(game, "main", 8, 1);
-        auto off = makeItem(game, "off", 3, 1);
-        auto baton = makeItem(game, "baton", 1, 1);
-        ASSERT_TRUE(subject->equip(slots.first, main));
-        ASSERT_TRUE(subject->equip(slots.second, off));
-        owner->addItem(baton);
-        EXPECT_EQ(EquipmentOperationOutcome::Applied,
-            applyEquipmentOperation(game, *subject, *owner, baton, slots.first));
-        EXPECT_FALSE(subject->getEquippedItem(slots.second));
-        EXPECT_EQ(baton, subject->getEquippedItem(slots.first));
-        EXPECT_EQ(2u, owner->items().size());
-        EXPECT_EQ(owner->id(), main->owner());
-        EXPECT_EQ(owner->id(), off->owner());
+TEST_F(EquipmentOperation, clears_paired_hand_for_restricted_weapons_and_supports_alternate_slots) {
+    for (int baseItem : {1, 6}) {
+        for (auto slots : {std::pair {InventorySlots::rightWeapon, InventorySlots::leftWeapon},
+                           std::pair {InventorySlots::rightWeapon2, InventorySlots::leftWeapon2}}) {
+            auto subject = game.newCreature();
+            auto owner = game.newCreature();
+            auto main = makeItem(game, "main", 8, 1);
+            auto off = makeItem(game, "off", 3, 1);
+            auto baton = makeItem(game, "restricted", baseItem, 1);
+            ASSERT_TRUE(subject->equip(slots.first, main));
+            ASSERT_TRUE(subject->equip(slots.second, off));
+            owner->addItem(baton);
+            EXPECT_EQ(EquipmentOperationOutcome::Applied,
+                      applyEquipmentOperation(game, *subject, *owner, baton, slots.first));
+            EXPECT_FALSE(subject->getEquippedItem(slots.second));
+            EXPECT_EQ(baton, subject->getEquippedItem(slots.first));
+            EXPECT_EQ(2u, owner->items().size());
+            EXPECT_EQ(owner->id(), main->owner());
+            EXPECT_EQ(owner->id(), off->owner());
+            EXPECT_EQ(EquipmentOperationOutcome::Applied,
+                      applyEquipmentOperation(game, *subject, *owner, nullptr, slots.first));
+            EXPECT_EQ(3u, owner->items().size());
+            EXPECT_EQ(EquipmentOperationOutcome::Applied,
+                      applyEquipmentOperation(game, *subject, *owner, main, slots.first));
+            EXPECT_EQ(EquipmentOperationOutcome::Applied,
+                      applyEquipmentOperation(game, *subject, *owner, off, slots.second));
+            EXPECT_EQ(1u, owner->items().size());
+            EXPECT_EQ(owner->id(), baton->owner());
+        }
     }
 }
 
@@ -156,18 +169,18 @@ TEST_F(EquipmentOperation, rejects_invalid_foreign_and_retired_requests_without_
     ASSERT_TRUE(subject->equip(InventorySlots::rightWeapon, main));
     owner->addItem(incompatible);
     EXPECT_EQ(EquipmentOperationOutcome::Rejected,
-        applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::leftWeapon));
+              applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::leftWeapon));
     EXPECT_EQ(EquipmentOperationOutcome::Rejected,
-        applyEquipmentOperation(game, *subject, *foreign, incompatible, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *foreign, incompatible, InventorySlots::rightWeapon));
     EXPECT_EQ(EquipmentOperationOutcome::Rejected,
-        applyEquipmentOperation(game, *subject, *owner, nullptr, -1));
+              applyEquipmentOperation(game, *subject, *owner, nullptr, -1));
     EXPECT_EQ(2, incompatible->stackSize());
     EXPECT_EQ(owner->id(), incompatible->owner());
     EXPECT_EQ(main, subject->getEquippedItem(InventorySlots::rightWeapon));
     game.destroyRuntimeObjectGraph(incompatible);
     EXPECT_EQ(EquipmentOperationOutcome::Rejected,
-        applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::rightWeapon));
     game.destroyRuntimeObjectGraph(subject);
     EXPECT_EQ(EquipmentOperationOutcome::Rejected,
-        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+              applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
 }

--- a/test/game/equipmentoperation.cpp
+++ b/test/game/equipmentoperation.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "../fixtures/engine.h"
+#include "reone/game/equipmentoperation.h"
+#include "reone/game/game.h"
+#include "reone/game/object/creature.h"
+#include "reone/game/object/item.h"
+#include "reone/resource/2da.h"
+#include "reone/resource/gff.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+std::shared_ptr<TwoDA> makeLightsaberBaseItemsTable() {
+    TwoDA::Builder builder;
+    builder.columns({"maxattackrange", "crithitmult", "critthreat", "damageflags", "dietoroll",
+                     "equipableslots", "itemclass", "numdice", "weapontype", "weaponwield",
+                     "ammunitiontype", "bodyvar"});
+    for (int i = 0; i <= 12; ++i) {
+        if (i == 1) {
+            builder.row({"1.5", "2", "2", "2", "4", "48", "w_stunbaton", "1", "1", "1", "-1", ""});
+        } else if (i == 3) {
+            builder.row({"1.5", "2", "2", "2", "6", "48", "w_vbroswrd", "1", "1", "2", "-1", ""});
+        } else if (i == 8) {
+            builder.row({"1.5", "2", "2", "2", "8", "48", "w_lghtsbr", "1", "1", "2", "-1", ""});
+        } else if (i == 12) {
+            builder.row({"23", "2", "2", "2", "6", "48", "w_blstrpstl", "1", "4", "4", "-1", ""});
+        } else {
+            builder.row({"", "", "", "", "", "", "", "", "", "", "", ""});
+        }
+    }
+    return std::shared_ptr<TwoDA>(builder.build());
+}
+
+std::shared_ptr<Item> makeItem(Game &game, std::string tag, int baseItem, int stackSize) {
+    auto gff = Gff::Builder()
+                   .field(Gff::Field::newCExoString("Tag", std::move(tag)))
+                   .field(Gff::Field::newInt("BaseItem", baseItem))
+                   .field(Gff::Field::newWord("StackSize", stackSize))
+                   .build();
+    auto item = game.newItem();
+    item->deserialize(*gff, SerializedIdentityContext::templateResource());
+    item->setDropable(true);
+    return item;
+}
+
+
+class EquipmentOperation : public Test {
+protected:
+    TestEngine &engine = testEngine();
+    StubConsole console;
+    Game game {GameID::KotOR, "", engine.options(), engine.services(), console};
+    void SetUp() override {
+        EXPECT_CALL(engine.resourceModule().twoDas(), get("baseitems"))
+            .Times(AnyNumber()).WillRepeatedly(Return(makeLightsaberBaseItemsTable()));
+    }
+};
+}
+
+TEST_F(EquipmentOperation, equips_replaces_and_returns_items_to_explicit_inventory) {
+    auto owner = game.newCreature();
+    auto subject = game.newCreature();
+    auto first = makeItem(game, "first", 8, 1);
+    auto second = makeItem(game, "second", 3, 1);
+    owner->addItem(first);
+    owner->addItem(second);
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, first, InventorySlots::rightWeapon));
+    EXPECT_EQ(subject->id(), first->owner());
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, second, InventorySlots::rightWeapon));
+    EXPECT_EQ(owner->id(), first->owner());
+    EXPECT_EQ(subject->id(), second->owner());
+    EXPECT_EQ(second, subject->getEquippedItem(InventorySlots::rightWeapon));
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+    EXPECT_EQ(2u, owner->items().size());
+    EXPECT_TRUE(subject->equipment().empty());
+    EXPECT_TRUE(subject->items().empty());
+    EXPECT_EQ(EquipmentOperationOutcome::Unchanged,
+        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+}
+
+TEST_F(EquipmentOperation, preserves_stacked_candidates_and_clears_both_hands) {
+    auto owner = game.newCreature();
+    auto subject = game.newCreature();
+    auto stack = makeItem(game, "saber", 8, 3);
+    owner->addItem(stack);
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
+    EXPECT_TRUE(subject->getEquippedItem(InventorySlots::rightWeapon));
+    EXPECT_FALSE(subject->getEquippedItem(InventorySlots::leftWeapon));
+    EXPECT_EQ(2, stack->stackSize());
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, stack, InventorySlots::leftWeapon));
+    auto off = subject->getEquippedItem(InventorySlots::leftWeapon);
+    ASSERT_TRUE(off);
+    EXPECT_NE(stack, off);
+    EXPECT_EQ(1, stack->stackSize());
+    EXPECT_EQ(EquipmentOperationOutcome::Applied,
+        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+    EXPECT_TRUE(subject->equipment().empty());
+    EXPECT_EQ(1u, owner->items().size());
+    EXPECT_EQ(3, stack->stackSize());
+    EXPECT_EQ(owner->id(), stack->owner());
+    EXPECT_FALSE(off->isRuntimeLive()); // merge consumes the exact split incarnation
+}
+
+TEST_F(EquipmentOperation, clears_paired_hand_for_a_stun_baton_and_supports_alternate_slots) {
+    for (auto slots : {std::pair {InventorySlots::rightWeapon, InventorySlots::leftWeapon},
+                       std::pair {InventorySlots::rightWeapon2, InventorySlots::leftWeapon2}}) {
+        auto subject = game.newCreature();
+        auto owner = game.newCreature();
+        auto main = makeItem(game, "main", 8, 1);
+        auto off = makeItem(game, "off", 3, 1);
+        auto baton = makeItem(game, "baton", 1, 1);
+        ASSERT_TRUE(subject->equip(slots.first, main));
+        ASSERT_TRUE(subject->equip(slots.second, off));
+        owner->addItem(baton);
+        EXPECT_EQ(EquipmentOperationOutcome::Applied,
+            applyEquipmentOperation(game, *subject, *owner, baton, slots.first));
+        EXPECT_FALSE(subject->getEquippedItem(slots.second));
+        EXPECT_EQ(baton, subject->getEquippedItem(slots.first));
+        EXPECT_EQ(2u, owner->items().size());
+        EXPECT_EQ(owner->id(), main->owner());
+        EXPECT_EQ(owner->id(), off->owner());
+    }
+}
+
+TEST_F(EquipmentOperation, rejects_invalid_foreign_and_retired_requests_without_mutation) {
+    auto subject = game.newCreature();
+    auto owner = game.newCreature();
+    auto foreign = game.newCreature();
+    auto main = makeItem(game, "main", 8, 1);
+    auto incompatible = makeItem(game, "blaster", 12, 2);
+    ASSERT_TRUE(subject->equip(InventorySlots::rightWeapon, main));
+    owner->addItem(incompatible);
+    EXPECT_EQ(EquipmentOperationOutcome::Rejected,
+        applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::leftWeapon));
+    EXPECT_EQ(EquipmentOperationOutcome::Rejected,
+        applyEquipmentOperation(game, *subject, *foreign, incompatible, InventorySlots::rightWeapon));
+    EXPECT_EQ(EquipmentOperationOutcome::Rejected,
+        applyEquipmentOperation(game, *subject, *owner, nullptr, -1));
+    EXPECT_EQ(2, incompatible->stackSize());
+    EXPECT_EQ(owner->id(), incompatible->owner());
+    EXPECT_EQ(main, subject->getEquippedItem(InventorySlots::rightWeapon));
+    game.destroyRuntimeObjectGraph(incompatible);
+    EXPECT_EQ(EquipmentOperationOutcome::Rejected,
+        applyEquipmentOperation(game, *subject, *owner, incompatible, InventorySlots::rightWeapon));
+    game.destroyRuntimeObjectGraph(subject);
+    EXPECT_EQ(EquipmentOperationOutcome::Rejected,
+        applyEquipmentOperation(game, *subject, *owner, nullptr, InventorySlots::rightWeapon));
+}


### PR DESCRIPTION
## Summary

Moves equipment application out of the GUI into `applyEquipmentOperation`.

The operation takes the subject, source/return inventory, item and slot explicitly, validates live registration and ownership, then uses the existing equipment and inventory operations. The Equipment screen delegates to it and refreshes afterward.

Equipment rules and item lifetimes are unchanged. This does not add atomic rollback: recoverable equip failure returns the candidate, but an already-cleared paired hand stays in inventory. Core exceptions still propagate.
