### PR TITLE
[game] Separate software pointer presentation

### DIFF
--- a/include/reone/game/game.h
+++ b/include/reone/game/game.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "presentationpointer.h"
+
 #include "reone/audio/source.h"
 #include "reone/graphics/cursor.h"
 #include "reone/graphics/types.h"
@@ -149,7 +151,8 @@ public:
         std::filesystem::path path,
         OptionsView &options,
         ServicesView &services,
-        IConsole &console) :
+        IConsole &console,
+        std::shared_ptr<PresentationPointer> pointer = nullptr) :
         _gameId(gameId),
         _path(std::move(path)),
         _options(options),
@@ -160,7 +163,8 @@ public:
         _swoopRace(*this),
         _turret(*this, services),
         _journal(services.resource.gffs, services.resource.strings),
-        _floatingText(*this, services) {
+        _floatingText(*this, services),
+        _pointer(pointer ? std::move(pointer) : std::make_shared<PresentationPointer>(services.resource.cursors)) {
         initJournalNotifications();
     }
 
@@ -327,7 +331,7 @@ public:
     }
 
     resource::CursorType cursorType() const {
-        return _cursorType;
+        return _pointer->type();
     }
 
     bool relativeMouseMode() const {
@@ -860,8 +864,7 @@ private:
 
     std::shared_ptr<movie::IMovie> _movie;
     std::queue<std::string> _moduleTransitionMovies;
-    resource::CursorType _cursorType {resource::CursorType::None};
-    std::shared_ptr<graphics::Cursor> _cursor;
+    std::shared_ptr<PresentationPointer> _pointer;
     float _gameSpeed {1.0f};
     CameraType _cameraType {CameraType::ThirdPerson};
     CameraType _savedCameraType {CameraType::ThirdPerson};

--- a/include/reone/game/presentationpointer.h
+++ b/include/reone/game/presentationpointer.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "reone/graphics/cursor.h"
+#include "reone/graphics/options.h"
+#include "reone/resource/provider/cursors.h"
+#include "types.h"
+
+namespace reone::game {
+
+/** One software pointer for a local presentation surface.
+ * The provider and graphics options outlive the surface. Screens do not own
+ * pointers: the surface draws this once, after its screens and modal overlays.
+ */
+class PresentationPointer {
+public:
+    explicit PresentationPointer(resource::ICursors &cursors) : _cursors(cursors) {}
+
+    void setType(resource::CursorType type);
+    resource::CursorType type() const { return _type; }
+    void setPosition(glm::ivec2 position);
+    void setPressed(bool pressed);
+    void render(const graphics::GraphicsOptions &options, bool relativeMouseMode);
+
+private:
+    resource::ICursors &_cursors;
+    resource::CursorType _type {resource::CursorType::None};
+    std::shared_ptr<graphics::Cursor> _cursor;
+};
+
+/** Existing cursor decision for an already selected object; performs no picking. */
+resource::CursorType contextualCursor(ObjectType type, bool dead, bool hostile);
+
+} // namespace reone::game

--- a/src/apps/engine/engine.cpp
+++ b/src/apps/engine/engine.cpp
@@ -187,12 +187,14 @@ void Engine::init() {
     _console->init();
     initAutomationCommands();
 
+    _pointer = std::make_shared<PresentationPointer>(_services->resource.cursors);
     _game = std::make_unique<Game>(
         gameId,
         _options.game.path,
         *_optionsView,
         *_services,
-        *_console);
+        *_console,
+        _pointer);
     _game->init();
 }
 
@@ -200,6 +202,7 @@ void Engine::deinit() {
     _console.reset();
     _profiler.reset();
     _game.reset();
+    _pointer.reset();
     _services.reset();
 
     _gameModule.reset();

--- a/src/apps/engine/engine.h
+++ b/src/apps/engine/engine.h
@@ -85,6 +85,7 @@ private:
     std::unique_ptr<game::GameModule> _gameModule;
 
     std::unique_ptr<game::ServicesView> _services;
+    std::shared_ptr<game::PresentationPointer> _pointer;
     std::unique_ptr<game::Game> _game;
     std::unique_ptr<Profiler> _profiler;
     std::unique_ptr<Console> _console;

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -189,6 +189,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/galaxymapstate.h
     ${GAME_INCLUDE_DIR}/game.h
     ${GAME_INCLUDE_DIR}/itemdescription.h
+    ${GAME_INCLUDE_DIR}/presentationpointer.h
     ${GAME_INCLUDE_DIR}/gui.h
     ${GAME_INCLUDE_DIR}/gui/actionbar.h
     ${GAME_INCLUDE_DIR}/gui/actionslot.h
@@ -521,6 +522,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/ingame/options.cpp
     ${GAME_SOURCE_DIR}/gui/ingame.cpp
     ${GAME_SOURCE_DIR}/gui/loadscreen.cpp
+    ${GAME_SOURCE_DIR}/presentationpointer.cpp
     ${GAME_SOURCE_DIR}/gui.cpp
     ${GAME_SOURCE_DIR}/gui/mainmenu.cpp
     ${GAME_SOURCE_DIR}/gui/map.cpp

--- a/src/libs/game/CMakeLists.txt
+++ b/src/libs/game/CMakeLists.txt
@@ -190,7 +190,6 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/galaxymapstate.h
     ${GAME_INCLUDE_DIR}/game.h
     ${GAME_INCLUDE_DIR}/itemdescription.h
-    ${GAME_INCLUDE_DIR}/presentationpointer.h
     ${GAME_INCLUDE_DIR}/gui.h
     ${GAME_INCLUDE_DIR}/gui/actionbar.h
     ${GAME_INCLUDE_DIR}/gui/actionslot.h
@@ -327,6 +326,7 @@ set(GAME_HEADERS
     ${GAME_INCLUDE_DIR}/object/trigger.h
     ${GAME_INCLUDE_DIR}/object/waypoint.h
     ${GAME_INCLUDE_DIR}/options.h
+    ${GAME_INCLUDE_DIR}/presentationpointer.h
     ${GAME_INCLUDE_DIR}/party.h
     ${GAME_INCLUDE_DIR}/pazaak.h
     ${GAME_INCLUDE_DIR}/pazaaksession.h
@@ -524,7 +524,6 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/gui/ingame/options.cpp
     ${GAME_SOURCE_DIR}/gui/ingame.cpp
     ${GAME_SOURCE_DIR}/gui/loadscreen.cpp
-    ${GAME_SOURCE_DIR}/presentationpointer.cpp
     ${GAME_SOURCE_DIR}/gui.cpp
     ${GAME_SOURCE_DIR}/gui/mainmenu.cpp
     ${GAME_SOURCE_DIR}/gui/map.cpp
@@ -565,6 +564,7 @@ set(GAME_SOURCES
     ${GAME_SOURCE_DIR}/party.cpp
     ${GAME_SOURCE_DIR}/pazaak.cpp
     ${GAME_SOURCE_DIR}/pazaaksession.cpp
+    ${GAME_SOURCE_DIR}/presentationpointer.cpp
     ${GAME_SOURCE_DIR}/pathfinder.cpp
     ${GAME_SOURCE_DIR}/player.cpp
     ${GAME_SOURCE_DIR}/portraits.cpp

--- a/src/libs/game/game.cpp
+++ b/src/libs/game/game.cpp
@@ -274,7 +274,6 @@ static constexpr char kDeveloperActorToggleHelp[] = "Ctrl+Shift+A";
 static constexpr char kDeveloperActorLongToggleHelp[] = "Ctrl+Shift+L";
 static constexpr char kDeveloperWatchToggleHelp[] = "Ctrl+Shift+W";
 static constexpr float kDeveloperActorLabelDistance = 32.0f;
-static constexpr float kCursorSizeScale = 0.5f;
 
 static std::shared_ptr<Gff> decodeSaveGff(std::optional<Resource> resource) {
     if (!resource) {
@@ -994,7 +993,7 @@ bool Game::handleDeveloperKeyDown(const input::KeyEvent &event) {
 }
 
 bool Game::handleMouseMotion(const input::MouseMotionEvent &event) {
-    _cursor->setPosition({event.x, event.y});
+    _pointer->setPosition({event.x, event.y});
     return false;
 }
 
@@ -1002,7 +1001,7 @@ bool Game::handleMouseButtonDown(const input::MouseButtonEvent &event) {
     if (event.button != input::MouseButton::Left) {
         return false;
     }
-    _cursor->setPressed(true);
+    _pointer->setPressed(true);
     if (_movie) {
         _movie->finish();
         return true;
@@ -1014,7 +1013,7 @@ bool Game::handleMouseButtonUp(const input::MouseButtonEvent &event) {
     if (event.button != input::MouseButton::Left) {
         return false;
     }
-    _cursor->setPressed(false);
+    _pointer->setPressed(false);
     return false;
 }
 
@@ -2448,15 +2447,7 @@ void Game::loadDefaultParty() {
 }
 
 void Game::setCursorType(CursorType type) {
-    if (_cursorType == type) {
-        return;
-    }
-    if (type == CursorType::None) {
-        _cursor.reset();
-    } else {
-        _cursor = _services.resource.cursors.get(type);
-    }
-    _cursorType = type;
+    _pointer->setType(type);
 }
 
 void Game::playVideo(const std::string &name) {
@@ -3222,12 +3213,7 @@ void Game::renderGUI() {
     if (_confirmPopup && _confirmPopup->isVisible()) {
         _confirmPopup->render();
     }
-    if (_cursor && !_relativeMouseMode) {
-        const auto &graphics = _options.graphics;
-        float cursorScale = std::min(graphics.width / 800.0f, graphics.height / 600.0f) *
-                            graphics.guiScale * kCursorSizeScale;
-        _cursor->render(cursorScale);
-    }
+    _pointer->render(_options.graphics, _relativeMouseMode);
     renderDeveloperOverlay();
 }
 

--- a/src/libs/game/object/module.cpp
+++ b/src/libs/game/object/module.cpp
@@ -296,25 +296,9 @@ bool Module::handleMouseMotion(const input::MouseMotionEvent &event) {
         auto objectPtr = _game.getObjectById(object->id());
         _area->hilightObject(objectPtr);
 
-        switch (object->type()) {
-        case ObjectType::Creature: {
-            if (object->isDead()) {
-                cursor = CursorType::Pickup;
-            } else {
-                auto creature = static_cast<Creature *>(object);
-                cursor = isHostileToPartyLeader(*creature) ? CursorType::Attack : CursorType::Talk;
-            }
-            break;
-        }
-        case ObjectType::Door:
-            cursor = CursorType::Door;
-            break;
-        case ObjectType::Placeable:
-            cursor = CursorType::Pickup;
-            break;
-        default:
-            break;
-        }
+        bool hostile = object->type() == ObjectType::Creature && !object->isDead()
+            ? isHostileToPartyLeader(*static_cast<Creature *>(object)) : false;
+        cursor = contextualCursor(object->type(), object->isDead(), hostile);
     } else {
         _area->hilightObject(nullptr);
     }

--- a/src/libs/game/presentationpointer.cpp
+++ b/src/libs/game/presentationpointer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 The reone project contributors
+ * Copyright (c) 2020-2026 The reone project contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,21 +20,25 @@
 namespace reone::game {
 
 void PresentationPointer::setType(resource::CursorType type) {
-    if (_type == type) return;
+    if (_type == type)
+        return;
     _cursor = type == resource::CursorType::None ? nullptr : _cursors.get(type);
     _type = type;
 }
 
 void PresentationPointer::setPosition(glm::ivec2 position) {
-    if (_cursor) _cursor->setPosition(position);
+    if (_cursor)
+        _cursor->setPosition(position);
 }
 
 void PresentationPointer::setPressed(bool pressed) {
-    if (_cursor) _cursor->setPressed(pressed);
+    if (_cursor)
+        _cursor->setPressed(pressed);
 }
 
 void PresentationPointer::render(const graphics::GraphicsOptions &options, bool relativeMouseMode) {
-    if (!_cursor || relativeMouseMode) return;
+    if (!_cursor || relativeMouseMode)
+        return;
     static constexpr float kCursorSizeScale = 0.5f;
     float scale = std::min(options.width / 800.0f, options.height / 600.0f) * options.guiScale * kCursorSizeScale;
     _cursor->render(scale);
@@ -43,10 +47,14 @@ void PresentationPointer::render(const graphics::GraphicsOptions &options, bool 
 resource::CursorType contextualCursor(ObjectType type, bool dead, bool hostile) {
     using resource::CursorType;
     switch (type) {
-    case ObjectType::Creature: return dead ? CursorType::Pickup : (hostile ? CursorType::Attack : CursorType::Talk);
-    case ObjectType::Door: return CursorType::Door;
-    case ObjectType::Placeable: return CursorType::Pickup;
-    default: return CursorType::Default;
+    case ObjectType::Creature:
+        return dead ? CursorType::Pickup : (hostile ? CursorType::Attack : CursorType::Talk);
+    case ObjectType::Door:
+        return CursorType::Door;
+    case ObjectType::Placeable:
+        return CursorType::Pickup;
+    default:
+        return CursorType::Default;
     }
 }
 

--- a/src/libs/game/presentationpointer.cpp
+++ b/src/libs/game/presentationpointer.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reone/game/presentationpointer.h"
+
+namespace reone::game {
+
+void PresentationPointer::setType(resource::CursorType type) {
+    if (_type == type) return;
+    _cursor = type == resource::CursorType::None ? nullptr : _cursors.get(type);
+    _type = type;
+}
+
+void PresentationPointer::setPosition(glm::ivec2 position) {
+    if (_cursor) _cursor->setPosition(position);
+}
+
+void PresentationPointer::setPressed(bool pressed) {
+    if (_cursor) _cursor->setPressed(pressed);
+}
+
+void PresentationPointer::render(const graphics::GraphicsOptions &options, bool relativeMouseMode) {
+    if (!_cursor || relativeMouseMode) return;
+    static constexpr float kCursorSizeScale = 0.5f;
+    float scale = std::min(options.width / 800.0f, options.height / 600.0f) * options.guiScale * kCursorSizeScale;
+    _cursor->render(scale);
+}
+
+resource::CursorType contextualCursor(ObjectType type, bool dead, bool hostile) {
+    using resource::CursorType;
+    switch (type) {
+    case ObjectType::Creature: return dead ? CursorType::Pickup : (hostile ? CursorType::Attack : CursorType::Talk);
+    case ObjectType::Door: return CursorType::Door;
+    case ObjectType::Placeable: return CursorType::Pickup;
+    default: return CursorType::Default;
+    }
+}
+
+} // namespace reone::game

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,7 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/reputes.cpp
     ${TESTS_SOURCE_DIR}/game/rostermaterialization.cpp
+    ${TESTS_SOURCE_DIR}/game/presentationpointer.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/stringroutines.cpp
     ${TESTS_SOURCE_DIR}/game/timingepoch.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,11 +83,11 @@ set(TESTS_SOURCES
     ${TESTS_SOURCE_DIR}/game/pazaak.cpp
     ${TESTS_SOURCE_DIR}/game/pazaakintegration.cpp
     ${TESTS_SOURCE_DIR}/game/pazaaksession.cpp
+    ${TESTS_SOURCE_DIR}/game/presentationpointer.cpp
     ${TESTS_SOURCE_DIR}/game/partyroutines.cpp
     ${TESTS_SOURCE_DIR}/game/pathfinder.cpp
     ${TESTS_SOURCE_DIR}/game/reputes.cpp
     ${TESTS_SOURCE_DIR}/game/rostermaterialization.cpp
-    ${TESTS_SOURCE_DIR}/game/presentationpointer.cpp
     ${TESTS_SOURCE_DIR}/game/statussummary.cpp
     ${TESTS_SOURCE_DIR}/game/stringroutines.cpp
     ${TESTS_SOURCE_DIR}/game/timingepoch.cpp

--- a/test/game/presentationpointer.cpp
+++ b/test/game/presentationpointer.cpp
@@ -15,16 +15,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "reone/game/presentationpointer.h"
 #include "reone/graphics/context.h"
 #include "reone/graphics/meshregistry.h"
-#include "reone/graphics/shaderregistry.h"
 #include "reone/graphics/shaderprogram.h"
+#include "reone/graphics/shaderregistry.h"
 #include "reone/graphics/statistic.h"
 #include "reone/graphics/texture.h"
 #include "reone/graphics/uniforms.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace reone;
 using namespace reone::game;
@@ -57,13 +57,18 @@ class CursorProvider : public ICursors {
 public:
     std::shared_ptr<Cursor> cursor;
     std::vector<CursorType> requests;
-    std::shared_ptr<Cursor> get(CursorType type) override { requests.push_back(type); return cursor; }
+    std::shared_ptr<Cursor> get(CursorType type) override {
+        requests.push_back(type);
+        return cursor;
+    }
 };
-}
+} // namespace
 
 TEST(PresentationPointer, uses_provider_and_preserves_visibility_position_pressed_state_and_scale_without_game) {
     GraphicsOptions options;
-    options.width = 1024; options.height = 768; options.guiScale = 1.0f;
+    options.width = 1024;
+    options.height = 768;
+    options.guiScale = 1.0f;
     RecordingContext context(options);
     Statistic statistic;
     MeshRegistry meshes(statistic);
@@ -77,13 +82,15 @@ TEST(PresentationPointer, uses_provider_and_preserves_visibility_position_presse
     CursorProvider provider;
     provider.cursor = std::make_shared<Cursor>(up, down, context, meshes, shaders, uniforms, statistic);
     PresentationPointer pointer(provider);
-    pointer.setPosition({5, 6}); pointer.setPressed(true);
+    pointer.setPosition({5, 6});
+    pointer.setPressed(true);
     pointer.render(options, false);
     EXPECT_TRUE(context.bound.empty());
     pointer.setType(CursorType::Default);
     pointer.setType(CursorType::Default);
     EXPECT_EQ((std::vector<CursorType> {CursorType::Default}), provider.requests);
-    pointer.setPosition({50, 60}); pointer.setPressed(false);
+    pointer.setPosition({50, 60});
+    pointer.setPressed(false);
     pointer.render(options, false);
     ASSERT_EQ(1u, context.bound.size());
     EXPECT_EQ(up.get(), context.bound.back());

--- a/test/game/presentationpointer.cpp
+++ b/test/game/presentationpointer.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 The reone project contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "reone/game/presentationpointer.h"
+#include "reone/graphics/context.h"
+#include "reone/graphics/meshregistry.h"
+#include "reone/graphics/shaderregistry.h"
+#include "reone/graphics/shaderprogram.h"
+#include "reone/graphics/statistic.h"
+#include "reone/graphics/texture.h"
+#include "reone/graphics/uniforms.h"
+
+using namespace reone;
+using namespace reone::game;
+using namespace reone::graphics;
+using namespace reone::resource;
+using namespace testing;
+
+namespace {
+class RecordingContext : public Context {
+public:
+    using Context::Context;
+    std::vector<Texture *> bound;
+    void bindTexture(Texture &texture, int) override { bound.push_back(&texture); }
+    void useProgram(ShaderProgram &) override {}
+    // Stop at raster submission: texture choice and transform are real Cursor code.
+    void withBlendMode(BlendMode, const std::function<void()> &) override {}
+};
+class RecordingUniforms : public Uniforms {
+public:
+    using Uniforms::Uniforms;
+    LocalUniforms locals;
+    void setLocals(const std::function<void(LocalUniforms &)> &f) override { f(locals); }
+};
+class PointerShaders : public ShaderRegistry {
+public:
+    ShaderProgram shader {std::vector<std::shared_ptr<Shader>> {}};
+    ShaderProgram &get(const std::string &) override { return shader; }
+};
+class CursorProvider : public ICursors {
+public:
+    std::shared_ptr<Cursor> cursor;
+    std::vector<CursorType> requests;
+    std::shared_ptr<Cursor> get(CursorType type) override { requests.push_back(type); return cursor; }
+};
+}
+
+TEST(PresentationPointer, uses_provider_and_preserves_visibility_position_pressed_state_and_scale_without_game) {
+    GraphicsOptions options;
+    options.width = 1024; options.height = 768; options.guiScale = 1.0f;
+    RecordingContext context(options);
+    Statistic statistic;
+    MeshRegistry meshes(statistic);
+    PointerShaders shaders;
+    RecordingUniforms uniforms(context);
+    auto up = std::make_shared<Texture>("up", TextureType::TwoDim, Texture::Properties {});
+    auto down = std::make_shared<Texture>("down", TextureType::TwoDim, Texture::Properties {});
+    auto pixels = std::make_shared<ByteBuffer>(32 * 32 * 4, 0);
+    up->setPixels(32, 32, PixelFormat::RGBA8, Texture::Layer {pixels});
+    down->setPixels(32, 32, PixelFormat::RGBA8, Texture::Layer {pixels});
+    CursorProvider provider;
+    provider.cursor = std::make_shared<Cursor>(up, down, context, meshes, shaders, uniforms, statistic);
+    PresentationPointer pointer(provider);
+    pointer.setPosition({5, 6}); pointer.setPressed(true);
+    pointer.render(options, false);
+    EXPECT_TRUE(context.bound.empty());
+    pointer.setType(CursorType::Default);
+    pointer.setType(CursorType::Default);
+    EXPECT_EQ((std::vector<CursorType> {CursorType::Default}), provider.requests);
+    pointer.setPosition({50, 60}); pointer.setPressed(false);
+    pointer.render(options, false);
+    ASSERT_EQ(1u, context.bound.size());
+    EXPECT_EQ(up.get(), context.bound.back());
+    EXPECT_FLOAT_EQ(50.0f, uniforms.locals.model[3].x);
+    EXPECT_FLOAT_EQ(60.0f, uniforms.locals.model[3].y);
+    EXPECT_FLOAT_EQ(32 * 0.64f, uniforms.locals.model[0].x);
+    pointer.setPressed(true);
+    pointer.render(options, false);
+    ASSERT_EQ(2u, context.bound.size());
+    EXPECT_EQ(down.get(), context.bound.back());
+    pointer.render(options, true);
+    EXPECT_EQ(2u, context.bound.size());
+    pointer.setType(CursorType::None);
+    pointer.render(options, false);
+    EXPECT_EQ(2u, context.bound.size());
+    pointer.setType(CursorType::Talk);
+    pointer.setPressed(false);
+    pointer.render(options, false);
+    EXPECT_EQ(3u, context.bound.size());
+    EXPECT_EQ(up.get(), context.bound.back());
+}
+
+TEST(PresentationPointer, preserves_the_existing_contextual_decision_table) {
+    EXPECT_EQ(CursorType::Talk, contextualCursor(ObjectType::Creature, false, false));
+    EXPECT_EQ(CursorType::Attack, contextualCursor(ObjectType::Creature, false, true));
+    EXPECT_EQ(CursorType::Pickup, contextualCursor(ObjectType::Creature, true, false));
+    EXPECT_EQ(CursorType::Pickup, contextualCursor(ObjectType::Creature, true, true));
+    EXPECT_EQ(CursorType::Door, contextualCursor(ObjectType::Door, false, false));
+    EXPECT_EQ(CursorType::Pickup, contextualCursor(ObjectType::Placeable, false, false));
+    EXPECT_EQ(CursorType::Default, contextualCursor(ObjectType::Item, false, false));
+}


### PR DESCRIPTION
## Summary

Extracts software-pointer presentation into `PresentationPointer`, which can be used without a `Game`.

The engine supplies one pointer; `Game` forwards its existing input and render calls. The existing contextual cursor choice is also extracted into a helper over object type, dead state and hostility.

Cursor resources, scaling and render order are unchanged. Picking, hostility calculation and interaction remain with their existing owners. This does not replace the cursor-source work in #335.

## Validation

Tests cover provider calls, visibility, position, pressed state, scaling and contextual cursor choices without constructing a `Game`.

Manual cursor, modal and return-to-world smoke remains pending.